### PR TITLE
Use venv instead of virtualenv (fixes #188)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 
+cache: pip
+
 sudo: required
 
 services:
@@ -16,5 +18,5 @@ install:
   - pip install -r requirements.dev.txt
 
 script:
-  - source environment
   - make test
+  

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ generic with minimal need for project-specific behavior.
 
 ### 1.1. Development Preequisites
 
-- Python 3.6 with `virtualenv` and `pip`
+- Python 3.6 with `pip`
 
 - Make sure that you are using the `bash` shell.
 
@@ -49,11 +49,11 @@ credentials. A subset of the test suite passes without configured AWS
 credentials. To validate your setup, we'll be running one of those tests at the
 end.
 
-1) Create a Python 3.6 `virtualenv` and activate it, for example 
+1) Create a Python 3.6 `venv` and activate it, for example 
    
    ```
    cd azul
-   virtualenv -p python3 .venv
+   python3 -m venv .venv
    source .venv/bin/activate
    ```
 

--- a/common.mk
+++ b/common.mk
@@ -4,7 +4,7 @@ ifndef AZUL_HOME
 $(error Please run "source environment" from the project root directory before running make commands)
 endif
 
-ifneq ($(shell python -c "import sys; print(hasattr(sys, 'real_prefix'))"),True)
+ifneq ($(shell python -c "import os; print('VIRTUAL_ENV' in os.environ)"),True)
 $(error Looks like no virtualenv is active)
 endif
 


### PR DESCRIPTION
Resolves #188

* Updated `virtualenv` testing mechanisms.
* Updated `venv` activation instructions.  