### PR TITLE
Deprecate indexer dss endpoint patch

### DIFF
--- a/test/indexer/__init__.py
+++ b/test/indexer/__init__.py
@@ -21,21 +21,9 @@ class IndexerTestCase(ElasticsearchTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls._old_dss_endpoint = os.environ.get('AZUL_DSS_ENDPOINT')
-        # FIXME: https://github.com/DataBiosphere/azul/issues/134
-        # FIXME: deprecate use of production server in favor of local, farm-to-table data files
-        os.environ['AZUL_DSS_ENDPOINT'] = "https://dss.data.humancellatlas.org/v1"
         cls.index_properties = IndexProperties(dss_url=config.dss_endpoint,
                                                es_endpoint=config.es_endpoint)
         cls.hca_indexer = Indexer(cls.index_properties)
-
-    @classmethod
-    def tearDownClass(cls):
-        if cls._old_dss_endpoint is None:
-            del os.environ['AZUL_DSS_ENDPOINT']
-        else:
-            os.environ['AZUL_DSS_ENDPOINT'] = cls._old_dss_endpoint
-        super().tearDownClass()
 
     def _make_fake_notification(self, uuid: str, version: str) -> Mapping[str, Any]:
         return {

--- a/test/indexer/test_projects.py
+++ b/test/indexer/test_projects.py
@@ -18,30 +18,15 @@ class TestDataExtractorTestCase(IndexerTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.test_bundles = {
-            "https://dss.dev.data.humancellatlas.org/v1": [],
-            "https://dss.integration.data.humancellatlas.org/v1": [("23e25ba4-094c-40ff-80b3-12861961a244", "2018-04-12T112557.587946Z")],
-            "https://dss.staging.data.humancellatlas.org/v1": [],
-            "https://dss.data.humancellatlas.org/v1": [("17a3d288-01a0-464a-9599-7375fda3353d", "2018-03-28T151023.074974Z"),
-                                                       ("2a87dc5c-0c3c-4d91-a348-5d784ab48b92", "2018-03-29T104041.822717Z"),
-                                                       ("4afbb0ea-81ad-49dc-9b12-9f77f4f50be8", "2018-03-29T090403.442059Z"),
-                                                       ("aee55415-d128-4b30-9644-e6b2742fa32b", "2018-03-29T152812.404846Z"),
-                                                       ("b0850e79-5544-49fe-b54d-e29b9fc3f61f", "2018-03-29T090340.934358Z"),
-                                                       ("c94a43f9-257f-4cd0-b2fe-eaf6d5d37d18", "2018-03-29T090343.782253Z")]
-        }
-        cls.test_same_ids_different_bundles = {
-            "https://dss.dev.data.humancellatlas.org/v1": [],
-            "https://dss.integration.data.humancellatlas.org/v1": [],
-            "https://dss.staging.data.humancellatlas.org/v1": [],
-            "https://dss.data.humancellatlas.org/v1": [("b2216048-7eaa-45f4-8077-5a3fb4204953", "2018-03-29T142048.835519Z"),
-                                                       ("ddb8f660-1160-4f6c-9ce4-c25664ac62c9", "2018-03-29T142057.907086Z")]
-        }
-        cls.test_duplicates_bundles = {
-            "https://dss.dev.data.humancellatlas.org/v1": [],
-            "https://dss.integration.data.humancellatlas.org/v1": [],
-            "https://dss.staging.data.humancellatlas.org/v1": [],
-            "https://dss.data.humancellatlas.org/v1": [("8543d32f-4c01-48d5-a79f-1c5439659da3", "2018-03-29T143828.884167Z")]
-        }
+        cls.production_test_bundles = [("17a3d288-01a0-464a-9599-7375fda3353d", "2018-03-28T151023.074974Z"),
+                                       ("2a87dc5c-0c3c-4d91-a348-5d784ab48b92", "2018-03-29T104041.822717Z"),
+                                       ("4afbb0ea-81ad-49dc-9b12-9f77f4f50be8", "2018-03-29T090403.442059Z"),
+                                       ("aee55415-d128-4b30-9644-e6b2742fa32b", "2018-03-29T152812.404846Z"),
+                                       ("b0850e79-5544-49fe-b54d-e29b9fc3f61f", "2018-03-29T090340.934358Z"),
+                                       ("c94a43f9-257f-4cd0-b2fe-eaf6d5d37d18", "2018-03-29T090343.782253Z")]
+        cls.test_same_ids_different_bundles = [("b2216048-7eaa-45f4-8077-5a3fb4204953", "2018-03-29T142048.835519Z"),
+                                               ("ddb8f660-1160-4f6c-9ce4-c25664ac62c9", "2018-03-29T142057.907086Z")]
+        cls.test_duplicate_bundle = ("8543d32f-4c01-48d5-a79f-1c5439659da3", "2018-03-29T143828.884167Z")
         cls.es_client = ESClientFactory.get()
 
     @classmethod
@@ -49,8 +34,7 @@ class TestDataExtractorTestCase(IndexerTestCase):
         super().tearDownClass()
 
     def test_hca_extraction(self):
-        for bundle_uuid, bundle_version in self.test_bundles[config.dss_endpoint]:
-            bundle_pack = (bundle_uuid, bundle_version)
+        for bundle_pack in self.production_test_bundles:
             self._mock_index(bundle_pack)
 
         @eventually(5.0, 0.5)
@@ -67,9 +51,7 @@ class TestDataExtractorTestCase(IndexerTestCase):
     # When two processes point at a file (this is the case for most files in production)
     # there is a bug where the files index contains duplicate dictionaries for the file.
     def test_no_duplicate_files_in_specimen(self):
-        bundle_uuid, bundle_version = self.test_duplicates_bundles[config.dss_endpoint][0]
-        bundle_pack = (bundle_uuid, bundle_version)
-        self._mock_index(bundle_pack)
+        self._mock_index(self.test_duplicate_bundle)
         results = self.es_client.get(
             index=config.es_index_name('specimens'),
             id='b3623b88-c369-46c9-a2e9-a16042d2c589')


### PR DESCRIPTION
Closing #134 eliminated all indexer URL references in exchange for local canned files. We don't need this patch anymore.