### PR TITLE
Update index mappings for: project, study, program (resolves #513)

### DIFF
--- a/indexer/chalicelib/dcc/transformer_mapping.json
+++ b/indexer/chalicelib/dcc/transformer_mapping.json
@@ -4,17 +4,17 @@
     "mappings": [
       {
         "source": "metadata.json",
-        "dss_field": "program",
+        "dss_field": "study.submitter_id",
         "index_field": "program"
       },
       {
         "source": "metadata.json",
-        "dss_field": "project",
+        "dss_field": "project.code",
         "index_field": "project"
       },
       {
         "source": "metadata.json",
-        "dss_field": "case.project_id",
+        "dss_field": "study.submitter_id",
         "index_field": "study"
       },
       {

--- a/indexer/test/dcc/test-files/gen3/example_metadata.json
+++ b/indexer/test/dcc/test-files/gen3/example_metadata.json
@@ -198,7 +198,22 @@
       "age_at_index": "",
       "year_of_death": ""
     },
-    "program": "topmed",
-    "project": "public"
+    "project": {
+      "availability_mechanism": null,
+      "availability_type": null,
+      "code": "public",
+      "date_collected": null,
+      "dbgap_accession_number": "public",
+      "id": "09c26ed7-ed2f-52b1-a366-d7dede15cc32",
+      "intended_release_date": null,
+      "investigator_affiliation": null,
+      "investigator_name": null,
+      "name": "Public Trans-Omics for Precision Medicine",
+      "releasable": null,
+      "released": null,
+      "state": "open",
+      "support_id": null,
+      "support_source": null
+    }
   }
 }

--- a/indexer/test/dcc/test_transformer.py
+++ b/indexer/test/dcc/test_transformer.py
@@ -75,9 +75,9 @@ class TestDCCTransformer(TestCase):
         expected_index_name = 'fb_index'
         expected_index = {
             "fb_index": {
-                "program": "topmed",
+                "program": "TOPMed_Public",
                 "project": "public",
-                "study": "topmed-public",
+                "study": "TOPMed_Public",
                 "donor": "NA12878",
                 "submittedDonorId": "NA12878",
                 "submitter_donor_id": "NA12878",


### PR DESCRIPTION
This change updates the Commons Azul index mappings for the ETL output format as
of 10/16/18 for: project, study, program.

Metadata Field | Azul Index Field
-- | --
project.code | project
study.submitter_id | study
study.submitter_id | program*

* Note: The mapping to program must be updated when the program object becomes available in the ETL output. 

These are mappings that I have been testing with since 10/16/18 and are currently in use in the Commons "dev" and "staging" deployments. I believe we are now at a point where the ETL process can/will successfully populate the program field as well, so the mapping for `program` should be updated (in a separate PR) to get the `program` value from the new `program` object at the time that we clear the data from the deployment and use the updated ETL process to extract/transform/load the GTEx and TOPMed project data.

