### PR TITLE
Change default sort criteria to specimenId (fixes #227)

### DIFF
--- a/lambdas/service/app.py
+++ b/lambdas/service/app.py
@@ -31,7 +31,7 @@ def _get_pagination(current_request):
     pagination = {
         "order": current_request.query_params.get('order', 'desc'),
         "size": int(current_request.query_params.get('size', ENTRIES_PER_PAGE)),
-        "sort": current_request.query_params.get('sort', 'entryId'),
+        "sort": current_request.query_params.get('sort', 'specimenId'),
     }
 
     sa = current_request.query_params.get('search_after')

--- a/test/service/test_response.py
+++ b/test/service/test_response.py
@@ -58,7 +58,7 @@ class TestResponse(WebServiceTestCase):
         response = requests.get(url)
         response.raise_for_status()
         summary_object = response.json()
-        self.assertEqual(summary_object['pagination']["sort"], "entryId")
+        self.assertEqual(summary_object['pagination']["sort"], "specimenId")
 
     def _load(self, filename):
         data_folder_filepath = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')


### PR DESCRIPTION
When no facets are selected, the sorting will default to the specimenId.
It was previously entityId, since this action uses the specimens index,
it is congruent to sort by the specimen field.