### PR TITLE
Redirect clients to download content from S3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ install:
   - pip install coveralls
 
 script:
+  # Travis VM images contain a /etc/boto.cfg which ultimately causes moto to look for the Python bindings for GCE.
+  # Setting BOTO_CONFIG seems to override that.
   - export BOTO_CONFIG=/dev/null
   - make test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
   - pip install coveralls
 
 script:
+  - export BOTO_CONFIG=/dev/null
   - make test
 
 after_success:

--- a/environment
+++ b/environment
@@ -102,6 +102,10 @@ azul_vars=(
     # like the number of shards in Elasticsearch.
     #
     AZUL_INDEXER_CONCURRENCY
+
+    # The name of the S3 bucket where the manifest API stores the downloadable
+    # content requested by client.
+    AZUL_S3_BUCKET
 )
 
 unset ${azul_vars[*]}
@@ -159,6 +163,7 @@ _set AZUL_RESOURCE_PREFIX "azul"
 _set AZUL_INDEX_PREFIX "azul"
 _set AZUL_ES_DOMAIN "azul-index-$AZUL_DEPLOYMENT_STAGE"
 _set AZUL_SHARE_ES_DOMAIN 0
+_set AZUL_S3_BUCKET "azul-storage-$AZUL_DEPLOYMENT_STAGE"
 _set AZUL_ES_INSTANCE_COUNT 2
 _set AZUL_ES_INSTANCE_TYPE "r4.2xlarge.elasticsearch"  # Indexing performance benefits from the increased memory offered
                                                        # by the `r` family, especially now that the number of shards is

--- a/lambdas/service/app.py
+++ b/lambdas/service/app.py
@@ -1,4 +1,5 @@
 import ast
+import json
 import logging.config
 import os
 

--- a/lambdas/service/lambda-policy.json.template.py
+++ b/lambdas/service/lambda-policy.json.template.py
@@ -32,6 +32,14 @@ emit({
                 "es:DescribeElasticsearchDomain"
             ],
             "Resource": f"arn:aws:es:{aws.region_name}:{aws.account}:domain/{config.es_domain}"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutObject",
+                "s3:GetObject"
+            ],
+            "Resource": f"arn:aws:s3:::{config.s3_bucket}/*"
         }
     ]
 })

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -5,4 +5,5 @@ locustio==0.8.1
 pytest==3.2.3
 coverage==4.0.3
 gitpython==2.1.11
+moto==1.3.6
 -r requirements.txt

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -43,6 +43,10 @@ class Config:
         return 0 != int(os.environ['AZUL_SHARE_ES_DOMAIN'])
 
     @property
+    def s3_bucket(self) -> str:
+        return os.environ['AZUL_S3_BUCKET']
+
+    @property
     def es_timeout(self) -> int:
         return int(os.environ['AZUL_ES_TIMEOUT'])
 

--- a/src/azul/service/responseobjects/elastic_request_builder.py
+++ b/src/azul/service/responseobjects/elastic_request_builder.py
@@ -577,13 +577,7 @@ class ElasticTransformDump(object):
             filters = {"file": {}}
         # Create an ElasticSearch request
         filters = filters['file']
-
-        es_search = self.create_request(
-            filters,
-            self.es_client,
-            request_config,
-            post_filter=False)
-
+        es_search = self.create_request(filters, self.es_client, request_config, post_filter=False)
         manifest = ManifestResponse(es_search, request_config['manifest'], request_config['translation'])
 
         return manifest.return_response()

--- a/src/azul/service/responseobjects/storage_service.py
+++ b/src/azul/service/responseobjects/storage_service.py
@@ -1,0 +1,50 @@
+from logging import getLogger
+from typing import Optional
+import boto3
+from azul import config
+
+logger = getLogger(__name__)
+
+
+class StorageService:
+
+    def __init__(self):
+        self.__bucket_name = config.s3_bucket
+        self.__client = None  # the default client will be assigned later to allow patching.
+
+    @property
+    def client(self):
+        if not self.__client:
+            self.__client = boto3.client('s3')
+        return self.__client
+
+    def set_client(self, client):
+        self.__client = client
+
+    def get(self, object_key: str):
+        try:
+            return self.client.get_object(Bucket=self.__bucket_name, Key=object_key)['Body'].read().decode()
+        except self.client.exceptions.NoSuchKey:
+            raise GetObjectError(object_key)
+
+    def put(self, object_key: str, data: bytes, content_type: Optional[str] = None) -> str:
+        params = {'Bucket': self.__bucket_name, 'Key': object_key, 'Body': data}
+
+        if content_type:
+            params['ContentType'] = content_type
+
+        self.client.put_object(**params)
+
+        return object_key
+
+    def get_presigned_url(self, key: str) -> str:
+        return self.client.generate_presigned_url(ClientMethod='get_object',
+                                                  Params=dict(Bucket=self.__bucket_name, Key=key))
+
+    def create_bucket(self, bucket_name: str = None):
+        self.client.create_bucket(Bucket=(bucket_name or self.__bucket_name))
+        logger.warning(f'{type(self).__name__}: Created a bucket called "{bucket_name or self.__bucket_name}"')
+
+
+class GetObjectError(RuntimeError):
+    pass

--- a/terraform/s3.tf.json.template.py
+++ b/terraform/s3.tf.json.template.py
@@ -1,0 +1,26 @@
+import boto3
+import json
+from azul import config
+from azul.deployment import aws
+from azul.template import emit
+
+emit({
+    "resource": [
+        {
+            "aws_s3_bucket": {
+                "bucket": {
+                    "bucket": config.s3_bucket,
+                    "acl": "private",
+                    "lifecycle_rule": {
+                        "id": "manifests",
+                        "enabled": True,
+                        "prefix": "manifests/",
+                        "expiration": {
+                            "days": 1
+                        }
+                    }
+                }
+            }
+        }
+    ]
+})

--- a/test/service/__init__.py
+++ b/test/service/__init__.py
@@ -1,7 +1,8 @@
+import os
+
 from app_test_case import LocalAppTestCase
 from es_test_case import ElasticsearchTestCase
 from service.data_generator.fake_data_utils import ElasticsearchFakeDataLoader
-import os
 
 
 class WebServiceTestCase(ElasticsearchTestCase, LocalAppTestCase):

--- a/test/service/test_storage_service.py
+++ b/test/service/test_storage_service.py
@@ -1,0 +1,60 @@
+import json
+from unittest import TestCase
+
+from moto import mock_s3, mock_sts
+import requests
+
+from azul import config
+from azul.service.responseobjects.storage_service import StorageService, GetObjectError
+
+
+class StorageServiceTest(TestCase):
+    """
+    Functional Test for Storage Service
+    """
+    storage_service: StorageService
+
+    @mock_s3
+    @mock_sts
+    def test_simple_get_put(self):
+        sample_key = 'foo-simple'
+        sample_content = 'bar'
+
+        storage_service = StorageService()
+        storage_service.create_bucket()
+
+        # NOTE: Ensure that the key does not exist before writing.
+        with self.assertRaises(GetObjectError):
+            storage_service.get(sample_key)
+
+        storage_service.put(sample_key, sample_content)
+
+        self.assertEqual(sample_content, storage_service.get(sample_key))
+
+    @mock_s3
+    @mock_sts
+    def test_simple_get_unknown_item(self):
+        sample_key = 'foo-simple'
+        sample_content = 'bar'
+
+        storage_service = StorageService()
+        storage_service.create_bucket()
+
+        with self.assertRaises(GetObjectError):
+            storage_service.get(sample_key)
+
+    @mock_s3
+    @mock_sts
+    def test_presigned_url(self):
+        sample_key = 'foo-presigned-url'
+        sample_content = json.dumps({"a": 1})
+
+        storage_service = StorageService()
+        storage_service.create_bucket()
+        storage_service.put(sample_key, sample_content)
+
+        presigned_url = storage_service.get_presigned_url(sample_key)
+
+        response = requests.get(presigned_url)
+
+        self.assertEqual(sample_content, response.text)


### PR DESCRIPTION
(Resolves #356)

In order to resolve the issue around the limit on the size of the response payload for AWS Lambda (6 MB at the time of implementation) and ensure that the response is achievable within 30 seconds, this updates makes the manifest API utilize a private S3 bucket as an intermediate storage for downloadable content and redirect the client to that downloadable content on S3 via an associated pre-signed URL with HTTP 302.

#### Potential Known Issues

Iterating through large result from ElasticSearch may affect how much data we can write to S3 before the response time exceeds 30 seconds.

#### New Environment Variables

| Environment Variable | Description | Required | Default Value |
| --- | --- | --- | --- |
| `AZUL_S3_BUCKET` | The name of S3 bucket used by Azul | No | `azul-storage-$AZUL_DEPLOYMENT_STAGE` |

#### Permission Updates

The web service lambda function `azul-service-*` will have `s3::GetObject` and `s3::PutObject` on the corresponding S3 bucket (as specified in `AZUL_S3_BUCKET`).

#### Infrastructure Updates

The Terraform script has been updated with provisioning a new S3 bucket as specified in `AZUL_S3_BUCKET`.