### PR TITLE
Obtain program name and project name from top-level metadata (fixes #383)

### DIFF
--- a/indexer/chalicelib/dcc/transformer_mapping.json
+++ b/indexer/chalicelib/dcc/transformer_mapping.json
@@ -16,7 +16,7 @@
       },
       {
         "source": "metadata.json",
-        "dss_field": "case.project_id",
+        "dss_field": "project",
         "index_field": "project"
       },
       {
@@ -25,7 +25,8 @@
         "index_field": "lastModified"
       },
       {
-        "constant": "TOPMed",
+        "source": "metadata.json",
+        "dss_field": "program",
         "index_field": "program"
       },
       {

--- a/indexer/test/dcc/test-files/gen3/example_metadata.json
+++ b/indexer/test/dcc/test-files/gen3/example_metadata.json
@@ -1,5 +1,7 @@
 {
   "metadata.json": {
+    "program": "TOPMed",
+    "project": "topmed-public",
     "aligned_reads_index": {
       "data_category": "Sequencing Reads",
       "data_format": "CRAI",


### PR DESCRIPTION
The `program` value was previously hardcoded to `TOPMed` and now we
are loading data from other programs, so the `program` value needs to be
obtained from the metadata.
The `project` value was previously obtained from nested metadata values,
and now it is obtained from a top-level value. This will provide more consistent
and convenient control of the `project` value going forward.