### PR TITLE
Make envhook.py warn if environment is stale, but not quit (#671)

### DIFF
--- a/src/azul/modules.py
+++ b/src/azul/modules.py
@@ -1,0 +1,19 @@
+import importlib.util
+
+
+def load_module(path: str, module_name: str):
+    """
+    Load a module from the .py file at the given path without affecting `sys.path` or `sys.modules`.
+
+    :param path: the file system path to the module file (typically ending in .py)
+
+    :param module_name: the value to assign to the __name__ attribute of the module.
+
+    :return: the module
+    """
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert path == module.__file__
+    assert module.__name__ == module_name
+    return module

--- a/test/app_test_case.py
+++ b/test/app_test_case.py
@@ -12,6 +12,7 @@ from chalice.local import LocalDevServer
 import requests
 
 from azul import config
+from azul.modules import load_module
 from azul_test_case import AzulTestCase
 
 log = logging.getLogger(__name__)
@@ -68,12 +69,7 @@ class LocalAppTestCase(AzulTestCase, metaclass=ABCMeta):
         # simplifies tear down and isolates the app modules from different lambdas loaded by different concrete
         # subclasses. It does, however, violate this one invariant: `sys.modules[module.__name__] == module`
         path = os.path.join(config.project_root, 'lambdas', cls.lambda_name(), 'app.py')
-        spec = importlib.util.spec_from_file_location('__main__', path)
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-        assert path == module.__file__
-        assert module.__name__ == '__main__'
-        cls.app_module = module
+        cls.app_module = load_module(path, '__main__')
 
     @classmethod
     def tearDownClass(cls):

--- a/test/test_doctests.py
+++ b/test/test_doctests.py
@@ -2,9 +2,10 @@ import doctest
 import unittest
 
 import azul
+import azul.json_freeze
+from azul.modules import load_module
 import azul.time
 import azul.transformer
-import azul.json_freeze
 import azul.vendored.frozendict
 
 
@@ -14,6 +15,7 @@ def load_tests(loader, tests, ignore):
     tests.addTests(doctest.DocTestSuite(azul.transformer))
     tests.addTests(doctest.DocTestSuite(azul.json_freeze))
     tests.addTests(doctest.DocTestSuite(azul.vendored.frozendict))
+    tests.addTests(doctest.DocTestSuite(load_module(azul.config.project_root + '/scripts/envhook.py', 'envhook')))
     return tests
 
 


### PR DESCRIPTION
Also fixes a bug causing envhook.py to change a variable twice, to the old value and the new value.