### PR TITLE
Fix vulnerable dependencies (closes TLP-686)

### DIFF
--- a/indexer/requirements.txt
+++ b/indexer/requirements.txt
@@ -1,6 +1,5 @@
-awscli==1.14.9
 aws-requests-auth==0.3.3
-boto3==1.4.4
+boto3==1.4.5
 boto==2.48.0
 botocore==1.8.13
 chalice==1.1.0

--- a/webservice/requirements.txt
+++ b/webservice/requirements.txt
@@ -11,18 +11,18 @@ bagit==1.6.3
 boto==2.46.1
 boto3==1.8.4
 botocore==1.11.4
-certifi==2017.1.23
+certifi==2018.8.24
 cffi==1.9.1
 chardet==3.0.4
 click==6.7
 configparser==3.5.0
-cryptography==2.1.4
+cryptography==2.3.1
 docutils==0.13.1
 elasticsearch==5.5.2
 elasticsearch-dsl==5.4.0
 enum34==1.1.6
 flake8==3.5.0
-Flask==0.12.2
+Flask==0.12.4
 Flask-APScheduler==1.5.0
 Flask-Cors==3.0.2
 Flask-Elasticsearch==0.2.5
@@ -33,7 +33,7 @@ Flask-Script==2.0.5
 Flask-SQLAlchemy==2.1
 funcsigs==1.0.2
 futures==3.0.5
-idna==2.2
+idna==2.7
 inflection==0.3.1
 ipaddress==1.0.18
 itsdangerous==0.24
@@ -42,7 +42,7 @@ jmespath==0.9.3
 jsonlines==1.1.0
 jsonobject==0.7.1
 lockfile==0.12.2
-luigi==2.3.3
+luigi==2.7.9
 lxml==3.6.4
 Mako==1.0.6
 MarkupSafe==0.23
@@ -76,7 +76,6 @@ six==1.10.0
 SQLAlchemy==1.1.5
 SQLAlchemy-Utils==0.33.3
 texttable==0.8.7
-tornado==4.4.2
 tzlocal==1.3
 urllib3==1.22
 Werkzeug==0.11.15


### PR DESCRIPTION
This commit addresses the Snyk vulnerable dependencies report
by remedying known-vulnerable packages used by both the indexer
and webservice.

In particular, the following recommendations are addressed in the webservice:
* luigi updated from v2.3.3 to v2.7.5 to address an [XSS](https://snyk.io/vuln/SNYK-PYTHON-LUIGI-42176) vuln
* certifi updated from v2017.1.23 to v2018.8.24 to address an [improper certificate validation](https://snyk.io/vuln/SNYK-PYTHON-CERTIFI-40618) vuln
* Flask updated from v0.12.2 to v0.12.3 to address an [improper input validation](https://snyk.io/vuln/SNYK-PYTHON-FLASK-42185) vuln
* cryptography update from v2.1.4 to v2.3.0 to address an [authentication bypass](https://snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-42164) vuln

The following recommendations are addressed in the indexer:
* boto3 updated from v1.4.4 to v1.4.5 to address an [information exposure](https://snyk.io/vuln/SNYK-PYTHON-BOTO3-40617) vuln
* awscli removed from requirements.txt so that pyyaml can be removed from the dependency tree and because it is used as a development tool (the installation of which is already specified in the README)

The following recommendations are not addressed in this pull request:
* The tornado requirement was removed as it is only used as a dependency of luigi. Tornado should be update from v4.4.2 to v4.5.3 to address a [denial of service](https://snyk.io/vuln/SNYK-PYTHON-TORNADO-40792) vuln but cannot as luigi requires `tornado<5,>=4.0`.

Handing off testing and deployment to @mikebaumann 