### PR TITLE
Added initial unit tests for the indexer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ aws-requests-auth==0.3.3
 boto==2.48.0
 boto3==1.7.46
 botocore==1.10.46
+docker==3.4.1
 elasticsearch>=5.0.0,<6.0.0
 elasticsearch-dsl>=5.0.0,<6.0.0
 jsonobject==0.7.1

--- a/test/indexer/data/56a338fe-7554-4b5d-96a2-7df127a7640b.data
+++ b/test/indexer/data/56a338fe-7554-4b5d-96a2-7df127a7640b.data
@@ -1,0 +1,26 @@
+{
+    "22467_6#209_1.fastq.gz": {
+        "content-type": "application/gzip; dcp-type=data",
+        "crc32c": "c3a170ed",
+        "indexed": false,
+        "name": "22467_6#209_1.fastq.gz",
+        "s3_etag": "7df2abd52fb511a5a0015a1d5a6d6652",
+        "sha1": "d671d9c43e24a5d3efce53db9e51783628992d0a",
+        "sha256": "be1413a1851354eaac53bf795f74d615b383626f4d78e7d8c7ce69806585f4c4",
+        "size": 1032483,
+        "uuid": "2d8cdf91-8162-4321-9923-e00e90fd9133",
+        "version": "2018-03-29T153501.427209Z"
+    },
+    "22467_6#209_2.fastq.gz": {
+        "content-type": "application/gzip; dcp-type=data",
+        "crc32c": "a39019f8",
+        "indexed": false,
+        "name": "22467_6#209_2.fastq.gz",
+        "s3_etag": "d478462fab81e0310d9efd4209420423",
+        "sha1": "94a4bfa3c6d1bf46cb424dff293311205971ad60",
+        "sha256": "1e0f159cf347a4a65ede1240f03101aab4885c9209a45b0d07bcd536a74b6998",
+        "size": 1205219,
+        "uuid": "d9087c74-a41e-4702-8481-cea3ef68379c",
+        "version": "2018-03-29T153502.542108Z"
+    }
+}

--- a/test/indexer/data/56a338fe-7554-4b5d-96a2-7df127a7640b.metadata
+++ b/test/indexer/data/56a338fe-7554-4b5d-96a2-7df127a7640b.metadata
@@ -1,0 +1,559 @@
+{
+    "protocol.json": {
+        "protocols": [
+            {
+                "content": {
+                    "protocol_core": {
+                        "protocol_name": "Extracting cells from lymph nodes",
+                        "document": "TissueDissociationProtocol.pdf",
+                        "protocol_id": "tissue_dissociation_protocol"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/protocol/5.1.0/protocol",
+                    "schema_type": "protocol"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:55:26.033Z",
+                    "updateDate": "2018-03-28T14:14:33.716Z",
+                    "document_id": "c9a1e203-bddc-45d3-87c4-6010be8e0127"
+                }
+            },
+            {
+                "content": {
+                    "protocol_core": {
+                        "protocol_name": "FACS sorting cells by surface markers",
+                        "document": "FACSsortingProtocol.pdf",
+                        "protocol_id": "FACS_sorting_protocol"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/protocol/5.1.0/protocol",
+                    "schema_type": "protocol"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:55:26.040Z",
+                    "updateDate": "2018-03-28T14:45:43.500Z",
+                    "document_id": "a1c80daf-58b0-4b7a-8e29-d0130493c8e6"
+                }
+            },
+            {
+                "content": {
+                    "protocol_core": {
+                        "protocol_name": "Make/amplify cDNA for each cell",
+                        "document": "SmartSeq2_RTPCR_protocol.pdf",
+                        "protocol_id": "SmartSeq2_RTPCR_protocol"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/protocol/5.1.0/protocol",
+                    "protocol_type": {
+                        "text": "Smart-seq2 protocol",
+                        "ontology": "EFO:0008442"
+                    },
+                    "schema_type": "protocol"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:55:26.044Z",
+                    "updateDate": "2018-03-28T14:24:04.790Z",
+                    "document_id": "52d79a89-4b49-4c1b-b857-5cc5da07f643"
+                }
+            },
+            {
+                "content": {
+                    "protocol_core": {
+                        "protocol_name": "Sequencing SmartSeq2 cells",
+                        "protocol_id": "SmartSeq2_sequencing_protocol"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/protocol/5.1.0/protocol",
+                    "schema_type": "protocol"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:55:26.050Z",
+                    "updateDate": "2018-03-28T14:30:39.321Z",
+                    "document_id": "ca6096cf-13c1-4930-8308-6ab05865e2c9"
+                }
+            }
+        ],
+        "describedBy": "https://schema.humancellatlas.org/bundle/5.1.0/protocol",
+        "schema_version": "5.1.0",
+        "schema_type": "protocol_bundle"
+    },
+    "links.json": {
+        "links": [
+            {
+                "source_id": "ffb809dd-3139-4162-b9af-ec88e491ee9c",
+                "source_type": "biomaterial",
+                "destination_id": "b7bbb2dc-3131-47c3-bcb9-4b7e0eeed902",
+                "destination_type": "dissociation_process"
+            },
+            {
+                "source_id": "b7bbb2dc-3131-47c3-bcb9-4b7e0eeed902",
+                "source_type": "dissociation_process",
+                "destination_id": "04e58fb0-384e-4997-a9e9-575d9887e737",
+                "destination_type": "biomaterial"
+            },
+            {
+                "source_id": "b7bbb2dc-3131-47c3-bcb9-4b7e0eeed902",
+                "source_type": "dissociation_process",
+                "destination_id": "c9a1e203-bddc-45d3-87c4-6010be8e0127",
+                "destination_type": "protocol"
+            },
+            {
+                "source_id": "0763320a-e0c4-4c07-b150-b83650fbef68",
+                "source_type": "process",
+                "destination_id": "ffb809dd-3139-4162-b9af-ec88e491ee9c",
+                "destination_type": "biomaterial"
+            },
+            {
+                "source_id": "689311a2-bfaf-4196-a753-554e69ab59b2",
+                "source_type": "biomaterial",
+                "destination_id": "0763320a-e0c4-4c07-b150-b83650fbef68",
+                "destination_type": "process"
+            },
+            {
+                "source_id": "ffb809dd-3139-4162-b9af-ec88e491ee9c",
+                "source_type": "biomaterial",
+                "destination_id": "bcef348b-3915-48b8-bc09-d24a5bff76c4",
+                "destination_type": "enrichment_process"
+            },
+            {
+                "source_id": "bcef348b-3915-48b8-bc09-d24a5bff76c4",
+                "source_type": "enrichment_process",
+                "destination_id": "04e58fb0-384e-4997-a9e9-575d9887e737",
+                "destination_type": "biomaterial"
+            },
+            {
+                "source_id": "bcef348b-3915-48b8-bc09-d24a5bff76c4",
+                "source_type": "enrichment_process",
+                "destination_id": "a1c80daf-58b0-4b7a-8e29-d0130493c8e6",
+                "destination_type": "protocol"
+            },
+            {
+                "source_id": "0763320a-e0c4-4c07-b150-b83650fbef68",
+                "source_type": "process",
+                "destination_id": "ffb809dd-3139-4162-b9af-ec88e491ee9c",
+                "destination_type": "biomaterial"
+            },
+            {
+                "source_id": "689311a2-bfaf-4196-a753-554e69ab59b2",
+                "source_type": "biomaterial",
+                "destination_id": "0763320a-e0c4-4c07-b150-b83650fbef68",
+                "destination_type": "process"
+            },
+            {
+                "source_id": "04e58fb0-384e-4997-a9e9-575d9887e737",
+                "source_type": "biomaterial",
+                "destination_id": "687065f3-c70f-46c3-8452-a5eead33a1bf",
+                "destination_type": "library_preparation_process"
+            },
+            {
+                "source_id": "687065f3-c70f-46c3-8452-a5eead33a1bf",
+                "source_type": "library_preparation_process",
+                "destination_id": "2d8cdf91-8162-4321-9923-e00e90fd9133",
+                "destination_type": "file"
+            },
+            {
+                "source_id": "687065f3-c70f-46c3-8452-a5eead33a1bf",
+                "source_type": "library_preparation_process",
+                "destination_id": "d9087c74-a41e-4702-8481-cea3ef68379c",
+                "destination_type": "file"
+            },
+            {
+                "source_id": "687065f3-c70f-46c3-8452-a5eead33a1bf",
+                "source_type": "library_preparation_process",
+                "destination_id": "52d79a89-4b49-4c1b-b857-5cc5da07f643",
+                "destination_type": "protocol"
+            },
+            {
+                "source_id": "04e58fb0-384e-4997-a9e9-575d9887e737",
+                "source_type": "biomaterial",
+                "destination_id": "4624400f-00c5-476a-9bd6-589e87ddb0fe",
+                "destination_type": "sequencing_process"
+            },
+            {
+                "source_id": "4624400f-00c5-476a-9bd6-589e87ddb0fe",
+                "source_type": "sequencing_process",
+                "destination_id": "2d8cdf91-8162-4321-9923-e00e90fd9133",
+                "destination_type": "file"
+            },
+            {
+                "source_id": "4624400f-00c5-476a-9bd6-589e87ddb0fe",
+                "source_type": "sequencing_process",
+                "destination_id": "d9087c74-a41e-4702-8481-cea3ef68379c",
+                "destination_type": "file"
+            },
+            {
+                "source_id": "4624400f-00c5-476a-9bd6-589e87ddb0fe",
+                "source_type": "sequencing_process",
+                "destination_id": "ca6096cf-13c1-4930-8308-6ab05865e2c9",
+                "destination_type": "protocol"
+            }
+        ],
+        "describedBy": "https://schema.humancellatlas.org/bundle/1.0.0/links",
+        "schema_version": "1.0.0",
+        "schema_type": "link_bundle"
+    },
+    "project.json": {
+        "content": {
+            "describedBy": "https://schema.humancellatlas.org/type/project/5.1.0/project",
+            "project_core": {
+                "project_shortname": "Mouse Melanoma",
+                "project_description": "The cancer microenvironment is a complex ecosystem characterized by dynamic interactions between diverse cell types, including malignant, immune and stromal cells. Here, we performed single-cell RNA sequencing on CD45+ and CD45- cells isolated from tumour and lymph nodes during a mouse model of melanoma. The transcriptional profiles of these individual cells taken at different time points coupled with assembled T cell receptor sequences, allowed us to identify distinct immune subpopulations and delineate their developmental trajectory. Our study provides insights into the complex interplay among cells within the tumour microenvironment and presents a valuable resource for future translational applications.",
+                "project_title": "Melanoma infiltration of stromal and immune cells"
+            },
+            "publications": [],
+            "contributors": [
+                {
+                    "country": "UK",
+                    "institution": "Wellcome Trust Sanger Institute",
+                    "address": "Wellcome Trust Genome Campus, Cambridge UK",
+                    "laboratory": "Sarah Teichmann",
+                    "contact_name": "Sarah,A,Teichmann",
+                    "email": "st9@sanger.ac.uk"
+                },
+                {
+                    "country": "UK",
+                    "institution": "Wellcome Trust Sanger Institute",
+                    "address": "Wellcome Trust Genome Campus, Cambridge UK",
+                    "laboratory": "Sarah Teichmann",
+                    "contact_name": "Mirjana,,Efremova",
+                    "email": "me5@sanger.ac.uk"
+                },
+                {
+                    "country": "UK",
+                    "institution": "Wellcome Trust Sanger Institute",
+                    "address": "Wellcome Trust Genome Campus, Cambridge UK",
+                    "laboratory": "Sarah Teichmann",
+                    "contact_name": "Bidesh,,Mahata",
+                    "email": "bm11@sanger.ac.uk"
+                },
+                {
+                    "country": "UK",
+                    "institution": "University of Cambridge",
+                    "address": "Box 197, Cambridge Biomedical Campus, Cambridge, CB2 0XZ",
+                    "laboratory": "MRC Cancer Unit",
+                    "contact_name": "Jacqueline,D,Shields",
+                    "email": "JS970@MRCCU.cam.ac.uk"
+                },
+                {
+                    "country": "UK",
+                    "institution": "University of Cambridge",
+                    "address": "Box 197, Cambridge Biomedical Campus, Cambridge, CB2 0XZ",
+                    "laboratory": "MRC Cancer Unit",
+                    "contact_name": "Sarah,,Davidson",
+                    "email": "SED49@MRCCU.cam.ac.uk"
+                },
+                {
+                    "country": "Germany",
+                    "contact_name": "Angela,,Riedel",
+                    "email": "a.riedel@dkfz-heidelberg.de",
+                    "institution": "DKFZ German Cancer Research Center"
+                },
+                {
+                    "country": "UK",
+                    "institution": "Wellcome Trust Sanger Institute",
+                    "address": "Wellcome Trust Genome Campus, Cambridge UK",
+                    "laboratory": "Sarah Teichmann",
+                    "contact_name": "Roser,,Veno-Tormo",
+                    "email": "rv4@sanger.ac.uk"
+                },
+                {
+                    "country": "UK",
+                    "institution": "Wellcome Trust Sanger Institute",
+                    "address": "Wellcome Trust Genome Campus, Cambridge UK",
+                    "laboratory": "Sarah Teichmann",
+                    "contact_name": "Jhuma,,Pramanik",
+                    "email": "jp19@sanger.ac.uk"
+                },
+                {
+                    "country": "UK",
+                    "institution": "EMBL-EBI",
+                    "address": "Wellcome Trust Genome Campus, Cambridge UK",
+                    "laboratory": "Sarah Teichmann",
+                    "contact_name": "Gozde,,Kar",
+                    "email": "gkar@ebi.ac.uk"
+                },
+                {
+                    "country": "Finland",
+                    "contact_name": "Jani,,Huuhtanen",
+                    "email": "jani.huuhtanen@helsinki.fi",
+                    "institution": "University of Helsinki"
+                }
+            ],
+            "schema_type": "project"
+        },
+        "hca_ingest": {
+            "accession": "",
+            "submissionDate": "2018-03-28T13:55:26.025Z",
+            "updateDate": "2018-03-28T14:27:32.460Z",
+            "document_id": "93f6a42f-1790-4af4-b5d1-8c436cb6feae"
+        },
+        "describedBy": "https://schema.humancellatlas.org/bundle/5.1.0/project",
+        "schema_version": "5.1.0",
+        "schema_type": "project_bundle"
+    },
+    "biomaterial.json": {
+        "biomaterials": [
+            {
+                "content": {
+                    "genus_species": [
+                        {
+                            "text": "Mus musculus",
+                            "ontology": "NCBITaxon:10090"
+                        }
+                    ],
+                    "total_estimated_cells": 1,
+                    "target_cell_type": [
+                        {
+                            "text": "CD11b+ Macrophages/monocytes"
+                        }
+                    ],
+                    "schema_type": "biomaterial",
+                    "biomaterial_core": {
+                        "has_input_biomaterial": "1117_T",
+                        "ncbi_taxon_id": [
+                            10090
+                        ],
+                        "biomaterial_id": "22467_6#209"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/biomaterial/5.1.0/cell_suspension"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:58:57.160Z",
+                    "updateDate": "2018-03-28T14:27:46.870Z",
+                    "document_id": "04e58fb0-384e-4997-a9e9-575d9887e737"
+                }
+            },
+            {
+                "content": {
+                    "biomaterial_core": {
+                        "has_input_biomaterial": "1117",
+                        "ncbi_taxon_id": [
+                            10090
+                        ],
+                        "biomaterial_id": "1117_T",
+                        "supplementary_files": [
+                            "FACS_sorting_markers.pdf"
+                        ],
+                        "biomaterial_name": "Mouse_day5_T_rep8"
+                    },
+                    "genus_species": [
+                        {
+                            "text": "Mus musculus",
+                            "ontology": "NCBITaxon:10090"
+                        }
+                    ],
+                    "describedBy": "https://schema.humancellatlas.org/type/biomaterial/5.1.0/specimen_from_organism",
+                    "organ": {
+                        "text": "tumor"
+                    },
+                    "schema_type": "biomaterial"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:56:12.647Z",
+                    "updateDate": "2018-03-28T14:19:05.173Z",
+                    "document_id": "ffb809dd-3139-4162-b9af-ec88e491ee9c"
+                }
+            },
+            {
+                "content": {
+                    "is_living": false,
+                    "mus_musculus_specific": {
+                        "strain": [
+                            {
+                                "text": "C57BL/6"
+                            }
+                        ]
+                    },
+                    "biological_sex": "female",
+                    "genus_species": [
+                        {
+                            "text": "Mus musculus",
+                            "ontology": "NCBITaxon:10090"
+                        }
+                    ],
+                    "disease": [
+                        {
+                            "text": "subcutaneous melanoma",
+                            "ontology": "EFO:0000756"
+                        }
+                    ],
+                    "organism_age": "6-12",
+                    "schema_type": "biomaterial",
+                    "biomaterial_core": {
+                        "ncbi_taxon_id": [
+                            10090
+                        ],
+                        "biomaterial_id": "1117",
+                        "biomaterial_name": "Mouse_day5_rep8"
+                    },
+                    "organism_age_unit": {
+                        "text": "week",
+                        "ontology": "UO:0000034"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/biomaterial/5.1.0/donor_organism"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:56:00.553Z",
+                    "updateDate": "2018-03-28T14:00:16.892Z",
+                    "document_id": "689311a2-bfaf-4196-a753-554e69ab59b2"
+                }
+            }
+        ],
+        "describedBy": "https://schema.humancellatlas.org/bundle/5.1.0/biomaterial",
+        "schema_version": "5.1.0",
+        "schema_type": "biomaterial_bundle"
+    },
+    "process.json": {
+        "processes": [
+            {
+                "content": {
+                    "nucleic_acid_source": "single cell",
+                    "process_core": {
+                        "process_id": "TissueDissociationProcess",
+                        "process_name": "Extracting cells from lymph nodes"
+                    },
+                    "dissociation_method": "mechanical",
+                    "describedBy": "https://schema.humancellatlas.org/type/process/biomaterial_collection/5.1.0/dissociation_process",
+                    "schema_type": "process"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T14:04:14.574Z",
+                    "updateDate": "2018-03-28T14:13:28.361Z",
+                    "document_id": "b7bbb2dc-3131-47c3-bcb9-4b7e0eeed902"
+                }
+            },
+            {
+                "content": {
+                    "process_core": {
+                        "process_id": "sampling_process_12"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/process/1.0.0/process",
+                    "schema_type": "process"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T14:00:16.640Z",
+                    "updateDate": "2018-03-28T14:00:59.234Z",
+                    "document_id": "0763320a-e0c4-4c07-b150-b83650fbef68"
+                }
+            },
+            {
+                "content": {
+                    "enrichment_method": "FACS",
+                    "process_core": {
+                        "process_id": "FACS3.2"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/process/biomaterial_collection/5.1.0/enrichment_process",
+                    "markers": "CD45+ CD3e- B220- CD11b+",
+                    "schema_type": "process"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T14:04:02.006Z",
+                    "updateDate": "2018-03-28T14:15:18.962Z",
+                    "document_id": "bcef348b-3915-48b8-bc09-d24a5bff76c4"
+                }
+            },
+            {
+                "content": {
+                    "input_nucleic_acid_molecule": {
+                        "text": "polyA RNA",
+                        "ontology": "OBI:0000869"
+                    },
+                    "process_core": {
+                        "process_id": "lib_prep_1",
+                        "process_name": "Library preparation process"
+                    },
+                    "umi_barcode": {
+                        "barcode_offset": 0,
+                        "barcode_length": 16,
+                        "barcode_read": "Read 1"
+                    },
+                    "library_construction_approach": "Smart-seq2",
+                    "schema_type": "process",
+                    "end_bias": "full length",
+                    "primer": "poly-dT",
+                    "describedBy": "https://schema.humancellatlas.org/type/process/sequencing/5.1.0/library_preparation_process",
+                    "strand": "unstranded"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T14:05:43.803Z",
+                    "updateDate": "2018-03-28T14:43:01.679Z",
+                    "document_id": "687065f3-c70f-46c3-8452-a5eead33a1bf"
+                }
+            },
+            {
+                "content": {
+                    "paired_ends": true,
+                    "instrument_manufacturer_model": {
+                        "text": "Illumina HiSeq 2500",
+                        "ontology": "EFO:0008567"
+                    },
+                    "process_core": {
+                        "process_id": "seq_5656",
+                        "process_name": "Sequencing process"
+                    },
+                    "smartseq2": {
+                        "well_name": "D5",
+                        "plate_id": "537"
+                    },
+                    "schema_type": "process",
+                    "describedBy": "https://schema.humancellatlas.org/type/process/sequencing/5.1.0/sequencing_process"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T14:05:51.198Z",
+                    "updateDate": "2018-03-28T14:10:52.303Z",
+                    "document_id": "4624400f-00c5-476a-9bd6-589e87ddb0fe"
+                }
+            }
+        ],
+        "describedBy": "https://schema.humancellatlas.org/bundle/5.2.1/process",
+        "schema_version": "5.2.1",
+        "schema_type": "process_bundle"
+    },
+    "file.json": {
+        "files": [
+            {
+                "content": {
+                    "file_core": {
+                        "file_name": "22467_6#209_1.fastq.gz",
+                        "file_format": "fastq.gz"
+                    },
+                    "lane_index": 6,
+                    "read_index": "read1",
+                    "describedBy": "https://schema.humancellatlas.org/type/file/5.1.0/sequence_file",
+                    "schema_type": "file"
+                },
+                "hca_ingest": {
+                    "submissionDate": "2018-03-28T14:02:56.078Z",
+                    "document_id": "2d8cdf91-8162-4321-9923-e00e90fd9133"
+                }
+            },
+            {
+                "content": {
+                    "file_core": {
+                        "file_name": "22467_6#209_2.fastq.gz",
+                        "file_format": "fastq.gz"
+                    },
+                    "lane_index": 6,
+                    "read_index": "read2",
+                    "describedBy": "https://schema.humancellatlas.org/type/file/5.1.0/sequence_file",
+                    "schema_type": "file"
+                },
+                "hca_ingest": {
+                    "submissionDate": "2018-03-28T14:02:56.090Z",
+                    "document_id": "d9087c74-a41e-4702-8481-cea3ef68379c"
+                }
+            }
+        ],
+        "describedBy": "https://schema.humancellatlas.org/bundle/1.0.0/file",
+        "schema_version": "1.0.0",
+        "schema_type": "file_bundle"
+    }
+}

--- a/test/indexer/data/9dec1bd6-ced8-448a-8e45-1fc7846d8995.data
+++ b/test/indexer/data/9dec1bd6-ced8-448a-8e45-1fc7846d8995.data
@@ -1,0 +1,26 @@
+{
+    "22467_6#373_1.fastq.gz": {
+        "content-type": "application/gzip; dcp-type=data",
+        "crc32c": "fa399aa2",
+        "indexed": false,
+        "name": "22467_6#373_1.fastq.gz",
+        "s3_etag": "cdb87a44f4ff0ee069e15773f593d970",
+        "sha1": "6af8e26b6d8a8ee8d2b4fe47b007db4493f824cc",
+        "sha256": "6c0599cb573d88d0f7d149d5ffc5b4e4d370904c1b421d2c729fcc4f4dd75c71",
+        "size": 2377581,
+        "uuid": "e080459e-e4ab-40ea-ab75-a2646b5fdd29",
+        "version": "2018-03-29T154313.328705Z"
+    },
+    "22467_6#373_2.fastq.gz": {
+        "content-type": "application/gzip; dcp-type=data",
+        "crc32c": "7453bf7a",
+        "indexed": false,
+        "name": "22467_6#373_2.fastq.gz",
+        "s3_etag": "b26ff362f46fd47c1cb027660b67bf75",
+        "sha1": "c12a30bfff4ea141807c32cd1d4600fa206d8a40",
+        "sha256": "853b9f75ff100ae1fd824d633ded540975e44dbc9643d4a3fbaffbed574e30b0",
+        "size": 2363269,
+        "uuid": "3417cdb5-5618-4c0c-bc27-62a4eb78916a",
+        "version": "2018-03-29T154314.679074Z"
+    }
+}

--- a/test/indexer/data/9dec1bd6-ced8-448a-8e45-1fc7846d8995.metadata
+++ b/test/indexer/data/9dec1bd6-ced8-448a-8e45-1fc7846d8995.metadata
@@ -1,0 +1,559 @@
+{
+    "project.json": {
+        "content": {
+            "describedBy": "https://schema.humancellatlas.org/type/project/5.1.0/project",
+            "project_core": {
+                "project_shortname": "Mouse Melanoma",
+                "project_description": "The cancer microenvironment is a complex ecosystem characterized by dynamic interactions between diverse cell types, including malignant, immune and stromal cells. Here, we performed single-cell RNA sequencing on CD45+ and CD45- cells isolated from tumour and lymph nodes during a mouse model of melanoma. The transcriptional profiles of these individual cells taken at different time points coupled with assembled T cell receptor sequences, allowed us to identify distinct immune subpopulations and delineate their developmental trajectory. Our study provides insights into the complex interplay among cells within the tumour microenvironment and presents a valuable resource for future translational applications.",
+                "project_title": "Melanoma infiltration of stromal and immune cells"
+            },
+            "publications": [],
+            "contributors": [
+                {
+                    "country": "UK",
+                    "institution": "Wellcome Trust Sanger Institute",
+                    "address": "Wellcome Trust Genome Campus, Cambridge UK",
+                    "laboratory": "Sarah Teichmann",
+                    "contact_name": "Sarah,A,Teichmann",
+                    "email": "st9@sanger.ac.uk"
+                },
+                {
+                    "country": "UK",
+                    "institution": "Wellcome Trust Sanger Institute",
+                    "address": "Wellcome Trust Genome Campus, Cambridge UK",
+                    "laboratory": "Sarah Teichmann",
+                    "contact_name": "Mirjana,,Efremova",
+                    "email": "me5@sanger.ac.uk"
+                },
+                {
+                    "country": "UK",
+                    "institution": "Wellcome Trust Sanger Institute",
+                    "address": "Wellcome Trust Genome Campus, Cambridge UK",
+                    "laboratory": "Sarah Teichmann",
+                    "contact_name": "Bidesh,,Mahata",
+                    "email": "bm11@sanger.ac.uk"
+                },
+                {
+                    "country": "UK",
+                    "institution": "University of Cambridge",
+                    "address": "Box 197, Cambridge Biomedical Campus, Cambridge, CB2 0XZ",
+                    "laboratory": "MRC Cancer Unit",
+                    "contact_name": "Jacqueline,D,Shields",
+                    "email": "JS970@MRCCU.cam.ac.uk"
+                },
+                {
+                    "country": "UK",
+                    "institution": "University of Cambridge",
+                    "address": "Box 197, Cambridge Biomedical Campus, Cambridge, CB2 0XZ",
+                    "laboratory": "MRC Cancer Unit",
+                    "contact_name": "Sarah,,Davidson",
+                    "email": "SED49@MRCCU.cam.ac.uk"
+                },
+                {
+                    "country": "Germany",
+                    "contact_name": "Angela,,Riedel",
+                    "email": "a.riedel@dkfz-heidelberg.de",
+                    "institution": "DKFZ German Cancer Research Center"
+                },
+                {
+                    "country": "UK",
+                    "institution": "Wellcome Trust Sanger Institute",
+                    "address": "Wellcome Trust Genome Campus, Cambridge UK",
+                    "laboratory": "Sarah Teichmann",
+                    "contact_name": "Roser,,Veno-Tormo",
+                    "email": "rv4@sanger.ac.uk"
+                },
+                {
+                    "country": "UK",
+                    "institution": "Wellcome Trust Sanger Institute",
+                    "address": "Wellcome Trust Genome Campus, Cambridge UK",
+                    "laboratory": "Sarah Teichmann",
+                    "contact_name": "Jhuma,,Pramanik",
+                    "email": "jp19@sanger.ac.uk"
+                },
+                {
+                    "country": "UK",
+                    "institution": "EMBL-EBI",
+                    "address": "Wellcome Trust Genome Campus, Cambridge UK",
+                    "laboratory": "Sarah Teichmann",
+                    "contact_name": "Gozde,,Kar",
+                    "email": "gkar@ebi.ac.uk"
+                },
+                {
+                    "country": "Finland",
+                    "contact_name": "Jani,,Huuhtanen",
+                    "email": "jani.huuhtanen@helsinki.fi",
+                    "institution": "University of Helsinki"
+                }
+            ],
+            "schema_type": "project"
+        },
+        "hca_ingest": {
+            "accession": "",
+            "submissionDate": "2018-03-28T13:55:26.025Z",
+            "updateDate": "2018-03-28T14:27:32.460Z",
+            "document_id": "93f6a42f-1790-4af4-b5d1-8c436cb6feae"
+        },
+        "describedBy": "https://schema.humancellatlas.org/bundle/5.1.0/project",
+        "schema_version": "5.1.0",
+        "schema_type": "project_bundle"
+    },
+    "file.json": {
+        "files": [
+            {
+                "content": {
+                    "file_core": {
+                        "file_name": "22467_6#373_1.fastq.gz",
+                        "file_format": "fastq.gz"
+                    },
+                    "lane_index": 6,
+                    "read_index": "read1",
+                    "describedBy": "https://schema.humancellatlas.org/type/file/5.1.0/sequence_file",
+                    "schema_type": "file"
+                },
+                "hca_ingest": {
+                    "submissionDate": "2018-03-28T14:03:00.756Z",
+                    "document_id": "e080459e-e4ab-40ea-ab75-a2646b5fdd29"
+                }
+            },
+            {
+                "content": {
+                    "file_core": {
+                        "file_name": "22467_6#373_2.fastq.gz",
+                        "file_format": "fastq.gz"
+                    },
+                    "lane_index": 6,
+                    "read_index": "read2",
+                    "describedBy": "https://schema.humancellatlas.org/type/file/5.1.0/sequence_file",
+                    "schema_type": "file"
+                },
+                "hca_ingest": {
+                    "submissionDate": "2018-03-28T14:03:00.761Z",
+                    "document_id": "3417cdb5-5618-4c0c-bc27-62a4eb78916a"
+                }
+            }
+        ],
+        "describedBy": "https://schema.humancellatlas.org/bundle/1.0.0/file",
+        "schema_version": "1.0.0",
+        "schema_type": "file_bundle"
+    },
+    "process.json": {
+        "processes": [
+            {
+                "content": {
+                    "nucleic_acid_source": "single cell",
+                    "process_core": {
+                        "process_id": "TissueDissociationProcess",
+                        "process_name": "Extracting cells from lymph nodes"
+                    },
+                    "dissociation_method": "mechanical",
+                    "describedBy": "https://schema.humancellatlas.org/type/process/biomaterial_collection/5.1.0/dissociation_process",
+                    "schema_type": "process"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T14:04:14.574Z",
+                    "updateDate": "2018-03-28T14:13:28.361Z",
+                    "document_id": "b7bbb2dc-3131-47c3-bcb9-4b7e0eeed902"
+                }
+            },
+            {
+                "content": {
+                    "process_core": {
+                        "process_id": "sampling_process_12"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/process/1.0.0/process",
+                    "schema_type": "process"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T14:00:16.640Z",
+                    "updateDate": "2018-03-28T14:00:59.234Z",
+                    "document_id": "0763320a-e0c4-4c07-b150-b83650fbef68"
+                }
+            },
+            {
+                "content": {
+                    "enrichment_method": "FACS",
+                    "process_core": {
+                        "process_id": "FACS3.2"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/process/biomaterial_collection/5.1.0/enrichment_process",
+                    "markers": "CD45+ CD3e- B220- CD11b+",
+                    "schema_type": "process"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T14:04:02.006Z",
+                    "updateDate": "2018-03-28T14:15:18.962Z",
+                    "document_id": "bcef348b-3915-48b8-bc09-d24a5bff76c4"
+                }
+            },
+            {
+                "content": {
+                    "input_nucleic_acid_molecule": {
+                        "text": "polyA RNA",
+                        "ontology": "OBI:0000869"
+                    },
+                    "process_core": {
+                        "process_id": "lib_prep_1",
+                        "process_name": "Library preparation process"
+                    },
+                    "umi_barcode": {
+                        "barcode_offset": 0,
+                        "barcode_length": 16,
+                        "barcode_read": "Read 1"
+                    },
+                    "library_construction_approach": "Smart-seq2",
+                    "schema_type": "process",
+                    "end_bias": "full length",
+                    "primer": "poly-dT",
+                    "describedBy": "https://schema.humancellatlas.org/type/process/sequencing/5.1.0/library_preparation_process",
+                    "strand": "unstranded"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T14:05:43.803Z",
+                    "updateDate": "2018-03-28T14:43:01.679Z",
+                    "document_id": "687065f3-c70f-46c3-8452-a5eead33a1bf"
+                }
+            },
+            {
+                "content": {
+                    "paired_ends": true,
+                    "instrument_manufacturer_model": {
+                        "text": "Illumina HiSeq 2500",
+                        "ontology": "EFO:0008567"
+                    },
+                    "process_core": {
+                        "process_id": "seq_5834",
+                        "process_name": "Sequencing process"
+                    },
+                    "smartseq2": {
+                        "well_name": "D85",
+                        "plate_id": "537"
+                    },
+                    "schema_type": "process",
+                    "describedBy": "https://schema.humancellatlas.org/type/process/sequencing/5.1.0/sequencing_process"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T14:04:09.031Z",
+                    "updateDate": "2018-03-28T14:10:22.768Z",
+                    "document_id": "b8a6acbe-6b57-4efb-b6c7-bceaa6d9924d"
+                }
+            }
+        ],
+        "describedBy": "https://schema.humancellatlas.org/bundle/5.2.1/process",
+        "schema_version": "5.2.1",
+        "schema_type": "process_bundle"
+    },
+    "protocol.json": {
+        "protocols": [
+            {
+                "content": {
+                    "protocol_core": {
+                        "protocol_name": "Extracting cells from lymph nodes",
+                        "document": "TissueDissociationProtocol.pdf",
+                        "protocol_id": "tissue_dissociation_protocol"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/protocol/5.1.0/protocol",
+                    "schema_type": "protocol"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:55:26.033Z",
+                    "updateDate": "2018-03-28T14:14:33.716Z",
+                    "document_id": "c9a1e203-bddc-45d3-87c4-6010be8e0127"
+                }
+            },
+            {
+                "content": {
+                    "protocol_core": {
+                        "protocol_name": "FACS sorting cells by surface markers",
+                        "document": "FACSsortingProtocol.pdf",
+                        "protocol_id": "FACS_sorting_protocol"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/protocol/5.1.0/protocol",
+                    "schema_type": "protocol"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:55:26.040Z",
+                    "updateDate": "2018-03-28T14:45:43.500Z",
+                    "document_id": "a1c80daf-58b0-4b7a-8e29-d0130493c8e6"
+                }
+            },
+            {
+                "content": {
+                    "protocol_core": {
+                        "protocol_name": "Make/amplify cDNA for each cell",
+                        "document": "SmartSeq2_RTPCR_protocol.pdf",
+                        "protocol_id": "SmartSeq2_RTPCR_protocol"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/protocol/5.1.0/protocol",
+                    "protocol_type": {
+                        "text": "Smart-seq2 protocol",
+                        "ontology": "EFO:0008442"
+                    },
+                    "schema_type": "protocol"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:55:26.044Z",
+                    "updateDate": "2018-03-28T14:24:04.790Z",
+                    "document_id": "52d79a89-4b49-4c1b-b857-5cc5da07f643"
+                }
+            },
+            {
+                "content": {
+                    "protocol_core": {
+                        "protocol_name": "Sequencing SmartSeq2 cells",
+                        "protocol_id": "SmartSeq2_sequencing_protocol"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/protocol/5.1.0/protocol",
+                    "schema_type": "protocol"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:55:26.050Z",
+                    "updateDate": "2018-03-28T14:30:39.321Z",
+                    "document_id": "ca6096cf-13c1-4930-8308-6ab05865e2c9"
+                }
+            }
+        ],
+        "describedBy": "https://schema.humancellatlas.org/bundle/5.1.0/protocol",
+        "schema_version": "5.1.0",
+        "schema_type": "protocol_bundle"
+    },
+    "links.json": {
+        "links": [
+            {
+                "source_id": "ffb809dd-3139-4162-b9af-ec88e491ee9c",
+                "source_type": "biomaterial",
+                "destination_id": "b7bbb2dc-3131-47c3-bcb9-4b7e0eeed902",
+                "destination_type": "dissociation_process"
+            },
+            {
+                "source_id": "b7bbb2dc-3131-47c3-bcb9-4b7e0eeed902",
+                "source_type": "dissociation_process",
+                "destination_id": "f59292f0-318f-40d0-bce5-29413b59a790",
+                "destination_type": "biomaterial"
+            },
+            {
+                "source_id": "b7bbb2dc-3131-47c3-bcb9-4b7e0eeed902",
+                "source_type": "dissociation_process",
+                "destination_id": "c9a1e203-bddc-45d3-87c4-6010be8e0127",
+                "destination_type": "protocol"
+            },
+            {
+                "source_id": "0763320a-e0c4-4c07-b150-b83650fbef68",
+                "source_type": "process",
+                "destination_id": "ffb809dd-3139-4162-b9af-ec88e491ee9c",
+                "destination_type": "biomaterial"
+            },
+            {
+                "source_id": "689311a2-bfaf-4196-a753-554e69ab59b2",
+                "source_type": "biomaterial",
+                "destination_id": "0763320a-e0c4-4c07-b150-b83650fbef68",
+                "destination_type": "process"
+            },
+            {
+                "source_id": "ffb809dd-3139-4162-b9af-ec88e491ee9c",
+                "source_type": "biomaterial",
+                "destination_id": "bcef348b-3915-48b8-bc09-d24a5bff76c4",
+                "destination_type": "enrichment_process"
+            },
+            {
+                "source_id": "bcef348b-3915-48b8-bc09-d24a5bff76c4",
+                "source_type": "enrichment_process",
+                "destination_id": "f59292f0-318f-40d0-bce5-29413b59a790",
+                "destination_type": "biomaterial"
+            },
+            {
+                "source_id": "bcef348b-3915-48b8-bc09-d24a5bff76c4",
+                "source_type": "enrichment_process",
+                "destination_id": "a1c80daf-58b0-4b7a-8e29-d0130493c8e6",
+                "destination_type": "protocol"
+            },
+            {
+                "source_id": "0763320a-e0c4-4c07-b150-b83650fbef68",
+                "source_type": "process",
+                "destination_id": "ffb809dd-3139-4162-b9af-ec88e491ee9c",
+                "destination_type": "biomaterial"
+            },
+            {
+                "source_id": "689311a2-bfaf-4196-a753-554e69ab59b2",
+                "source_type": "biomaterial",
+                "destination_id": "0763320a-e0c4-4c07-b150-b83650fbef68",
+                "destination_type": "process"
+            },
+            {
+                "source_id": "f59292f0-318f-40d0-bce5-29413b59a790",
+                "source_type": "biomaterial",
+                "destination_id": "687065f3-c70f-46c3-8452-a5eead33a1bf",
+                "destination_type": "library_preparation_process"
+            },
+            {
+                "source_id": "687065f3-c70f-46c3-8452-a5eead33a1bf",
+                "source_type": "library_preparation_process",
+                "destination_id": "e080459e-e4ab-40ea-ab75-a2646b5fdd29",
+                "destination_type": "file"
+            },
+            {
+                "source_id": "687065f3-c70f-46c3-8452-a5eead33a1bf",
+                "source_type": "library_preparation_process",
+                "destination_id": "3417cdb5-5618-4c0c-bc27-62a4eb78916a",
+                "destination_type": "file"
+            },
+            {
+                "source_id": "687065f3-c70f-46c3-8452-a5eead33a1bf",
+                "source_type": "library_preparation_process",
+                "destination_id": "52d79a89-4b49-4c1b-b857-5cc5da07f643",
+                "destination_type": "protocol"
+            },
+            {
+                "source_id": "f59292f0-318f-40d0-bce5-29413b59a790",
+                "source_type": "biomaterial",
+                "destination_id": "b8a6acbe-6b57-4efb-b6c7-bceaa6d9924d",
+                "destination_type": "sequencing_process"
+            },
+            {
+                "source_id": "b8a6acbe-6b57-4efb-b6c7-bceaa6d9924d",
+                "source_type": "sequencing_process",
+                "destination_id": "e080459e-e4ab-40ea-ab75-a2646b5fdd29",
+                "destination_type": "file"
+            },
+            {
+                "source_id": "b8a6acbe-6b57-4efb-b6c7-bceaa6d9924d",
+                "source_type": "sequencing_process",
+                "destination_id": "3417cdb5-5618-4c0c-bc27-62a4eb78916a",
+                "destination_type": "file"
+            },
+            {
+                "source_id": "b8a6acbe-6b57-4efb-b6c7-bceaa6d9924d",
+                "source_type": "sequencing_process",
+                "destination_id": "ca6096cf-13c1-4930-8308-6ab05865e2c9",
+                "destination_type": "protocol"
+            }
+        ],
+        "describedBy": "https://schema.humancellatlas.org/bundle/1.0.0/links",
+        "schema_version": "1.0.0",
+        "schema_type": "link_bundle"
+    },
+    "biomaterial.json": {
+        "biomaterials": [
+            {
+                "content": {
+                    "genus_species": [
+                        {
+                            "text": "Mus musculus",
+                            "ontology": "NCBITaxon:10090"
+                        }
+                    ],
+                    "total_estimated_cells": 1,
+                    "target_cell_type": [
+                        {
+                            "text": "CD11b+ Macrophages/monocytes"
+                        }
+                    ],
+                    "schema_type": "biomaterial",
+                    "biomaterial_core": {
+                        "has_input_biomaterial": "1117_T",
+                        "ncbi_taxon_id": [
+                            10090
+                        ],
+                        "biomaterial_id": "22467_6#373"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/biomaterial/5.1.0/cell_suspension"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:58:01.823Z",
+                    "updateDate": "2018-03-28T14:27:21.201Z",
+                    "document_id": "f59292f0-318f-40d0-bce5-29413b59a790"
+                }
+            },
+            {
+                "content": {
+                    "biomaterial_core": {
+                        "has_input_biomaterial": "1117",
+                        "ncbi_taxon_id": [
+                            10090
+                        ],
+                        "biomaterial_id": "1117_T",
+                        "supplementary_files": [
+                            "FACS_sorting_markers.pdf"
+                        ],
+                        "biomaterial_name": "Mouse_day5_T_rep8"
+                    },
+                    "genus_species": [
+                        {
+                            "text": "Mus musculus",
+                            "ontology": "NCBITaxon:10090"
+                        }
+                    ],
+                    "describedBy": "https://schema.humancellatlas.org/type/biomaterial/5.1.0/specimen_from_organism",
+                    "organ": {
+                        "text": "tumor"
+                    },
+                    "schema_type": "biomaterial"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:56:12.647Z",
+                    "updateDate": "2018-03-28T14:19:05.173Z",
+                    "document_id": "ffb809dd-3139-4162-b9af-ec88e491ee9c"
+                }
+            },
+            {
+                "content": {
+                    "is_living": false,
+                    "mus_musculus_specific": {
+                        "strain": [
+                            {
+                                "text": "C57BL/6"
+                            }
+                        ]
+                    },
+                    "biological_sex": "female",
+                    "genus_species": [
+                        {
+                            "text": "Mus musculus",
+                            "ontology": "NCBITaxon:10090"
+                        }
+                    ],
+                    "disease": [
+                        {
+                            "text": "subcutaneous melanoma",
+                            "ontology": "EFO:0000756"
+                        }
+                    ],
+                    "organism_age": "6-12",
+                    "schema_type": "biomaterial",
+                    "biomaterial_core": {
+                        "ncbi_taxon_id": [
+                            10090
+                        ],
+                        "biomaterial_id": "1117",
+                        "biomaterial_name": "Mouse_day5_rep8"
+                    },
+                    "organism_age_unit": {
+                        "text": "week",
+                        "ontology": "UO:0000034"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/biomaterial/5.1.0/donor_organism"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:56:00.553Z",
+                    "updateDate": "2018-03-28T14:00:16.892Z",
+                    "document_id": "689311a2-bfaf-4196-a753-554e69ab59b2"
+                }
+            }
+        ],
+        "describedBy": "https://schema.humancellatlas.org/bundle/5.1.0/biomaterial",
+        "schema_version": "5.1.0",
+        "schema_type": "biomaterial_bundle"
+    }
+}

--- a/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.data
+++ b/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.data
@@ -1,0 +1,26 @@
+{
+    "22421_8#139_1.fastq.gz": {
+        "content-type": "application/gzip; dcp-type=data",
+        "crc32c": "49d22bda",
+        "indexed": false,
+        "name": "22421_8#139_1.fastq.gz",
+        "s3_etag": "bd55aed6465d1f9685a9f6f58368d38a",
+        "sha1": "30fd5e8a3074124085ebb4894c3e22ff3576c8a4",
+        "sha256": "9a0d5d39b095214e7857594ac2f2f0b26cd6ce90549e8f613f928762f335af75",
+        "size": 54404,
+        "uuid": "455aed8d-4d12-48d6-bf5d-803de295b08a",
+        "version": "2018-03-29T152807.172039Z"
+    },
+    "22421_8#139_2.fastq.gz": {
+        "content-type": "application/gzip; dcp-type=data",
+        "crc32c": "fff8c9be",
+        "indexed": false,
+        "name": "22421_8#139_2.fastq.gz",
+        "s3_etag": "f2ef02290165b9d5c7965640a2cc2d24",
+        "sha1": "8f490fca4b6c3d60c06571b0cc1e12ece5781dd3",
+        "sha256": "46759bbf6b74b010c6d9cd8b70688cfa10eb28ae9eed13efe01da4d0872ad088",
+        "size": 60343,
+        "uuid": "ab110a95-2f7c-4180-bb13-e85dbabe903a",
+        "version": "2018-03-29T152808.364540Z"
+    }
+}

--- a/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.metadata
+++ b/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.metadata
@@ -1,0 +1,559 @@
+{
+    "links.json": {
+        "links": [
+            {
+                "source_id": "4e8744e9-a038-4c0c-80ef-3b235d0f5af7",
+                "source_type": "biomaterial",
+                "destination_id": "b7bbb2dc-3131-47c3-bcb9-4b7e0eeed902",
+                "destination_type": "dissociation_process"
+            },
+            {
+                "source_id": "b7bbb2dc-3131-47c3-bcb9-4b7e0eeed902",
+                "source_type": "dissociation_process",
+                "destination_id": "bac7fdae-cbf7-40d6-baa7-a14157307011",
+                "destination_type": "biomaterial"
+            },
+            {
+                "source_id": "b7bbb2dc-3131-47c3-bcb9-4b7e0eeed902",
+                "source_type": "dissociation_process",
+                "destination_id": "c9a1e203-bddc-45d3-87c4-6010be8e0127",
+                "destination_type": "protocol"
+            },
+            {
+                "source_id": "b762baea-1c09-4de2-a34f-e396e6976b45",
+                "source_type": "process",
+                "destination_id": "4e8744e9-a038-4c0c-80ef-3b235d0f5af7",
+                "destination_type": "biomaterial"
+            },
+            {
+                "source_id": "70b55c20-3574-41b6-9b01-800cc6b30edc",
+                "source_type": "biomaterial",
+                "destination_id": "b762baea-1c09-4de2-a34f-e396e6976b45",
+                "destination_type": "process"
+            },
+            {
+                "source_id": "4e8744e9-a038-4c0c-80ef-3b235d0f5af7",
+                "source_type": "biomaterial",
+                "destination_id": "2b258172-eb5f-4a7a-96a5-f4c2cfdec7d8",
+                "destination_type": "enrichment_process"
+            },
+            {
+                "source_id": "2b258172-eb5f-4a7a-96a5-f4c2cfdec7d8",
+                "source_type": "enrichment_process",
+                "destination_id": "bac7fdae-cbf7-40d6-baa7-a14157307011",
+                "destination_type": "biomaterial"
+            },
+            {
+                "source_id": "2b258172-eb5f-4a7a-96a5-f4c2cfdec7d8",
+                "source_type": "enrichment_process",
+                "destination_id": "a1c80daf-58b0-4b7a-8e29-d0130493c8e6",
+                "destination_type": "protocol"
+            },
+            {
+                "source_id": "b762baea-1c09-4de2-a34f-e396e6976b45",
+                "source_type": "process",
+                "destination_id": "4e8744e9-a038-4c0c-80ef-3b235d0f5af7",
+                "destination_type": "biomaterial"
+            },
+            {
+                "source_id": "70b55c20-3574-41b6-9b01-800cc6b30edc",
+                "source_type": "biomaterial",
+                "destination_id": "b762baea-1c09-4de2-a34f-e396e6976b45",
+                "destination_type": "process"
+            },
+            {
+                "source_id": "bac7fdae-cbf7-40d6-baa7-a14157307011",
+                "source_type": "biomaterial",
+                "destination_id": "687065f3-c70f-46c3-8452-a5eead33a1bf",
+                "destination_type": "library_preparation_process"
+            },
+            {
+                "source_id": "687065f3-c70f-46c3-8452-a5eead33a1bf",
+                "source_type": "library_preparation_process",
+                "destination_id": "455aed8d-4d12-48d6-bf5d-803de295b08a",
+                "destination_type": "file"
+            },
+            {
+                "source_id": "687065f3-c70f-46c3-8452-a5eead33a1bf",
+                "source_type": "library_preparation_process",
+                "destination_id": "ab110a95-2f7c-4180-bb13-e85dbabe903a",
+                "destination_type": "file"
+            },
+            {
+                "source_id": "687065f3-c70f-46c3-8452-a5eead33a1bf",
+                "source_type": "library_preparation_process",
+                "destination_id": "52d79a89-4b49-4c1b-b857-5cc5da07f643",
+                "destination_type": "protocol"
+            },
+            {
+                "source_id": "bac7fdae-cbf7-40d6-baa7-a14157307011",
+                "source_type": "biomaterial",
+                "destination_id": "60b38cea-9769-42c9-bf2f-263430882939",
+                "destination_type": "sequencing_process"
+            },
+            {
+                "source_id": "60b38cea-9769-42c9-bf2f-263430882939",
+                "source_type": "sequencing_process",
+                "destination_id": "455aed8d-4d12-48d6-bf5d-803de295b08a",
+                "destination_type": "file"
+            },
+            {
+                "source_id": "60b38cea-9769-42c9-bf2f-263430882939",
+                "source_type": "sequencing_process",
+                "destination_id": "ab110a95-2f7c-4180-bb13-e85dbabe903a",
+                "destination_type": "file"
+            },
+            {
+                "source_id": "60b38cea-9769-42c9-bf2f-263430882939",
+                "source_type": "sequencing_process",
+                "destination_id": "ca6096cf-13c1-4930-8308-6ab05865e2c9",
+                "destination_type": "protocol"
+            }
+        ],
+        "describedBy": "https://schema.humancellatlas.org/bundle/1.0.0/links",
+        "schema_version": "1.0.0",
+        "schema_type": "link_bundle"
+    },
+    "project.json": {
+        "content": {
+            "describedBy": "https://schema.humancellatlas.org/type/project/5.1.0/project",
+            "project_core": {
+                "project_shortname": "Mouse Melanoma",
+                "project_description": "The cancer microenvironment is a complex ecosystem characterized by dynamic interactions between diverse cell types, including malignant, immune and stromal cells. Here, we performed single-cell RNA sequencing on CD45+ and CD45- cells isolated from tumour and lymph nodes during a mouse model of melanoma. The transcriptional profiles of these individual cells taken at different time points coupled with assembled T cell receptor sequences, allowed us to identify distinct immune subpopulations and delineate their developmental trajectory. Our study provides insights into the complex interplay among cells within the tumour microenvironment and presents a valuable resource for future translational applications.",
+                "project_title": "Melanoma infiltration of stromal and immune cells"
+            },
+            "publications": [],
+            "contributors": [
+                {
+                    "country": "UK",
+                    "institution": "Wellcome Trust Sanger Institute",
+                    "address": "Wellcome Trust Genome Campus, Cambridge UK",
+                    "laboratory": "Sarah Teichmann",
+                    "contact_name": "Sarah,A,Teichmann",
+                    "email": "st9@sanger.ac.uk"
+                },
+                {
+                    "country": "UK",
+                    "institution": "Wellcome Trust Sanger Institute",
+                    "address": "Wellcome Trust Genome Campus, Cambridge UK",
+                    "laboratory": "Sarah Teichmann",
+                    "contact_name": "Mirjana,,Efremova",
+                    "email": "me5@sanger.ac.uk"
+                },
+                {
+                    "country": "UK",
+                    "institution": "Wellcome Trust Sanger Institute",
+                    "address": "Wellcome Trust Genome Campus, Cambridge UK",
+                    "laboratory": "Sarah Teichmann",
+                    "contact_name": "Bidesh,,Mahata",
+                    "email": "bm11@sanger.ac.uk"
+                },
+                {
+                    "country": "UK",
+                    "institution": "University of Cambridge",
+                    "address": "Box 197, Cambridge Biomedical Campus, Cambridge, CB2 0XZ",
+                    "laboratory": "MRC Cancer Unit",
+                    "contact_name": "Jacqueline,D,Shields",
+                    "email": "JS970@MRCCU.cam.ac.uk"
+                },
+                {
+                    "country": "UK",
+                    "institution": "University of Cambridge",
+                    "address": "Box 197, Cambridge Biomedical Campus, Cambridge, CB2 0XZ",
+                    "laboratory": "MRC Cancer Unit",
+                    "contact_name": "Sarah,,Davidson",
+                    "email": "SED49@MRCCU.cam.ac.uk"
+                },
+                {
+                    "country": "Germany",
+                    "contact_name": "Angela,,Riedel",
+                    "email": "a.riedel@dkfz-heidelberg.de",
+                    "institution": "DKFZ German Cancer Research Center"
+                },
+                {
+                    "country": "UK",
+                    "institution": "Wellcome Trust Sanger Institute",
+                    "address": "Wellcome Trust Genome Campus, Cambridge UK",
+                    "laboratory": "Sarah Teichmann",
+                    "contact_name": "Roser,,Veno-Tormo",
+                    "email": "rv4@sanger.ac.uk"
+                },
+                {
+                    "country": "UK",
+                    "institution": "Wellcome Trust Sanger Institute",
+                    "address": "Wellcome Trust Genome Campus, Cambridge UK",
+                    "laboratory": "Sarah Teichmann",
+                    "contact_name": "Jhuma,,Pramanik",
+                    "email": "jp19@sanger.ac.uk"
+                },
+                {
+                    "country": "UK",
+                    "institution": "EMBL-EBI",
+                    "address": "Wellcome Trust Genome Campus, Cambridge UK",
+                    "laboratory": "Sarah Teichmann",
+                    "contact_name": "Gozde,,Kar",
+                    "email": "gkar@ebi.ac.uk"
+                },
+                {
+                    "country": "Finland",
+                    "contact_name": "Jani,,Huuhtanen",
+                    "email": "jani.huuhtanen@helsinki.fi",
+                    "institution": "University of Helsinki"
+                }
+            ],
+            "schema_type": "project"
+        },
+        "hca_ingest": {
+            "accession": "",
+            "submissionDate": "2018-03-28T13:55:26.025Z",
+            "updateDate": "2018-03-28T14:27:32.460Z",
+            "document_id": "93f6a42f-1790-4af4-b5d1-8c436cb6feae"
+        },
+        "describedBy": "https://schema.humancellatlas.org/bundle/5.1.0/project",
+        "schema_version": "5.1.0",
+        "schema_type": "project_bundle"
+    },
+    "biomaterial.json": {
+        "biomaterials": [
+            {
+                "content": {
+                    "genus_species": [
+                        {
+                            "text": "Mus musculus",
+                            "ontology": "NCBITaxon:10090"
+                        }
+                    ],
+                    "total_estimated_cells": 1,
+                    "target_cell_type": [
+                        {
+                            "text": "CD11b+CD11c+DC"
+                        }
+                    ],
+                    "schema_type": "biomaterial",
+                    "biomaterial_core": {
+                        "has_input_biomaterial": "1113_T",
+                        "ncbi_taxon_id": [
+                            10090
+                        ],
+                        "biomaterial_id": "22421_8#139"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/biomaterial/5.1.0/cell_suspension"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:57:33.283Z",
+                    "updateDate": "2018-03-28T14:35:13.453Z",
+                    "document_id": "bac7fdae-cbf7-40d6-baa7-a14157307011"
+                }
+            },
+            {
+                "content": {
+                    "biomaterial_core": {
+                        "has_input_biomaterial": "1113",
+                        "ncbi_taxon_id": [
+                            10090
+                        ],
+                        "biomaterial_id": "1113_T",
+                        "supplementary_files": [
+                            "FACS_sorting_markers.pdf"
+                        ],
+                        "biomaterial_name": "Mouse_day5_T_rep6"
+                    },
+                    "genus_species": [
+                        {
+                            "text": "Mus musculus",
+                            "ontology": "NCBITaxon:10090"
+                        }
+                    ],
+                    "describedBy": "https://schema.humancellatlas.org/type/biomaterial/5.1.0/specimen_from_organism",
+                    "organ": {
+                        "text": "tumor"
+                    },
+                    "schema_type": "biomaterial"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:56:08.893Z",
+                    "updateDate": "2018-03-28T14:35:11.442Z",
+                    "document_id": "4e8744e9-a038-4c0c-80ef-3b235d0f5af7"
+                }
+            },
+            {
+                "content": {
+                    "is_living": false,
+                    "mus_musculus_specific": {
+                        "strain": [
+                            {
+                                "text": "C57BL/6"
+                            }
+                        ]
+                    },
+                    "biological_sex": "female",
+                    "genus_species": [
+                        {
+                            "text": "Mus musculus",
+                            "ontology": "NCBITaxon:10090"
+                        }
+                    ],
+                    "disease": [
+                        {
+                            "text": "subcutaneous melanoma",
+                            "ontology": "EFO:0000756"
+                        }
+                    ],
+                    "organism_age": "6-12",
+                    "schema_type": "biomaterial",
+                    "biomaterial_core": {
+                        "ncbi_taxon_id": [
+                            10090
+                        ],
+                        "biomaterial_id": "1113",
+                        "biomaterial_name": "Mouse_day5_rep6"
+                    },
+                    "organism_age_unit": {
+                        "text": "week",
+                        "ontology": "UO:0000034"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/biomaterial/5.1.0/donor_organism"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:56:00.446Z",
+                    "updateDate": "2018-03-28T14:08:58.809Z",
+                    "document_id": "70b55c20-3574-41b6-9b01-800cc6b30edc"
+                }
+            }
+        ],
+        "describedBy": "https://schema.humancellatlas.org/bundle/5.1.0/biomaterial",
+        "schema_version": "5.1.0",
+        "schema_type": "biomaterial_bundle"
+    },
+    "protocol.json": {
+        "protocols": [
+            {
+                "content": {
+                    "protocol_core": {
+                        "protocol_name": "Extracting cells from lymph nodes",
+                        "document": "TissueDissociationProtocol.pdf",
+                        "protocol_id": "tissue_dissociation_protocol"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/protocol/5.1.0/protocol",
+                    "schema_type": "protocol"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:55:26.033Z",
+                    "updateDate": "2018-03-28T14:14:33.716Z",
+                    "document_id": "c9a1e203-bddc-45d3-87c4-6010be8e0127"
+                }
+            },
+            {
+                "content": {
+                    "protocol_core": {
+                        "protocol_name": "FACS sorting cells by surface markers",
+                        "document": "FACSsortingProtocol.pdf",
+                        "protocol_id": "FACS_sorting_protocol"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/protocol/5.1.0/protocol",
+                    "schema_type": "protocol"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:55:26.040Z",
+                    "updateDate": "2018-03-28T14:45:43.500Z",
+                    "document_id": "a1c80daf-58b0-4b7a-8e29-d0130493c8e6"
+                }
+            },
+            {
+                "content": {
+                    "protocol_core": {
+                        "protocol_name": "Make/amplify cDNA for each cell",
+                        "document": "SmartSeq2_RTPCR_protocol.pdf",
+                        "protocol_id": "SmartSeq2_RTPCR_protocol"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/protocol/5.1.0/protocol",
+                    "protocol_type": {
+                        "text": "Smart-seq2 protocol",
+                        "ontology": "EFO:0008442"
+                    },
+                    "schema_type": "protocol"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:55:26.044Z",
+                    "updateDate": "2018-03-28T14:24:04.790Z",
+                    "document_id": "52d79a89-4b49-4c1b-b857-5cc5da07f643"
+                }
+            },
+            {
+                "content": {
+                    "protocol_core": {
+                        "protocol_name": "Sequencing SmartSeq2 cells",
+                        "protocol_id": "SmartSeq2_sequencing_protocol"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/protocol/5.1.0/protocol",
+                    "schema_type": "protocol"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:55:26.050Z",
+                    "updateDate": "2018-03-28T14:30:39.321Z",
+                    "document_id": "ca6096cf-13c1-4930-8308-6ab05865e2c9"
+                }
+            }
+        ],
+        "describedBy": "https://schema.humancellatlas.org/bundle/5.1.0/protocol",
+        "schema_version": "5.1.0",
+        "schema_type": "protocol_bundle"
+    },
+    "file.json": {
+        "files": [
+            {
+                "content": {
+                    "file_core": {
+                        "file_name": "22421_8#139_1.fastq.gz",
+                        "file_format": "fastq.gz"
+                    },
+                    "lane_index": 8,
+                    "read_index": "read1",
+                    "describedBy": "https://schema.humancellatlas.org/type/file/5.1.0/sequence_file",
+                    "schema_type": "file"
+                },
+                "hca_ingest": {
+                    "submissionDate": "2018-03-28T14:02:45.703Z",
+                    "document_id": "455aed8d-4d12-48d6-bf5d-803de295b08a"
+                }
+            },
+            {
+                "content": {
+                    "file_core": {
+                        "file_name": "22421_8#139_2.fastq.gz",
+                        "file_format": "fastq.gz"
+                    },
+                    "lane_index": 8,
+                    "read_index": "read2",
+                    "describedBy": "https://schema.humancellatlas.org/type/file/5.1.0/sequence_file",
+                    "schema_type": "file"
+                },
+                "hca_ingest": {
+                    "submissionDate": "2018-03-28T14:02:45.720Z",
+                    "document_id": "ab110a95-2f7c-4180-bb13-e85dbabe903a"
+                }
+            }
+        ],
+        "describedBy": "https://schema.humancellatlas.org/bundle/1.0.0/file",
+        "schema_version": "1.0.0",
+        "schema_type": "file_bundle"
+    },
+    "process.json": {
+        "processes": [
+            {
+                "content": {
+                    "nucleic_acid_source": "single cell",
+                    "process_core": {
+                        "process_id": "TissueDissociationProcess",
+                        "process_name": "Extracting cells from lymph nodes"
+                    },
+                    "dissociation_method": "mechanical",
+                    "describedBy": "https://schema.humancellatlas.org/type/process/biomaterial_collection/5.1.0/dissociation_process",
+                    "schema_type": "process"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T14:04:14.574Z",
+                    "updateDate": "2018-03-28T14:13:28.361Z",
+                    "document_id": "b7bbb2dc-3131-47c3-bcb9-4b7e0eeed902"
+                }
+            },
+            {
+                "content": {
+                    "process_core": {
+                        "process_id": "sampling_process_10"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/process/1.0.0/process",
+                    "schema_type": "process"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T14:00:16.312Z",
+                    "updateDate": "2018-03-28T14:51:16.131Z",
+                    "document_id": "b762baea-1c09-4de2-a34f-e396e6976b45"
+                }
+            },
+            {
+                "content": {
+                    "enrichment_method": "FACS",
+                    "process_core": {
+                        "process_id": "FACS4.2"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/process/biomaterial_collection/5.1.0/enrichment_process",
+                    "markers": "CD45+ CD3e- B220- CD11b+ CD11c+",
+                    "schema_type": "process"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T14:03:38.573Z",
+                    "updateDate": "2018-03-28T14:31:35.636Z",
+                    "document_id": "2b258172-eb5f-4a7a-96a5-f4c2cfdec7d8"
+                }
+            },
+            {
+                "content": {
+                    "input_nucleic_acid_molecule": {
+                        "text": "polyA RNA",
+                        "ontology": "OBI:0000869"
+                    },
+                    "process_core": {
+                        "process_id": "lib_prep_1",
+                        "process_name": "Library preparation process"
+                    },
+                    "umi_barcode": {
+                        "barcode_offset": 0,
+                        "barcode_length": 16,
+                        "barcode_read": "Read 1"
+                    },
+                    "library_construction_approach": "Smart-seq2",
+                    "schema_type": "process",
+                    "end_bias": "full length",
+                    "primer": "poly-dT",
+                    "describedBy": "https://schema.humancellatlas.org/type/process/sequencing/5.1.0/library_preparation_process",
+                    "strand": "unstranded"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T14:05:43.803Z",
+                    "updateDate": "2018-03-28T14:43:01.679Z",
+                    "document_id": "687065f3-c70f-46c3-8452-a5eead33a1bf"
+                }
+            },
+            {
+                "content": {
+                    "paired_ends": true,
+                    "instrument_manufacturer_model": {
+                        "text": "Illumina HiSeq 2500",
+                        "ontology": "EFO:0008567"
+                    },
+                    "process_core": {
+                        "process_id": "seq_5226",
+                        "process_name": "Sequencing process"
+                    },
+                    "smartseq2": {
+                        "well_name": "B67",
+                        "plate_id": "545"
+                    },
+                    "schema_type": "process",
+                    "describedBy": "https://schema.humancellatlas.org/type/process/sequencing/5.1.0/sequencing_process"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T14:05:02.716Z",
+                    "updateDate": "2018-03-28T14:21:19.468Z",
+                    "document_id": "60b38cea-9769-42c9-bf2f-263430882939"
+                }
+            }
+        ],
+        "describedBy": "https://schema.humancellatlas.org/bundle/5.2.1/process",
+        "schema_version": "5.2.1",
+        "schema_type": "process_bundle"
+    }
+}

--- a/test/indexer/data/updated.data
+++ b/test/indexer/data/updated.data
@@ -1,0 +1,26 @@
+{
+    "22421_8#139_1.fastq.gz": {
+        "content-type": "application/gzip; dcp-type=data",
+        "crc32c": "49d22bda",
+        "indexed": false,
+        "name": "22421_8#139_1.fastq.gz",
+        "s3_etag": "bd55aed6465d1f9685a9f6f58368d38a",
+        "sha1": "30fd5e8a3074124085ebb4894c3e22ff3576c8a4",
+        "sha256": "9a0d5d39b095214e7857594ac2f2f0b26cd6ce90549e8f613f928762f335af75",
+        "size": 54404,
+        "uuid": "455aed8d-4d12-48d6-bf5d-803de295b08a",
+        "version": "2018-03-30T152812.404846Z"
+    },
+    "22421_8#139_2.fastq.gz": {
+        "content-type": "application/gzip; dcp-type=data",
+        "crc32c": "fff8c9be",
+        "indexed": false,
+        "name": "22421_8#139_2.fastq.gz",
+        "s3_etag": "f2ef02290165b9d5c7965640a2cc2d24",
+        "sha1": "8f490fca4b6c3d60c06571b0cc1e12ece5781dd3",
+        "sha256": "46759bbf6b74b010c6d9cd8b70688cfa10eb28ae9eed13efe01da4d0872ad088",
+        "size": 60343,
+        "uuid": "ab110a95-2f7c-4180-bb13-e85dbabe903a",
+        "version": "2018-03-30T152812.404846Z"
+    }
+}

--- a/test/indexer/data/updated.metadata
+++ b/test/indexer/data/updated.metadata
@@ -1,0 +1,559 @@
+{
+    "links.json": {
+        "links": [
+            {
+                "source_id": "4e8744e9-a038-4c0c-80ef-3b235d0f5af7",
+                "source_type": "biomaterial",
+                "destination_id": "b7bbb2dc-3131-47c3-bcb9-4b7e0eeed902",
+                "destination_type": "dissociation_process"
+            },
+            {
+                "source_id": "b7bbb2dc-3131-47c3-bcb9-4b7e0eeed902",
+                "source_type": "dissociation_process",
+                "destination_id": "bac7fdae-cbf7-40d6-baa7-a14157307011",
+                "destination_type": "biomaterial"
+            },
+            {
+                "source_id": "b7bbb2dc-3131-47c3-bcb9-4b7e0eeed902",
+                "source_type": "dissociation_process",
+                "destination_id": "c9a1e203-bddc-45d3-87c4-6010be8e0127",
+                "destination_type": "protocol"
+            },
+            {
+                "source_id": "b762baea-1c09-4de2-a34f-e396e6976b45",
+                "source_type": "process",
+                "destination_id": "4e8744e9-a038-4c0c-80ef-3b235d0f5af7",
+                "destination_type": "biomaterial"
+            },
+            {
+                "source_id": "70b55c20-3574-41b6-9b01-800cc6b30edc",
+                "source_type": "biomaterial",
+                "destination_id": "b762baea-1c09-4de2-a34f-e396e6976b45",
+                "destination_type": "process"
+            },
+            {
+                "source_id": "4e8744e9-a038-4c0c-80ef-3b235d0f5af7",
+                "source_type": "biomaterial",
+                "destination_id": "2b258172-eb5f-4a7a-96a5-f4c2cfdec7d8",
+                "destination_type": "enrichment_process"
+            },
+            {
+                "source_id": "2b258172-eb5f-4a7a-96a5-f4c2cfdec7d8",
+                "source_type": "enrichment_process",
+                "destination_id": "bac7fdae-cbf7-40d6-baa7-a14157307011",
+                "destination_type": "biomaterial"
+            },
+            {
+                "source_id": "2b258172-eb5f-4a7a-96a5-f4c2cfdec7d8",
+                "source_type": "enrichment_process",
+                "destination_id": "a1c80daf-58b0-4b7a-8e29-d0130493c8e6",
+                "destination_type": "protocol"
+            },
+            {
+                "source_id": "b762baea-1c09-4de2-a34f-e396e6976b45",
+                "source_type": "process",
+                "destination_id": "4e8744e9-a038-4c0c-80ef-3b235d0f5af7",
+                "destination_type": "biomaterial"
+            },
+            {
+                "source_id": "70b55c20-3574-41b6-9b01-800cc6b30edc",
+                "source_type": "biomaterial",
+                "destination_id": "b762baea-1c09-4de2-a34f-e396e6976b45",
+                "destination_type": "process"
+            },
+            {
+                "source_id": "bac7fdae-cbf7-40d6-baa7-a14157307011",
+                "source_type": "biomaterial",
+                "destination_id": "687065f3-c70f-46c3-8452-a5eead33a1bf",
+                "destination_type": "library_preparation_process"
+            },
+            {
+                "source_id": "687065f3-c70f-46c3-8452-a5eead33a1bf",
+                "source_type": "library_preparation_process",
+                "destination_id": "455aed8d-4d12-48d6-bf5d-803de295b08a",
+                "destination_type": "file"
+            },
+            {
+                "source_id": "687065f3-c70f-46c3-8452-a5eead33a1bf",
+                "source_type": "library_preparation_process",
+                "destination_id": "ab110a95-2f7c-4180-bb13-e85dbabe903a",
+                "destination_type": "file"
+            },
+            {
+                "source_id": "687065f3-c70f-46c3-8452-a5eead33a1bf",
+                "source_type": "library_preparation_process",
+                "destination_id": "52d79a89-4b49-4c1b-b857-5cc5da07f643",
+                "destination_type": "protocol"
+            },
+            {
+                "source_id": "bac7fdae-cbf7-40d6-baa7-a14157307011",
+                "source_type": "biomaterial",
+                "destination_id": "60b38cea-9769-42c9-bf2f-263430882939",
+                "destination_type": "sequencing_process"
+            },
+            {
+                "source_id": "60b38cea-9769-42c9-bf2f-263430882939",
+                "source_type": "sequencing_process",
+                "destination_id": "455aed8d-4d12-48d6-bf5d-803de295b08a",
+                "destination_type": "file"
+            },
+            {
+                "source_id": "60b38cea-9769-42c9-bf2f-263430882939",
+                "source_type": "sequencing_process",
+                "destination_id": "ab110a95-2f7c-4180-bb13-e85dbabe903a",
+                "destination_type": "file"
+            },
+            {
+                "source_id": "60b38cea-9769-42c9-bf2f-263430882939",
+                "source_type": "sequencing_process",
+                "destination_id": "ca6096cf-13c1-4930-8308-6ab05865e2c9",
+                "destination_type": "protocol"
+            }
+        ],
+        "describedBy": "https://schema.humancellatlas.org/bundle/1.0.0/links",
+        "schema_version": "1.0.0",
+        "schema_type": "link_bundle"
+    },
+    "project.json": {
+        "content": {
+            "describedBy": "https://schema.humancellatlas.org/type/project/5.1.0/project",
+            "project_core": {
+                "project_shortname": "Aardvark Ailment",
+                "project_description": "The cancer microenvironment is a complex ecosystem characterized by dynamic interactions between diverse cell types, including malignant, immune and stromal cells. Here, we performed single-cell RNA sequencing on CD45+ and CD45- cells isolated from tumour and lymph nodes during a mouse model of melanoma. The transcriptional profiles of these individual cells taken at different time points coupled with assembled T cell receptor sequences, allowed us to identify distinct immune subpopulations and delineate their developmental trajectory. Our study provides insights into the complex interplay among cells within the tumour microenvironment and presents a valuable resource for future translational applications.",
+                "project_title": "Melanoma infiltration of stromal and immune cells"
+            },
+            "publications": [],
+            "contributors": [
+                {
+                    "country": "UK",
+                    "institution": "Wellcome Trust Sanger Institute",
+                    "address": "Wellcome Trust Genome Campus, Cambridge UK",
+                    "laboratory": "John Denver",
+                    "contact_name": "Sarah,A,Teichmann",
+                    "email": "st9@sanger.ac.uk"
+                },
+                {
+                    "country": "UK",
+                    "institution": "Wellcome Trust Sanger Institute",
+                    "address": "Wellcome Trust Genome Campus, Cambridge UK",
+                    "laboratory": "John Denver",
+                    "contact_name": "Mirjana,,Efremova",
+                    "email": "me5@sanger.ac.uk"
+                },
+                {
+                    "country": "UK",
+                    "institution": "Wellcome Trust Sanger Institute",
+                    "address": "Wellcome Trust Genome Campus, Cambridge UK",
+                    "laboratory": "John Denver",
+                    "contact_name": "Bidesh,,Mahata",
+                    "email": "bm11@sanger.ac.uk"
+                },
+                {
+                    "country": "UK",
+                    "institution": "University of Cambridge",
+                    "address": "Box 197, Cambridge Biomedical Campus, Cambridge, CB2 0XZ",
+                    "laboratory": "MRC Cancer Unit",
+                    "contact_name": "Jacqueline,D,Shields",
+                    "email": "JS970@MRCCU.cam.ac.uk"
+                },
+                {
+                    "country": "UK",
+                    "institution": "University of Cambridge",
+                    "address": "Box 197, Cambridge Biomedical Campus, Cambridge, CB2 0XZ",
+                    "laboratory": "MRC Cancer Unit",
+                    "contact_name": "Sarah,,Davidson",
+                    "email": "SED49@MRCCU.cam.ac.uk"
+                },
+                {
+                    "country": "Germany",
+                    "contact_name": "Angela,,Riedel",
+                    "email": "a.riedel@dkfz-heidelberg.de",
+                    "institution": "DKFZ German Cancer Research Center"
+                },
+                {
+                    "country": "UK",
+                    "institution": "Wellcome Trust Sanger Institute",
+                    "address": "Wellcome Trust Genome Campus, Cambridge UK",
+                    "laboratory": "John Denver",
+                    "contact_name": "Roser,,Veno-Tormo",
+                    "email": "rv4@sanger.ac.uk"
+                },
+                {
+                    "country": "UK",
+                    "institution": "Wellcome Trust Sanger Institute",
+                    "address": "Wellcome Trust Genome Campus, Cambridge UK",
+                    "laboratory": "John Denver",
+                    "contact_name": "Jhuma,,Pramanik",
+                    "email": "jp19@sanger.ac.uk"
+                },
+                {
+                    "country": "UK",
+                    "institution": "EMBL-EBI",
+                    "address": "Wellcome Trust Genome Campus, Cambridge UK",
+                    "laboratory": "John Denver",
+                    "contact_name": "Gozde,,Kar",
+                    "email": "gkar@ebi.ac.uk"
+                },
+                {
+                    "country": "Finland",
+                    "contact_name": "Jani,,Huuhtanen",
+                    "email": "jani.huuhtanen@helsinki.fi",
+                    "institution": "University of Helsinki"
+                }
+            ],
+            "schema_type": "project"
+        },
+        "hca_ingest": {
+            "accession": "",
+            "submissionDate": "2018-03-28T13:55:26.025Z",
+            "updateDate": "2018-03-28T14:27:32.460Z",
+            "document_id": "93f6a42f-1790-4af4-b5d1-8c436cb6feae"
+        },
+        "describedBy": "https://schema.humancellatlas.org/bundle/5.1.0/project",
+        "schema_version": "5.1.0",
+        "schema_type": "project_bundle"
+    },
+    "biomaterial.json": {
+        "biomaterials": [
+            {
+                "content": {
+                    "genus_species": [
+                        {
+                            "text": "Lorem ipsum",
+                            "ontology": "NCBITaxon:10090"
+                        }
+                    ],
+                    "total_estimated_cells": 1,
+                    "target_cell_type": [
+                        {
+                            "text": "CD11b+CD11c+DC"
+                        }
+                    ],
+                    "schema_type": "biomaterial",
+                    "biomaterial_core": {
+                        "has_input_biomaterial": "1113_T",
+                        "ncbi_taxon_id": [
+                            10090
+                        ],
+                        "biomaterial_id": "22421_8#139"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/biomaterial/5.1.0/cell_suspension"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:57:33.283Z",
+                    "updateDate": "2018-03-28T14:35:13.453Z",
+                    "document_id": "bac7fdae-cbf7-40d6-baa7-a14157307011"
+                }
+            },
+            {
+                "content": {
+                    "biomaterial_core": {
+                        "has_input_biomaterial": "1113",
+                        "ncbi_taxon_id": [
+                            10090
+                        ],
+                        "biomaterial_id": "1113_T",
+                        "supplementary_files": [
+                            "FACS_sorting_markers.pdf"
+                        ],
+                        "biomaterial_name": "Mouse_day5_T_rep6"
+                    },
+                    "genus_species": [
+                        {
+                            "text": "Lorem ipsum",
+                            "ontology": "NCBITaxon:10090"
+                        }
+                    ],
+                    "describedBy": "https://schema.humancellatlas.org/type/biomaterial/5.1.0/specimen_from_organism",
+                    "organ": {
+                        "text": "tumor"
+                    },
+                    "schema_type": "biomaterial"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:56:08.893Z",
+                    "updateDate": "2018-03-28T14:35:11.442Z",
+                    "document_id": "4e8744e9-a038-4c0c-80ef-3b235d0f5af7"
+                }
+            },
+            {
+                "content": {
+                    "is_living": false,
+                    "mus_musculus_specific": {
+                        "strain": [
+                            {
+                                "text": "C57BL/6"
+                            }
+                        ]
+                    },
+                    "biological_sex": "female",
+                    "genus_species": [
+                        {
+                            "text": "Lorem ipsum",
+                            "ontology": "NCBITaxon:10090"
+                        }
+                    ],
+                    "disease": [
+                        {
+                            "text": "subcutaneous melanoma",
+                            "ontology": "EFO:0000756"
+                        }
+                    ],
+                    "organism_age": "6-12",
+                    "schema_type": "biomaterial",
+                    "biomaterial_core": {
+                        "ncbi_taxon_id": [
+                            10090
+                        ],
+                        "biomaterial_id": "1113",
+                        "biomaterial_name": "Mouse_day5_rep6"
+                    },
+                    "organism_age_unit": {
+                        "text": "week",
+                        "ontology": "UO:0000034"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/biomaterial/5.1.0/donor_organism"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:56:00.446Z",
+                    "updateDate": "2018-03-28T14:08:58.809Z",
+                    "document_id": "70b55c20-3574-41b6-9b01-800cc6b30edc"
+                }
+            }
+        ],
+        "describedBy": "https://schema.humancellatlas.org/bundle/5.1.0/biomaterial",
+        "schema_version": "5.1.0",
+        "schema_type": "biomaterial_bundle"
+    },
+    "protocol.json": {
+        "protocols": [
+            {
+                "content": {
+                    "protocol_core": {
+                        "protocol_name": "Extracting cells from lymph nodes",
+                        "document": "TissueDissociationProtocol.pdf",
+                        "protocol_id": "tissue_dissociation_protocol"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/protocol/5.1.0/protocol",
+                    "schema_type": "protocol"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:55:26.033Z",
+                    "updateDate": "2018-03-28T14:14:33.716Z",
+                    "document_id": "c9a1e203-bddc-45d3-87c4-6010be8e0127"
+                }
+            },
+            {
+                "content": {
+                    "protocol_core": {
+                        "protocol_name": "FACS sorting cells by surface markers",
+                        "document": "FACSsortingProtocol.pdf",
+                        "protocol_id": "FACS_sorting_protocol"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/protocol/5.1.0/protocol",
+                    "schema_type": "protocol"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:55:26.040Z",
+                    "updateDate": "2018-03-28T14:45:43.500Z",
+                    "document_id": "a1c80daf-58b0-4b7a-8e29-d0130493c8e6"
+                }
+            },
+            {
+                "content": {
+                    "protocol_core": {
+                        "protocol_name": "Make/amplify cDNA for each cell",
+                        "document": "SmartSeq2_RTPCR_protocol.pdf",
+                        "protocol_id": "SmartSeq2_RTPCR_protocol"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/protocol/5.1.0/protocol",
+                    "protocol_type": {
+                        "text": "Smart-seq2 protocol",
+                        "ontology": "EFO:0008442"
+                    },
+                    "schema_type": "protocol"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:55:26.044Z",
+                    "updateDate": "2018-03-28T14:24:04.790Z",
+                    "document_id": "52d79a89-4b49-4c1b-b857-5cc5da07f643"
+                }
+            },
+            {
+                "content": {
+                    "protocol_core": {
+                        "protocol_name": "Sequencing SmartSeq2 cells",
+                        "protocol_id": "SmartSeq2_sequencing_protocol"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/protocol/5.1.0/protocol",
+                    "schema_type": "protocol"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T13:55:26.050Z",
+                    "updateDate": "2018-03-28T14:30:39.321Z",
+                    "document_id": "ca6096cf-13c1-4930-8308-6ab05865e2c9"
+                }
+            }
+        ],
+        "describedBy": "https://schema.humancellatlas.org/bundle/5.1.0/protocol",
+        "schema_version": "5.1.0",
+        "schema_type": "protocol_bundle"
+    },
+    "file.json": {
+        "files": [
+            {
+                "content": {
+                    "file_core": {
+                        "file_name": "22421_8#139_1.fastq.gz",
+                        "file_format": "fastq.gz"
+                    },
+                    "lane_index": 8,
+                    "read_index": "read1",
+                    "describedBy": "https://schema.humancellatlas.org/type/file/5.1.0/sequence_file",
+                    "schema_type": "file"
+                },
+                "hca_ingest": {
+                    "submissionDate": "2018-03-28T14:02:45.703Z",
+                    "document_id": "455aed8d-4d12-48d6-bf5d-803de295b08a"
+                }
+            },
+            {
+                "content": {
+                    "file_core": {
+                        "file_name": "22421_8#139_2.fastq.gz",
+                        "file_format": "fastq.gz"
+                    },
+                    "lane_index": 8,
+                    "read_index": "read2",
+                    "describedBy": "https://schema.humancellatlas.org/type/file/5.1.0/sequence_file",
+                    "schema_type": "file"
+                },
+                "hca_ingest": {
+                    "submissionDate": "2018-03-28T14:02:45.720Z",
+                    "document_id": "ab110a95-2f7c-4180-bb13-e85dbabe903a"
+                }
+            }
+        ],
+        "describedBy": "https://schema.humancellatlas.org/bundle/1.0.0/file",
+        "schema_version": "1.0.0",
+        "schema_type": "file_bundle"
+    },
+    "process.json": {
+        "processes": [
+            {
+                "content": {
+                    "nucleic_acid_source": "single cell",
+                    "process_core": {
+                        "process_id": "TissueDissociationProcess",
+                        "process_name": "Extracting cells from lymph nodes"
+                    },
+                    "dissociation_method": "mechanical",
+                    "describedBy": "https://schema.humancellatlas.org/type/process/biomaterial_collection/5.1.0/dissociation_process",
+                    "schema_type": "process"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T14:04:14.574Z",
+                    "updateDate": "2018-03-28T14:13:28.361Z",
+                    "document_id": "b7bbb2dc-3131-47c3-bcb9-4b7e0eeed902"
+                }
+            },
+            {
+                "content": {
+                    "process_core": {
+                        "process_id": "sampling_process_10"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/process/1.0.0/process",
+                    "schema_type": "process"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T14:00:16.312Z",
+                    "updateDate": "2018-03-28T14:51:16.131Z",
+                    "document_id": "b762baea-1c09-4de2-a34f-e396e6976b45"
+                }
+            },
+            {
+                "content": {
+                    "enrichment_method": "FACS",
+                    "process_core": {
+                        "process_id": "FACS4.2"
+                    },
+                    "describedBy": "https://schema.humancellatlas.org/type/process/biomaterial_collection/5.1.0/enrichment_process",
+                    "markers": "CD45+ CD3e- B220- CD11b+ CD11c+",
+                    "schema_type": "process"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T14:03:38.573Z",
+                    "updateDate": "2018-03-28T14:31:35.636Z",
+                    "document_id": "2b258172-eb5f-4a7a-96a5-f4c2cfdec7d8"
+                }
+            },
+            {
+                "content": {
+                    "input_nucleic_acid_molecule": {
+                        "text": "polyA RNA",
+                        "ontology": "OBI:0000869"
+                    },
+                    "process_core": {
+                        "process_id": "lib_prep_1",
+                        "process_name": "Library preparation process"
+                    },
+                    "umi_barcode": {
+                        "barcode_offset": 0,
+                        "barcode_length": 16,
+                        "barcode_read": "Read 1"
+                    },
+                    "library_construction_approach": "Smart-seq2",
+                    "schema_type": "process",
+                    "end_bias": "full length",
+                    "primer": "poly-dT",
+                    "describedBy": "https://schema.humancellatlas.org/type/process/sequencing/5.1.0/library_preparation_process",
+                    "strand": "unstranded"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T14:05:43.803Z",
+                    "updateDate": "2018-03-28T14:43:01.679Z",
+                    "document_id": "687065f3-c70f-46c3-8452-a5eead33a1bf"
+                }
+            },
+            {
+                "content": {
+                    "paired_ends": true,
+                    "instrument_manufacturer_model": {
+                        "text": "Illumina HiSeq 2500",
+                        "ontology": "EFO:0008567"
+                    },
+                    "process_core": {
+                        "process_id": "seq_5226",
+                        "process_name": "Sequencing process"
+                    },
+                    "smartseq2": {
+                        "well_name": "B67",
+                        "plate_id": "545"
+                    },
+                    "schema_type": "process",
+                    "describedBy": "https://schema.humancellatlas.org/type/process/sequencing/5.1.0/sequencing_process"
+                },
+                "hca_ingest": {
+                    "accession": "",
+                    "submissionDate": "2018-03-28T14:05:02.716Z",
+                    "updateDate": "2018-03-28T14:21:19.468Z",
+                    "document_id": "60b38cea-9769-42c9-bf2f-263430882939"
+                }
+            }
+        ],
+        "describedBy": "https://schema.humancellatlas.org/bundle/5.2.1/process",
+        "schema_version": "5.2.1",
+        "schema_type": "process_bundle"
+    }
+}

--- a/test/indexer/test_hca_indexer.py
+++ b/test/indexer/test_hca_indexer.py
@@ -1,0 +1,281 @@
+# -*- coding: utf-8 -*-
+"""
+Suite for unit testing indexer.py
+"""
+
+import docker
+import json
+import logging
+import time
+import unittest
+
+from concurrent.futures import ThreadPoolExecutor
+from elasticsearch import Elasticsearch
+from functools import partial
+from typing import Mapping, Any
+from unittest.mock import patch
+from uuid import uuid4
+
+from azul.project.hca.indexer import Indexer
+from azul.project.hca.config import IndexProperties
+from azul.downloader import MetadataDownloader
+from azul import eventually
+
+
+class TestHCAIndexer(unittest.TestCase):
+    @staticmethod
+    def _get_data_files(metadata_file, data_file):
+        data_prefix = "data/"
+
+        with open(data_prefix + metadata_file, 'r') as infile:
+            metadata = json.loads(infile.read())
+
+        with open(data_prefix + data_file, 'r') as infile:
+            data = json.loads(infile.read())
+
+        return metadata, data
+
+    def _get_data_by_uuid(self, uuid):
+        return self._get_data_files(uuid + '.metadata', uuid + '.data')
+
+    @staticmethod
+    def _make_fake_notification(uuid: str, version: str) -> Mapping[str, Any]:
+        return {
+            "query": {
+                "match_all": {}
+            },
+            "subscription_id": str(uuid4()),
+            "transaction_id": str(uuid4()),
+            "match": {
+                "bundle_uuid": uuid,
+                "bundle_version": version
+            }
+        }
+
+    def _mock_index(self, test_bundles, data_pack):
+        bundle_uuid, bundle_version = test_bundles
+        metadata, data = data_pack
+        fake_event = self._make_fake_notification(bundle_uuid, bundle_version)
+
+        with patch.object(MetadataDownloader, 'extract_bundle') as mock_method:
+            mock_method.return_value = metadata, data
+            self.hca_indexer.index(fake_event)
+
+    @eventually(5.0, 0.5)
+    def _get_es_results(self, assert_func):
+        es_results = []
+        for entity_index in self.index_names:
+            results = self.es_client.search(index=entity_index,
+                                            doc_type="doc",
+                                            size=100)
+            if "project" not in entity_index:
+                for result_dict in results["hits"]["hits"]:
+                    es_results.append(result_dict)
+
+        assert_func(es_results)
+        return es_results
+
+    @classmethod
+    def setUpClass(cls):
+        cls.old_bundle = ("aee55415-d128-4b30-9644-e6b2742fa32b",
+                          "2018-03-29T152812.404846Z")
+        cls.new_bundle = ("aee55415-d128-4b30-9644-e6b2742fa32b",
+                          "2018-03-30T152812.404846Z")
+        cls.spec1_bundle = ("9dec1bd6-ced8-448a-8e45-1fc7846d8995",
+                            "2018-03-29T154319.834528Z")
+        cls.spec2_bundle = ("56a338fe-7554-4b5d-96a2-7df127a7640b",
+                            "2018-03-29T153507.198365Z")
+
+        dss_url = "https://rtfbvgfncgfjkolpcgfcdg.fcdgf/gibberish"
+        index_properties = IndexProperties(dss_url, es_endpoint=("localhost", 9200))
+        cls.hca_indexer = Indexer(index_properties)
+        cls.es_client = index_properties.elastic_search_client
+        cls.index_names = index_properties.index_names
+
+        docker_client = docker.from_env()
+        cls.container_obj = docker_client.containers.run("docker.elastic.co/elasticsearch/elasticsearch:5.5.3",
+                                                         detach=True,
+                                                         ports={9200: 9200, 9300: 9300},
+                                                         environment=["xpack.security.enabled=false",
+                                                                      "discovery.type=single-node"])
+        # try wait here for the elasticsearch container
+        with patch.object(logging.getLogger('elasticsearch'), 'level', new=logging.ERROR):
+            while True:
+                if cls.es_client.ping():
+                    break
+                else:
+                    time.sleep(2)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.container_obj.kill()
+
+    def tearDown(self):
+        for index_name in self.index_names:
+            self.es_client.indices.delete(index=index_name, ignore=[400, 404])
+
+    def test_index_correctness(self):
+        """
+        Index a bundle and check that the index contains the correct attributes
+        """
+        data_pack = self._get_data_files('updated.metadata',
+                                         'updated.data')
+
+        self._mock_index(self.new_bundle, data_pack)
+
+        def check_bundle_correctness(es_results):
+            for result_dict in es_results:
+                result_uuid = result_dict["_source"]["bundles"][0]["uuid"]
+                result_version = result_dict["_source"]["bundles"][0]["version"]
+                result_contents = result_dict["_source"]["bundles"][0]["contents"]
+
+                self.assertEqual(self.new_bundle[0], result_uuid)
+                self.assertEqual(self.new_bundle[1], result_version)
+                self.assertEqual("Aardvark Ailment", result_contents["project"]["project"])
+                self.assertIn("John Denver", result_contents["project"]["laboratory"])
+                self.assertIn("Lorem ipsum", result_contents["specimens"][0]["species"])
+
+        self._get_es_results(check_bundle_correctness)
+
+    def test_update_with_newer_version(self):
+        """
+        Updating a bundle with a future version should overwrite the old version.
+        """
+        old_data = self._get_data_by_uuid(self.old_bundle[0])
+        new_data = self._get_data_files('updated.metadata',
+                                        'updated.data')
+
+        self._mock_index(self.old_bundle, old_data)
+
+        def check_old_submission(es_results):
+            for result_dict in es_results:
+                old_result_version = result_dict["_source"]["bundles"][0]["version"]
+                old_result_contents = result_dict["_source"]["bundles"][0]["contents"]
+
+                self.assertEqual(self.old_bundle[1], old_result_version)
+                self.assertEqual("Mouse Melanoma", old_result_contents["project"]["project"])
+                self.assertIn("Sarah Teichmann", old_result_contents["project"]["laboratory"])
+                self.assertIn("Mus musculus", old_result_contents["specimens"][0]["species"])
+
+        old_results = self._get_es_results(check_old_submission)
+
+        self._mock_index(self.new_bundle, new_data)
+
+        def check_updated_submission(old_results_list, new_results_list):
+            for old_result_dict, new_result_dict in list(zip(old_results_list, new_results_list)):
+                old_result_version = old_result_dict["_source"]["bundles"][0]["version"]
+                old_result_contents = old_result_dict["_source"]["bundles"][0]["contents"]
+
+                new_result_version = new_result_dict["_source"]["bundles"][0]["version"]
+                new_result_contents = new_result_dict["_source"]["bundles"][0]["contents"]
+
+                self.assertNotEqual(old_result_version, new_result_version)
+                self.assertNotEqual(old_result_contents["project"]["project"],
+                                    new_result_contents["project"]["project"])
+                self.assertNotEqual(old_result_contents["project"]["laboratory"],
+                                    new_result_contents["project"]["laboratory"])
+                self.assertNotEqual(old_result_contents["specimens"][0]["species"],
+                                    new_result_contents["specimens"][0]["species"])
+
+        self._get_es_results(partial(check_updated_submission, old_results))
+
+    def test_old_version_overwrite(self):
+        """
+        An attempt to overwrite a newer version of a bundle with an older version should fail.
+        """
+        old_data = self._get_data_by_uuid(self.old_bundle[0])
+        new_data = self._get_data_files('updated.metadata',
+                                        'updated.data')
+
+        self._mock_index(self.new_bundle, new_data)
+
+        def check_new_submission(es_results):
+            for result_dict in es_results:
+                old_result_version = result_dict["_source"]["bundles"][0]["version"]
+                old_result_contents = result_dict["_source"]["bundles"][0]["contents"]
+
+                self.assertEqual(self.new_bundle[1], old_result_version)
+                self.assertEqual("Aardvark Ailment", old_result_contents["project"]["project"])
+                self.assertIn("John Denver", old_result_contents["project"]["laboratory"])
+                self.assertIn("Lorem ipsum", old_result_contents["specimens"][0]["species"])
+
+        old_results = self._get_es_results(check_new_submission)
+
+        self._mock_index(self.old_bundle, old_data)
+
+        def check_for_overwrite(old_results_list, new_results_list):
+            for old_result_dict, new_result_dict in list(zip(old_results_list, new_results_list)):
+                old_result_version = old_result_dict["_source"]["bundles"][0]["version"]
+                old_result_contents = old_result_dict["_source"]["bundles"][0]["contents"]
+
+                new_result_version = new_result_dict["_source"]["bundles"][0]["version"]
+                new_result_contents = new_result_dict["_source"]["bundles"][0]["contents"]
+
+                self.assertEqual(old_result_version, new_result_version)
+                self.assertEqual(old_result_contents["project"]["project"],
+                                 new_result_contents["project"]["project"])
+                self.assertEqual(old_result_contents["project"]["laboratory"],
+                                 new_result_contents["project"]["laboratory"])
+                self.assertEqual(old_result_contents["specimens"][0]["species"],
+                                 new_result_contents["specimens"][0]["species"])
+
+        self._get_es_results(partial(check_for_overwrite, old_results))
+
+    def test_concurrent_specimen_submissions(self):
+        """
+        We submit two different bundles for the same specimen. What happens?
+        """
+        spec1_pack = self._get_data_by_uuid(self.spec1_bundle[0])
+        spec2_pack = self._get_data_by_uuid(self.spec2_bundle[0])
+        specimen_list = [(self.spec1_bundle, spec1_pack),
+                         (self.spec2_bundle, spec2_pack)]
+
+        unmocked_mget = Elasticsearch.mget
+
+        def mocked_mget(self, body):
+            mget_return = unmocked_mget(self, body=body)
+            # both threads sleep after reading to force conflict while writing
+            time.sleep(0.5)
+            return mget_return
+
+        def help_index(specimen_tuple):
+            self._mock_index(specimen_tuple[0], specimen_tuple[1])
+
+        with patch.object(Elasticsearch, 'mget', new=mocked_mget):
+            with self.assertLogs(level='WARNING') as cm:
+                with ThreadPoolExecutor(max_workers=2) as executor:
+                    thread_results = executor.map(help_index, specimen_list)
+                    self.assertNotEqual(None, thread_results)
+                    self.assertTrue(all(r is None for r in thread_results))
+                self.assertNotEqual(None, cm.records)
+
+                num_hits = 0
+                for log_msg in cm.output:
+                    if "There was a conflict with document" in log_msg:
+                        num_hits += 1
+                self.assertEqual(3, num_hits)
+
+        def check_specimen_merge(es_results):
+            specimen_uuids = []
+            file_uuids = []
+            for result_dict in es_results:
+                result_contents = result_dict["_source"]["bundles"][0]["contents"]
+                if "files" in result_dict["_index"]:
+                    for file_dict in result_contents["files"]:
+                        file_uuids.append(file_dict["uuid"])
+                elif "specimens" in result_dict["_index"]:
+                    self.assertLess(1, len(result_contents["files"]))
+                    for file_dict in result_contents["files"]:
+                        specimen_uuids.append(file_dict["uuid"])
+                else:
+                    continue
+
+            self.assertEqual(len(file_uuids), len(specimen_uuids))
+            for uuid in specimen_uuids:
+                self.assertIn(uuid, file_uuids)
+
+        self._get_es_results(check_specimen_merge)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`test_hca_indexer.py` contains unit tests for the three bundle upload cases: correctness ([#158](https://github.com/HumanCellAtlas/data-browser/issues/158)) updating with different versions ([#159](https://github.com/HumanCellAtlas/data-browser/issues/159)), and concurrent specimen upload ([#160](https://github.com/HumanCellAtlas/data-browser/issues/160)). This pull request generally addresses data browser issue [#15](https://github.com/HumanCellAtlas/data-browser/issues/15).

`docker_es` is a brief script to retrieve the official Elasticsearch docker container and run it. I've used it in lieu of setting up my own Elasticsearch server on my machine, it might useful as we set up continuous integration for the rest of the Orange Box.

The `/testdata` folder contains all the data/metadata files referenced in `test_hca_indexer.py`, used in the mock MetadataDownloader. 

Finally, I modified imports in the dependencies of `test_hca_indexer.py` to conform to the latest repo structure.