### PR TITLE
 Limit impact of reindexing on DSS in personal deployments (#646)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    patch: off
+    project:
+      default:
+        target: 80%
+        threshold: 1%

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -13,6 +13,13 @@ meta:
                    and needs to be copied to local deployments
 
 changes:
+  - title: Personal deployment should index a limited subset of bundles
+    issues:
+      - https://github.com/DataBiosphere/azul/issues/646
+    upgrade:
+      - environment
+      - reindex
+    notes: Please append `_set azul_dss_query_prefix '42'` to deployments/*.local/environment.
 
   - title: Add endpoint to shorten URLs
     issues:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ subscribe:
 	if [[ $$AZUL_SUBSCRIBE_TO_DSS != 0 ]]; then python scripts/subscribe.py --shared; fi
 
 reindex:
-	python scripts/reindex.py --delete --prefix=2
+	python scripts/reindex.py --delete --partition-prefix-length=2
 
 clean:
 	for d in lambdas terraform; do $(MAKE) -C $$d clean; done

--- a/common.mk
+++ b/common.mk
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 
-ifndef AZUL_HOME
+ifndef azul_home
 $(error Please run "source environment" from the project root directory before running make commands)
 endif
 

--- a/deployments/.example.local/environment
+++ b/deployments/.example.local/environment
@@ -26,3 +26,5 @@ _set AZUL_URL_REDIRECT_FULL_DOMAIN_NAME "$AZUL_DEPLOYMENT_STAGE.$AZUL_URL_REDIRE
 #
 _set AZUL_SHARE_ES_DOMAIN 1
 _set AZUL_ES_DOMAIN "azul-index-dev"
+
+_set azul_dss_query_prefix '42'

--- a/environment
+++ b/environment
@@ -1,6 +1,10 @@
+# Only variables whose names start in `AZUL_` will be exported to a deployed
+# Lambda. Note that by implication, `azul_` variables will not be exported, even
+# though they are considered part of Azul.
+
 azul_vars=(
-    # The path to the project root directory
-    AZUL_HOME
+    # The path to the root directory of the project
+    azul_home
 
     # The name of the current deployment. This variable controls the name of all
     # cloud resources and is the main vehicle for isolating cloud resources
@@ -140,9 +144,9 @@ azul_vars=(
 
 unset ${azul_vars[*]}
 
-AZUL_HOME="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+azul_home="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-if [[ ! -f "${AZUL_HOME}/deployments/.active/environment" ]]; then
+if [[ ! -f "${azul_home}/deployments/.active/environment" ]]; then
     echo "Please create a symlink to the active deployment. " \
          "For example 'cd deployments && ln -snf dev .active'"
     return
@@ -154,7 +158,7 @@ _set () {
             eval ": \${$1:='$2'}"
             # Only echo in interactive shells
             if [[ -n $PS1 ]]; then
-                self=${BASH_SOURCE[1]#${AZUL_HOME}/}
+                self=${BASH_SOURCE[1]#${azul_home}/}
                 if [[ ${!1} == $2 ]]; then
                     echo ${self}: Set $1 to "'$2'"
                 else
@@ -173,16 +177,16 @@ _set () {
 
 # Set variables specific to the active deployment and the current user. This is
 # the most specific level.
-if [[ -f "${AZUL_HOME}/deployments/.active/environment.local" ]]; then
-    source "${AZUL_HOME}/deployments/.active/environment.local"
+if [[ -f "${azul_home}/deployments/.active/environment.local" ]]; then
+    source "${azul_home}/deployments/.active/environment.local"
 fi
 
 # Set variables specific to the active deployment
-source "${AZUL_HOME}/deployments/.active/environment"
+source "${azul_home}/deployments/.active/environment"
 
 # Set variables specific to the current user
-if [[ -f "${AZUL_HOME}/environment.local" ]]; then
-    source "${AZUL_HOME}/environment.local"
+if [[ -f "${azul_home}/environment.local" ]]; then
+    source "${azul_home}/environment.local"
 fi
 
 # Set the global defaults. This is the least specific level.
@@ -222,7 +226,7 @@ export ${azul_vars[*]}
 # A little helper to make re-sourcing this script easier.
 #
 _refresh () {
-    source ${AZUL_HOME}/environment
+    source ${azul_home}/environment
 }
 
 # Manage the symlink to the active deployment
@@ -230,15 +234,15 @@ _refresh () {
 _select () {
     if [[ $1 != "" ]]; then
         ( # use sub-shell so `cd` is temporary
-            cd ${AZUL_HOME}/deployments &&
+            cd ${azul_home}/deployments &&
             test -d "$1" &&
             { [ ! -e .active ] || { [ -L .active ] && rm .active ;} ;} &&
             ln -s "$1" .active
         ) || { echo error: "$1" && return ;}
         _refresh
     fi
-    ( cd ${AZUL_HOME}/deployments && ls -l .active )
+    ( cd ${azul_home}/deployments && ls -l .active )
 }
 
-export PYTHONPATH="$AZUL_HOME/src:$AZUL_HOME/test"
-export TF_DATA_DIR="${AZUL_HOME}/deployments/.active/.terraform"
+export PYTHONPATH="${azul_home}/src:${azul_home}/test"
+export TF_DATA_DIR="${azul_home}/deployments/.active/.terraform"

--- a/environment
+++ b/environment
@@ -140,6 +140,12 @@ azul_vars=(
     # Space separated list of IP addresses to allow access to Cart API endpoint
     # TODO: Remove when authentication is added
     AZUL_CART_API_IP_WHITELIST
+
+    # The default bundle UUID prefix to use for reindexing bundles in the DSS
+    # and for subscriptions to the DSS. If this variable is set to a non-empty
+    # string, only bundles whose UUID starts with the specified string will be
+    # indexed.
+    azul_dss_query_prefix
 )
 
 unset ${azul_vars[*]}
@@ -220,6 +226,8 @@ _set AZUL_TERRAFORM_BACKEND_BUCKET_TEMPLATE "org-humancellatlas-dss-config-{acco
 _set AZUL_ENABLE_CLOUDWATCH_ALARMS 0
 
 _set AZUL_CART_API_IP_WHITELIST  # TODO: Remove when authentication is added
+
+_set azul_dss_query_prefix
 
 unset -f _set
 

--- a/environment
+++ b/environment
@@ -213,8 +213,10 @@ _set AZUL_INDEXER_CONCURRENCY 64
 _set AZUL_SUBSCRIBE_TO_DSS 1
 _set AZUL_DISABLE_MULTIPART_MANIFESTS 0
 
-# This is the same TF bucket as the one DSS uses
+# FIXME: This is the TF bucket DSS used to use. We should have one exclusively for Azul.
+# https://github.com/DataBiosphere/azul/issues/645
 _set AZUL_TERRAFORM_BACKEND_BUCKET_TEMPLATE "org-humancellatlas-dss-config-{account_id}"
+
 _set AZUL_ENABLE_CLOUDWATCH_ALARMS 0
 
 _set AZUL_CART_API_IP_WHITELIST  # TODO: Remove when authentication is added

--- a/lambdas/indexer/Makefile
+++ b/lambdas/indexer/Makefile
@@ -5,17 +5,17 @@ all: deploy
 config: .chalice/config.json lambda-policy.json
 
 state: config
-	python $(AZUL_HOME)/scripts/manage_chalice_deployed.py indexer download
+	python $(azul_home)/scripts/manage_chalice_deployed.py indexer download
 
 deploy: state
 	python -m azul.changelog vendor
-	python $(AZUL_HOME)/scripts/manage_lambda_iam_role.py indexer lambda-policy.json
+	python $(azul_home)/scripts/manage_lambda_iam_role.py indexer lambda-policy.json
 	chalice deploy --stage $(AZUL_DEPLOYMENT_STAGE)
-	python $(AZUL_HOME)/scripts/manage_chalice_deployed.py indexer upload
+	python $(azul_home)/scripts/manage_chalice_deployed.py indexer upload
 
 delete: state
 	chalice delete --stage $(AZUL_DEPLOYMENT_STAGE)
-	python $(AZUL_HOME)/scripts/manage_chalice_deployed.py indexer upload
+	python $(azul_home)/scripts/manage_chalice_deployed.py indexer upload
 
 local: config
 	chalice local

--- a/lambdas/service/Makefile
+++ b/lambdas/service/Makefile
@@ -5,17 +5,17 @@ all: deploy
 config: .chalice/config.json lambda-policy.json
 
 state: config
-	python $(AZUL_HOME)/scripts/manage_chalice_deployed.py service download
+	python $(azul_home)/scripts/manage_chalice_deployed.py service download
 
 deploy: state
 	python -m azul.changelog vendor
-	python $(AZUL_HOME)/scripts/manage_lambda_iam_role.py service lambda-policy.json
+	python $(azul_home)/scripts/manage_lambda_iam_role.py service lambda-policy.json
 	chalice deploy --stage $(AZUL_DEPLOYMENT_STAGE)
-	python $(AZUL_HOME)/scripts/manage_chalice_deployed.py service upload
+	python $(azul_home)/scripts/manage_chalice_deployed.py service upload
 
 delete: state
 	chalice delete --stage $(AZUL_DEPLOYMENT_STAGE)
-	python $(AZUL_HOME)/scripts/manage_chalice_deployed.py service upload
+	python $(azul_home)/scripts/manage_chalice_deployed.py service upload
 
 local: config
 	chalice local

--- a/scripts/envhook.py
+++ b/scripts/envhook.py
@@ -62,7 +62,7 @@ def setenv():
     before = _parse(_run('env'))
     after = _parse(_run(f'source {environment} && env'))
     diff = set(after.items()).symmetric_difference(before.items())
-    for k, v in diff:
+    for k, v in sorted(diff):
         print(f"{self.name}: Setting {k} to '{v}'", file=sys.stderr)
         os.environ[k] = v
 

--- a/scripts/reindex.py
+++ b/scripts/reindex.py
@@ -7,6 +7,7 @@ Command line utility to trigger indexing of bundles from DSS into Azul
 import argparse
 import json
 import logging
+import shutil
 import sys
 from typing import List
 
@@ -16,18 +17,30 @@ logger = logging.getLogger(__name__)
 
 defaults = Reindexer()
 
-parser = argparse.ArgumentParser(description=__doc__)
+
+class MyFormatter(argparse.ArgumentDefaultsHelpFormatter):
+    def __init__(self, prog) -> None:
+        super().__init__(prog,
+                         max_help_position=50,
+                         width=min(shutil.get_terminal_size((80, 25)).columns, 120))
+
+
+parser = argparse.ArgumentParser(description=__doc__, formatter_class=MyFormatter)
 parser.add_argument('--dss-url',
+                    metavar='URL',
                     default=defaults.dss_url,
                     help='The URL of the DSS aka Blue Box REST API endpoint')
 parser.add_argument('--indexer-url',
+                    metavar='URL',
                     default=defaults.indexer_url,
                     help="The URL of the indexer's notification endpoint to send bundles to")
 parser.add_argument('--es-query',
                     default=defaults.es_query,
+                    metavar='JSON',
                     type=json.loads,
                     help='The Elasticsearch query to use against DSS to enumerate the bundles to be indexed')
 parser.add_argument('--workers',
+                    metavar='NUM',
                     dest='num_workers',
                     default=defaults.num_workers,
                     type=int,
@@ -40,6 +53,7 @@ group.add_argument('--sync',
                    help='Have the indexer lambda process the notification synchronously instead of queueing it for '
                         'asynchronous processing by a worker lambda.')
 group.add_argument('--prefix',
+                    metavar='NUM',
                    default=0,
                    type=int,
                    help='The length of the bundle UUID prefix by which to partition the set of bundles that match the '
@@ -56,10 +70,19 @@ parser.add_argument('--dryrun', '--dry-run',
                     default=False,
                     action='store_true',
                     help='Just print what would be done, do not actually do it.')
+parser.add_argument('--verbose',
+                    default=False,
+                    action='store_true',
+                    help='Enable verbose logging')
 
 
 def main(argv: List[str]):
     args = parser.parse_args(argv)
+
+    level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(format="%(asctime)s %(levelname)-7s %(threadName)-7s: %(message)s", level=level)
+    logging.getLogger().setLevel(logging.INFO)
+    logging.getLogger('azul').setLevel(level)
 
     reindexer = Reindexer(indexer_url=args.indexer_url,
                           dss_url=args.dss_url,
@@ -75,5 +98,4 @@ def main(argv: List[str]):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(format="%(asctime)s %(levelname)-7s %(threadName)-7s: %(message)s", level=logging.INFO)
     main(sys.argv[1:])

--- a/scripts/subscribe.py
+++ b/scripts/subscribe.py
@@ -43,9 +43,10 @@ def subscribe(options, dss_client):
     if options.subscribe:
         plugin = Plugin.load()
         base_url = "https://" + config.api_lambda_domain('indexer')
+        prefix = config.dss_query_prefix
         new_subscriptions = [freeze(dict(replica='aws', es_query=query, callback_url=base_url + path))
-                             for query, path in [(plugin.dss_subscription_query(), '/'),
-                                                 (plugin.dss_deletion_subscription_query(), '/delete')]]
+                             for query, path in [(plugin.dss_subscription_query(prefix), '/'),
+                                                 (plugin.dss_deletion_subscription_query(prefix), '/delete')]]
     else:
         new_subscriptions = []
 

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -36,7 +36,7 @@ class Config:
 
     @property
     def project_root(self) -> str:
-        return os.environ['AZUL_HOME']
+        return os.environ['azul_home']
 
     @property
     def es_domain(self) -> str:
@@ -210,7 +210,7 @@ class Config:
         repo = git.Repo(self.project_root)
         host, port = self.es_endpoint
         return {
-            **{k: v for k, v in os.environ.items() if k.startswith('AZUL_') and k != 'AZUL_HOME'},
+            **{k: v for k, v in os.environ.items() if k.startswith('AZUL_')},
             # Hard-wire the ES endpoint, so we don't need to look it up at run-time, for every request/invocation
             'AZUL_ES_ENDPOINT': f"{host}:{port}",
             'azul_git_commit': repo.head.object.hexsha,

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -71,6 +71,10 @@ class Config:
         return os.environ['AZUL_DSS_ENDPOINT']
 
     @property
+    def dss_query_prefix(self) -> str:
+        return os.environ['azul_dss_query_prefix']
+
+    @property
     def num_dss_workers(self) -> int:
         return int(os.environ['AZUL_DSS_WORKERS'])
 

--- a/src/azul/plugin.py
+++ b/src/azul/plugin.py
@@ -23,10 +23,25 @@ class Plugin(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def dss_subscription_query(self) -> JSON:
+    def dss_subscription_query(self, prefix: str) -> JSON:
+        """
+        The query to use for subscribing Azul to bundle additions in the DSS. This query will also be used for
+        listing bundles in the DSS during reindexing.
+
+        :param prefix: a prefix that restricts the set of bundles to subscribe to. This parameter is used to subset
+                       or partition the set of bundles in the DSS. The returned query should only match bundles whose
+                       UUID starts with the given prefix.
+        """
         raise NotImplementedError()
 
-    def dss_deletion_subscription_query(self) -> JSON:
+    def dss_deletion_subscription_query(self, prefix: str) -> JSON:
+        """
+        The query to use for subscribing Azul to bundle deletions in the DSS.
+
+        :param prefix: a prefix that restricts the set of bundles to subscribe to. This parameter is used to subset
+                       or partition the set of bundles in the DSS. The returned query should only match bundles whose
+                       UUID starts with the given prefix.
+        """
         raise NotImplementedError()
 
     @classmethod

--- a/src/azul/project/hca/__init__.py
+++ b/src/azul/project/hca/__init__.py
@@ -12,7 +12,7 @@ class Plugin(azul.plugin.Plugin):
     def indexer_class(self) -> Type[BaseIndexer]:
         return Indexer
 
-    def dss_subscription_query(self) -> JSON:
+    def dss_subscription_query(self, prefix: str) -> JSON:
         return {
             "query": {
                 "bool": {
@@ -28,7 +28,9 @@ class Plugin(azul.plugin.Plugin):
                             "exists": {
                                 "field": "files.project_json"
                             }
-                        }, *(
+                        },
+                        *self._prefix_clause(prefix),
+                        *(
                             [
                                 {
                                     "range": {
@@ -125,7 +127,7 @@ class Plugin(azul.plugin.Plugin):
             }
         }
 
-    def dss_deletion_subscription_query(self) -> JSON:
+    def dss_deletion_subscription_query(self, prefix: str) -> JSON:
         return {
             "query": {
                 "bool": {
@@ -134,8 +136,18 @@ class Plugin(azul.plugin.Plugin):
                             "term": {
                                 "admin_deleted": True
                             }
-                        }
+                        },
+                        *self._prefix_clause(prefix)
                     ]
                 }
             }
         }
+
+    def _prefix_clause(self, prefix):
+        return [
+            {
+                'prefix': {
+                    'uuid': prefix
+                }
+            }
+        ] if prefix else []

--- a/test/app_test_case.py
+++ b/test/app_test_case.py
@@ -48,7 +48,7 @@ class LocalAppTestCase(unittest.TestCase, metaclass=ABCMeta):
     def lambda_name(cls) -> str:
         """
         Return the name of the AWS Lambda function aka. Chalice app to start locally. Must match the name of a
-        subdirectory of $AZUL_HOME/lambdas. Subclasses must override this to select which Chalice app to start locally.
+        subdirectory of ${azul_home}/lambdas. Subclasses must override this to select which Chalice app to start locally.
         """
         raise NotImplementedError()
 


### PR DESCRIPTION
- environment: introduce `azul_dss_query_prefix` to be set in personal deployments
- reindex.py: rename `--es_query` argument to `--query`
- add `prefix` parameter to indexer plugin methods that return queries
- reindex.py: rename `--prefix` argument to --partition-prefix-length
- reindex.py: reintroduce `--prefix` for overriding `azul_dss_query_prefix`
- Rename AZUL_HOME to azul_home
- Cosmetics