### PR TITLE
Project Tab Indexer r4

### DIFF
--- a/src/azul/project/hca/transformers.py
+++ b/src/azul/project/hca/transformers.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 import logging
-from typing import Any, List, Mapping, MutableMapping, Sequence, Set, Iterable
+from typing import Any, List, Mapping, MutableMapping, Sequence, Set
 
 from humancellatlas.data import metadata as api
 from humancellatlas.data.metadata import AgeRange
@@ -19,7 +19,7 @@ def _project_dict(bundle: api.Bundle) -> dict:
     project, *additional_projects = bundle.projects.values()
     reject(additional_projects, "Azul can currently only handle a single project per bundle")
 
-    laboratories = set()\
+    laboratories = set()
 
     # Extract the list of laboratories from contributors.
     # NOTE: This is for backward compatibility. The list of contact names and institutes

--- a/src/azul/project/hca/transformers.py
+++ b/src/azul/project/hca/transformers.py
@@ -30,6 +30,7 @@ def _project_dict(bundle: api.Bundle) -> dict:
 
     return {
         'project_title': project.project_title,
+        'project_description': project.project_description,
         'project_shortname': project.project_short_name,
         'laboratory': sorted(laboratories),
         'contributors': sorted(project.contributors, key=lambda contributor: contributor.email.lower() if contributor.email else None),

--- a/src/azul/project/hca/transformers.py
+++ b/src/azul/project/hca/transformers.py
@@ -36,8 +36,8 @@ def _project_dict(bundle: api.Bundle) -> dict:
         'laboratory': sorted(laboratories),
         'contributors': sorted(contributors),
         'document_id': project.document_id,
-        # 'contact': _project_contact_dict(project.contributors),
-        # 'publications': sorted(project.publications),
+        'contact': _project_contact_dict(project.contributors),
+        'publications': sorted(project.publications),
         '_type': 'project'
     }
 

--- a/test/indexer/data/56a338fe-7554-4b5d-96a2-7df127a7640b.metadata.json
+++ b/test/indexer/data/56a338fe-7554-4b5d-96a2-7df127a7640b.metadata.json
@@ -194,13 +194,28 @@
     },
     "project.json": {
         "content": {
-            "describedBy": "https://schema.humancellatlas.org/type/project/5.1.0/project",
+            "describedBy": "https://schema.humancellatlas.org/type/project/9.0.0/project",
             "project_core": {
                 "project_shortname": "Mouse Melanoma",
                 "project_description": "The cancer microenvironment is a complex ecosystem characterized by dynamic interactions between diverse cell types, including malignant, immune and stromal cells. Here, we performed single-cell RNA sequencing on CD45+ and CD45- cells isolated from tumour and lymph nodes during a mouse model of melanoma. The transcriptional profiles of these individual cells taken at different time points coupled with assembled T cell receptor sequences, allowed us to identify distinct immune subpopulations and delineate their developmental trajectory. Our study provides insights into the complex interplay among cells within the tumour microenvironment and presents a valuable resource for future translational applications.",
                 "project_title": "Melanoma infiltration of stromal and immune cells"
             },
-            "publications": [],
+            "publications": [
+                {
+                    "describedBy": "http://schema.humancellatlas.org/module/project/5.2.2/publication",
+                    "authors": [
+                        "Katrina Meeth",
+                        "Jake Wang",
+                        "Goran Micevic",
+                        "William Damsky",
+                        "Marcus W. Bosenberg"
+                    ],
+                    "publication_title": "The YUMM lines: a series of congenic mouse melanoma cell lines with defined genetic alterations",
+                    "doi": "10.1111/pcmr.12498",
+                    "pmid": 5331933,
+                    "publication_url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5331933/"
+                }
+            ],
             "contributors": [
                 {
                     "country": "UK",

--- a/test/indexer/data/56a338fe-7554-4b5d-96a2-7df127a7640b.metadata.json
+++ b/test/indexer/data/56a338fe-7554-4b5d-96a2-7df127a7640b.metadata.json
@@ -223,7 +223,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Sarah,A,Teichmann",
-                    "email": "st9@sanger.ac.uk"
+                    "email": "st9@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -231,7 +232,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Mirjana,,Efremova",
-                    "email": "me5@sanger.ac.uk"
+                    "email": "me5@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -239,7 +241,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Bidesh,,Mahata",
-                    "email": "bm11@sanger.ac.uk"
+                    "email": "bm11@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -247,7 +250,8 @@
                     "address": "Box 197, Cambridge Biomedical Campus, Cambridge, CB2 0XZ",
                     "laboratory": "MRC Cancer Unit",
                     "contact_name": "Jacqueline,D,Shields",
-                    "email": "JS970@MRCCU.cam.ac.uk"
+                    "email": "JS970@MRCCU.cam.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -255,13 +259,15 @@
                     "address": "Box 197, Cambridge Biomedical Campus, Cambridge, CB2 0XZ",
                     "laboratory": "MRC Cancer Unit",
                     "contact_name": "Sarah,,Davidson",
-                    "email": "SED49@MRCCU.cam.ac.uk"
+                    "email": "SED49@MRCCU.cam.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "Germany",
                     "contact_name": "Angela,,Riedel",
                     "email": "a.riedel@dkfz-heidelberg.de",
-                    "institution": "DKFZ German Cancer Research Center"
+                    "institution": "DKFZ German Cancer Research Center",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -269,7 +275,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Roser,,Veno-Tormo",
-                    "email": "rv4@sanger.ac.uk"
+                    "email": "rv4@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -277,7 +284,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Jhuma,,Pramanik",
-                    "email": "jp19@sanger.ac.uk"
+                    "email": "jp19@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -285,13 +293,15 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Gozde,,Kar",
-                    "email": "gkar@ebi.ac.uk"
+                    "email": "gkar@ebi.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "Finland",
                     "contact_name": "Jani,,Huuhtanen",
                     "email": "jani.huuhtanen@helsinki.fi",
-                    "institution": "University of Helsinki"
+                    "institution": "University of Helsinki",
+                    "corresponding_contributor": true
                 }
             ],
             "schema_type": "project"

--- a/test/indexer/data/8543d32f-4c01-48d5-a79f-1c5439659da3.metadata.json
+++ b/test/indexer/data/8543d32f-4c01-48d5-a79f-1c5439659da3.metadata.json
@@ -30,7 +30,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Sarah,A,Teichmann",
-                    "email": "st9@sanger.ac.uk"
+                    "email": "st9@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -38,7 +39,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Mirjana,,Efremova",
-                    "email": "me5@sanger.ac.uk"
+                    "email": "me5@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -46,7 +48,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Bidesh,,Mahata",
-                    "email": "bm11@sanger.ac.uk"
+                    "email": "bm11@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -54,7 +57,8 @@
                     "address": "Box 197, Cambridge Biomedical Campus, Cambridge, CB2 0XZ",
                     "laboratory": "MRC Cancer Unit",
                     "contact_name": "Jacqueline,D,Shields",
-                    "email": "JS970@MRCCU.cam.ac.uk"
+                    "email": "JS970@MRCCU.cam.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -62,13 +66,15 @@
                     "address": "Box 197, Cambridge Biomedical Campus, Cambridge, CB2 0XZ",
                     "laboratory": "MRC Cancer Unit",
                     "contact_name": "Sarah,,Davidson",
-                    "email": "SED49@MRCCU.cam.ac.uk"
+                    "email": "SED49@MRCCU.cam.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "Germany",
                     "contact_name": "Angela,,Riedel",
                     "email": "a.riedel@dkfz-heidelberg.de",
-                    "institution": "DKFZ German Cancer Research Center"
+                    "institution": "DKFZ German Cancer Research Center",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -76,7 +82,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Roser,,Veno-Tormo",
-                    "email": "rv4@sanger.ac.uk"
+                    "email": "rv4@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -84,7 +91,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Jhuma,,Pramanik",
-                    "email": "jp19@sanger.ac.uk"
+                    "email": "jp19@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -92,13 +100,15 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Gozde,,Kar",
-                    "email": "gkar@ebi.ac.uk"
+                    "email": "gkar@ebi.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "Finland",
                     "contact_name": "Jani,,Huuhtanen",
                     "email": "jani.huuhtanen@helsinki.fi",
-                    "institution": "University of Helsinki"
+                    "institution": "University of Helsinki",
+                    "corresponding_contributor": true
                 }
             ],
             "schema_type": "project"

--- a/test/indexer/data/8543d32f-4c01-48d5-a79f-1c5439659da3.metadata.json
+++ b/test/indexer/data/8543d32f-4c01-48d5-a79f-1c5439659da3.metadata.json
@@ -7,7 +7,22 @@
                 "project_description": "The cancer microenvironment is a complex ecosystem characterized by dynamic interactions between diverse cell types, including malignant, immune and stromal cells. Here, we performed single-cell RNA sequencing on CD45+ and CD45- cells isolated from tumour and lymph nodes during a mouse model of melanoma. The transcriptional profiles of these individual cells taken at different time points coupled with assembled T cell receptor sequences, allowed us to identify distinct immune subpopulations and delineate their developmental trajectory. Our study provides insights into the complex interplay among cells within the tumour microenvironment and presents a valuable resource for future translational applications.",
                 "project_title": "Melanoma infiltration of stromal and immune cells"
             },
-            "publications": [],
+            "publications": [
+                {
+                    "describedBy": "http://schema.humancellatlas.org/module/project/5.2.2/publication",
+                    "authors": [
+                        "Katrina Meeth",
+                        "Jake Wang",
+                        "Goran Micevic",
+                        "William Damsky",
+                        "Marcus W. Bosenberg"
+                    ],
+                    "publication_title": "The YUMM lines: a series of congenic mouse melanoma cell lines with defined genetic alterations",
+                    "doi": "10.1111/pcmr.12498",
+                    "pmid": 5331933,
+                    "publication_url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5331933/"
+                }
+            ],
             "contributors": [
                 {
                     "country": "UK",

--- a/test/indexer/data/9dec1bd6-ced8-448a-8e45-1fc7846d8995.metadata.json
+++ b/test/indexer/data/9dec1bd6-ced8-448a-8e45-1fc7846d8995.metadata.json
@@ -1,7 +1,7 @@
 {
     "project.json": {
         "content": {
-            "describedBy": "https://schema.humancellatlas.org/type/project/5.1.0/project",
+            "describedBy": "https://schema.humancellatlas.org/type/project/9.0.0/project",
             "project_core": {
                 "project_shortname": "Mouse Melanoma",
                 "project_description": "The cancer microenvironment is a complex ecosystem characterized by dynamic interactions between diverse cell types, including malignant, immune and stromal cells. Here, we performed single-cell RNA sequencing on CD45+ and CD45- cells isolated from tumour and lymph nodes during a mouse model of melanoma. The transcriptional profiles of these individual cells taken at different time points coupled with assembled T cell receptor sequences, allowed us to identify distinct immune subpopulations and delineate their developmental trajectory. Our study provides insights into the complex interplay among cells within the tumour microenvironment and presents a valuable resource for future translational applications.",

--- a/test/indexer/data/9dec1bd6-ced8-448a-8e45-1fc7846d8995.metadata.json
+++ b/test/indexer/data/9dec1bd6-ced8-448a-8e45-1fc7846d8995.metadata.json
@@ -30,7 +30,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Sarah,A,Teichmann",
-                    "email": "st9@sanger.ac.uk"
+                    "email": "st9@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -38,7 +39,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Mirjana,,Efremova",
-                    "email": "me5@sanger.ac.uk"
+                    "email": "me5@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -46,7 +48,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Bidesh,,Mahata",
-                    "email": "bm11@sanger.ac.uk"
+                    "email": "bm11@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -54,7 +57,8 @@
                     "address": "Box 197, Cambridge Biomedical Campus, Cambridge, CB2 0XZ",
                     "laboratory": "MRC Cancer Unit",
                     "contact_name": "Jacqueline,D,Shields",
-                    "email": "JS970@MRCCU.cam.ac.uk"
+                    "email": "JS970@MRCCU.cam.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -62,13 +66,15 @@
                     "address": "Box 197, Cambridge Biomedical Campus, Cambridge, CB2 0XZ",
                     "laboratory": "MRC Cancer Unit",
                     "contact_name": "Sarah,,Davidson",
-                    "email": "SED49@MRCCU.cam.ac.uk"
+                    "email": "SED49@MRCCU.cam.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "Germany",
                     "contact_name": "Angela,,Riedel",
                     "email": "a.riedel@dkfz-heidelberg.de",
-                    "institution": "DKFZ German Cancer Research Center"
+                    "institution": "DKFZ German Cancer Research Center",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -76,7 +82,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Roser,,Veno-Tormo",
-                    "email": "rv4@sanger.ac.uk"
+                    "email": "rv4@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -84,7 +91,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Jhuma,,Pramanik",
-                    "email": "jp19@sanger.ac.uk"
+                    "email": "jp19@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -92,13 +100,15 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Gozde,,Kar",
-                    "email": "gkar@ebi.ac.uk"
+                    "email": "gkar@ebi.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "Finland",
                     "contact_name": "Jani,,Huuhtanen",
                     "email": "jani.huuhtanen@helsinki.fi",
-                    "institution": "University of Helsinki"
+                    "institution": "University of Helsinki",
+                    "corresponding_contributor": true
                 }
             ],
             "schema_type": "project"

--- a/test/indexer/data/9dec1bd6-ced8-448a-8e45-1fc7846d8995.metadata.json
+++ b/test/indexer/data/9dec1bd6-ced8-448a-8e45-1fc7846d8995.metadata.json
@@ -7,7 +7,22 @@
                 "project_description": "The cancer microenvironment is a complex ecosystem characterized by dynamic interactions between diverse cell types, including malignant, immune and stromal cells. Here, we performed single-cell RNA sequencing on CD45+ and CD45- cells isolated from tumour and lymph nodes during a mouse model of melanoma. The transcriptional profiles of these individual cells taken at different time points coupled with assembled T cell receptor sequences, allowed us to identify distinct immune subpopulations and delineate their developmental trajectory. Our study provides insights into the complex interplay among cells within the tumour microenvironment and presents a valuable resource for future translational applications.",
                 "project_title": "Melanoma infiltration of stromal and immune cells"
             },
-            "publications": [],
+            "publications": [
+                {
+                    "describedBy": "http://schema.humancellatlas.org/module/project/5.2.2/publication",
+                    "authors": [
+                        "Katrina Meeth",
+                        "Jake Wang",
+                        "Goran Micevic",
+                        "William Damsky",
+                        "Marcus W. Bosenberg"
+                    ],
+                    "publication_title": "The YUMM lines: a series of congenic mouse melanoma cell lines with defined genetic alterations",
+                    "doi": "10.1111/pcmr.12498",
+                    "pmid": 5331933,
+                    "publication_url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5331933/"
+                }
+            ],
             "contributors": [
                 {
                     "country": "UK",

--- a/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.files.results.json
+++ b/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.files.results.json
@@ -124,6 +124,7 @@
                                 ],
                                 "project": {
                                     "project_title": "Melanoma infiltration of stromal and immune cells",
+                                    "project_description": "The cancer microenvironment is a complex ecosystem characterized by dynamic interactions between diverse cell types, including malignant, immune and stromal cells. Here, we performed single-cell RNA sequencing on CD45+ and CD45- cells isolated from tumour and lymph nodes during a mouse model of melanoma. The transcriptional profiles of these individual cells taken at different time points coupled with assembled T cell receptor sequences, allowed us to identify distinct immune subpopulations and delineate their developmental trajectory. Our study provides insights into the complex interplay among cells within the tumour microenvironment and presents a valuable resource for future translational applications.",
                                     "project_shortname": "Mouse Melanoma",
                                     "laboratory": [
                                         "MRC Cancer Unit",
@@ -358,6 +359,7 @@
                                 ],
                                 "project": {
                                     "project_title": "Melanoma infiltration of stromal and immune cells",
+                                    "project_description": "The cancer microenvironment is a complex ecosystem characterized by dynamic interactions between diverse cell types, including malignant, immune and stromal cells. Here, we performed single-cell RNA sequencing on CD45+ and CD45- cells isolated from tumour and lymph nodes during a mouse model of melanoma. The transcriptional profiles of these individual cells taken at different time points coupled with assembled T cell receptor sequences, allowed us to identify distinct immune subpopulations and delineate their developmental trajectory. Our study provides insights into the complex interplay among cells within the tumour microenvironment and presents a valuable resource for future translational applications.",
                                     "project_shortname": "Mouse Melanoma",
                                     "laboratory": [
                                         "MRC Cancer Unit",

--- a/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.files.results.json
+++ b/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.files.results.json
@@ -137,7 +137,11 @@
                                         "University of Helsinki",
                                         "Wellcome Trust Sanger Institute"
                                     ],
-                                    "contact": null,
+                                    "contact": {
+                                        "contact_name": "Jani,,Huuhtanen",
+                                        "contact_email": "jani.huuhtanen@helsinki.fi",
+                                        "contact_institute": "University of Helsinki"
+                                    },
                                     "publications": [
                                         {
                                             "authors": [
@@ -287,7 +291,11 @@
                                         "University of Helsinki",
                                         "Wellcome Trust Sanger Institute"
                                     ],
-                                    "contact": null,
+                                    "contact": {
+                                        "contact_name": "Jani,,Huuhtanen",
+                                        "contact_email": "jani.huuhtanen@helsinki.fi",
+                                        "contact_institute": "University of Helsinki"
+                                    },
                                     "publications": [
                                         {
                                             "authors": [

--- a/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.files.results.json
+++ b/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.files.results.json
@@ -138,7 +138,21 @@
                                         "Wellcome Trust Sanger Institute"
                                     ],
                                     "contact": null,
-                                    "publications": [],
+                                    "publications": [
+                                        {
+                                            "authors": [
+                                                "Katrina Meeth",
+                                                "Jake Wang",
+                                                "Goran Micevic",
+                                                "William Damsky",
+                                                "Marcus W. Bosenberg"
+                                            ],
+                                            "publication_title": "The YUMM lines: a series of congenic mouse melanoma cell lines with defined genetic alterations",
+                                            "doi": "10.1111/pcmr.12498",
+                                            "pmid": 5331933,
+                                            "publication_url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5331933/"
+                                        }
+                                    ],
                                     "_type": "project"
                                 }
                             }
@@ -274,7 +288,21 @@
                                         "Wellcome Trust Sanger Institute"
                                     ],
                                     "contact": null,
-                                    "publications": [],
+                                    "publications": [
+                                        {
+                                            "authors": [
+                                                "Katrina Meeth",
+                                                "Jake Wang",
+                                                "Goran Micevic",
+                                                "William Damsky",
+                                                "Marcus W. Bosenberg"
+                                            ],
+                                            "publication_title": "The YUMM lines: a series of congenic mouse melanoma cell lines with defined genetic alterations",
+                                            "doi": "10.1111/pcmr.12498",
+                                            "pmid": 5331933,
+                                            "publication_url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5331933/"
+                                        }
+                                    ],
                                     "_type": "project"
                                 }
                             }

--- a/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.files.results.json
+++ b/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.files.results.json
@@ -131,17 +131,97 @@
                                     ],
                                     "document_id": "93f6a42f-1790-4af4-b5d1-8c436cb6feae",
                                     "contributors": [
-                                        "DKFZ German Cancer Research Center",
-                                        "EMBL-EBI",
-                                        "University of Cambridge",
-                                        "University of Helsinki",
-                                        "Wellcome Trust Sanger Institute"
+                                        {
+                                            "contact_name": "Angela,,Riedel",
+                                            "corresponding_contributor": false,
+                                            "email": "a.riedel@dkfz-heidelberg.de",
+                                            "institution": "DKFZ German Cancer Research Center",
+                                            "laboratory": null,
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Bidesh,,Mahata",
+                                            "corresponding_contributor": false,
+                                            "email": "bm11@sanger.ac.uk",
+                                            "institution": "Wellcome Trust Sanger Institute",
+                                            "laboratory": "Sarah Teichmann",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Gozde,,Kar",
+                                            "corresponding_contributor": false,
+                                            "email": "gkar@ebi.ac.uk",
+                                            "institution": "EMBL-EBI",
+                                            "laboratory": "Sarah Teichmann",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Jani,,Huuhtanen",
+                                            "corresponding_contributor": true,
+                                            "email": "jani.huuhtanen@helsinki.fi",
+                                            "institution": "University of Helsinki",
+                                            "laboratory": null,
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Jhuma,,Pramanik",
+                                            "corresponding_contributor": false,
+                                            "email": "jp19@sanger.ac.uk",
+                                            "institution": "Wellcome Trust Sanger Institute",
+                                            "laboratory": "Sarah Teichmann",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Jacqueline,D,Shields",
+                                            "corresponding_contributor": false,
+                                            "email": "JS970@MRCCU.cam.ac.uk",
+                                            "institution": "University of Cambridge",
+                                            "laboratory": "MRC Cancer Unit",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Mirjana,,Efremova",
+                                            "corresponding_contributor": false,
+                                            "email": "me5@sanger.ac.uk",
+                                            "institution": "Wellcome Trust Sanger Institute",
+                                            "laboratory": "Sarah Teichmann",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Roser,,Veno-Tormo",
+                                            "corresponding_contributor": false,
+                                            "email": "rv4@sanger.ac.uk",
+                                            "institution": "Wellcome Trust Sanger Institute",
+                                            "laboratory": "Sarah Teichmann",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Sarah,,Davidson",
+                                            "corresponding_contributor": false,
+                                            "email": "SED49@MRCCU.cam.ac.uk",
+                                            "institution": "University of Cambridge",
+                                            "laboratory": "MRC Cancer Unit",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Sarah,A,Teichmann",
+                                            "corresponding_contributor": false,
+                                            "email": "st9@sanger.ac.uk",
+                                            "institution": "Wellcome Trust Sanger Institute",
+                                            "laboratory": "Sarah Teichmann",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        }
                                     ],
-                                    "contact": {
-                                        "contact_name": "Jani,,Huuhtanen",
-                                        "contact_email": "jani.huuhtanen@helsinki.fi",
-                                        "contact_institute": "University of Helsinki"
-                                    },
                                     "publications": [
                                         {
                                             "authors": [
@@ -285,17 +365,97 @@
                                     ],
                                     "document_id": "93f6a42f-1790-4af4-b5d1-8c436cb6feae",
                                     "contributors": [
-                                        "DKFZ German Cancer Research Center",
-                                        "EMBL-EBI",
-                                        "University of Cambridge",
-                                        "University of Helsinki",
-                                        "Wellcome Trust Sanger Institute"
+                                        {
+                                            "contact_name": "Angela,,Riedel",
+                                            "corresponding_contributor": false,
+                                            "email": "a.riedel@dkfz-heidelberg.de",
+                                            "institution": "DKFZ German Cancer Research Center",
+                                            "laboratory": null,
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Bidesh,,Mahata",
+                                            "corresponding_contributor": false,
+                                            "email": "bm11@sanger.ac.uk",
+                                            "institution": "Wellcome Trust Sanger Institute",
+                                            "laboratory": "Sarah Teichmann",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Gozde,,Kar",
+                                            "corresponding_contributor": false,
+                                            "email": "gkar@ebi.ac.uk",
+                                            "institution": "EMBL-EBI",
+                                            "laboratory": "Sarah Teichmann",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Jani,,Huuhtanen",
+                                            "corresponding_contributor": true,
+                                            "email": "jani.huuhtanen@helsinki.fi",
+                                            "institution": "University of Helsinki",
+                                            "laboratory": null,
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Jhuma,,Pramanik",
+                                            "corresponding_contributor": false,
+                                            "email": "jp19@sanger.ac.uk",
+                                            "institution": "Wellcome Trust Sanger Institute",
+                                            "laboratory": "Sarah Teichmann",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Jacqueline,D,Shields",
+                                            "corresponding_contributor": false,
+                                            "email": "JS970@MRCCU.cam.ac.uk",
+                                            "institution": "University of Cambridge",
+                                            "laboratory": "MRC Cancer Unit",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Mirjana,,Efremova",
+                                            "corresponding_contributor": false,
+                                            "email": "me5@sanger.ac.uk",
+                                            "institution": "Wellcome Trust Sanger Institute",
+                                            "laboratory": "Sarah Teichmann",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Roser,,Veno-Tormo",
+                                            "corresponding_contributor": false,
+                                            "email": "rv4@sanger.ac.uk",
+                                            "institution": "Wellcome Trust Sanger Institute",
+                                            "laboratory": "Sarah Teichmann",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Sarah,,Davidson",
+                                            "corresponding_contributor": false,
+                                            "email": "SED49@MRCCU.cam.ac.uk",
+                                            "institution": "University of Cambridge",
+                                            "laboratory": "MRC Cancer Unit",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Sarah,A,Teichmann",
+                                            "corresponding_contributor": false,
+                                            "email": "st9@sanger.ac.uk",
+                                            "institution": "Wellcome Trust Sanger Institute",
+                                            "laboratory": "Sarah Teichmann",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        }
                                     ],
-                                    "contact": {
-                                        "contact_name": "Jani,,Huuhtanen",
-                                        "contact_email": "jani.huuhtanen@helsinki.fi",
-                                        "contact_institute": "University of Helsinki"
-                                    },
                                     "publications": [
                                         {
                                             "authors": [

--- a/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.files.results.json
+++ b/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.files.results.json
@@ -137,6 +137,8 @@
                                         "University of Helsinki",
                                         "Wellcome Trust Sanger Institute"
                                     ],
+                                    "contact": null,
+                                    "publications": [],
                                     "_type": "project"
                                 }
                             }
@@ -271,6 +273,8 @@
                                         "University of Helsinki",
                                         "Wellcome Trust Sanger Institute"
                                     ],
+                                    "contact": null,
+                                    "publications": [],
                                     "_type": "project"
                                 }
                             }

--- a/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.metadata.json
+++ b/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.metadata.json
@@ -145,7 +145,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Sarah,A,Teichmann",
-                    "email": "st9@sanger.ac.uk"
+                    "email": "st9@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -153,7 +154,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Mirjana,,Efremova",
-                    "email": "me5@sanger.ac.uk"
+                    "email": "me5@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -161,7 +163,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Bidesh,,Mahata",
-                    "email": "bm11@sanger.ac.uk"
+                    "email": "bm11@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -169,7 +172,8 @@
                     "address": "Box 197, Cambridge Biomedical Campus, Cambridge, CB2 0XZ",
                     "laboratory": "MRC Cancer Unit",
                     "contact_name": "Jacqueline,D,Shields",
-                    "email": "JS970@MRCCU.cam.ac.uk"
+                    "email": "JS970@MRCCU.cam.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -177,13 +181,15 @@
                     "address": "Box 197, Cambridge Biomedical Campus, Cambridge, CB2 0XZ",
                     "laboratory": "MRC Cancer Unit",
                     "contact_name": "Sarah,,Davidson",
-                    "email": "SED49@MRCCU.cam.ac.uk"
+                    "email": "SED49@MRCCU.cam.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "Germany",
                     "contact_name": "Angela,,Riedel",
                     "email": "a.riedel@dkfz-heidelberg.de",
-                    "institution": "DKFZ German Cancer Research Center"
+                    "institution": "DKFZ German Cancer Research Center",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -191,7 +197,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Roser,,Veno-Tormo",
-                    "email": "rv4@sanger.ac.uk"
+                    "email": "rv4@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -199,7 +206,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Jhuma,,Pramanik",
-                    "email": "jp19@sanger.ac.uk"
+                    "email": "jp19@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -207,13 +215,15 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Gozde,,Kar",
-                    "email": "gkar@ebi.ac.uk"
+                    "email": "gkar@ebi.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "Finland",
                     "contact_name": "Jani,,Huuhtanen",
                     "email": "jani.huuhtanen@helsinki.fi",
-                    "institution": "University of Helsinki"
+                    "institution": "University of Helsinki",
+                    "corresponding_contributor": true
                 }
             ],
             "schema_type": "project"

--- a/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.metadata.json
+++ b/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.metadata.json
@@ -122,7 +122,22 @@
                 "project_description": "The cancer microenvironment is a complex ecosystem characterized by dynamic interactions between diverse cell types, including malignant, immune and stromal cells. Here, we performed single-cell RNA sequencing on CD45+ and CD45- cells isolated from tumour and lymph nodes during a mouse model of melanoma. The transcriptional profiles of these individual cells taken at different time points coupled with assembled T cell receptor sequences, allowed us to identify distinct immune subpopulations and delineate their developmental trajectory. Our study provides insights into the complex interplay among cells within the tumour microenvironment and presents a valuable resource for future translational applications.",
                 "project_title": "Melanoma infiltration of stromal and immune cells"
             },
-            "publications": [],
+            "publications": [
+                {
+                    "describedBy": "http://schema.humancellatlas.org/module/project/5.2.2/publication",
+                    "authors": [
+                        "Katrina Meeth",
+                        "Jake Wang",
+                        "Goran Micevic",
+                        "William Damsky",
+                        "Marcus W. Bosenberg"
+                    ],
+                    "publication_title": "The YUMM lines: a series of congenic mouse melanoma cell lines with defined genetic alterations",
+                    "doi": "10.1111/pcmr.12498",
+                    "pmid": 5331933,
+                    "publication_url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5331933/"
+                }
+            ],
             "contributors": [
                 {
                     "country": "UK",

--- a/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.projects.results.json
+++ b/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.projects.results.json
@@ -141,6 +141,7 @@
                                 ],
                                 "project": {
                                     "project_title": "Melanoma infiltration of stromal and immune cells",
+                                    "project_description": "The cancer microenvironment is a complex ecosystem characterized by dynamic interactions between diverse cell types, including malignant, immune and stromal cells. Here, we performed single-cell RNA sequencing on CD45+ and CD45- cells isolated from tumour and lymph nodes during a mouse model of melanoma. The transcriptional profiles of these individual cells taken at different time points coupled with assembled T cell receptor sequences, allowed us to identify distinct immune subpopulations and delineate their developmental trajectory. Our study provides insights into the complex interplay among cells within the tumour microenvironment and presents a valuable resource for future translational applications.",
                                     "project_shortname": "Mouse Melanoma",
                                     "laboratory": [
                                         "MRC Cancer Unit",

--- a/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.projects.results.json
+++ b/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.projects.results.json
@@ -154,6 +154,8 @@
                                         "Wellcome Trust Sanger Institute"
                                     ],
                                     "document_id": "93f6a42f-1790-4af4-b5d1-8c436cb6feae",
+                                    "contact": null,
+                                    "publications": [],
                                     "_type": "project"
                                 }
                             }

--- a/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.projects.results.json
+++ b/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.projects.results.json
@@ -154,7 +154,11 @@
                                         "Wellcome Trust Sanger Institute"
                                     ],
                                     "document_id": "93f6a42f-1790-4af4-b5d1-8c436cb6feae",
-                                    "contact": null,
+                                    "contact": {
+                                        "contact_name": "Jani,,Huuhtanen",
+                                        "contact_email": "jani.huuhtanen@helsinki.fi",
+                                        "contact_institute": "University of Helsinki"
+                                    },
                                     "publications": [
                                         {
                                             "authors": [

--- a/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.projects.results.json
+++ b/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.projects.results.json
@@ -147,18 +147,98 @@
                                         "Sarah Teichmann"
                                     ],
                                     "contributors": [
-                                        "DKFZ German Cancer Research Center",
-                                        "EMBL-EBI",
-                                        "University of Cambridge",
-                                        "University of Helsinki",
-                                        "Wellcome Trust Sanger Institute"
+                                        {
+                                            "contact_name": "Angela,,Riedel",
+                                            "corresponding_contributor": false,
+                                            "email": "a.riedel@dkfz-heidelberg.de",
+                                            "institution": "DKFZ German Cancer Research Center",
+                                            "laboratory": null,
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Bidesh,,Mahata",
+                                            "corresponding_contributor": false,
+                                            "email": "bm11@sanger.ac.uk",
+                                            "institution": "Wellcome Trust Sanger Institute",
+                                            "laboratory": "Sarah Teichmann",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Gozde,,Kar",
+                                            "corresponding_contributor": false,
+                                            "email": "gkar@ebi.ac.uk",
+                                            "institution": "EMBL-EBI",
+                                            "laboratory": "Sarah Teichmann",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Jani,,Huuhtanen",
+                                            "corresponding_contributor": true,
+                                            "email": "jani.huuhtanen@helsinki.fi",
+                                            "institution": "University of Helsinki",
+                                            "laboratory": null,
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Jhuma,,Pramanik",
+                                            "corresponding_contributor": false,
+                                            "email": "jp19@sanger.ac.uk",
+                                            "institution": "Wellcome Trust Sanger Institute",
+                                            "laboratory": "Sarah Teichmann",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Jacqueline,D,Shields",
+                                            "corresponding_contributor": false,
+                                            "email": "JS970@MRCCU.cam.ac.uk",
+                                            "institution": "University of Cambridge",
+                                            "laboratory": "MRC Cancer Unit",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Mirjana,,Efremova",
+                                            "corresponding_contributor": false,
+                                            "email": "me5@sanger.ac.uk",
+                                            "institution": "Wellcome Trust Sanger Institute",
+                                            "laboratory": "Sarah Teichmann",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Roser,,Veno-Tormo",
+                                            "corresponding_contributor": false,
+                                            "email": "rv4@sanger.ac.uk",
+                                            "institution": "Wellcome Trust Sanger Institute",
+                                            "laboratory": "Sarah Teichmann",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Sarah,,Davidson",
+                                            "corresponding_contributor": false,
+                                            "email": "SED49@MRCCU.cam.ac.uk",
+                                            "institution": "University of Cambridge",
+                                            "laboratory": "MRC Cancer Unit",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Sarah,A,Teichmann",
+                                            "corresponding_contributor": false,
+                                            "email": "st9@sanger.ac.uk",
+                                            "institution": "Wellcome Trust Sanger Institute",
+                                            "laboratory": "Sarah Teichmann",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        }
                                     ],
                                     "document_id": "93f6a42f-1790-4af4-b5d1-8c436cb6feae",
-                                    "contact": {
-                                        "contact_name": "Jani,,Huuhtanen",
-                                        "contact_email": "jani.huuhtanen@helsinki.fi",
-                                        "contact_institute": "University of Helsinki"
-                                    },
                                     "publications": [
                                         {
                                             "authors": [

--- a/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.projects.results.json
+++ b/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.projects.results.json
@@ -155,7 +155,21 @@
                                     ],
                                     "document_id": "93f6a42f-1790-4af4-b5d1-8c436cb6feae",
                                     "contact": null,
-                                    "publications": [],
+                                    "publications": [
+                                        {
+                                            "authors": [
+                                                "Katrina Meeth",
+                                                "Jake Wang",
+                                                "Goran Micevic",
+                                                "William Damsky",
+                                                "Marcus W. Bosenberg"
+                                            ],
+                                            "publication_title": "The YUMM lines: a series of congenic mouse melanoma cell lines with defined genetic alterations",
+                                            "doi": "10.1111/pcmr.12498",
+                                            "pmid": 5331933,
+                                            "publication_url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5331933/"
+                                        }
+                                    ],
                                     "_type": "project"
                                 }
                             }

--- a/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.specimens.results.json
+++ b/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.specimens.results.json
@@ -141,6 +141,7 @@
                                 ],
                                 "project": {
                                     "project_title": "Melanoma infiltration of stromal and immune cells",
+                                    "project_description": "The cancer microenvironment is a complex ecosystem characterized by dynamic interactions between diverse cell types, including malignant, immune and stromal cells. Here, we performed single-cell RNA sequencing on CD45+ and CD45- cells isolated from tumour and lymph nodes during a mouse model of melanoma. The transcriptional profiles of these individual cells taken at different time points coupled with assembled T cell receptor sequences, allowed us to identify distinct immune subpopulations and delineate their developmental trajectory. Our study provides insights into the complex interplay among cells within the tumour microenvironment and presents a valuable resource for future translational applications.",
                                     "project_shortname": "Mouse Melanoma",
                                     "laboratory": [
                                         "MRC Cancer Unit",

--- a/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.specimens.results.json
+++ b/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.specimens.results.json
@@ -154,7 +154,11 @@
                                         "University of Helsinki",
                                         "Wellcome Trust Sanger Institute"
                                     ],
-                                    "contact": null,
+                                    "contact": {
+                                        "contact_name": "Jani,,Huuhtanen",
+                                        "contact_email": "jani.huuhtanen@helsinki.fi",
+                                        "contact_institute": "University of Helsinki"
+                                    },
                                     "publications": [
                                         {
                                             "authors": [

--- a/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.specimens.results.json
+++ b/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.specimens.results.json
@@ -148,17 +148,97 @@
                                     ],
                                     "document_id": "93f6a42f-1790-4af4-b5d1-8c436cb6feae",
                                     "contributors": [
-                                        "DKFZ German Cancer Research Center",
-                                        "EMBL-EBI",
-                                        "University of Cambridge",
-                                        "University of Helsinki",
-                                        "Wellcome Trust Sanger Institute"
+                                        {
+                                            "contact_name": "Angela,,Riedel",
+                                            "corresponding_contributor": false,
+                                            "email": "a.riedel@dkfz-heidelberg.de",
+                                            "institution": "DKFZ German Cancer Research Center",
+                                            "laboratory": null,
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Bidesh,,Mahata",
+                                            "corresponding_contributor": false,
+                                            "email": "bm11@sanger.ac.uk",
+                                            "institution": "Wellcome Trust Sanger Institute",
+                                            "laboratory": "Sarah Teichmann",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Gozde,,Kar",
+                                            "corresponding_contributor": false,
+                                            "email": "gkar@ebi.ac.uk",
+                                            "institution": "EMBL-EBI",
+                                            "laboratory": "Sarah Teichmann",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Jani,,Huuhtanen",
+                                            "corresponding_contributor": true,
+                                            "email": "jani.huuhtanen@helsinki.fi",
+                                            "institution": "University of Helsinki",
+                                            "laboratory": null,
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Jhuma,,Pramanik",
+                                            "corresponding_contributor": false,
+                                            "email": "jp19@sanger.ac.uk",
+                                            "institution": "Wellcome Trust Sanger Institute",
+                                            "laboratory": "Sarah Teichmann",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Jacqueline,D,Shields",
+                                            "corresponding_contributor": false,
+                                            "email": "JS970@MRCCU.cam.ac.uk",
+                                            "institution": "University of Cambridge",
+                                            "laboratory": "MRC Cancer Unit",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Mirjana,,Efremova",
+                                            "corresponding_contributor": false,
+                                            "email": "me5@sanger.ac.uk",
+                                            "institution": "Wellcome Trust Sanger Institute",
+                                            "laboratory": "Sarah Teichmann",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Roser,,Veno-Tormo",
+                                            "corresponding_contributor": false,
+                                            "email": "rv4@sanger.ac.uk",
+                                            "institution": "Wellcome Trust Sanger Institute",
+                                            "laboratory": "Sarah Teichmann",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Sarah,,Davidson",
+                                            "corresponding_contributor": false,
+                                            "email": "SED49@MRCCU.cam.ac.uk",
+                                            "institution": "University of Cambridge",
+                                            "laboratory": "MRC Cancer Unit",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        },
+                                        {
+                                            "contact_name": "Sarah,A,Teichmann",
+                                            "corresponding_contributor": false,
+                                            "email": "st9@sanger.ac.uk",
+                                            "institution": "Wellcome Trust Sanger Institute",
+                                            "laboratory": "Sarah Teichmann",
+                                            "orcid_id": null,
+                                            "phone": null
+                                        }
                                     ],
-                                    "contact": {
-                                        "contact_name": "Jani,,Huuhtanen",
-                                        "contact_email": "jani.huuhtanen@helsinki.fi",
-                                        "contact_institute": "University of Helsinki"
-                                    },
                                     "publications": [
                                         {
                                             "authors": [

--- a/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.specimens.results.json
+++ b/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.specimens.results.json
@@ -155,7 +155,21 @@
                                         "Wellcome Trust Sanger Institute"
                                     ],
                                     "contact": null,
-                                    "publications": [],
+                                    "publications": [
+                                        {
+                                            "authors": [
+                                                "Katrina Meeth",
+                                                "Jake Wang",
+                                                "Goran Micevic",
+                                                "William Damsky",
+                                                "Marcus W. Bosenberg"
+                                            ],
+                                            "publication_title": "The YUMM lines: a series of congenic mouse melanoma cell lines with defined genetic alterations",
+                                            "doi": "10.1111/pcmr.12498",
+                                            "pmid": 5331933,
+                                            "publication_url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5331933/"
+                                        }
+                                    ],
                                     "_type": "project"
                                 }
                             }

--- a/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.specimens.results.json
+++ b/test/indexer/data/aee55415-d128-4b30-9644-e6b2742fa32b.specimens.results.json
@@ -154,6 +154,8 @@
                                         "University of Helsinki",
                                         "Wellcome Trust Sanger Institute"
                                     ],
+                                    "contact": null,
+                                    "publications": [],
                                     "_type": "project"
                                 }
                             }

--- a/test/indexer/data/b2216048-7eaa-45f4-8077-5a3fb4204953.metadata.json
+++ b/test/indexer/data/b2216048-7eaa-45f4-8077-5a3fb4204953.metadata.json
@@ -30,7 +30,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Sarah,A,Teichmann",
-                    "email": "st9@sanger.ac.uk"
+                    "email": "st9@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -38,7 +39,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Mirjana,,Efremova",
-                    "email": "me5@sanger.ac.uk"
+                    "email": "me5@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -46,7 +48,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Bidesh,,Mahata",
-                    "email": "bm11@sanger.ac.uk"
+                    "email": "bm11@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -54,7 +57,8 @@
                     "address": "Box 197, Cambridge Biomedical Campus, Cambridge, CB2 0XZ",
                     "laboratory": "MRC Cancer Unit",
                     "contact_name": "Jacqueline,D,Shields",
-                    "email": "JS970@MRCCU.cam.ac.uk"
+                    "email": "JS970@MRCCU.cam.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -62,13 +66,15 @@
                     "address": "Box 197, Cambridge Biomedical Campus, Cambridge, CB2 0XZ",
                     "laboratory": "MRC Cancer Unit",
                     "contact_name": "Sarah,,Davidson",
-                    "email": "SED49@MRCCU.cam.ac.uk"
+                    "email": "SED49@MRCCU.cam.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "Germany",
                     "contact_name": "Angela,,Riedel",
                     "email": "a.riedel@dkfz-heidelberg.de",
-                    "institution": "DKFZ German Cancer Research Center"
+                    "institution": "DKFZ German Cancer Research Center",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -76,7 +82,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Roser,,Veno-Tormo",
-                    "email": "rv4@sanger.ac.uk"
+                    "email": "rv4@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -84,7 +91,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Jhuma,,Pramanik",
-                    "email": "jp19@sanger.ac.uk"
+                    "email": "jp19@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -92,13 +100,15 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Gozde,,Kar",
-                    "email": "gkar@ebi.ac.uk"
+                    "email": "gkar@ebi.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "Finland",
                     "contact_name": "Jani,,Huuhtanen",
                     "email": "jani.huuhtanen@helsinki.fi",
-                    "institution": "University of Helsinki"
+                    "institution": "University of Helsinki",
+                    "corresponding_contributor": true
                 }
             ],
             "schema_type": "project"

--- a/test/indexer/data/b2216048-7eaa-45f4-8077-5a3fb4204953.metadata.json
+++ b/test/indexer/data/b2216048-7eaa-45f4-8077-5a3fb4204953.metadata.json
@@ -7,7 +7,22 @@
                 "project_description": "The cancer microenvironment is a complex ecosystem characterized by dynamic interactions between diverse cell types, including malignant, immune and stromal cells. Here, we performed single-cell RNA sequencing on CD45+ and CD45- cells isolated from tumour and lymph nodes during a mouse model of melanoma. The transcriptional profiles of these individual cells taken at different time points coupled with assembled T cell receptor sequences, allowed us to identify distinct immune subpopulations and delineate their developmental trajectory. Our study provides insights into the complex interplay among cells within the tumour microenvironment and presents a valuable resource for future translational applications.",
                 "project_title": "Melanoma infiltration of stromal and immune cells"
             },
-            "publications": [],
+            "publications": [
+                {
+                    "describedBy": "http://schema.humancellatlas.org/module/project/5.2.2/publication",
+                    "authors": [
+                        "Katrina Meeth",
+                        "Jake Wang",
+                        "Goran Micevic",
+                        "William Damsky",
+                        "Marcus W. Bosenberg"
+                    ],
+                    "publication_title": "The YUMM lines: a series of congenic mouse melanoma cell lines with defined genetic alterations",
+                    "doi": "10.1111/pcmr.12498",
+                    "pmid": 5331933,
+                    "publication_url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5331933/"
+                }
+            ],
             "contributors": [
                 {
                     "country": "UK",

--- a/test/indexer/data/ddb8f660-1160-4f6c-9ce4-c25664ac62c9.metadata.json
+++ b/test/indexer/data/ddb8f660-1160-4f6c-9ce4-c25664ac62c9.metadata.json
@@ -30,7 +30,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Sarah,A,Teichmann",
-                    "email": "st9@sanger.ac.uk"
+                    "email": "st9@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -38,7 +39,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Mirjana,,Efremova",
-                    "email": "me5@sanger.ac.uk"
+                    "email": "me5@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -46,7 +48,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Bidesh,,Mahata",
-                    "email": "bm11@sanger.ac.uk"
+                    "email": "bm11@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -54,7 +57,8 @@
                     "address": "Box 197, Cambridge Biomedical Campus, Cambridge, CB2 0XZ",
                     "laboratory": "MRC Cancer Unit",
                     "contact_name": "Jacqueline,D,Shields",
-                    "email": "JS970@MRCCU.cam.ac.uk"
+                    "email": "JS970@MRCCU.cam.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -62,13 +66,15 @@
                     "address": "Box 197, Cambridge Biomedical Campus, Cambridge, CB2 0XZ",
                     "laboratory": "MRC Cancer Unit",
                     "contact_name": "Sarah,,Davidson",
-                    "email": "SED49@MRCCU.cam.ac.uk"
+                    "email": "SED49@MRCCU.cam.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "Germany",
                     "contact_name": "Angela,,Riedel",
                     "email": "a.riedel@dkfz-heidelberg.de",
-                    "institution": "DKFZ German Cancer Research Center"
+                    "institution": "DKFZ German Cancer Research Center",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -76,7 +82,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Roser,,Veno-Tormo",
-                    "email": "rv4@sanger.ac.uk"
+                    "email": "rv4@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -84,7 +91,8 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Jhuma,,Pramanik",
-                    "email": "jp19@sanger.ac.uk"
+                    "email": "jp19@sanger.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "UK",
@@ -92,13 +100,15 @@
                     "address": "Wellcome Trust Genome Campus, Cambridge UK",
                     "laboratory": "Sarah Teichmann",
                     "contact_name": "Gozde,,Kar",
-                    "email": "gkar@ebi.ac.uk"
+                    "email": "gkar@ebi.ac.uk",
+                    "corresponding_contributor": false
                 },
                 {
                     "country": "Finland",
                     "contact_name": "Jani,,Huuhtanen",
                     "email": "jani.huuhtanen@helsinki.fi",
-                    "institution": "University of Helsinki"
+                    "institution": "University of Helsinki",
+                    "corresponding_contributor": true
                 }
             ],
             "schema_type": "project"

--- a/test/indexer/data/ddb8f660-1160-4f6c-9ce4-c25664ac62c9.metadata.json
+++ b/test/indexer/data/ddb8f660-1160-4f6c-9ce4-c25664ac62c9.metadata.json
@@ -7,7 +7,22 @@
                 "project_description": "The cancer microenvironment is a complex ecosystem characterized by dynamic interactions between diverse cell types, including malignant, immune and stromal cells. Here, we performed single-cell RNA sequencing on CD45+ and CD45- cells isolated from tumour and lymph nodes during a mouse model of melanoma. The transcriptional profiles of these individual cells taken at different time points coupled with assembled T cell receptor sequences, allowed us to identify distinct immune subpopulations and delineate their developmental trajectory. Our study provides insights into the complex interplay among cells within the tumour microenvironment and presents a valuable resource for future translational applications.",
                 "project_title": "Melanoma infiltration of stromal and immune cells"
             },
-            "publications": [],
+            "publications": [
+                {
+                    "describedBy": "http://schema.humancellatlas.org/module/project/5.2.2/publication",
+                    "authors": [
+                        "Katrina Meeth",
+                        "Jake Wang",
+                        "Goran Micevic",
+                        "William Damsky",
+                        "Marcus W. Bosenberg"
+                    ],
+                    "publication_title": "The YUMM lines: a series of congenic mouse melanoma cell lines with defined genetic alterations",
+                    "doi": "10.1111/pcmr.12498",
+                    "pmid": 5331933,
+                    "publication_url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5331933/"
+                }
+            ],
             "contributors": [
                 {
                     "country": "UK",

--- a/test/indexer/test_hca_indexer.py
+++ b/test/indexer/test_hca_indexer.py
@@ -96,7 +96,8 @@ class TestHCAIndexer(IndexerTestCase):
                                  old_result_contents["project"]["project_title"])
                 self.assertEqual("Mouse Melanoma", old_result_contents["project"]["project_shortname"])
                 self.assertIn("Sarah Teichmann", old_result_contents["project"]["laboratory"])
-                self.assertIn("University of Helsinki", old_result_contents["project"]["contributors"])
+                self.assertIn("University of Helsinki",
+                              [c.get('institution') for c in old_result_contents["project"]["contributors"]])
                 self.assertIn("Mus musculus", old_result_contents["specimens"][0]["genus_species"])
 
         old_results = self._get_es_results(check_old_submission)
@@ -128,7 +129,8 @@ class TestHCAIndexer(IndexerTestCase):
 
                 self.assertNotEqual(old_result_contents["project"]["contributors"],
                                     new_result_contents["project"]["contributors"])
-                self.assertNotIn("University of Helsinki", new_result_contents["project"]["contributors"])
+                self.assertNotIn("University of Helsinki",
+                                 [c.get('institution') for c in new_result_contents["project"]["contributors"]])
 
                 self.assertNotEqual(old_result_contents["specimens"][0]["genus_species"],
                                     new_result_contents["specimens"][0]["genus_species"])
@@ -152,7 +154,8 @@ class TestHCAIndexer(IndexerTestCase):
                                  old_result_contents["project"]["project_title"])
                 self.assertEqual("Aardvark Ailment", old_result_contents["project"]["project_shortname"])
                 self.assertIn("John Denver", old_result_contents["project"]["laboratory"])
-                self.assertNotIn("University of Helsinki", old_result_contents["project"]["contributors"])
+                self.assertNotIn("University of Helsinki",
+                                 [c.get('institution') for c in old_result_contents["project"]["contributors"]])
                 self.assertIn("Lorem ipsum", old_result_contents["specimens"][0]["genus_species"])
 
         old_results = self._get_es_results(check_new_submission)


### PR DESCRIPTION
This is to update the code to work with the latest HumanCellAtlas/metadata-api#20 which is based on [v9.0.0 Project Schema](http://schema.staging.data.humancellatlas.org/type/project/9.0.0/project).

The changes will map, extract and index the data with project contact and publication.