### PR TITLE
Set indexed "access" value to the empty string (Commons) (fixes #380)

### DIFF
--- a/indexer/chalicelib/dcc/transformer_mapping.json
+++ b/indexer/chalicelib/dcc/transformer_mapping.json
@@ -2,7 +2,7 @@
   "transformer_settings": [{
     "indexer_name": "fb_index",
     "mappings": [{
-        "constant": "public",
+        "constant": "",
         "index_field": "access"
       },
       {

--- a/indexer/test/dcc/test_transformer.py
+++ b/indexer/test/dcc/test_transformer.py
@@ -75,6 +75,10 @@ class TestDCCTransformer(TestCase):
         expected_index = 'fb_index'
         expected_results = [
             {
+                "index_field": "access",
+                "value": ""
+            },
+            {
                 "index_field": "analysis_type",
                 "value": ""
             },


### PR DESCRIPTION
Now that we are (preparing to) load data with various access constraints,
and the Commons webservice expects but does not currently display the
access constraints, and it is unclear what the access values should/will be going
forward, simply set the value of "access" to the empty string.