### PR TITLE
Fix: DSS notifications give 500 error (#677)

### DIFF
--- a/lambdas/indexer/app.py
+++ b/lambdas/indexer/app.py
@@ -87,7 +87,7 @@ def post_notification():
     else:
         message = dict(action='add', notification=notification)
         notify_queue = queue(config.notify_queue_name)
-        notify_queue.send_message(MessageBody=message)
+        notify_queue.send_message(MessageBody=json.dumps(message))
         log.info("Queued notification %r", notification)
     return {"status": "done"}
 
@@ -101,7 +101,7 @@ def delete_notification():
     log.info("Received deletion notification %r", notification)
     message = dict(action='delete', notification=notification)
     notify_queue = queue(config.notify_queue_name)
-    notify_queue.send_message(MessageBody=message)
+    notify_queue.send_message(MessageBody=json.dumps(message))
     log.info("Queued notification %r", notification)
 
     return chalice.app.Response(body='', status_code=http.HTTPStatus.ACCEPTED)


### PR DESCRIPTION
'Invalid type for parameter MessageBody'

Regression from dc6f9c6c5dbcd7bbed0b7f9673a8152d10037062

Also occurs on local reindexing (without `--partition-prefix-length`).