### PR TITLE
Service health endpoint throws 503 status code when 'DOWN' (fixes #624)

### DIFF
--- a/lambdas/service/app.py
+++ b/lambdas/service/app.py
@@ -17,7 +17,8 @@ from chalice import BadRequestError, Chalice, ChaliceViewError, NotFoundError, R
 from more_itertools import one
 import requests
 
-from azul import config, parse_http_date
+from azul import config
+from azul.health import Health
 from azul.service import service_config
 from azul.service.responseobjects.cart_item_manager import CartItemManager, DuplicateItemError, ResourceAccessError
 from azul.service.responseobjects.elastic_request_builder import (BadArgumentException,
@@ -75,14 +76,20 @@ def hello():
     return {'Hello': 'World!'}
 
 
+@app.route('/health/basic', methods=['GET'], cors=True)
+def basic_health():
+    return {
+        'up': True,
+    }
+
+
 @app.route('/health', methods=['GET'], cors=True)
 def health():
-    from azul.health import get_elasticsearch_health
-
-    return {
-        'status': 'UP',
-        'elasticsearch': get_elasticsearch_health()
-    }
+    health = Health('service')
+    return Response(
+        body=json.dumps(health.as_json),
+        status_code=200 if health.up else 503
+    )
 
 
 @app.route('/version', methods=['GET'], cors=True)

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -3,7 +3,7 @@ import functools
 import os
 import re
 import time
-from typing import Mapping, Optional, Tuple
+from typing import Mapping, Optional, Tuple, List
 
 from hca.dss import DSSClient
 from urllib3 import Timeout
@@ -126,11 +126,20 @@ class Config:
     def subdomain(self, lambda_name):
         return os.environ['AZUL_SUBDOMAIN_TEMPLATE'].format(lambda_name=lambda_name)
 
-    def api_lambda_domain(self, lambda_name):
-        return config.subdomain(lambda_name) + "." + config.domain_name
+    def api_lambda_domain(self, lambda_name: str) -> str:
+        return self.subdomain(lambda_name) + "." + self.domain_name
 
-    def service_endpoint(self):
-        return "https://" + config.api_lambda_domain('service')
+    def lambda_endpoint(self, lambda_name: str) -> str:
+        return "https://" + self.api_lambda_domain(lambda_name)
+
+    def indexer_endpoint(self) -> str:
+        return self.lambda_endpoint('indexer')
+
+    def service_endpoint(self) -> str:
+        return self.lambda_endpoint('service')
+
+    def lambda_names(self) -> List[str]:
+        return ['indexer', 'service']
 
     @property
     def indexer_name(self) -> str:
@@ -269,6 +278,19 @@ class Config:
     @property
     def document_queue_name(self):
         return config.qualified_resource_name('documents', suffix='.fifo')
+
+    @property
+    def fail_queue_name(self):
+        return config.qualified_resource_name('fail')
+
+    @property
+    def fail_fifo_queue_name(self):
+        return config.qualified_resource_name('fail', suffix='.fifo')
+
+    @property
+    def all_queue_names(self):
+        return self.token_queue_name, self.document_queue_name, self.fail_queue_name, \
+               self.fail_fifo_queue_name, self.notify_queue_name
 
     @property
     def manifest_lambda_basename(self):

--- a/src/azul/decorators.py
+++ b/src/azul/decorators.py
@@ -1,0 +1,5 @@
+from functools import lru_cache
+
+
+def memoized_property(f):
+    return property(lru_cache(maxsize=1)(f))

--- a/src/azul/deployment.py
+++ b/src/azul/deployment.py
@@ -6,9 +6,7 @@ import boto3
 import botocore.session
 from more_itertools import one
 
-
-def memoized_property(f):
-    return property(lru_cache(maxsize=1)(f))
+from azul.decorators import memoized_property
 
 
 class AWS:
@@ -78,8 +76,6 @@ class AWS:
         es_domain_status = self.es.describe_elasticsearch_domain(DomainName=es_domain)
         return es_domain_status['DomainStatus']['Endpoint'], 443
 
-
-del memoized_property
 
 aws = AWS()
 

--- a/src/azul/health.py
+++ b/src/azul/health.py
@@ -1,40 +1,85 @@
+from functools import lru_cache
+
 import boto3
+import requests
 from botocore.exceptions import ClientError
 
 from azul import config
+from azul.decorators import memoized_property
 from azul.es import ESClientFactory
+from azul.types import JSON
 
 
-def get_elasticsearch_health():
-    is_es_reachable = ESClientFactory.get().ping()
+class Health:
 
-    result = {
-        'status': 'UP' if is_es_reachable else 'DOWN',
-        'domain': config.es_domain
-    }
-    if not is_es_reachable:
-        result['message'] = 'Unable to reach the host'
-    return result
+    def __init__(self, lambda_name):
+        self.lambda_name = lambda_name
 
+    @memoized_property
+    def as_json(self) -> JSON:
+        return {
+            'up': self.up,
+            'elastic_search': self.elastic_search,
+            'queues': self.queues,
+            **({
+                lambda_name: self._lambda(lambda_name)
+                for lambda_name in config.lambda_names()
+                if lambda_name != self.lambda_name
+            }),
+            'unindexed_bundles': sum(self.queues[config.notify_queue_name].get('messages',{}).values()),
 
-def get_queue_health():
-    sqs = boto3.resource('sqs')
+            'unindexed_documents': sum(self.queues[config.document_queue_name].get('messages',{}).values())
+        }
 
-    def queue_health(queue_name):
-        try:
-            queue = sqs.get_queue_by_name(QueueName=f'azul-{queue_name}-{config.deployment_stage}')
-            return {
-                'status': 'UP',
-                'messages': {
-                    'queued': queue.attributes['ApproximateNumberOfMessages'],
-                    'delayed': queue.attributes['ApproximateNumberOfMessagesDelayed'],
-                    'invisible': queue.attributes['ApproximateNumberOfMessagesNotVisible']
+    @memoized_property
+    def queues(self):
+        sqs = boto3.resource('sqs')
+        response = {'up': True}
+        for queue in config.all_queue_names:
+            try:
+                queue_instance = sqs.get_queue_by_name(QueueName=queue).attributes
+            except ClientError as ex:
+                response[queue] = {
+                    'up': False,
+                    'error': ex.response['Error']['Message']
                 }
-            }
-        except ClientError as ex:
+                response['up'] = False
+            else:
+                response[queue] = {
+                    'up': True,
+                    'messages':{
+                    'delayed': int(queue_instance['ApproximateNumberOfMessagesDelayed']),
+                    'invisible': int(queue_instance['ApproximateNumberOfMessagesNotVisible']),
+                    'queued': int(queue_instance['ApproximateNumberOfMessages'])
+                    }
+                }
+        return response
+
+    @memoized_property
+    def elastic_search(self):
+        return {
+            'up': ESClientFactory.get().ping(),
+        }
+
+    @memoized_property
+    def up(self):
+        return (self.elastic_search['up'] and
+                self.queues['up'] and
+                all(self._lambda(lambda_name)['up']
+                    for lambda_name in config.lambda_names()
+                    if lambda_name != self.lambda_name))
+
+    @lru_cache()
+    def _lambda(self, lambda_name) -> JSON:
+        try:
+            up = requests.get(f'{config.lambda_endpoint(lambda_name)}/health/basic').json()['up']
+        except BaseException as e:
             return {
-                'status': 'DOWN',
-                'message': ex.response['Error']['Message']
+                'up': False,
+                'message': str(e)
+            }
+        else:
+            return {
+                'up': up,
             }
 
-    return {queue_name: queue_health(queue_name) for queue_name in ['notify', 'fail']}

--- a/terraform/cloudwatch.tf.json.template.py
+++ b/terraform/cloudwatch.tf.json.template.py
@@ -1,3 +1,5 @@
+import json
+
 from azul.template import emit
 from azul import config
 from azul.deployment import aws
@@ -16,7 +18,10 @@ emit({
                     "period": "3600",
                     "statistic": "Average",
                     "threshold": "85",
-                    "alarm_description": "This metric monitors ES CPU utilization",
+                    "alarm_description": json.dumps({
+                        "slack_channel": "dcp-ops-alerts",
+                        "description": config.es_domain + " CPUUtilization alarm"
+                    }),
                     "dimensions": {
                         "ClientId": aws.account,
                         "DomainName": config.es_domain
@@ -40,7 +45,10 @@ emit({
                     "period": "300",
                     "statistic": "Average",
                     "threshold": "14000",
-                    "alarm_description": "This metric monitors ES Disk usage",
+                    "alarm_description": json.dumps({
+                        "slack_channel": "dcp-ops-alerts",
+                        "description": config.es_domain + " FreeStorageSpace alarm"
+                    }),
                     "dimensions": {
                         "ClientId": aws.account,
                         "DomainName": config.es_domain
@@ -64,7 +72,10 @@ emit({
                     "period": "300",
                     "statistic": "Minimum",
                     "threshold": "65",
-                    "alarm_description": "This metric monitors memory pressure, should not exceed 65%",
+                    "alarm_description": json.dumps({
+                        "slack_channel": "dcp-ops-alerts",
+                        "description": config.es_domain + " JVMMemoryPressure alarm"
+                    }),
                     "dimensions": {
                         "ClientId": aws.account,
                         "DomainName": config.es_domain

--- a/test/app_test_case.py
+++ b/test/app_test_case.py
@@ -86,9 +86,8 @@ class LocalAppTestCase(unittest.TestCase, metaclass=ABCMeta):
         self.server_thread.start()
         deadline = time.time() + 10
         while True:
-            url = self.base_url
             try:
-                response = requests.get(url)
+                response = self._ping()
                 response.raise_for_status()
             except Exception:
                 if time.time() > deadline:
@@ -97,6 +96,9 @@ class LocalAppTestCase(unittest.TestCase, metaclass=ABCMeta):
                 time.sleep(1)
             else:
                 break
+
+    def _ping(self):
+        return requests.get(self.base_url)
 
     def chalice_config(self):
         return ChaliceConfig()

--- a/test/health_check_test_case.py
+++ b/test/health_check_test_case.py
@@ -1,0 +1,288 @@
+import os
+
+import boto3
+import logging
+import requests
+import responses
+
+from abc import ABCMeta
+
+from typing import List
+from unittest import mock, TestSuite
+from moto import mock_sqs, mock_sts
+from chalice.config import Config as ChaliceConfig
+
+from azul import config
+from app_test_case import LocalAppTestCase
+from es_test_case import ElasticsearchTestCase
+
+
+log = logging.getLogger(__name__)
+
+
+# FIXME: This is inelegant: https://github.com/DataBiosphere/azul/issues/652
+# noinspection PyUnusedLocal
+def load_tests(loader, tests, pattern):
+    suite = TestSuite()
+    return suite
+
+
+class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABCMeta):
+    def chalice_config(self):
+        return ChaliceConfig.create(lambda_timeout=15)
+
+    def _supplemental_lambda_names(self) -> List[str]:
+        return [
+            lambda_name
+            for lambda_name in config.lambda_names()
+            if lambda_name != self.lambda_name()
+        ]
+
+    @mock_sts
+    @mock_sqs
+    def test_ok_response(self):
+        self._create_mock_queues()
+        response = self._create_mock_response(up=True)
+        health_object = response.json()
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({
+            'up': True,
+            'elastic_search': {
+                'up': True
+            },
+            'queues': {
+                'up': True,
+                'azul-documents-abraham': {
+                    'up': True,
+                    'messages': {
+                        'delayed': 0,
+                        'invisible': 0,
+                        'queued': 0
+                    }
+                },
+                'azul-documents-abraham.fifo': {
+                    'up': True,
+                    'messages': {
+                        'delayed': 0,
+                        'invisible': 0,
+                        'queued': 0
+                    }
+                },
+                'azul-fail-abraham': {
+                    'up': True,
+                    'messages': {
+                        'delayed': 0,
+                        'invisible': 0,
+                        'queued': 0
+                    }
+                },
+                'azul-fail-abraham.fifo': {
+                    'up': True,
+                    'messages': {
+                        'delayed': 0,
+                        'invisible': 0,
+                        'queued': 0
+                    }
+                },
+                'azul-notify-abraham': {
+                    'up': True,
+                    'messages': {
+                        'delayed': 0,
+                        'invisible': 0,
+                        'queued': 0
+                    }
+                }
+            },
+            **({
+                lambda_name: {'up': True}
+                for lambda_name in self._supplemental_lambda_names()
+            }),
+            'unindexed_bundles': 0,
+            'unindexed_documents': 0
+        }, health_object)
+
+    @mock_sts
+    @mock_sqs
+    def test_supplemental_lambda_down(self):
+        self._create_mock_queues()
+        response = self._create_mock_response(up=False)
+        health_object = response.json()
+        self.assertEqual(503, response.status_code)
+        self.assertEqual({
+            'up': False,
+            'elastic_search': {
+                'up': True
+            },
+            'queues': {
+                'up': True,
+                'azul-documents-abraham': {
+                    'up': True,
+                    'messages': {
+                        'delayed': 0,
+                        'invisible': 0,
+                        'queued': 0
+                    }
+                },
+                'azul-documents-abraham.fifo': {
+                    'up': True,
+                    'messages': {
+                        'delayed': 0,
+                        'invisible': 0,
+                        'queued': 0
+                    }
+                },
+                'azul-fail-abraham': {
+                    'up': True,
+                    'messages': {
+                        'delayed': 0,
+                        'invisible': 0,
+                        'queued': 0
+                    }
+                },
+                'azul-fail-abraham.fifo': {
+                    'up': True,
+                    'messages': {
+                        'delayed': 0,
+                        'invisible': 0,
+                        'queued': 0
+                    }
+                },
+                'azul-notify-abraham': {
+                    'up': True,
+                    'messages': {
+                        'delayed': 0,
+                        'invisible': 0,
+                        'queued': 0
+                    }
+                }
+            },
+            **({
+                lambda_name: {'up': False}
+                for lambda_name in self._supplemental_lambda_names()
+            }),
+            'unindexed_bundles': 0,
+            'unindexed_documents': 0
+        }, health_object)
+    
+    @mock_sqs
+    @mock_sts
+    def test_queues_down(self):
+        response = self._create_mock_response(up=True)
+        health_object = response.json()
+        self.assertEqual(503, response.status_code)
+        self.assertEqual({
+            "up": False,
+            "elastic_search": {
+                "up": True
+            },
+            "queues": {
+                "up": False,
+                "azul-documents-abraham": {
+                    "up": False,
+                    "error": "The specified queue does not exist for this wsdl version."
+                },
+                "azul-documents-abraham.fifo": {
+                    "up": False,
+                    "error": "The specified queue does not exist for this wsdl version."
+                },
+                "azul-fail-abraham": {
+                    "up": False,
+                    "error": "The specified queue does not exist for this wsdl version."
+                },
+                "azul-fail-abraham.fifo": {
+                    "up": False,
+                    "error": "The specified queue does not exist for this wsdl version."
+                },
+                "azul-notify-abraham": {
+                    "up": False,
+                    "error": "The specified queue does not exist for this wsdl version."
+                }
+            },
+            **({
+                lambda_name: {'up': True}
+                for lambda_name in self._supplemental_lambda_names()
+            }),
+            "unindexed_bundles": 0,
+            "unindexed_documents": 0
+        }, health_object)
+
+    @mock_sqs
+    @mock_sts
+    def test_elasticsearch_down(self):
+        self._create_mock_queues()
+        with mock.patch.dict(os.environ, AZUL_ES_ENDPOINT='nonexisting-index.com:80'):
+            response = self._create_mock_response(up=True)
+            health_object = response.json()
+            self.assertEqual(503, response.status_code)
+            documents_ = {
+                'up': False,
+                'elastic_search': {
+                    'up': False
+                },
+                'queues': {
+                    'up': True,
+                    'azul-documents-abraham': {
+                        'up': True,
+                        'messages': {
+                            'delayed': 0,
+                            'invisible': 0,
+                            'queued': 0
+                        }
+                    },
+                    'azul-documents-abraham.fifo': {
+                        'up': True,
+                        'messages': {
+                            'delayed': 0,
+                            'invisible': 0,
+                            'queued': 0
+                        }
+                    },
+                    'azul-fail-abraham': {
+                        'up': True,
+                        'messages': {
+                            'delayed': 0,
+                            'invisible': 0,
+                            'queued': 0
+                        }
+                    },
+                    'azul-fail-abraham.fifo': {
+                        'up': True,
+                        'messages': {
+                            'delayed': 0,
+                            'invisible': 0,
+                            'queued': 0
+                        }
+                    },
+                    'azul-notify-abraham': {
+                        'up': True,
+                        'messages': {
+                            'delayed': 0,
+                            'invisible': 0,
+                            'queued': 0
+                        }
+                    }
+                },
+                **({
+                    lambda_name: {'up': True}
+                    for lambda_name in self._supplemental_lambda_names()
+                }),
+                'unindexed_bundles': 0,
+                'unindexed_documents': 0
+            }
+            self.assertEqual(documents_, health_object)
+
+    def _create_mock_response(self, up: bool):
+        with responses.RequestsMock() as _response:
+            _response.add_passthru(self.base_url)
+            for lambda_name in self._supplemental_lambda_names():
+                _response.add(responses.Response(method='GET',
+                                                 url=config.lambda_endpoint(lambda_name) + '/health/basic',
+                                                 status=200 if up else 503,
+                                                 json={'up': up}))
+            response = requests.get(self.base_url + '/health')
+        return response
+
+    def _create_mock_queues(self):
+        sqs = boto3.resource('sqs')
+        for queue_name in config.all_queue_names:
+            sqs.create_queue(QueueName=queue_name)

--- a/test/indexer/test_health_check.py
+++ b/test/indexer/test_health_check.py
@@ -1,0 +1,16 @@
+import unittest
+
+from health_check_test_case import HealthCheckTestCase
+
+
+class TestHealthEndpoint(HealthCheckTestCase):
+
+    @classmethod
+    def lambda_name(cls) -> str:
+        return 'indexer'
+
+# FIXME: This is inelegant: https://github.com/DataBiosphere/azul/issues/652
+del HealthCheckTestCase
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/service/test_health_check.py
+++ b/test/service/test_health_check.py
@@ -1,0 +1,17 @@
+import unittest
+
+from health_check_test_case import HealthCheckTestCase
+
+
+class TestHealthEndpoint(HealthCheckTestCase):
+
+    @classmethod
+    def lambda_name(cls) -> str:
+        return 'service'
+
+
+# FIXME: This is inelegant: https://github.com/DataBiosphere/azul/issues/652
+del HealthCheckTestCase
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/service/test_request_validation.py
+++ b/test/service/test_request_validation.py
@@ -38,34 +38,6 @@ class FacetNameValidationTest(WebServiceTestCase):
                           "Message": "BadRequestError: Unable to sort by undefined facet bad-facet."}
     service_config_dir = os.path.dirname(service_config.__file__)
 
-    def test_health(self):
-        url = self.base_url + "/health"
-        response = requests.get(url)
-        response.raise_for_status()
-        expected_json = {
-            'status': 'UP',
-            'elasticsearch': {
-                'domain': config.es_domain,
-                'status': 'UP'
-            }
-        }
-        self.assertEqual(response.json(), expected_json)
-
-    def test_health_es_unreachable(self):
-        with mock.patch.dict(os.environ, AZUL_ES_ENDPOINT='nonexisting-index.com:80'):
-            url = self.base_url + "/health"
-            response = requests.get(url)
-            response.raise_for_status()
-            expected_json = {
-                'status': 'UP',
-                'elasticsearch': {
-                    'domain': config.es_domain,
-                    'message': 'Unable to reach the host',
-                    'status': 'DOWN'
-                }
-            }
-            self.assertEqual(response.json(), expected_json)
-
     def test_version(self):
         commit = 'a9eb85ea214a6cfa6882f4be041d5cce7bee3e45'
         with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
If the service can not ping the Elasticsearch instance, it will respond
with a 503 status code.