### PR TITLE
 Set ES index based on deployment name (fixes #220)

### DIFF
--- a/environment
+++ b/environment
@@ -52,14 +52,8 @@ azul_vars=(
     # Elasticsearch operation timeout in seconds
     AZUL_ES_TIMEOUT
 
-    # The name of the index containing Specimen entities
-    AZUL_SPECIMEN_INDEX
-
-    # The name of the index containing File entities
-    AZUL_FILE_INDEX
-
-    # The name of the index containing Donor entities
-    AZUL_DONOR_INDEX
+    # The template for the name of the ES index to use
+    AZUL_ES_INDEX_NAME_TEMPLATE
 
     # The name of the bucket where TerraForm maintains its state, allowing
     # multiple developers to collaboratively use TerraForm in a single AWS
@@ -159,6 +153,7 @@ _set AZUL_SUBDOMAIN_TEMPLATE "{lambda_name}"
 _set AZUL_RESOURCE_PREFIX "azul-"
 _set AZUL_ES_INDEX "azul-$AZUL_DEPLOYMENT_STAGE"
 _set AZUL_ES_DOMAIN "azul-index-$AZUL_DEPLOYMENT_STAGE"
+_set AZUL_ES_INDEX_NAME_TEMPLATE "azul_{entity_type}_$AZUL_DEPLOYMENT_STAGE"
 _set AZUL_ES_INSTANCE_COUNT 2
 _set AZUL_ES_INSTANCE_TYPE "m4.xlarge.elasticsearch"
 _set AZUL_ES_VOLUME_SIZE 35
@@ -166,14 +161,6 @@ _set AZUL_ES_TIMEOUT 60
 _set AZUL_INDEX_WORKERS 16
 _set AZUL_DSS_WORKERS 8
 _set AZUL_SUBSCRIBE_TO_DSS 1
-
-# FIXME: the index name should contain the stage name so we can share an ES
-# instance between deployments. However, the indexer seems to be hard-wired
-# to this particular index name.
-
-_set AZUL_FILE_INDEX "browser_files_dev"
-_set AZUL_SPECIMEN_INDEX "browser_specimens_dev"
-_set AZUL_DONOR_INDEX "browser_donor_dev"
 
 # This is the same TF bucket as the one DSS uses
 _set AZUL_TERRAFORM_BACKEND_BUCKET_TEMPLATE "org-humancellatlas-dss-config-{account_id}"

--- a/lambdas/service/app.py
+++ b/lambdas/service/app.py
@@ -142,7 +142,7 @@ def get_data(file_id=None):
         response = es_td.transform_request(filters=filters,
                                            pagination=pagination,
                                            post_filter=True,
-                                           index="AZUL_FILE_INDEX")
+                                           entity_type='files')
     except BadArgumentException as bae:
         raise BadRequestError(msg=bae.message)
     else:
@@ -222,7 +222,7 @@ def get_specimen_data(specimen_id=None):
         response = es_td.transform_request(filters=filters,
                                            pagination=pagination,
                                            post_filter=True,
-                                           index="AZUL_SPECIMEN_INDEX")
+                                           entity_type='specimens')
     except BadArgumentException as bae:
         raise BadRequestError(msg=bae.message)
     else:

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -93,6 +93,9 @@ class Config:
     def es_index(self) -> str:
         return os.environ['AZUL_ES_INDEX']
 
+    def es_index_name(self, entity_type) -> str:
+        return os.environ['AZUL_ES_INDEX_NAME_TEMPLATE'].format(entity_type=entity_type)
+
     @property
     def domain_name(self) -> str:
         return os.environ['AZUL_DOMAIN_NAME']

--- a/src/azul/base_config.py
+++ b/src/azul/base_config.py
@@ -1,7 +1,7 @@
 from abc import ABC
-import os
 from typing import Any, Iterable, Mapping
 
+from azul import config
 from azul.transformer import Transformer
 
 
@@ -30,5 +30,4 @@ class BaseIndexProperties(ABC):
     @property
     def index_names(self) -> Iterable[str]:
         entities = self.entities
-        environment = os.getenv("STAGE_ENVIRONMENT", "dev")
-        return ["browser_{}_{}".format(entity, environment) for entity in entities]
+        return [config.es_index_name(entity) for entity in entities]

--- a/src/azul/service/config/request_config.json
+++ b/src/azul/service/config/request_config.json
@@ -25,11 +25,11 @@
     "cellCount": "bundles.contents.specimens.total_estimated_cells"
   },
   "autocomplete-translation": {
-    "AZUL_FILE_INDEX": {
+    "files": {
       "entity_id": "entity_id",
       "entity_version":"entity_version"
     },
-    "AZUL_DONOR_INDEX": {
+    "donor": {
       "donor": "donor_uuid"
     }
   },

--- a/src/azul/transformer.py
+++ b/src/azul/transformer.py
@@ -1,10 +1,10 @@
 from abc import ABC, abstractmethod
 from itertools import filterfalse, tee
 import logging
-import os
 import re
 from typing import List, Mapping, Sequence
 
+from azul import config
 from azul.types import JSON
 
 module_logger = logging.getLogger(__name__)
@@ -36,10 +36,10 @@ class Document:
 
 
 class ElasticSearchDocument:
-    def __init__(self, elastic_search_id: str, content: Document, entity_name: str, _type: str="doc") -> None:
+    def __init__(self, elastic_search_id: str, content: Document, entity_type: str, _type: str="doc") -> None:
         self.elastic_search_id = elastic_search_id
         self._content = content
-        self.index = "browser_{}_{}".format(entity_name, os.getenv("STAGE_ENVIRONMENT", "dev"))
+        self.index = config.es_index_name(entity_type)
         self._type = _type
         self._version = 1
 

--- a/test/indexer/test_projects.py
+++ b/test/indexer/test_projects.py
@@ -65,9 +65,11 @@ class TestDataExtractorTestCase(IndexerTestCase):
 
         @eventually(5.0, 0.5)
         def _assert_number_of_files():
-            total_files = self.es_client.count(index="browser_files_dev", doc_type="doc")
+            total_files = self.es_client.count(
+                index=config.es_index_name('files'), doc_type='doc')
             self.assertEqual(776, total_files["count"])
-            total_specimens = self.es_client.count(index="browser_specimens_dev", doc_type="doc")
+            total_specimens = self.es_client.count(
+                index=config.es_index_name('specimens'), doc_type='doc')
             self.assertEqual(129, total_specimens["count"])
 
         _assert_number_of_files()
@@ -86,8 +88,9 @@ class TestDataExtractorTestCase(IndexerTestCase):
         module_logger.info("End computation %s",
                            datetime.now().isoformat(timespec='microseconds'))
         # Check values in ElasticSearch
-        results = self.es_client.get(index="browser_specimens_dev",
-                                     id="b3623b88-c369-46c9-a2e9-a16042d2c589")
+        results = self.es_client.get(
+            index=config.es_index_name('specimens'),
+            id='b3623b88-c369-46c9-a2e9-a16042d2c589')
         file_ids = [f["uuid"] for f in
                     results["_source"]["bundles"][0]["contents"]["files"]]
         self.assertEqual(len(file_ids), len(set(file_ids)))

--- a/test/service/data/test_request_config.json
+++ b/test/service/data/test_request_config.json
@@ -4,11 +4,11 @@
     "entity_version":"entity_version"
   },
   "autocomplete-translation": {
-    "AZUL_FILE_INDEX": {
+    "files": {
       "entity_id": "entity_id",
       "entity_version":"entity_version"
     },
-    "AZUL_DONOR_INDEX": {
+    "donor": {
       "donor": "donor_uuid"
     }
   },

--- a/test/service/data_generator/fake_data_utils.py
+++ b/test/service/data_generator/fake_data_utils.py
@@ -5,6 +5,8 @@ import elasticsearch5
 import logging
 import os
 
+from azul import config
+
 logger = logging.getLogger(__name__)
 
 
@@ -41,7 +43,7 @@ class FakerSchemaGenerator(object):
 
 
 class ElasticsearchFakeDataLoader(object):
-    test_index_name = 'browser_files_dev'
+    test_index_name = config.es_index_name('files')
 
     def __init__(self, number_of_documents=1000, azul_es_endpoint=None):
 


### PR DESCRIPTION
Set index name based on deployment name to allow for a single ES domain with separated indexes.

@hannes-ucsc Can you explain what this snippet in `request_config.json` is for and if changes need to be made here for this issue?

https://github.com/DataBiosphere/azul/blob/dbde42ea5f4913d530bb9ee2cc421eca0be9c3df/src/azul/service/config/request_config.json#L27-L35