### PR TITLE
Config signature for v4 for encryption

### DIFF
--- a/webservice/s3_file_handler.py
+++ b/webservice/s3_file_handler.py
@@ -3,6 +3,7 @@
 import requests
 import boto3
 import botocore.session
+import botocore.config
 from botocore.exceptions import ClientError
 
 
@@ -23,7 +24,8 @@ class S3FileHandler:
         service = 's3'
         self.bucket = boto3.client(service,
                                    aws_access_key_id=access_key_id,
-                                   aws_secret_access_key=secret_key)
+                                   aws_secret_access_key=secret_key,
+                                   config=botocore.config.Config(signature_version='s3v4'))
         self.resource = boto3.resource(service)
         session = botocore.session.get_session()
         self.session = session.create_client(service, region)


### PR DESCRIPTION
The default signature version would not allow presigned urls for
SSE-KMS encrypted objects in s3 to be generated.
Updating fo s3v4 resolves the problem.