### PR TITLE
Comprehensive fileFormat aggregate (fixes #535)

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -11,6 +11,14 @@ meta:
     - clients: the service API changed in a way that requires clients to be updated
 
 changes:
+  - title: >
+        Fix: file type summary is truncated to ten entries
+    issues:
+      - https://github.com/DataBiosphere/azul/issues/535
+      - https://github.com/HumanCellAtlas/data-browser/issues/318
+    upgrade:
+      - deploy
+
   - title: Remove protocol facet from service response
     issues:
       - https://github.com/DataBiosphere/azul/issues/516

--- a/src/azul/service/responseobjects/elastic_request_builder.py
+++ b/src/azul/service/responseobjects/elastic_request_builder.py
@@ -407,6 +407,7 @@ class ElasticTransformDump(object):
         #  which has the format for the summary request
         self.logger.info('Creating a SummaryResponse object')
         final_response = SummaryResponse(es_response.to_dict())
+        logger.info("Elasticsearch request: %s", json.dumps(es_search.to_dict(), indent=4))
         self.logger.info(
             'Returning the final response for transform_summary()')
         return final_response.apiResponse.to_json()

--- a/src/azul/service/responseobjects/hca_response_v5.py
+++ b/src/azul/service/responseobjects/hca_response_v5.py
@@ -314,7 +314,7 @@ class SummaryResponse(BaseSummaryResponse):
     def __init__(self, raw_response):
         super().__init__(raw_response)
 
-        _sum = raw_response['aggregations']['by_type']
+        _sum = raw_response['aggregations']['fileFormat']["myTerms"]
         _organ_group = raw_response['aggregations']['group_by_organ']
 
         # Create a SummaryRepresentation object

--- a/test/service/test_request_builder.py
+++ b/test/service/test_request_builder.py
@@ -3,11 +3,13 @@
 import difflib
 import json
 import logging.config
+import os
 import unittest
 
 from elasticsearch_dsl.utils import AttrList
 
-from azul.service.responseobjects.elastic_request_builder import ElasticTransformDump as EsTd
+from azul.service.responseobjects.elastic_request_builder import ElasticTransformDump as EsTd, ElasticTransformDump
+from azul.service import service_config
 from service import WebServiceTestCase
 
 logger = logging.getLogger(__name__)
@@ -381,13 +383,15 @@ class TestRequestBuilder(WebServiceTestCase):
         }
 
         sample_filter = {}
-
+        request_config_path = os.path.join(os.path.dirname(service_config.__file__), 'request_config.json')
+        request_config = ElasticTransformDump.open_and_return_json(request_config_path)
         # Create a request object
         agg_field = 'facet1'
         aggregation = EsTd.create_aggregate(
             sample_filter,
             facet_config={agg_field: f'{agg_field}.translation'},
-            agg=agg_field
+            agg=agg_field,
+            request_config=request_config
         )
         # Convert objects to be compared to strings
         expected_output = json.dumps(

--- a/test/service/test_response.py
+++ b/test/service/test_response.py
@@ -563,15 +563,15 @@ class TestResponse(WebServiceTestCase):
                          json.dumps(expected_output, sort_keys=True, indent=4))
 
     def test_summary_endpoint(self):
-        for entity_type in 'specimens', 'files':
-            with self.subTest(entity_type=entity_type):
-                url = self.base_url + "/repository/summary"
-                response = requests.get(url)
-                response.raise_for_status()
-                summary_object = response.json()
-                self.assertGreater(summary_object['fileCount'], 0)
-                self.assertGreater(summary_object['organCount'], 0)
-                self.assertIsNotNone(summary_object['organSummaries'])
+        url = self.base_url + "/repository/summary"
+        response = requests.get(url)
+        response.raise_for_status()
+        summary_object = response.json()
+        self.assertGreaterEqual(summary_object['fileCount'], 1)
+        self.assertGreaterEqual(summary_object['organCount'], 1)
+        self.assertGreaterEqual(len(summary_object['fileTypeSummaries']), 1)
+        self.assertGreaterEqual(summary_object['fileTypeSummaries'][0]['totalSize'], 1)
+        self.assertIsNotNone(summary_object['organSummaries'])
 
     def test_default_sorting_parameter(self):
         base_url = self.base_url


### PR DESCRIPTION
Obtain fields for formation of fileFormat aggregate from one aggregate.
Added log for ES request of /summary endpoint.