### PR TITLE
Only indexes bundles `2018-10-10` inclusive (fixes #398)

### DIFF
--- a/src/azul/project/hca/__init__.py
+++ b/src/azul/project/hca/__init__.py
@@ -20,7 +20,15 @@ dss_subscription_query = {
                                   if config.dss_endpoint != "https://dss.data.humancellatlas.org/v1"
                                   else "files.biomaterial_json")
                     }
-                }
+                },
+                {
+                    "range": {
+                        "manifest.version": {
+                            "gte": "2018-10-10"
+                        }
+                    }
+                } if config.dss_endpoint == "https://dss.integration.data.humancellatlas.org/v1"
+                else {}
             ]
         }
     }


### PR DESCRIPTION
This fix only indexes bundles with a `manifest.version` field greater than `2018-10-10` inclusive, until the present day in which the query is executed `now`