### PR TITLE
Added summary endpoints for the two supported indexes (fixes #186)

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ The responseobjects module is responsible for handling the faceting and API resp
 There are currently five working endpoints:
 <ul>
 <li>"<code>/repository/files/</code>" returns the index search results along with a count of the terms available for the facets.</li>
-<li>"<code>/repository/files/summary</code>" returns a summary of the current data stored.</li>
+<li>"<code>/repository/summary/files</code>" returns a summary of the current data stored.</li>
 <li>"<code>/repository/files/export</code>" returns a manifest file with the filters provided.</li>
 <li>"<code>/repository/files/order</code>" returns the desired order for the facets.</li>
 <li>"<code>/keywords</code>" returns a list of search results for some search query.</li>
@@ -683,11 +683,11 @@ Currently there are 6 parameters supported. They are as follows:<br>
 
 <br>
 
-***/repository/files/summary***<br>
+***/repository/summary/files***<br>
 
 |Parameter|Description|Data Type|Example|
 |--- |--- |--- |--- |
-|filters|Specifies which filters to use to return only the summary with the matching criteria. Supplied as a string with the format:`{"file":{"fieldA":{"is":["VALUE_A", "VALUE_B"]}, "fieldB":{"is":["VALUE_C", "VALUE_D"]}, ...}}`|String|http://ucsc-cgp.org/api/v1/repository/files/summary?filters=%7B%22file%22%3A%7B%22file_type%22%3A%7B%22is%22%3A%5B%22bam%22%5D%7D%7D%7D This will return a manifest with only those files who have a file format of type "bam"|
+|filters|Specifies which filters to use to return only the summary with the matching criteria. Supplied as a string with the format:`{"file":{"fieldA":{"is":["VALUE_A", "VALUE_B"]}, "fieldB":{"is":["VALUE_C", "VALUE_D"]}, ...}}`|String|http://ucsc-cgp.org/api/v1/repository/summary/files?filters=%7B%22file%22%3A%7B%22file_type%22%3A%7B%22is%22%3A%5B%22bam%22%5D%7D%7D%7D This will return a manifest with only those files who have a file format of type "bam"|
 
 <br>
 

--- a/lambdas/service/app.py
+++ b/lambdas/service/app.py
@@ -307,8 +307,8 @@ def get_data_pie():
         return "Malformed filters parameter"
 
 
-@app.route('/repository/files/summary', methods=['GET'], cors=True)
-def get_summary():
+@app.route('/repository/summary/{entity_type}', methods=['GET'], cors=True)
+def get_summary(entity_type=None):
     """
     Returns a summary based on the filters passed on to the call. Based on the
     ICGC endpoint.
@@ -321,6 +321,13 @@ def get_summary():
     """
     # Setup logging
     logger = logging.getLogger("dashboardService.webservice.get_summary")
+    # Determine index
+    if entity_type == "specimens":
+        index = "AZUL_SPECIMEN_INDEX"
+    elif entity_type == "files":
+        index = "AZUL_FILE_INDEX"
+    else:
+        return "No index summary for current request"
     if app.current_request.query_params is None:
         app.current_request.query_params = {}
     # Get the filters from the URL
@@ -338,7 +345,7 @@ def get_summary():
     es_td = EsTd()
     # Get the response back
     logger.info("Creating the API response")
-    response = es_td.transform_summary(filters=filters)
+    response = es_td.transform_summary(filters=filters, index=index)
     # Returning a single response if <file_id> request form is used
     return response
 

--- a/src/azul/service/responseobjects/elastic_request_builder.py
+++ b/src/azul/service/responseobjects/elastic_request_builder.py
@@ -316,7 +316,8 @@ class ElasticTransformDump(object):
     def transform_summary(
             self,
             request_config_file='request_config.json',
-            filters=None):
+            filters=None,
+            index=None):
         # Use this as the base to construct the paths
         # stackoverflow.com/questions/247770/retrieving-python-module-path
         # Use that to get the path of the config module
@@ -336,7 +337,7 @@ class ElasticTransformDump(object):
         es_search = self.create_request(
             filters, self.es_client,
             request_config,
-            post_filter=False)
+            post_filter=False, index=index)
         # Add a total_size aggregate to the ElasticSearch request
         es_search.aggs.metric(
             'total_size',
@@ -363,9 +364,14 @@ class ElasticTransformDump(object):
         es_search.aggs['by_type'].metric('size_by_type', 'sum', field=request_config['translation']['fileSize'])
         # Override the aggregates for Samples,
         # Primary site count, and project count
+        if index == "AZUL_SPECIMEN_INDEX":
+            type_id, type_count = ['fileId', 'fileCount']
+        elif index == "AZUL_FILE_INDEX":
+            type_id, type_count = ['specimenId', 'specimenCount']
+        else:
+            assert False
         for field, agg_name in (
-                ('specimenId',
-                 'specimenCount'),
+                (type_id, type_count),
                 ('organ', 'organCount'),
                 ('donorId', 'donorCount'),
                 ('lab', 'labCount'),

--- a/src/azul/service/responseobjects/hca_response_v5.py
+++ b/src/azul/service/responseobjects/hca_response_v5.py
@@ -280,25 +280,25 @@ class SummaryResponse(AbstractResponse):
         _organ_group = raw_response['aggregations']['group_by_organ']
     
         # Create a SummaryRepresentation object
-        self.apiResponse = SummaryRepresentation(
-            fileCount=hits['total'],
-            specimenCount=self.agg_contents(
-                aggregates, 'specimenCount', agg_form='value'),
-            projectCount=self.agg_contents(
-                aggregates, 'projectCode', agg_form='value'),
-            totalFileSize=self.agg_contents(
-                aggregates, 'total_size', agg_form='value'),
-            organCount=self.agg_contents(
-                aggregates, 'organCount', agg_form='value'),
-            donorCount=self.agg_contents(
-                aggregates, 'donorCount', agg_form='value'),
-            labCount=self.agg_contents(
-                aggregates, 'labCount', agg_form='value'),
-            totalCellCount=self.agg_contents(
-                aggregates, 'total_cell_count', agg_form='value'),
+        kwargs = dict(
+            projectCount=self.agg_contents(aggregates, 'projectCode', agg_form='value'),
+            totalFileSize=self.agg_contents(aggregates, 'total_size', agg_form='value'),
+            organCount=self.agg_contents(aggregates, 'organCount', agg_form='value'),
+            donorCount=self.agg_contents(aggregates, 'donorCount', agg_form='value'),
+            labCount=self.agg_contents(aggregates, 'labCount', agg_form='value'),
+            totalCellCount=self.agg_contents(aggregates, 'total_cell_count', agg_form='value'),
             fileTypeSummaries=[FileTypeSummary.create_object(bucket) for bucket in _sum['buckets']],
-            organSummaries=[OrganCellCountSummary.create_object(bucket) for bucket in _organ_group['buckets']]
-        )
+            organSummaries=[OrganCellCountSummary.create_object(bucket) for bucket in _organ_group['buckets']])
+
+        if 'specimenCount' in aggregates:
+            kwargs['fileCount'] = hits['total']
+            kwargs['specimenCount'] = self.agg_contents(aggregates, 'specimenCount', agg_form='value')
+        elif 'fileCount' in aggregates:
+            kwargs['specimenCount'] = hits['total']
+            kwargs['fileCount'] = self.agg_contents(aggregates, 'fileCount', agg_form='value')
+        else:
+            assert False
+        self.apiResponse = SummaryRepresentation(**kwargs)
 
 
 class KeywordSearchResponse(AbstractResponse, EntryFetcher):

--- a/test/service/test_response.py
+++ b/test/service/test_response.py
@@ -101,7 +101,7 @@ class TestResponse(WebServiceTestCase):
         self.assertEqual(json_test, json_response)
 
     def test_summary_endpoint(self):
-        url = self.base_url + "repository/files/summary"
+        url = self.base_url + "repository/summary/files"
         response = requests.get(url)
         response.raise_for_status()
         summary_object = response.json()


### PR DESCRIPTION

* Route `/repository/files/summary` changed to '/repository/summary/{entity_type}` where entity type is `specimens` or `files` exclusively
* Modified test correlated to the `files/summary` endpoint.
* Modified instructions describing the endpoints.