### PR TITLE
Refactored reindex.py into a importable module

### DIFF
--- a/scripts/reindex.py
+++ b/scripts/reindex.py
@@ -82,8 +82,8 @@ def main(argv: List[str]):
                         es_client.indices.delete(index=index_name)
 
     Reindexer(indexer_url=args.indexer_url, dss_url=args.dss_url, es_query=args.es_query,
-              will_sync_notifications=args.sync, number_of_workers=args.num_workers,
-              is_dry_run=args.dryrun).reindex()
+              sync=args.sync, num_workers=args.num_workers,
+              dryrun=args.dryrun).reindex()
 
 
 if __name__ == "__main__":

--- a/scripts/reindex.py
+++ b/scripts/reindex.py
@@ -5,21 +5,14 @@ Command line utility to trigger indexing of bundles from DSS into Azul
 """
 
 import argparse
-from collections import defaultdict
-from concurrent.futures import Future, ThreadPoolExecutor
-from functools import partial
 import json
 import logging
-from pprint import PrettyPrinter
 import sys
 from typing import List
-from urllib.error import HTTPError
-from urllib.parse import urlparse, urlencode, parse_qs
-from urllib.request import Request, urlopen
-from uuid import uuid4
 
 from azul import config
 from azul.es import ESClientFactory
+from azul.reindexer import Reindexer
 
 logger = logging.getLogger(__name__)
 
@@ -71,27 +64,6 @@ parser.add_argument('--dryrun', '--dry-run',
                     help='Just print what would be done, do not actually do it.')
 
 
-def post_bundle(bundle_fqid, es_query, indexer_url):
-    """
-    Send a mock DSS notification to the indexer
-    """
-    bundle_uuid, _, bundle_version = bundle_fqid.partition('.')
-    simulated_event = {
-        "query": es_query,
-        "subscription_id": str(uuid4()),
-        "transaction_id": str(uuid4()),
-        "match": {
-            "bundle_uuid": bundle_uuid,
-            "bundle_version": bundle_version
-        }
-    }
-    body = json.dumps(simulated_event).encode('utf-8')
-    request = Request(indexer_url, body)
-    request.add_header("content-type", "application/json")
-    with urlopen(request) as f:
-        return f.read()
-
-
 def main(argv: List[str]):
     args = parser.parse_args(argv)
 
@@ -109,73 +81,9 @@ def main(argv: List[str]):
                     else:
                         es_client.indices.delete(index=index_name)
 
-    logger.info('Querying DSS using %s', json.dumps(args.es_query, indent=4))
-    dss_client = config.dss_client(dss_endpoint=args.dss_url)
-    # noinspection PyUnresolvedReferences
-    response = dss_client.post_search.iterate(es_query=args.es_query, replica="aws")
-    bundle_fqids = [r['bundle_fqid'] for r in response]
-    logger.info("Bundle FQIDs to index: %i", len(bundle_fqids))
-
-    errors = defaultdict(int)
-    missing = {}
-    indexed = 0
-    total = 0
-
-    with ThreadPoolExecutor(max_workers=args.num_workers, thread_name_prefix='pool') as tpe:
-
-        def attempt(bundle_fqid, i):
-            try:
-                logger.info("Bundle %s, attempt %i: Sending notification", bundle_fqid, i)
-                url = urlparse(args.indexer_url)
-                if args.sync is not None:
-                    # noinspection PyProtectedMember
-                    url = url._replace(query=urlencode({**parse_qs(url.query), 'sync': args.sync}, doseq=True))
-                if not args.dryrun:
-                    post_bundle(bundle_fqid=bundle_fqid,
-                                es_query=args.es_query,
-                                indexer_url=url.geturl())
-            except HTTPError as e:
-                if i < 3:
-                    logger.warning("Bundle %s, attempt %i: scheduling retry after error %s", bundle_fqid, i, e)
-                    return bundle_fqid, tpe.submit(partial(attempt, bundle_fqid, i + 1))
-                else:
-                    logger.warning("Bundle %s, attempt %i: giving up after error %s", bundle_fqid, i, e)
-                    return bundle_fqid, e
-            else:
-                logger.info("Bundle %s, attempt %i: success", bundle_fqid, i)
-                return bundle_fqid, None
-
-        def handle_future(future):
-            nonlocal indexed
-            # Block until future raises or succeeds
-            exception = future.exception()
-            if exception is None:
-                bundle_fqid, result = future.result()
-                if result is None:
-                    indexed += 1
-                elif isinstance(result, HTTPError):
-                    errors[result.code] += 1
-                    missing[bundle_fqid] = result.code
-                elif isinstance(result, Future):
-                    # The task scheduled a follow-on task, presumably a retry. Follow that new task.
-                    handle_future(result)
-                else:
-                    assert False
-            else:
-                logger.warning("Unhandled exception in worker:", exc_info=exception)
-
-        futures = []
-        for bundle_fqid in bundle_fqids:
-            total += 1
-            futures.append(tpe.submit(partial(attempt, bundle_fqid, 0)))
-        for future in futures:
-            handle_future(future)
-
-    printer = PrettyPrinter(stream=None, indent=1, width=80, depth=None, compact=False)
-    logger.info("Total of bundle FQIDs read: %i", total)
-    logger.info("Total of bundle FQIDs indexed: %i", indexed)
-    logger.warning("Total number of errors by code:\n%s", printer.pformat(dict(errors)))
-    logger.warning("Missing bundle_fqids and their error code:\n%s", printer.pformat(missing))
+    Reindexer(indexer_url=args.indexer_url, dss_url=args.dss_url, es_query=args.es_query,
+              will_sync_notifications=args.sync, number_of_workers=args.num_workers,
+              is_dry_run=args.dryrun).reindex()
 
 
 if __name__ == "__main__":

--- a/src/azul/reindexer.py
+++ b/src/azul/reindexer.py
@@ -1,0 +1,137 @@
+#! /usr/bin/env python3
+
+"""
+Command line utility to trigger indexing of bundles from DSS into Azul
+"""
+
+from collections import defaultdict
+from concurrent.futures import Future, ThreadPoolExecutor
+from functools import partial
+import json
+import logging
+from pprint import PrettyPrinter
+from urllib.error import HTTPError
+from urllib.parse import urlparse, urlencode, parse_qs
+from urllib.request import Request, urlopen
+from uuid import uuid4
+
+from azul import config
+
+logger = logging.getLogger(__name__)
+
+plugin = config.plugin()
+
+
+class Defaults:
+    dss_url = config.dss_endpoint
+    indexer_url = "https://" + config.api_lambda_domain('indexer') + "/"
+    es_query = plugin.dss_subscription_query
+    num_workers = 16
+
+
+def post_bundle(bundle_fqid, es_query, indexer_url):
+    """
+    Send a mock DSS notification to the indexer
+    """
+    bundle_uuid, _, bundle_version = bundle_fqid.partition('.')
+    simulated_event = {
+        "query": es_query,
+        "subscription_id": str(uuid4()),
+        "transaction_id": str(uuid4()),
+        "match": {
+            "bundle_uuid": bundle_uuid,
+            "bundle_version": bundle_version
+        }
+    }
+    body = json.dumps(simulated_event).encode('utf-8')
+    request = Request(indexer_url, body)
+    request.add_header("content-type", "application/json")
+    with urlopen(request) as f:
+        return f.read()
+
+
+class Reindexer(object):
+    def __init__(self, indexer_url: str = Defaults.indexer_url,
+                 dss_url: str = Defaults.dss_url,
+                 es_query: dict = Defaults.es_query,
+                 will_sync_notifications: bool = False,
+                 number_of_workers: int = Defaults.num_workers,
+                 test_name: str = None,
+                 is_dry_run: bool = None):
+
+        self.number_of_workers = number_of_workers
+        self.will_sync_notifications = will_sync_notifications
+        self.es_query = es_query
+        self.dss_url = dss_url
+        self.indexer_url = indexer_url
+        self.test_name = test_name
+        self.is_dry_run = is_dry_run
+
+    def reindex(self):
+        errors = defaultdict(int)
+        missing = {}
+        indexed = 0
+        total = 0
+
+        logger.info('Querying DSS using %s', json.dumps(self.es_query, indent=4))
+        dss_client = config.dss_client(dss_endpoint=self.dss_url)
+        # noinspection PyUnresolvedReferences
+        response = dss_client.post_search.iterate(es_query=self.es_query, replica="aws")
+        bundle_fqids = [r['bundle_fqid'] for r in response]
+        logger.info("Bundle FQIDs to index: %i", len(bundle_fqids))
+
+        with ThreadPoolExecutor(max_workers=self.number_of_workers, thread_name_prefix='pool') as tpe:
+
+            def attempt(bundle_fqid, i):
+                try:
+                    logger.info("Bundle %s, attempt %i: Sending notification", bundle_fqid, i)
+                    url = urlparse(self.indexer_url)
+                    if self.will_sync_notifications is not None:
+                        # noinspection PyProtectedMember
+                        url = url._replace(query=urlencode({**parse_qs(url.query),
+                                                            'sync': self.will_sync_notifications}, doseq=True))
+                    if not self.is_dry_run:
+                        post_bundle(bundle_fqid=bundle_fqid,
+                                    es_query=self.es_query,
+                                    indexer_url=url.geturl())
+                except HTTPError as e:
+                    if i < 3:
+                        logger.warning("Bundle %s, attempt %i: scheduling retry after error %s", bundle_fqid, i, e)
+                        return bundle_fqid, tpe.submit(partial(attempt, bundle_fqid, i + 1))
+                    else:
+                        logger.warning("Bundle %s, attempt %i: giving up after error %s", bundle_fqid, i, e)
+                        return bundle_fqid, e
+                else:
+                    logger.info("Bundle %s, attempt %i: success", bundle_fqid, i)
+                    return bundle_fqid, None
+
+            def handle_future(future):
+                nonlocal indexed
+                # Block until future raises or succeeds
+                exception = future.exception()
+                if exception is None:
+                    bundle_fqid, result = future.result()
+                    if result is None:
+                        indexed += 1
+                    elif isinstance(result, HTTPError):
+                        errors[result.code] += 1
+                        missing[bundle_fqid] = result.code
+                    elif isinstance(result, Future):
+                        # The task scheduled a follow-on task, presumably a retry. Follow that new task.
+                        handle_future(result)
+                    else:
+                        assert False
+                else:
+                    logger.warning("Unhandled exception in worker:", exc_info=exception)
+
+            futures = []
+            for bundle_fqid in bundle_fqids:
+                total += 1
+                futures.append(tpe.submit(partial(attempt, bundle_fqid, 0)))
+            for future in futures:
+                handle_future(future)
+        printer = PrettyPrinter(stream=None, indent=1, width=80, depth=None, compact=False)
+        logger.info("Total of bundle FQIDs read: %i", total)
+        logger.info("Total of bundle FQIDs indexed: %i", indexed)
+        logger.warning("Total number of errors by code:\n%s", printer.pformat(dict(errors)))
+        logger.warning("Missing bundle_fqids and their error code:\n%s", printer.pformat(missing))


### PR DESCRIPTION
Refactored reindexer code from scripts/reindex.py to src/azul/reindexer.py. All `argparser` related code is kept in scripts/reindex.py.