### PR TITLE
Follow-up: Don't index unknown matrix files (fixes #397)

### DIFF
--- a/src/azul/project/hca/transformers.py
+++ b/src/azul/project/hca/transformers.py
@@ -145,6 +145,10 @@ class TransformerVisitor(api.EntityVisitor):
                 process_protocol = self._merge_process_protocol(entity, pl)
                 self.processes[process_protocol['document_id']] = process_protocol
         elif isinstance(entity, api.File):
+            if entity.file_format == 'unknown' and '.zarr!' in entity.manifest_entry.name:
+                # FIXME: Remove once https://github.com/HumanCellAtlas/metadata-schema/issues/579 is resolved
+                #
+                return
             self.files[entity.document_id] = _file_dict(entity)
 
 

--- a/test/indexer/test_hca_indexer.py
+++ b/test/indexer/test_hca_indexer.py
@@ -317,13 +317,11 @@ class TestHCAIndexer(IndexerTestCase):
             for result_dict in es_results:
                 entity_type, aggregate = config.parse_es_index_name(result_dict["_index"])
                 if aggregate: continue  # FIXME (https://github.com/DataBiosphere/azul/issues/425)
-                if entity_type == 'files':
-                    bundles = result_dict["_source"]['bundles']
-                    self.assertEqual(1, len(bundles))
-                    files = bundles[0]['contents']['files']
-                    self.assertEqual(1, len(files))
-                    file_name = files[0]['name']
-                    self.assertNotIn(file_name, file_names)
+                bundles = result_dict["_source"]['bundles']
+                self.assertEqual(1, len(bundles))
+                files = bundles[0]['contents']['files']
+                for file in files:
+                    file_name = file['name']
                     file_names.add(file_name)
             matrix_file_names = {file_name for file_name in file_names if '.zarr!' in file_name}
             self.assertEqual({'377f2f5a-4a45-4c62-8fb0-db9ef33f5cf0.zarr!.zattrs'}, matrix_file_names)


### PR DESCRIPTION
I had missed a spot in #455.