### PR TITLE
Add AWS auth headers when using AWS Elasticsearch

### DIFF
--- a/webservice/requirements.txt
+++ b/webservice/requirements.txt
@@ -4,6 +4,7 @@ appdirs==1.4.0
 APScheduler==3.3.1
 arrow==0.12.1
 asn1crypto==0.24.0
+aws-requests-auth==0.4.2
 backports-abc==0.5
 backports.functools-lru-cache==1.5
 bagit==1.6.3


### PR DESCRIPTION
This allows Azul webservice to auth with an AWS Elasticsearch instance, which will have more constrained IAM policies for Commons. This is essentially the same change that has already been made the the HCA Azul webservice. 

This is dependent upon changes to cgp-deployment, specifically: https://github.com/DataBiosphere/cgp-deployment/pull/66 being merged.