### PR TITLE
Renamed Terraform S3 bucket to an Azul-specific name

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Error inspecting states in the "s3" backend:
 
 … but the bucket does exist. Make sure
 `deployments/.active/.terraform/terraform.tfstate` refers to the correct
-bucket, the one configured in `AZUL_TERRAFORM_BACKEND_BUCKET_TEMPLATE`. If it
+bucket, the one configured in `AZUL_TERRAFORM_BACKEND_BUCKET`. If it
 doesn't, you may have to remove that file or modify it to fix the bucket name.
 
 ## 5. Branch flow & development process

--- a/deployments/prod/environment
+++ b/deployments/prod/environment
@@ -13,7 +13,7 @@
 _set AZUL_DEPLOYMENT_STAGE prod
 _set AZUL_DSS_ENDPOINT "https://dss.data.humancellatlas.org/v1"
 
-_set AZUL_TERRAFORM_BACKEND_BUCKET_TEMPLATE "org-humancellatlas-{account_id}-terraform"
+_set AZUL_TERRAFORM_BACKEND_BUCKET "org-humancellatlas-azul-prod-config"
 _set AZUL_DOMAIN_NAME "explore.data.humancellatlas.org"
 
 _set AZUL_URL_REDIRECT_FULL_DOMAIN_NAME "url.data.humancellatlas.org"

--- a/environment
+++ b/environment
@@ -61,9 +61,8 @@ azul_vars=(
     # multiple developers to collaboratively use TerraForm in a single AWS
     # account. This bucket is likely going be shared with other projects such as
     # DSS and might require some coordination with the developers of those
-    # projects. The special string {account_id} is replaced with the ID of the
-    # AWS account the currently configured AWS credentials belong to.
-    AZUL_TERRAFORM_BACKEND_BUCKET_TEMPLATE
+    # projects.
+    AZUL_TERRAFORM_BACKEND_BUCKET
 
     # The number of workers pulling files from DSS. There is one such set of DSS
     # workers per index worker!
@@ -219,9 +218,7 @@ _set AZUL_INDEXER_CONCURRENCY 64
 _set AZUL_SUBSCRIBE_TO_DSS 1
 _set AZUL_DISABLE_MULTIPART_MANIFESTS 0
 
-# FIXME: This is the TF bucket DSS used to use. We should have one exclusively for Azul.
-# https://github.com/DataBiosphere/azul/issues/645
-_set AZUL_TERRAFORM_BACKEND_BUCKET_TEMPLATE "org-humancellatlas-dss-config-{account_id}"
+_set AZUL_TERRAFORM_BACKEND_BUCKET "org-humancellatlas-azul-dev-config"
 
 _set AZUL_ENABLE_CLOUDWATCH_ALARMS 0
 

--- a/scripts/manage_chalice_deployed.py
+++ b/scripts/manage_chalice_deployed.py
@@ -15,7 +15,7 @@ logger.setLevel(logging.INFO)
 
 app_name, command = sys.argv[1:]
 
-bucket_name = config.terraform_backend_bucket_template.format(account_id=aws.account)
+bucket_name = config.terraform_backend_bucket
 file_path = f'.chalice/deployed/{config.deployment_stage}.json'
 key = f'azul-{app_name}-{config.deployment_stage}/deployed.json'
 

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -189,8 +189,8 @@ class Config:
         return self._term_from_env('AZUL_DEPLOYMENT_STAGE')
 
     @property
-    def terraform_backend_bucket_template(self) -> str:
-        return os.environ['AZUL_TERRAFORM_BACKEND_BUCKET_TEMPLATE']
+    def terraform_backend_bucket(self) -> str:
+        return os.environ['AZUL_TERRAFORM_BACKEND_BUCKET']
 
     @property
     def enable_cloudwatch_alarms(self) -> bool:

--- a/terraform/backend.tf.json.template.py
+++ b/terraform/backend.tf.json.template.py
@@ -7,7 +7,7 @@ emit(
         "terraform": {
             "backend": {
                 "s3": {
-                    "bucket": config.terraform_backend_bucket_template.format(account_id=aws.account),
+                    "bucket": config.terraform_backend_bucket,
                     # If we break the TF config up into components, the component name goes in between the two dashes.
                     "key": "azul--" + config.deployment_stage + ".tfstate",
                     "region": aws.region_name,


### PR DESCRIPTION
Renamed variable "AZUL_TERRAFORM_BACKEND_BUCKET_TEMPLATE" to "AZUL_TERRAFORM_BACKEND_BUCKET".

Updated code to use the variable value without inserting aws account id.

Renamed buckets to "org-humancellatlas-azul-dev-config" for personal, dev, integration and staging deployments, and "org-humancellatlas-azul-prod-config" for prod