### PR TITLE
Set indexed MD5 sum value to the empty string (Commons)

### DIFF
--- a/indexer/chalicelib/dcc/transformer_mapping.json
+++ b/indexer/chalicelib/dcc/transformer_mapping.json
@@ -48,8 +48,7 @@
         "index_field": "file_version"
       },
       {
-        "from_file_data": true,
-        "dss_field": "sha1",
+        "constant": "",
         "index_field": "fileMd5sum"
       },
       {

--- a/indexer/test/dcc/test_transformer.py
+++ b/indexer/test/dcc/test_transformer.py
@@ -112,7 +112,7 @@ class TestDCCTransformer(TestCase):
             },
             {
                 "index_field": "fileMd5sum",
-                "value": "bbafabaffbbabdafbabbafafbafbbafafbafffaf"
+                "value": ""
             },
             {
                 "index_field": "download_id",


### PR DESCRIPTION
The HCA DSS does not provide an MD5 sum value, so set the indexed MD5 value
(which is expected by the Commons webservice) to the empty string,
instead of the sha1 value, as was previously incorrectly done.