### PR TITLE
Only indexes bundles `[2018-10-10]` and newer for integration dss (fixes #398)

### DIFF
--- a/src/azul/project/hca/__init__.py
+++ b/src/azul/project/hca/__init__.py
@@ -20,7 +20,8 @@ dss_subscription_query = {
                                   if config.dss_endpoint != "https://dss.data.humancellatlas.org/v1"
                                   else "files.biomaterial_json")
                     }
-                }
+                }, ({"range": {"manifest.version": {"gte": "2018-10-10"}}}
+                    if config.dss_endpoint == "https://dss.integration.data.humancellatlas.org/v1" else {})
             ]
         }
     }


### PR DESCRIPTION
* Including a range query for bundle versions from `2018-10-10` and more recent when indexing from the integration dss. 