### PR TITLE
Fix: Worker fails due to read-only file system

### DIFF
--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -114,6 +114,7 @@ class Config:
             'AZUL_ES_ENDPOINT': f"{host}:{port}",
             'azul_git_commit': repo.head.object.hexsha,
             'azul_git_dirty': str(repo.is_dirty()),
+            'HOME': '/tmp'
         }
 
     def google_service_account(self, lambda_name):


### PR DESCRIPTION
OSError: [Errno 30] Read-only file system: '/home/sbx_user1068'

Regression from d7c6dd6a3699bad5c9ee960d79b6c6b229d73931