### PR TITLE
Feature/achave11/251 cast to integer

### DIFF
--- a/src/azul/service/responseobjects/hca_response_v5.py
+++ b/src/azul/service/responseobjects/hca_response_v5.py
@@ -84,7 +84,7 @@ class FileTypeSummary(JsonObject):
     def _create_object_with_bucket(cls, bucket):
         new_object = cls()
         new_object.count = bucket['doc_count']
-        new_object.totalSize = bucket['size_by_type']['value']
+        new_object.totalSize = int(bucket['size_by_type']['value'])  # Casting to integer since ES returns a double
         new_object.fileType = bucket['key']
         return new_object
 

--- a/test/service/__init__.py
+++ b/test/service/__init__.py
@@ -21,4 +21,3 @@ class WebServiceTestCase(ElasticsearchTestCase, LocalAppTestCase):
     def tearDownClass(cls):
         cls._data_loader.clean_up()
         super().tearDownClass()
-

--- a/test/service/data/response_filesearch_output1.json
+++ b/test/service/data/response_filesearch_output1.json
@@ -8,14 +8,11 @@
         }
       ],
       "entryId": "08d3440a-7481-41c5-5140-e15ed269ea63",
-      "files": [
+      "fileTypeSummaries": [
         {
-          "format": "csv",
-          "name": "billion.key",
-          "sha1": "fc5923256fb9dd349698d29228246a5c94653e80",
-          "size": 6667,
-          "uuid": "e9772583-4240-4757-6357-32bef0e51150",
-          "version": "2001-03-16T05:26:40"
+          "count": 1,
+          "fileType": "csv",
+          "totalSize": 6667
         }
       ],
       "processes": [

--- a/test/service/data/response_filesearch_output2.json
+++ b/test/service/data/response_filesearch_output2.json
@@ -8,14 +8,11 @@
         }
       ],
       "entryId": "08d3440a-7481-41c5-5140-e15ed269ea63",
-      "files": [
+      "fileTypeSummaries": [
         {
-          "format": "csv",
-          "name": "billion.key",
-          "sha1": "fc5923256fb9dd349698d29228246a5c94653e80",
-          "size": 6667,
-          "uuid": "e9772583-4240-4757-6357-32bef0e51150",
-          "version": "2001-03-16T05:26:40"
+          "count": 1,
+          "fileType": "csv",
+          "totalSize": 6667
         }
       ],
       "processes": [

--- a/test/service/data/response_keysearch_output.json
+++ b/test/service/data/response_keysearch_output.json
@@ -8,14 +8,11 @@
         }
       ],
       "entryId": "08d3440a-7481-41c5-5140-e15ed269ea63",
-      "files": [
+      "fileTypeSummaries": [
         {
-          "format": "csv",
-          "name": "billion.key",
-          "sha1": "fc5923256fb9dd349698d29228246a5c94653e80",
-          "size": 6667,
-          "uuid": "e9772583-4240-4757-6357-32bef0e51150",
-          "version": "2001-03-16T05:26:40"
+          "count": 1,
+          "fileType": "csv",
+          "totalSize": 6667
         }
       ],
       "processes": [

--- a/test/service/data_generator/fake_data_utils.py
+++ b/test/service/data_generator/fake_data_utils.py
@@ -43,7 +43,7 @@ class FakerSchemaGenerator(object):
 
 
 class ElasticsearchFakeDataLoader(object):
-    test_index_name = config.es_index_name('files')
+    indices = [config.es_index_name('files'), config.es_index_name('specimens')]
 
     def __init__(self, number_of_documents=1000, azul_es_endpoint=None):
 
@@ -56,31 +56,26 @@ class ElasticsearchFakeDataLoader(object):
         self.elasticsearch_client = elasticsearch5.Elasticsearch(hosts=[self.azul_es_url], port=9200)
         self.number_of_documents = number_of_documents
 
-    def load_data(self, will_clean_up=True):
-        logger.log(logging.INFO, f"Deleting leftover data in test index "
-                                 f"'{self.test_index_name}' at\n{self.azul_es_url}.")
-
-        if will_clean_up:
-            self.clean_up()
-
+    def load_data(self):
+        self.clean_up()
         try:
-            self.elasticsearch_client.indices.delete(index=self.test_index_name)
+            for index in self.indices:
+                logger.log(logging.INFO, f"Creating new test index '{index}'.")
+                self.elasticsearch_client.indices.create(index)
+                logger.log(logging.INFO, f"Loading data into test index '{index}'.")
+                faker = FakerSchemaGenerator()
+                fake_data_body = ""
+                for i in range(self.number_of_documents):
+                    fake_data_body += json.dumps({"index": {"_type": "meta", "_id": i}}) + "\n"
+                    fake_data_body += json.dumps(faker.generate_fake(self.doc_template)) + "\n"
+                self.elasticsearch_client.bulk(fake_data_body, index=index, doc_type='meta', refresh='wait_for')
         except elasticsearch5.exceptions.NotFoundError:
-            logger.log(logging.DEBUG, f"The index {self.test_index_name} doesn't exist yet. Skipping clean up.")
-
-        logger.log(logging.INFO, f"Creating new test index '{self.test_index_name}' at\n{self.azul_es_url}.")
-        self.elasticsearch_client.indices.create(self.test_index_name)
-
-        logger.log(logging.INFO, f"Loading data into test index '{self.test_index_name}' at\n{self.azul_es_url}.")
-        faker = FakerSchemaGenerator()
-        fake_data_body = ""
-        for i in range(self.number_of_documents):
-            fake_data_body += json.dumps({"index": {"_type": "meta", "_id": i}}) + "\n"
-            fake_data_body += json.dumps(faker.generate_fake(self.doc_template)) + "\n"
-        self.elasticsearch_client.bulk(fake_data_body, index=self.test_index_name, doc_type='meta', refresh='wait_for')
+            logger.log(logging.DEBUG, f"The index {index} doesn't exist yet.")
 
     def clean_up(self):
+        logger.log(logging.INFO, "Deleting leftover data in test indices")
         try:
-            self.elasticsearch_client.indices.delete(index=self.test_index_name)
+            for index in self.indices:
+                self.elasticsearch_client.indices.delete(index=index)
         except elasticsearch5.exceptions.NotFoundError:
-            logger.log(logging.DEBUG, f"The index {self.test_index_name} doesn't exist yet. Skipping clean up.")
+            logger.log(logging.DEBUG, f"The index {index} doesn't exist yet.")

--- a/test/service/test_repository_specimen.py
+++ b/test/service/test_repository_specimen.py
@@ -1,0 +1,31 @@
+import requests
+
+from service import WebServiceTestCase
+
+
+class RepositorySpecimenEndpointTest(WebServiceTestCase):
+
+    def test_basic_response(self):
+        url = self.base_url + "repository/specimens"
+        response = requests.get(url)
+        response.raise_for_status()
+        response_json = response.json()
+
+        def assert_file_type_summaries(hit):
+            self.assertEqual(len(hit['fileTypeSummaries']), 1)
+            self.assertTrue('fileType' in hit['fileTypeSummaries'][0])
+            self.assertGreater(hit['fileTypeSummaries'][0]['count'], 0)
+            self.assertGreater(hit['fileTypeSummaries'][0]['totalSize'], 0)
+
+        self.assertTrue('hits' in response_json)
+        self.assertGreater(len(response_json['hits']), 0)
+        for hit in response_json['hits']:
+            self.assertTrue('processes' in hit)
+            self.assertTrue('entryId' in hit)
+            assert_file_type_summaries(hit)
+            self.assertTrue('projects' in hit)
+            self.assertTrue('specimens' in hit)
+            self.assertTrue('bundles' in hit)
+            self.assertFalse('files' in hit)
+        self.assertTrue('pagination' in response_json)
+        self.assertTrue('termFacets' in response_json)

--- a/test/service/test_request_validation.py
+++ b/test/service/test_request_validation.py
@@ -4,7 +4,7 @@ import logging
 from unittest import mock
 import requests
 
-from azul import Config as AzulConfig
+from azul import config
 from service import WebServiceTestCase
 
 log = logging.getLogger(__name__)
@@ -34,7 +34,7 @@ class FacetNameValidationTest(WebServiceTestCase):
         expected_json = {
             'status': 'UP',
             'elasticsearch': {
-                'domain': AzulConfig().es_domain,
+                'domain': config.es_domain,
                 'status': 'UP'
             }
         }
@@ -48,7 +48,7 @@ class FacetNameValidationTest(WebServiceTestCase):
             expected_json = {
                 'status': 'UP',
                 'elasticsearch': {
-                    'domain': AzulConfig().es_domain,
+                    'domain': config.es_domain,
                     'message': 'Unable to reach the host',
                     'status': 'DOWN'
                 }


### PR DESCRIPTION
Assigning totalSize to an integer. Since int is the assumed value through the system. Value needs to be cast since ElasticSearch returns a double value, and it is not congruent with our data type of the value. 