### PR TITLE
Update translation mapping for cell count (fixes #142)

### DIFF
--- a/src/azul/project/hca/config.py
+++ b/src/azul/project/hca/config.py
@@ -15,7 +15,7 @@ class IndexProperties(BaseIndexProperties):
         self._es_mapping = {
             "dynamic_templates": [
                 {
-                    "strings": {
+                    "strings_as_text": {
                         "match_mapping_type": "string",
                         "mapping": {
                             "type": "text",
@@ -29,6 +29,20 @@ class IndexProperties(BaseIndexProperties):
                             }
                         }
                     }
+                },
+                {
+                    "longs_with_keyword": {
+                        "match_mapping_type": "long",
+                        "mapping": {
+                            "type": "long",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 256
+                                }
+                            }
+                        }
+                    },
                 }
             ]
         }

--- a/src/azul/service/config/request_config.json
+++ b/src/azul/service/config/request_config.json
@@ -22,7 +22,7 @@
     "fileId": "bundles.contents.files.uuid",
     "donorId": "bundles.contents.specimens.donor_biomaterial_id",
     "lab": "bundles.contents.project.laboratory",
-    "cellCount": "bundles.contents.specimens.total_cells"
+    "cellCount": "bundles.contents.specimens.total_estimated_cells"
   },
   "autocomplete-translation": {
     "AZUL_FILE_INDEX": {
@@ -62,6 +62,7 @@
     "protocol",
     "fileFormat",
     "laboratory",
-    "preservationMethod"
+    "preservationMethod",
+    "cellCount"
   ]
 }


### PR DESCRIPTION
Note that this PR is not full fix to support sorting.

Our current implementation uses [`keywords` for sorting](https://github.com/DataBiosphere/azul/blob/feature/milan/142-cell-count-mapping/src/azul/service/responseobjects/elastic_request_builder.py#L267), but our current mapping for `cellCount` is following:

![screenshot from 2018-08-21 11-38-47](https://user-images.githubusercontent.com/5015486/44400311-ff0cec00-a54a-11e8-91a9-34157da7d482.png)

To support `cellCount` sorting we must (most likely drop the indices and) update mapping for the relevant field `total_estimated_cells`. I've tested with following mapping:
```
{
  "properties": {
    "bundles": {
      "properties": {
        "contents": {
          "properties": {
            "specimens": {
              "properties": {
                "total_estimated_cells": {
                  "type": "text",
                  "fields": {
                    "keyword": {
                      "type": "keyword",
                      "ignore_above": 256
                    }
                  }
                }
              }
            }
          }
        }
      }
    }
  }
}
```
