### PR TITLE
Refactor and consolidate elasticsearch client usage

### DIFF
--- a/environment
+++ b/environment
@@ -49,6 +49,9 @@ azul_vars=(
     # The name of the ES index to be populated in response to events from DSS
     AZUL_ES_INDEX
 
+    # Elasticsearch operation timeout in seconds
+    AZUL_ES_TIMEOUT
+
     # The name of the index containing Specimen entities
     AZUL_SPECIMEN_INDEX
 
@@ -159,6 +162,7 @@ _set AZUL_ES_DOMAIN "azul-index-$AZUL_DEPLOYMENT_STAGE"
 _set AZUL_ES_INSTANCE_COUNT 2
 _set AZUL_ES_INSTANCE_TYPE "m4.xlarge.elasticsearch"
 _set AZUL_ES_VOLUME_SIZE 35
+_set AZUL_ES_TIMEOUT 60
 _set AZUL_INDEX_WORKERS 16
 _set AZUL_DSS_WORKERS 8
 _set AZUL_SUBSCRIBE_TO_DSS 1

--- a/lambdas/indexer/app.py
+++ b/lambdas/indexer/app.py
@@ -79,7 +79,7 @@ def post_notification():
 @app.route('/escheck')
 def es_check():
     """Check the status of ElasticSearch by returning its info."""
-    return json.dumps(properties.elastic_search_client.info())
+    return json.dumps(ElasticsearchClientFactory.get().info())
 
 
 # Work around https://github.com/aws/chalice/issues/856

--- a/lambdas/indexer/app.py
+++ b/lambdas/indexer/app.py
@@ -76,12 +76,6 @@ def post_notification():
     return {"status": "done"}
 
 
-@app.route('/escheck')
-def es_check():
-    """Check the status of ElasticSearch by returning its info."""
-    return json.dumps(ElasticsearchClientFactory.get().info())
-
-
 # Work around https://github.com/aws/chalice/issues/856
 
 def new_handler(self, event, context):

--- a/lambdas/service/app.py
+++ b/lambdas/service/app.py
@@ -136,7 +136,7 @@ def get_data(file_id=None):
             filters['file']['fileId'] = {"is": [file_id]}
         # Create and instance of the ElasticTransformDump
         logger.info("Creating ElasticTransformDump object")
-        es_td = EsTd(es_endpoint=config.es_endpoint)
+        es_td = EsTd()
         # Get the response back
         logger.info("Creating the API response")
         response = es_td.transform_request(filters=filters,
@@ -216,7 +216,7 @@ def get_specimen_data(specimen_id=None):
             filters['file']['fileId'] = {"is": [specimen_id]}
         # Create and instance of the ElasticTransformDump
         logger.info("Creating ElasticTransformDump object")
-        es_td = EsTd(es_endpoint=config.es_endpoint)
+        es_td = EsTd()
         # Get the response back
         logger.info("Creating the API response")
         response = es_td.transform_request(filters=filters,
@@ -292,7 +292,7 @@ def get_data_pie():
         pagination = _get_pagination(app.current_request)
         # Create and instance of the ElasticTransformDump
         logger.info("Creating ElasticTransformDump object")
-        es_td = EsTd(es_endpoint=config.es_endpoint)
+        es_td = EsTd()
         # Get the response back
         logger.info("Creating the API response")
         response = es_td.transform_request(filters=filters,
@@ -335,7 +335,7 @@ def get_summary():
         return "Malformed filters parameter"
     # Create and instance of the ElasticTransformDump
     logger.info("Creating ElasticTransformDump object")
-    es_td = EsTd(es_endpoint=config.es_endpoint)
+    es_td = EsTd()
     # Get the response back
     logger.info("Creating the API response")
     response = es_td.transform_summary(filters=filters)
@@ -421,7 +421,7 @@ def get_search():
         field = 'donor'
     # Create and instance of the ElasticTransformDump
     logger.info("Creating ElasticTransformDump object")
-    es_td = EsTd(es_endpoint=config.es_endpoint)
+    es_td = EsTd()
     # Get the response back
     logger.info("Creating the API response")
     response = es_td.transform_autocomplete_request(pagination,
@@ -474,7 +474,7 @@ def get_manifest():
         return "Malformed filters parameter"
     # Create and instance of the ElasticTransformDump
     logger.info("Creating ElasticTransformDump object")
-    es_td = EsTd(es_endpoint=config.es_endpoint)
+    es_td = EsTd()
     # Get the response back
     logger.info("Creating the API response")
     response = es_td.transform_manifest(filters=filters)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aws-requests-auth==0.3.3
+aws-requests-auth==0.4.2
 boto==2.48.0
 boto3==1.7.46
 botocore==1.10.46
@@ -12,6 +12,5 @@ hca==4.1.0
 git+git://github.com/hannes-ucsc/jmespath.py@hannes-fix-cache-race#egg=jmespath
 git+git://github.com/HumanCellAtlas/metadata-api@release/1.0b1#egg=hca-metadata-api
 requests==2.19.1
-requests-aws4auth==0.9
 requests-http-signature==0.0.3
 urllib3==1.23

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -36,6 +36,10 @@ class Config:
         return os.environ['AZUL_ES_DOMAIN']
 
     @property
+    def es_timeout(self) -> int:
+        return int(os.environ['AZUL_ES_TIMEOUT'])
+
+    @property
     def dss_endpoint(self) -> str:
         return os.environ['AZUL_DSS_ENDPOINT']
 

--- a/src/azul/base_config.py
+++ b/src/azul/base_config.py
@@ -2,15 +2,10 @@ from abc import ABC
 import os
 from typing import Any, Iterable, Mapping
 
-from elasticsearch import Elasticsearch
-
 from azul.transformer import Transformer
 
 
 class BaseIndexProperties(ABC):
-    @property
-    def elastic_search_client(self) -> Elasticsearch:
-        return Elasticsearch()
 
     @property
     def dss_url(self) -> str:

--- a/src/azul/es.py
+++ b/src/azul/es.py
@@ -1,25 +1,30 @@
+import logging
+from functools import lru_cache
+
+from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
 from elasticsearch import Elasticsearch, RequestsHttpConnection
-from aws_requests_auth import boto_utils
-from aws_requests_auth.aws_auth import AWSRequestsAuth
 
 from azul import config
 from azul.deployment import aws
 
+logger = logging.getLogger(__name__)
 
-def es_client():
-    host = config.es_endpoint[0]
-    port = config.es_endpoint[1]
-    ssl_required = True if port == 443 else False
-    if ssl_required:
-        aws_auth = AWSRequestsAuth(aws_host=host,
-                                   aws_region=aws.region_name,
-                                   aws_service='es',
-                                   **boto_utils.get_credentials())
-        return Elasticsearch(hosts=[{'host': host, 'port': port}],
-                             http_auth=aws_auth,
-                             use_ssl=True,
-                             verify_certs=True,
-                             connection_class=RequestsHttpConnection)
-    else:
-        return Elasticsearch(hosts=[{'host': host, 'port': port}],
-                             connection_class=RequestsHttpConnection)
+
+class ESClientFactory:
+
+    @classmethod
+    def get(cls):
+        host, port = config.es_endpoint
+        return cls._create_client(host, port, config.es_timeout)
+
+    @classmethod
+    @lru_cache(maxsize=32)
+    def _create_client(cls, host, port, timeout):
+        logger.debug(f'Creating ES client [{host}:{port}]')
+        common_params = dict(hosts=[dict(host=host, port=port)], timeout=timeout)
+        if host.endswith(".amazonaws.com"):
+            aws_auth = BotoAWSRequestsAuth(aws_host=host, aws_region=aws.region_name, aws_service='es')
+            return Elasticsearch(http_auth=aws_auth, use_ssl=True, verify_certs=True,
+                                 connection_class=RequestsHttpConnection, **common_params)
+        else:
+            return Elasticsearch(**common_params)

--- a/src/azul/health.py
+++ b/src/azul/health.py
@@ -1,13 +1,12 @@
 import boto3
-
 from botocore.exceptions import ClientError
 
 from azul import config
-from azul.es import es_client
+from azul.es import ESClientFactory
 
 
 def get_elasticsearch_health():
-    is_es_reachable = es_client().ping()
+    is_es_reachable = ESClientFactory.get().ping()
 
     result = {
         'status': 'UP' if is_es_reachable else 'DOWN',

--- a/src/azul/indexer.py
+++ b/src/azul/indexer.py
@@ -8,6 +8,7 @@ from elasticsearch.helpers import parallel_bulk, streaming_bulk
 
 from azul.base_config import BaseIndexProperties
 from azul.downloader import MetadataDownloader
+from azul.es import ESClientFactory
 
 log = logging.getLogger(__name__)
 
@@ -25,7 +26,7 @@ class BaseIndexer(ABC):
         bundle_version = dss_notification['match']['bundle_version']
         metadata_downloader = MetadataDownloader(self.properties.dss_url)
         metadata_files, manifest = metadata_downloader.extract_bundle(dss_notification)
-        es_client = self.properties.elastic_search_client
+        es_client = ESClientFactory.get()
 
         # Create indices and populate mappings
         for index_name in self.properties.index_names:

--- a/test/es_test_case.py
+++ b/test/es_test_case.py
@@ -5,7 +5,8 @@ import unittest
 from unittest.mock import patch
 
 import docker
-from elasticsearch5 import Elasticsearch
+
+from azul.es import ESClientFactory
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +36,7 @@ class ElasticsearchTestCase(unittest.TestCase):
         es_host = f'{es_host_ip}:{es_host_port}'
         cls._old_es_endpoint = os.environ.get('AZUL_ES_ENDPOINT')
         os.environ['AZUL_ES_ENDPOINT'] = es_host
-        cls.es_client = Elasticsearch(hosts=[es_host], use_ssl=False)
+        cls.es_client = ESClientFactory.get()
         cls._wait_for_es()
 
     @classmethod

--- a/test/indexer/test_projects.py
+++ b/test/indexer/test_projects.py
@@ -3,6 +3,7 @@ import unittest
 from datetime import datetime
 
 from azul import config, eventually
+from azul.es import ESClientFactory
 from indexer.test_hca_indexer import IndexerTestCase
 
 module_logger = logging.getLogger(__name__)
@@ -41,7 +42,7 @@ class TestDataExtractorTestCase(IndexerTestCase):
             "https://dss.staging.data.humancellatlas.org/v1": [],
             "https://dss.data.humancellatlas.org/v1": [("8543d32f-4c01-48d5-a79f-1c5439659da3", "2018-03-29T143828.884167Z")]
         }
-        cls.es_client = cls.index_properties.elastic_search_client
+        cls.es_client = ESClientFactory.get()
 
     @classmethod
     def tearDownClass(cls):

--- a/test/service/test_request_builder.py
+++ b/test/service/test_request_builder.py
@@ -7,7 +7,6 @@ import os
 import unittest
 from service import WebServiceTestCase
 from azul.service.responseobjects.elastic_request_builder import ElasticTransformDump as EsTd
-from azul import config
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +37,7 @@ class TestRequestBuilder(WebServiceTestCase):
         # - The complex multiple filters case
 
         # Create ElasticTransformDump instance
-        es_ts_instance = EsTd(es_endpoint=config.es_endpoint)
+        es_ts_instance = EsTd()
         # Create a request object
         es_search = EsTd.create_request(
             sample_filter,
@@ -85,7 +84,7 @@ class TestRequestBuilder(WebServiceTestCase):
         # TODO: Need some form of handler for the query language
         sample_filter = {}
         # Create ElasticTransformDump instance
-        es_ts_instance = EsTd(es_endpoint=config.es_endpoint)
+        es_ts_instance = EsTd()
         # Create a request object
         es_search = EsTd.create_request(
             sample_filter,
@@ -134,7 +133,7 @@ class TestRequestBuilder(WebServiceTestCase):
         }
 
         # Create ElasticTransformDump instance
-        es_ts_instance = EsTd(es_endpoint=config.es_endpoint)
+        es_ts_instance = EsTd()
         # Create a request object
         es_search = EsTd.create_request(
             sample_filter,

--- a/test/service/test_request_validation.py
+++ b/test/service/test_request_validation.py
@@ -41,7 +41,7 @@ class FacetNameValidationTest(WebServiceTestCase):
         self.assertEqual(response.json(), expected_json)
 
     def test_health_es_unreachable(self):
-        with mock.patch.dict(os.environ, AZUL_ES_ENDPOINT='nonexisting-index.us-east-1.es.amazonaws.com:80'):
+        with mock.patch.dict(os.environ, AZUL_ES_ENDPOINT='nonexisting-index.com:80'):
             url = self.base_url + "health"
             response = requests.get(url)
             response.raise_for_status()


### PR DESCRIPTION
I've decided to go with [AWSRequestsAuth](https://github.com/DavidMuller/aws-requests-auth)
few reasons:
- seems more up to date (in contrary with the other library which last commit was on Feb 8, 2016)
- has neat built-in feature to retrieve aws credentials with help of boto library

@hannes-ucsc  is `es_check()` safe to delete, from the name of the function it suppose to be health check for `es`, which we already have