### PR TITLE
Modified README and common.mk for Python36 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ generic with minimal need for project-specific behavior.
 
 ### 1.1. Development Preequisites
 
-- Python 3.6 with `virtualenv` and `pip`
+- Python 3.6 (3.7 does not work) with `virtualenv` and `pip`
 
 - The `bash` shell
 

--- a/common.mk
+++ b/common.mk
@@ -8,7 +8,7 @@ ifneq ($(shell python -c "import os; print('VIRTUAL_ENV' in os.environ)"),True)
 $(error Looks like no virtualenv is active)
 endif
 
-ifneq ($(shell python -c "import sys; print(sys.version_info >= (3,6))"),True)
+ifneq ($(shell python -c "import sys; print(sys.version_info[0:2] == (3,6))"),True)
 $(error Looks like Python 3.6 is not installed or active in the current virtualenv)
 endif
 


### PR DESCRIPTION
chalice currently checks for v3.6 but only gives warning if diff version found