### PR TITLE
Fix pg_isready.. error following execution of `docker-compose ... up` (fixes #396)

### DIFF
--- a/webservice/Dockerfile
+++ b/webservice/Dockerfile
@@ -34,7 +34,7 @@ ENV APACHE_PATH=""
 # Add app code
 COPY . /app
 #Make the runnable executable
-RUN chmod a+x /app/run.sh
+#RUN chmod a+x /app/run.sh
 #Remove the current uwsgi.ini
 RUN rm /app/uwsgi.ini
 #Add the in app uwsgi

--- a/webservice/Dockerfile
+++ b/webservice/Dockerfile
@@ -33,8 +33,6 @@ ENV APACHE_PATH=""
 
 # Add app code
 COPY . /app
-#Make the runnable executable
-#RUN chmod a+x /app/run.sh
 #Remove the current uwsgi.ini
 RUN rm /app/uwsgi.ini
 #Add the in app uwsgi

--- a/webservice/supervisord.conf
+++ b/webservice/supervisord.conf
@@ -9,13 +9,6 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 autostart=true
 
-[program:initialize_db]
-command=/app/run.sh
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-
 [program:uwsgi]
 command=/usr/local/bin/uwsgi --ini /etc/uwsgi/uwsgi.ini --ini /app/uwsgi.ini
 stdout_logfile=/dev/stdout

--- a/webservice/supervisord.conf
+++ b/webservice/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:start]
-command=bash -c "env > /app/log/env.txt && cat /app/log/env.txt && cron -f -L 15 && /app/run.sh"
+command=bash -c "env > /app/log/env.txt && cat /app/log/env.txt && cron -f -L 15"
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr


### PR DESCRIPTION
This PR addresses the problem of an apparent endless loop that ensues after executing 
`docker-compose -f dev.yml up` (when the docker compose network is in the down state). I removed code in two files in the webservice, `Dockerfile` and `supervisord.conf`. This PR works in conjunction with PR https://github.com/DataBiosphere/cgp-dashboard/pull/85.

Implementation of both code changes fix the error described above. 