### PR TITLE
Comprehensive fileFormat agg (fixes HumanCellAtlas/data-browser#318)

### DIFF
--- a/src/azul/service/responseobjects/hca_response_v5.py
+++ b/src/azul/service/responseobjects/hca_response_v5.py
@@ -313,7 +313,7 @@ class SummaryResponse(BaseSummaryResponse):
     def __init__(self, raw_response):
         super().__init__(raw_response)
 
-        _sum = raw_response['aggregations']['by_type']
+        _sum = raw_response['aggregations']['fileFormat']["myTerms"]
         _organ_group = raw_response['aggregations']['group_by_organ']
 
         # Create a SummaryRepresentation object


### PR DESCRIPTION


Obtain fields for formation of fileFormat aggregate from one aggregate.
Added log for ES request of /summary endpoint.