### PR TITLE
Added url field to hits.files at /files (resolves #453)

### DIFF
--- a/lambdas/service/app.py
+++ b/lambdas/service/app.py
@@ -145,6 +145,7 @@ def get_data(file_id=None):
         response = es_td.transform_request(filters=filters,
                                            pagination=pagination,
                                            post_filter=True,
+                                           include_file_urls=True,
                                            entity_type='files')
     except BadArgumentException as bae:
         raise BadRequestError(msg=bae.message)

--- a/src/azul/service/responseobjects/elastic_request_builder.py
+++ b/src/azul/service/responseobjects/elastic_request_builder.py
@@ -412,6 +412,7 @@ class ElasticTransformDump(object):
                           filters=None,
                           pagination=None,
                           post_filter=False,
+                          include_file_urls=False,
                           entity_type='files'):
         """
         This function does the whole transformation process. It takes
@@ -428,6 +429,7 @@ class ElasticTransformDump(object):
         :param pagination: Pagination to be used for the API
         :param post_filter: Flag to indicate whether to do a post_filter
         call instead of the regular query.
+        :param include_file_urls: Show file url field in request
         :param entity_type: the string referring to the entity type used to get
         the ElasticSearch index to search
         :return: Returns the transformed request
@@ -545,6 +547,15 @@ class ElasticTransformDump(object):
         if entity_type == 'projects':  # Add project summaries to each project hit
             self.add_project_summaries(final_response['hits'], es_response)
 
+        if include_file_urls:
+            try:
+                for h in final_response['hits']:
+                    for data_file in h['files']:
+                        data_file['url'] = f"{config.dss_endpoint}/files/{data_file['uuid']}" \
+                                           f"?replica=aws&version={data_file['version']}"
+            except KeyError as e:
+                logging.error('Unable to add file url. Due to the following exception:')
+                logging.error(str(e))
         return final_response
 
     def transform_manifest(

--- a/src/azul/service/responseobjects/elastic_request_builder.py
+++ b/src/azul/service/responseobjects/elastic_request_builder.py
@@ -548,9 +548,10 @@ class ElasticTransformDump(object):
             self.add_project_summaries(final_response['hits'], es_response)
 
         if include_file_urls:
-            for h in final_response['hits']:
-                for data_file in h['files']:
-                    data_file['url'] = f"{config.dss_endpoint}/files/{data_file['uuid']}?replica=aws&version={data_file['version']}"
+            for hit in final_response['hits']:
+                for data_file in hit['files']:
+                    query_params = f"?replica=aws&version={data_file['version']}"
+                    data_file['url'] = f"{config.dss_endpoint}/files/{data_file['uuid']}{query_params}"
         return final_response
 
     def transform_manifest(

--- a/src/azul/service/responseobjects/elastic_request_builder.py
+++ b/src/azul/service/responseobjects/elastic_request_builder.py
@@ -429,7 +429,7 @@ class ElasticTransformDump(object):
         :param pagination: Pagination to be used for the API
         :param post_filter: Flag to indicate whether to do a post_filter
         call instead of the regular query.
-        :param include_file_urls: Show file url field in request
+        :param include_file_urls: Show file URL field in request
         :param entity_type: the string referring to the entity type used to get
         the ElasticSearch index to search
         :return: Returns the transformed request
@@ -548,14 +548,9 @@ class ElasticTransformDump(object):
             self.add_project_summaries(final_response['hits'], es_response)
 
         if include_file_urls:
-            try:
-                for h in final_response['hits']:
-                    for data_file in h['files']:
-                        data_file['url'] = f"{config.dss_endpoint}/files/{data_file['uuid']}" \
-                                           f"?replica=aws&version={data_file['version']}"
-            except KeyError as e:
-                logging.error('Unable to add file url. Due to the following exception:')
-                logging.error(str(e))
+            for h in final_response['hits']:
+                for data_file in h['files']:
+                    data_file['url'] = f"{config.dss_endpoint}/files/{data_file['uuid']}?replica=aws&version={data_file['version']}"
         return final_response
 
     def transform_manifest(

--- a/test/service/test_request_builder.py
+++ b/test/service/test_request_builder.py
@@ -640,6 +640,16 @@ class TestRequestBuilder(WebServiceTestCase):
 
         self.assertEqual(actual_output, expected_output)
 
+    def test_transform_request_with_file_url(self):
+        response_json = EsTd().transform_request(filters={"file": {}},
+                                                 pagination={'order': 'desc',
+                                                             'size': 10,
+                                                             'sort': 'specimenId'},
+                                                 post_filter=True,
+                                                 include_file_urls=True,
+                                                 entity_type='files')
+        self.assertTrue(all(['url' in file_data.keys() for hit in response_json['hits'] for file_data in hit['files']]))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added the `hits.files.url` field to /files endpoint response.

Preview:
https://service.geryl.dev.explore.data.humancellatlas.org/repository/files