### PR TITLE
Parallelized Elasticsearch request for serving summary response (fixes #467)

### DIFF
--- a/lambdas/service/app.py
+++ b/lambdas/service/app.py
@@ -2,6 +2,7 @@ import ast
 import json
 import logging.config
 import os
+from concurrent.futures import ThreadPoolExecutor
 
 from chalice import Chalice, BadRequestError, NotFoundError
 
@@ -367,8 +368,10 @@ def get_summary():
         'specimens': ['organCount', 'donorCount', 'labCount', 'totalCellCount', 'organSummaries', 'specimenCount'],
         'projects': ['projectCount']
     }
-    summaries = {entity_type: es_td.transform_summary(filters=filters, entity_type=entity_type)
-                 for entity_type, summary_fields in summary_fields_by_authority.items()}
+    with ThreadPoolExecutor(max_workers=len(summary_fields_by_authority)) as executor:
+        summaries = dict(executor.map(lambda entity_type:
+                                      (entity_type, es_td.transform_summary(filters=filters, entity_type=entity_type)),
+                                      summary_fields_by_authority))
     unified_summary = {field: summaries[entity_type][field]
                         for entity_type, summary_fields in summary_fields_by_authority.items()
                         for field in summary_fields}

--- a/lambdas/service/app.py
+++ b/lambdas/service/app.py
@@ -1,5 +1,4 @@
 import ast
-import json
 import logging.config
 import os
 from concurrent.futures import ThreadPoolExecutor
@@ -373,8 +372,8 @@ def get_summary():
                                       (entity_type, es_td.transform_summary(filters=filters, entity_type=entity_type)),
                                       summary_fields_by_authority))
     unified_summary = {field: summaries[entity_type][field]
-                        for entity_type, summary_fields in summary_fields_by_authority.items()
-                        for field in summary_fields}
+                       for entity_type, summary_fields in summary_fields_by_authority.items()
+                       for field in summary_fields}
     assert all(len(unified_summary) == len(summary) for summary in summaries.values())
 
     # Returning a single response if <file_id> request form is used


### PR DESCRIPTION
Threaded Elasticsearch requests for serving `repository/summary` faster. 