### PR TITLE
Ensure that tests run without configured AWS credentials (#668)

### DIFF
--- a/scripts/envhook.py
+++ b/scripts/envhook.py
@@ -62,9 +62,13 @@ def setenv():
     before = _parse(_run('env'))
     after = _parse(_run(f'source {environment} && env'))
     diff = set(after.items()).symmetric_difference(before.items())
-    for k, v in sorted(diff):
-        print(f"{self.name}: Setting {k} to '{v}'", file=sys.stderr)
-        os.environ[k] = v
+    if diff:
+        pycharm_hosted = bool(int(os.environ.get('PYCHARM_HOSTED', '0')))
+        if not pycharm_hosted:
+            raise RuntimeError(f'It appears as though you need to source {environment}')
+        for k, v in sorted(diff):
+            print(f"{self.name}: Setting {k} to '{v}'", file=sys.stderr)
+            os.environ[k] = v
 
 
 def _run(command) -> str:

--- a/test/app_test_case.py
+++ b/test/app_test_case.py
@@ -1,20 +1,18 @@
-from abc import abstractmethod, ABCMeta
+from abc import ABCMeta, abstractmethod
 import importlib.util
-import os
-import sys
-import time
 import logging
-import unittest
-
-import requests
+import os
 from threading import Thread
-# noinspection PyPackageRequirements
-from chalice.local import LocalDevServer
+import time
+
 # noinspection PyPackageRequirements
 from chalice.config import Config as ChaliceConfig
+# noinspection PyPackageRequirements
+from chalice.local import LocalDevServer
+import requests
 
 from azul import config
-
+from azul_test_case import AzulTestCase
 
 log = logging.getLogger(__name__)
 
@@ -36,7 +34,7 @@ class ChaliceServerThread(Thread):
         return self.server_wrapper.server.server_address
 
 
-class LocalAppTestCase(unittest.TestCase, metaclass=ABCMeta):
+class LocalAppTestCase(AzulTestCase, metaclass=ABCMeta):
     """
     A mixin for test cases against a locally running instance of a AWS Lambda Function aka Chalice application. By
     default, the local instance will use the remote AWS Elasticsearch domain configured via AZUL_ES_DOMAIN or

--- a/test/azul_test_case.py
+++ b/test/azul_test_case.py
@@ -1,0 +1,22 @@
+import os
+from unittest import TestCase
+
+import boto3.session
+
+
+class AzulTestCase(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.aws_profile = os.environ.pop('AWS_PROFILE', None)
+        assert boto3.session.Session().get_credentials() is None, (
+            "This test does not work while there are configured AWS credentials available. Make sure "
+            "that neither AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY or AWS_SESSION_TOKEN are set. If you "
+            "have credentials configured in ~/.aws/config or ~/.aws/credentials, make sure that they are "
+            "configured in a separate [profile] so they are not active by default.")
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls.aws_profile is not None:
+            os.environ['AWS_PROFILE'] = cls.aws_profile
+        super().tearDownClass()

--- a/test/docker_container_test_case.py
+++ b/test/docker_container_test_case.py
@@ -1,15 +1,16 @@
 import logging
 import os
 from typing import Tuple
-from unittest import TestCase
 
 import docker
 from more_itertools import one
 
+from azul_test_case import AzulTestCase
+
 logger = logging.getLogger(__name__)
 
 
-class DockerContainerTestCase(TestCase):
+class DockerContainerTestCase(AzulTestCase):
     """
     A test case facilitating the creation of Docker containers that live as long as the class.
     """

--- a/test/health_check_test_case.py
+++ b/test/health_check_test_case.py
@@ -1,23 +1,17 @@
+from abc import ABCMeta
 import os
+from typing import List
+from unittest import TestSuite, mock
 
 import boto3
-import logging
+from moto import mock_sqs, mock_sts
 import requests
 import responses
 
-from abc import ABCMeta
-
-from typing import List
-from unittest import mock, TestSuite
-from moto import mock_sqs, mock_sts
-
-from azul import config
 from app_test_case import LocalAppTestCase
+from azul import config
 from es_test_case import ElasticsearchTestCase
 from retorts import ResponsesHelper
-
-
-logger = logging.getLogger(__name__)
 
 
 # FIXME: This is inelegant: https://github.com/DataBiosphere/azul/issues/652

--- a/test/indexer/test_health_check.py
+++ b/test/indexer/test_health_check.py
@@ -1,6 +1,11 @@
+import logging
 import unittest
 
 from health_check_test_case import HealthCheckTestCase
+
+
+def setUpModule():
+    logging.basicConfig(level=logging.INFO)
 
 
 class TestHealthCheck(HealthCheckTestCase):

--- a/test/service/test_buffer.py
+++ b/test/service/test_buffer.py
@@ -1,9 +1,10 @@
-from unittest import TestCase
 from unittest.mock import Mock
+
 from azul.service.responseobjects.buffer import FlushableBuffer
+from azul_test_case import AzulTestCase
 
 
-class FlushableBufferTest(TestCase):
+class FlushableBufferTest(AzulTestCase):
     def test_not_flushed_because_of_no_data(self):
         test_min_size = 5
         mock_callback = Mock()

--- a/test/service/test_cart_item_manager.py
+++ b/test/service/test_cart_item_manager.py
@@ -13,6 +13,7 @@ def setUpModule():
 
 
 class TestCartItemManager(WebServiceTestCase, DynamoTestCase):
+
     number_of_documents = 1500
 
     @classmethod
@@ -28,9 +29,9 @@ class TestCartItemManager(WebServiceTestCase, DynamoTestCase):
         self.create_tables()
 
     def tearDown(self):
-        super().tearDown()
         self.dynamo_accessor.get_table(config.dynamo_cart_table_name).delete()
         self.dynamo_accessor.get_table(config.dynamo_cart_item_table_name).delete()
+        super().tearDown()
 
     def create_tables(self):
         # Table definitions here must match definitions in Terraform

--- a/test/service/test_dss_proxy.py
+++ b/test/service/test_dss_proxy.py
@@ -1,5 +1,6 @@
 import io
 import json
+import logging
 import os
 import time
 from unittest import mock
@@ -14,6 +15,11 @@ import responses
 from app_test_case import LocalAppTestCase
 from azul import config
 from retorts import ResponsesHelper
+
+
+def setUpModule():
+    logging.basicConfig(level=logging.INFO)
+
 
 # These are the credentials defined in moto.instance_metadata.responses.InstanceMetadataResponse which, for reasons
 # yet to be determined, is used on Travis but not when I run this locally. Maybe it's the absence of

--- a/test/service/test_dynamo_accessor.py
+++ b/test/service/test_dynamo_accessor.py
@@ -11,10 +11,7 @@ def setUpModule():
 
 class TestDynamoAccessor(DynamoTestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.table_name = 'Carts'
+    table_name = 'Carts'
 
     def create_tables(self):
         self.dynamo_accessor.dynamo_client.create_table(
@@ -69,8 +66,8 @@ class TestDynamoAccessor(DynamoTestCase):
         self.create_tables()
 
     def tearDown(self):
-        super().tearDown()
         self.dynamo_accessor.get_table(self.table_name).delete()
+        super().tearDown()
 
     def test_query_empty(self):
         """

--- a/test/service/test_health_check.py
+++ b/test/service/test_health_check.py
@@ -1,6 +1,11 @@
+import logging
 import unittest
 
 from health_check_test_case import HealthCheckTestCase
+
+
+def setUpModule():
+    logging.basicConfig(level=logging.INFO)
 
 
 class TestHealthCheck(HealthCheckTestCase):

--- a/test/service/test_manifest_endpoints.py
+++ b/test/service/test_manifest_endpoints.py
@@ -1,15 +1,20 @@
 import json
+import logging
 from unittest import mock
 
-import requests
 from botocore.exceptions import ClientError
 from chalice import BadRequestError, ChaliceViewError
 from moto import mock_s3, mock_sts
+import requests
 
 from azul import config
 from azul.service.responseobjects.step_function_helper import StateMachineError
 from azul.service.responseobjects.storage_service import StorageService
 from service import WebServiceTestCase
+
+
+def setUpModule():
+    logging.basicConfig(level=logging.INFO)
 
 
 class ManifestEndpointTest(WebServiceTestCase):

--- a/test/service/test_manifest_service.py
+++ b/test/service/test_manifest_service.py
@@ -11,8 +11,6 @@ from azul.service.responseobjects.step_function_helper import StateMachineError,
 from azul_test_case import AzulTestCase
 
 
-    # @mock_sts is required for tests calling the arn helper methods in StepFunctionHelper
-    # because they require an account id
 def setUpModule():
     logging.basicConfig(level=logging.INFO)
 
@@ -28,6 +26,9 @@ class ManifestServiceTest(AzulTestCase):
 
         encoding = 'IjRkMWE4MGQxLWU5MmUtMTFlOC1iYzc2LWY5NTQ3MzRjNmU5YiI='
         self.assertEqual(encoding, ManifestService().encode_params(ManifestService().decode_params(encoding)))
+
+    # @mock_sts is required for tests calling the arn helper methods in StepFunctionHelper
+    # because they require an account id
 
     @mock_sts
     @mock.patch('azul.service.responseobjects.manifest_service.ManifestService.step_function_helper')

--- a/test/service/test_manifest_service.py
+++ b/test/service/test_manifest_service.py
@@ -1,17 +1,18 @@
 import datetime
 import json
-from unittest import mock, TestCase
+from unittest import mock
 
 from moto import mock_sts
 
 from azul import config
 from azul.service.responseobjects.manifest_service import ManifestService
 from azul.service.responseobjects.step_function_helper import StepFunctionHelper, StateMachineError
+from azul_test_case import AzulTestCase
 
 
-class ManifestServiceTest(TestCase):
     # @mock_sts is required for tests calling the arn helper methods in StepFunctionHelper
     # because they require an account id
+class ManifestServiceTest(AzulTestCase):
 
     def test_param_encoding_invertibility(self):
         """

--- a/test/service/test_manifest_service.py
+++ b/test/service/test_manifest_service.py
@@ -1,17 +1,22 @@
 import datetime
 import json
+import logging
 from unittest import mock
 
 from moto import mock_sts
 
 from azul import config
 from azul.service.responseobjects.manifest_service import ManifestService
-from azul.service.responseobjects.step_function_helper import StepFunctionHelper, StateMachineError
+from azul.service.responseobjects.step_function_helper import StateMachineError, StepFunctionHelper
 from azul_test_case import AzulTestCase
 
 
     # @mock_sts is required for tests calling the arn helper methods in StepFunctionHelper
     # because they require an account id
+def setUpModule():
+    logging.basicConfig(level=logging.INFO)
+
+
 class ManifestServiceTest(AzulTestCase):
 
     def test_param_encoding_invertibility(self):

--- a/test/service/test_pagination.py
+++ b/test/service/test_pagination.py
@@ -1,11 +1,15 @@
 #!/usr/bin/python
-
-import requests
 import json
+import logging
 import unittest
 
+import requests
 
 from service import WebServiceTestCase
+
+
+def setUpModule():
+    logging.basicConfig(level=logging.INFO)
 
 
 class PaginationTestCase(WebServiceTestCase):

--- a/test/service/test_query_shortener.py
+++ b/test/service/test_query_shortener.py
@@ -1,3 +1,4 @@
+import logging
 from unittest import mock
 
 from chalice import BadRequestError, ChaliceViewError
@@ -6,6 +7,10 @@ from moto import mock_s3, mock_sts
 from azul import config
 from azul.service.responseobjects.storage_service import StorageService
 from azul_test_case import AzulTestCase
+
+
+def setUpModule():
+    logging.basicConfig(level=logging.INFO)
 
 
 class TestQueryShortener(AzulTestCase):

--- a/test/service/test_query_shortener.py
+++ b/test/service/test_query_shortener.py
@@ -1,13 +1,14 @@
-from unittest import mock, TestCase
+from unittest import mock
 
 from chalice import BadRequestError, ChaliceViewError
 from moto import mock_s3, mock_sts
 
 from azul import config
 from azul.service.responseobjects.storage_service import StorageService
+from azul_test_case import AzulTestCase
 
 
-class TestQueryShortener(TestCase):
+class TestQueryShortener(AzulTestCase):
 
     @mock.patch('azul.service.responseobjects.storage_service.StorageService.put')
     @mock.patch('azul.service.responseobjects.storage_service.StorageService.get')

--- a/test/service/test_repository_projects.py
+++ b/test/service/test_repository_projects.py
@@ -1,10 +1,15 @@
+import logging
+
 import requests
 
 from service import WebServiceTestCase
 
 
-class RepositoryProjectsEndpointTest(WebServiceTestCase):
+def setUpModule():
+    logging.basicConfig(level=logging.INFO)
 
+
+class RepositoryProjectsEndpointTest(WebServiceTestCase):
     # Set a seed so that we can test the detail response with a stable project ID
     seed = 123
 

--- a/test/service/test_repository_specimen.py
+++ b/test/service/test_repository_specimen.py
@@ -1,6 +1,12 @@
+import logging
+
 import requests
 
 from service import WebServiceTestCase
+
+
+def setUpModule():
+    logging.basicConfig(level=logging.INFO)
 
 
 class RepositorySpecimenEndpointTest(WebServiceTestCase):

--- a/test/service/test_request_builder.py
+++ b/test/service/test_request_builder.py
@@ -8,11 +8,13 @@ import unittest
 
 from elasticsearch_dsl.utils import AttrList
 
-from azul.service.responseobjects.elastic_request_builder import ElasticTransformDump as EsTd, ElasticTransformDump
 from azul.service import service_config
+from azul.service.responseobjects.elastic_request_builder import ElasticTransformDump, ElasticTransformDump as EsTd
 from service import WebServiceTestCase
 
-logger = logging.getLogger(__name__)
+
+def setUpModule():
+    logging.basicConfig(level=logging.INFO)
 
 
 class TestRequestBuilder(WebServiceTestCase):

--- a/test/service/test_request_builder.py
+++ b/test/service/test_request_builder.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 import difflib
 import json
 import logging.config

--- a/test/service/test_request_validation.py
+++ b/test/service/test_request_validation.py
@@ -8,9 +8,7 @@ from unittest import mock
 
 from moto import mock_s3, mock_sts
 import requests
-import responses
 
-from azul import config
 import azul.changelog
 from azul.service import service_config
 from azul.service.responseobjects.storage_service import StorageService
@@ -20,11 +18,8 @@ from service import WebServiceTestCase
 log = logging.getLogger(__name__)
 
 
-# noinspection PyPep8Naming
 def setUpModule():
-    log.setLevel(logging.DEBUG)
-    stream_handler = logging.StreamHandler(sys.stdout)
-    log.addHandler(stream_handler)
+    logging.basicConfig(level=logging.INFO)
 
 
 class FacetNameValidationTest(WebServiceTestCase):

--- a/test/service/test_response.py
+++ b/test/service/test_response.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
 import json
+import logging
 import unittest
 import urllib.parse
 
@@ -12,6 +13,10 @@ from azul.service.responseobjects.hca_response_v5 import (FileSearchResponse,
                                                           KeywordSearchResponse,
                                                           ProjectSummaryResponse)
 from service import WebServiceTestCase
+
+
+def setUpModule():
+    logging.basicConfig(level=logging.INFO)
 
 
 class TestResponse(WebServiceTestCase):

--- a/test/service/test_storage_service.py
+++ b/test/service/test_storage_service.py
@@ -1,13 +1,18 @@
 import json
+import logging
 from unittest.mock import patch
 
 from moto import mock_s3, mock_sts
 import requests
 
-from azul.service.responseobjects.storage_service import (StorageService,
-                                                          MultipartUploadError,
-                                                          MultipartUploadHandler)
+from azul.service.responseobjects.storage_service import (MultipartUploadError,
+                                                          MultipartUploadHandler,
+                                                          StorageService)
 from azul_test_case import AzulTestCase
+
+
+def setUpModule():
+    logging.basicConfig(level=logging.INFO)
 
 
 class StorageServiceTest(AzulTestCase):

--- a/test/service/test_storage_service.py
+++ b/test/service/test_storage_service.py
@@ -1,5 +1,4 @@
 import json
-from unittest import TestCase
 from unittest.mock import patch
 
 from moto import mock_s3, mock_sts
@@ -8,9 +7,10 @@ import requests
 from azul.service.responseobjects.storage_service import (StorageService,
                                                           MultipartUploadError,
                                                           MultipartUploadHandler)
+from azul_test_case import AzulTestCase
 
 
-class StorageServiceTest(TestCase):
+class StorageServiceTest(AzulTestCase):
     """
     Functional Test for Storage Service
     """

--- a/test/test_changelog.py
+++ b/test/test_changelog.py
@@ -1,12 +1,13 @@
 from operator import itemgetter
 import sys
 from tempfile import TemporaryDirectory
-from unittest import TestCase, mock
+from unittest import mock
 
 import azul.changelog
+from azul_test_case import AzulTestCase
 
 
-class TestChangeLog(TestCase):
+class TestChangeLog(AzulTestCase):
     def test_changelog(self):
         changelog = azul.changelog.changelog()
         with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
* `envhook.py` refuses to apply differences outside of PyCharm
* Consistent test logging; optimized imports in affected modules 
* Fix teardown order in cart tests
