### PR TITLE
Commons google auth for azul indexer doc and code updates

### DIFF
--- a/indexer/app.py
+++ b/indexer/app.py
@@ -82,7 +82,7 @@ def post_notification():
     # Create a DataExtractor instance
     extractor = DataExtractor(bb_host)
     # Extract the relevant files and metadata to the bundle
-    metadata_files, data_files = extractor.extract_bundle(payload, replica, will_include_urls=True)
+    metadata_files, data_files = extractor.extract_bundle(payload, replica, will_include_urls=False)
     # Create an instance of the Indexers and run it
     file_indexer = FileIndexer(metadata_files,
                                data_files,

--- a/indexer/test/find-golden-tickets.py
+++ b/indexer/test/find-golden-tickets.py
@@ -2,6 +2,7 @@
 """Command line utility to trigger indexing of bundles based on a query."""
 import argparse
 from collections import defaultdict
+from hca import HCAConfig
 from hca.dss import DSSClient
 import json
 from pprint import pprint
@@ -38,7 +39,6 @@ class DefaultProperties:
 
 
 default = DefaultProperties()
-dss_client = DSSClient()
 
 parser = argparse.ArgumentParser(
     description='Process options the finder of golden bundles.')
@@ -105,7 +105,14 @@ def post_bundle(bundle_uuid, bundle_version):
 
 def main():
     """Entrypoint method for the script."""
-    dss_client.host = args.dss_url
+
+    # Workaround known issues with setting-up HCAConfig/DSSClient
+    # See: https://github.com/HumanCellAtlas/dcp-cli/issues/170
+    HCAConfig._user_config_home = '/tmp/'
+    config = HCAConfig(save_on_exit=False, autosave=False)
+    config['DSSClient'].swagger_url = args.dss_url + '/swagger.json'
+    dss_client = DSSClient(config=config)
+
     parameters = {
         "es_query": args.es_query,
         "replica": "aws"


### PR DESCRIPTION
This PR is actually a combination of documentation updates and minor code changes made for the Azul indexer in the process of getting it working with Google token OIDC auth.
There are three distinct commits, which can/should be reviewed independently.
The documentation changes are primarily corrections to previously existing content.
The code changes were mostly to address issues with the HCA `DSSClient` initialization, or to address changes to HCA DSS functionality in the newer version of the HCA DSS to which we recently updated.
The changes for auth per se were few and minor.