### PR TITLE
Export manifest in BDBag to Terra (addresses #604)

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -53,6 +53,18 @@ changes:
     notes: Before reinstalling your requirements, delete your virtual environment. Then, use the `python -m venv`
            command instead of `virtualenv` to create your virtual environment.
 
+  - title: Add BDBag as an alternative manifest format
+    issues:
+      - https://github.com/DataBiosphere/azul/issues/604
+    upgrade:
+      - deploy
+      - requirements
+      - clients
+    notes: The query parameter `format` has been added to the '/repository/files/export' endpoint. Possible values are
+           `tsv` (default, retains previous functionality) and `bdbag`. The latter creates a manifest containing the
+           information necessary for importing samples from a DSS instance into Broad's Terra analysis platform. The
+           manifest data will be packaged in a BDBag and persisted as a compressed ZIP file in an S3 bucket.
+
   - title: Include content disposition header in manifest responses
     issues:
       - https://github.com/DataBiosphere/azul/issues/655

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 asn1crypto==0.24.0
 aws-requests-auth==0.4.2
+bdbag==1.5.1
 boto==2.48.0
 boto3==1.7.48
 botocore==1.10.48

--- a/src/azul/project/hca/transformers.py
+++ b/src/azul/project/hca/transformers.py
@@ -256,8 +256,6 @@ class CellSuspensionAggregator(GroupingAggregator):
     def _get_accumulator(self, field) -> Optional[Accumulator]:
         if field == 'total_estimated_cells':
             return SumAccumulator(0)
-        elif field == 'document_id':
-            return None
         else:
             return SetAccumulator(max_size=100)
 

--- a/src/azul/service/manifest.py
+++ b/src/azul/service/manifest.py
@@ -38,6 +38,7 @@ class ManifestService(AbstractService):
     def start_or_inspect_manifest_generation(self,
                                              self_url,
                                              token: Optional[str] = None,
+                                             format: Optional[str] = None,
                                              filters: Optional[str] = None
                                              ) -> Tuple[float, str]:
         """
@@ -52,7 +53,7 @@ class ManifestService(AbstractService):
 
         if token is None:
             execution_id = str(uuid.uuid4())
-            self._start_manifest_generation(filters, execution_id)
+            self._start_manifest_generation(format, filters, execution_id)
             token = {'execution_id': execution_id}
         else:
             token = self.decode_token(token)
@@ -66,7 +67,7 @@ class ManifestService(AbstractService):
         else:
             return 0, result
 
-    def _start_manifest_generation(self, filters: dict, execution_id: str):
+    def _start_manifest_generation(self, format: str, filters: dict, execution_id: str) -> None:
         """
         Start the execution of a state machine generating the manifest
 

--- a/src/azul/service/responseobjects/elastic_request_builder.py
+++ b/src/azul/service/responseobjects/elastic_request_builder.py
@@ -531,7 +531,7 @@ class ElasticTransformDump(object):
 
         return final_response
 
-    def transform_manifest(self, request_config_file='request_config.json', filters=None):
+    def transform_manifest(self, format, filters=None, request_config_file='request_config.json'):
         config_folder = os.path.dirname(service_config.__file__)
         request_config_path = "{}/{}".format(config_folder, request_config_file)
         request_config = self.open_and_return_json(request_config_path)
@@ -549,7 +549,7 @@ class ElasticTransformDump(object):
                                         source_filter=source_filter,
                                         enable_aggregation=False)
 
-        manifest = ManifestResponse(es_search, manifest_config, request_config['translation'])
+        manifest = ManifestResponse(es_search, manifest_config, request_config['translation'], format)
 
         return manifest.return_response()
 

--- a/src/azul/service/responseobjects/hca_response_v5.py
+++ b/src/azul/service/responseobjects/hca_response_v5.py
@@ -1,11 +1,13 @@
 #!/usr/bin/python
 import abc
 from collections import OrderedDict, defaultdict
+import os
 import csv
+from tempfile import TemporaryDirectory
 from io import TextIOWrapper, StringIO
 from itertools import chain
 import logging
-import os
+
 from uuid import uuid4
 
 from chalice import Response
@@ -15,7 +17,9 @@ from jsonobject import (FloatProperty,
                         ListProperty,
                         ObjectProperty,
                         StringProperty)
-
+from bdbag import bdbag_api
+from shutil import copy
+from more_itertools import one
 from azul import config
 from azul.service.responseobjects.storage_service import (MultipartUploadHandler,
                                                           StorageService,
@@ -212,7 +216,7 @@ class ManifestResponse(AbstractResponse):
                 writer.writerow(list(self.manifest_entries['bundles'].keys()) +
                                 list(self.manifest_entries['contents.files'].keys()))
                 for hit in self.es_search.scan():
-                    self._iterate_hit(hit, writer)
+                    self._iterate_hit_tsv(hit, writer)
 
         return object_key
 
@@ -222,9 +226,19 @@ class ManifestResponse(AbstractResponse):
 
         :return: S3 object key
         """
-        parameters = dict(object_key=f'manifests/{uuid4()}.tsv',
-                          data=self._construct_tsv_content().encode(),
-                          content_type='text/tab-separated-values')
+        if self.format == 'tsv':
+            data = self._construct_tsv_content().encode()
+            content_type = 'text/tab-separated-values'
+            object_key = f'manifests/{uuid4()}.tsv'
+        elif self.format == 'bdbag':
+            data = self._construct_bdbag()
+            content_type = 'application/zip'
+            object_key = f'manifests/{uuid4()}.zip'
+        else:
+            assert False
+        parameters = dict(object_key=object_key,
+                          data=data,
+                          content_type=content_type)
         return self.storage_service.put(**parameters)
 
     def _construct_tsv_content(self):
@@ -232,33 +246,114 @@ class ManifestResponse(AbstractResponse):
 
         output = StringIO()
         writer = csv.writer(output, dialect='excel-tab')
-
         writer.writerow(list(self.manifest_entries['bundles'].keys()) +
                         list(self.manifest_entries['contents.files'].keys()))
         for hit in es_search.scan():
-            self._iterate_hit(hit, writer)
+            self._iterate_hit_tsv(hit, writer)
 
         return output.getvalue()
 
-    def _iterate_hit(self, es_search_hit, writer):
+    def _construct_bdbag(self) -> str:
+        """
+        Create and return a file object of the sample data.
+        """
+        es_search = self.es_search
+        sample_file_object = StringIO()
+        sample_writer = csv.writer(sample_file_object, dialect='excel-tab')
+        # Add fieldnames.
+        sample_writer.writerow(list(chain(self.manifest_entries['contents.specimens'].keys(),
+                                          self.manifest_entries['contents.cell_suspensions'].keys(),
+                                          self.manifest_entries['bundles'].keys(),
+                                          self.manifest_entries['contents.files'].keys(),
+                                          ['file_url'])))
+        participant_file_object = StringIO()
+        participant_writer = csv.writer(participant_file_object, dialect='excel-tab')
+        participant_writer.writerow(['entity:participant_id'])
+        for hit in es_search.scan():
+            self._iterate_hit_bdbag(hit, participant_file_object, participant_writer, sample_writer)
+
+        return self._create_zipped_bdbag(participant_file_object, sample_file_object)
+
+    @staticmethod
+    def _create_zipped_bdbag(participant_file_object: StringIO, sample_file_object: StringIO) -> str:
+        """
+        Create write participant and sample data files to disk, and create and return zipped BDBag.
+        """
+
+        with TemporaryDirectory() as bag_path, TemporaryDirectory() as tsv_file_dir:
+            bag = bdbag_api.make_bag(bag_path)
+            data_path = os.path.join(bag_path, 'data')
+
+            # Write participant and sample data to their respective files.
+            tsv_filenames = ['participant.tsv', 'sample.tsv']
+            for tsv_filename in tsv_filenames:
+                with open(os.path.join(tsv_file_dir, tsv_filename), 'w') as f:
+                    if tsv_filename == 'participant.tsv':
+                        f.write(participant_file_object.getvalue())
+                    else:
+                        f.write(sample_file_object.getvalue())
+                copy(os.path.join(tsv_file_dir, tsv_filename), data_path)
+
+            assert tsv_filenames == os.listdir(data_path)
+            bag = bdbag_api.make_bag(bag_path, update=True)  # update TSV checksums
+            assert bdbag_api.is_bag(bag_path)
+            bdbag_api.validate_bag(bag_path)
+            assert bdbag_api.check_payload_consistency(bag)
+
+            return bdbag_api.archive_bag(bag_path, 'zip')
+
+    def _iterate_hit_tsv(self, es_search_hit, writer):
         hit_dict = es_search_hit.to_dict()
         assert len(hit_dict['contents']['files']) == 1
         file = hit_dict['contents']['files'][0]
         file_fields = self._translate(file, 'contents.files')
+
         for bundle in hit_dict['bundles']:
             # FIXME: If a file is in multiple bundles, the manifest will list it twice. `hca dss download_manifest`
             # would download the file twice (https://github.com/DataBiosphere/azul/issues/423).
             writer.writerow(self._translate(bundle, 'bundles') + file_fields)
 
+    def _iterate_hit_bdbag(self, es_search_hit, participant_file_object, participant_writer, sample_writer):
+        hit_dict = es_search_hit.to_dict()
+
+        assert len(hit_dict['contents']['specimens']) == 1
+        assert len(hit_dict['contents']['cell_suspensions']) == 1
+        assert len(hit_dict['contents']['files']) == 1
+
+        specimen = one(hit_dict['contents']['specimens'])
+        cell_suspension = one(hit_dict['contents']['cell_suspensions'])
+        file = one(hit_dict['contents']['files'])
+
+        specimen_fields = self._translate(specimen, 'contents.specimens')
+        cell_suspension_fields = self._translate(cell_suspension, 'contents.cell_suspensions')
+        file_fields = self._translate(file, 'contents.files')
+
+        # Construct URL for file.
+        file_id = file['uuid']
+        version = file['version']
+        replica = 'gcp'
+        endpoint = f'files/{file_id}?version={version}&replica={replica}'
+        fetch_url = [config.dss_endpoint + '/' + endpoint]
+
+        for bundle in hit_dict['bundles']:
+            sample_writer.writerow(chain(specimen_fields[0], specimen_fields[1], cell_suspension_fields[0],
+                                         self._translate(bundle, 'bundles'), file_fields + fetch_url))
+            # Keep participant file object as a set.
+            if specimen_fields[1][0] not in participant_file_object.getvalue():
+                participant_writer.writerow(specimen_fields[1])
+
     def return_response(self):
-        object_key = self._push_content_single_part() if config.disable_multipart_manifests else self._push_content()
+        if config.disable_multipart_manifests or self.format == 'bdbag':
+            object_key = self._push_content_single_part()
+        else:
+            object_key = self._push_content()
         file_name = 'hca-manifest-' + object_key.rsplit('/', )[-1]
         presigned_url = self.storage_service.get_presigned_url(object_key, file_name=file_name)
         headers = {'Content-Type': 'application/json', 'Location': presigned_url}
 
         return Response(body='', headers=headers, status_code=302)
 
-    def __init__(self, es_search, manifest_entries, mapping):
+    def __init__(self, es_search, manifest_entries, mapping, format):
         """
         The constructor takes the raw response from ElasticSearch and creates
         a csv file based on the columns from the manifest_entries
@@ -270,6 +365,7 @@ class ManifestResponse(AbstractResponse):
         self.manifest_entries = OrderedDict(manifest_entries)
         self.mapping = mapping
         self.storage_service = StorageService()
+        self.format = format
 
 
 class EntryFetcher:

--- a/src/azul/service/service_config/request_config.json
+++ b/src/azul/service/service_config/request_config.json
@@ -48,6 +48,13 @@
     }
   },
   "manifest": {
+    "contents.cell_suspensions": {
+      "cell_suspension_id": "document_id"
+    },
+    "contents.specimens": {
+      "entity:sample_id": "donor_biomaterial_id",
+      "participant_id": "donor_document_id"
+    },
     "contents.files": {
       "file_content_type": "content-type",
       "file_name": "name",

--- a/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T113344.698028Z.results.json
+++ b/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T113344.698028Z.results.json
@@ -682,6 +682,9 @@
                 ],
                 "cell_suspensions": [
                     {
+                        "document_id": [
+                            "412898c5-5b9b-4907-b07c-e9b89666e204"
+                        ],
                         "total_estimated_cells": 1,
                         "organ": [
                             "pancreas"
@@ -817,6 +820,9 @@
                 ],
                 "cell_suspensions": [
                     {
+                        "document_id": [
+                            "412898c5-5b9b-4907-b07c-e9b89666e204"
+                        ],
                         "total_estimated_cells": 1,
                         "organ": [
                             "pancreas"
@@ -936,6 +942,9 @@
                 ],
                 "cell_suspensions": [
                     {
+                        "document_id": [
+                            "412898c5-5b9b-4907-b07c-e9b89666e204"
+                        ],
                         "total_estimated_cells": 1,
                         "organ": [
                             "pancreas"
@@ -1064,6 +1073,9 @@
                 ],
                 "cell_suspensions": [
                     {
+                        "document_id": [
+                            "412898c5-5b9b-4907-b07c-e9b89666e204"
+                        ],
                         "total_estimated_cells": 1,
                         "organ": [
                             "pancreas"

--- a/test/service/test_manifest_endpoints.py
+++ b/test/service/test_manifest_endpoints.py
@@ -51,7 +51,7 @@ class ManifestEndpointTest(WebServiceTestCase):
         mock_uuid.return_value = execution_name
         step_function_helper.describe_execution.return_value = {'status': 'RUNNING'}
         filters = {'file': {'organ': {'is': ['lymph node']}}}
-        current_request.query_params = {'filters': json.dumps(filters)}
+        current_request.query_params = {'filters': json.dumps(filters), 'format': format}
         response = start_manifest_generation()
         self.assertEqual(301, response.status_code)
         self.assertIn('Retry-After', response.headers)
@@ -77,7 +77,7 @@ class ManifestEndpointTest(WebServiceTestCase):
         mock_uuid.return_value = execution_name
         step_function_helper.describe_execution.return_value = {'status': 'RUNNING'}
         filters = {'file': {'organ': {'is': ['lymph node']}}}
-        current_request.query_params = {'filters': json.dumps(filters)}
+        current_request.query_params = {'filters': json.dumps(filters), 'format': format}
         response = start_manifest_generation_fetch()
         self.assertEqual(301, response['Status'])
         self.assertIn('Retry-After', response)

--- a/test/service/test_request_validation.py
+++ b/test/service/test_request_validation.py
@@ -3,6 +3,8 @@ import json
 import logging
 import os
 import sys
+import re
+
 from tempfile import TemporaryDirectory
 from unittest import mock
 
@@ -10,10 +12,12 @@ from moto import mock_s3, mock_sts
 import requests
 
 import azul.changelog
+from azul import config
 from azul.service import service_config
 from azul.service.responseobjects.storage_service import StorageService
 from retorts import ResponsesHelper
 from service import WebServiceTestCase
+from zipfile import ZipFile
 
 log = logging.getLogger(__name__)
 
@@ -177,3 +181,60 @@ class FacetNameValidationTest(WebServiceTestCase):
             manifest_config = json.load(open('{}/request_config.json'.format(self.service_config_dir), 'r'))['manifest']
             expected_fieldnames = list(manifest_config['bundles'].keys()) + list(manifest_config['contents.files'].keys())
             self.assertEqual(expected_fieldnames, tsv_file.fieldnames, 'Manifest headers are not configured correctly')
+
+    @mock_sts
+    @mock_s3
+    def test_bdbag_manifest(self):
+        """
+        As in test_manifest, moto will mock the requests.get call so we can't hit localhost; add_passthru let's us hit
+        the server (see GitHub issue and comment: https://github.com/spulec/moto/issues/1026#issuecomment-380054270)
+        """
+        logging.getLogger('test_request_validation').warning('test_manifest is invoked')
+        with ResponsesHelper() as helper, TemporaryDirectory() as zip_dir:
+            helper.add_passthru(self.base_url)
+            storage_service = StorageService()
+            storage_service.create_bucket()
+            url = self.base_url + '/repository/files/export?filters={"file":{}}&format=bdbag'
+            response = requests.get(url)
+            self.assertEqual(200, response.status_code, 'Unable to download manifest')
+            with ZipFile(response.text, 'r') as zip_fh:
+                zip_fh.extractall(zip_dir)
+            zip_fname = os.path.basename(os.path.splitext(response.text)[0])
+            with open(os.path.join(zip_dir, zip_fname, 'data', 'participant.tsv'), 'r') as fh:
+                participant = csv.reader(fh, delimiter='\t')
+                expected = ['entity:participant_id', '7b07b9d0-cc0e-4098-9f64-f4a569f7d746']
+                observed = []
+                for row in participant:
+                    observed.append(row[0])
+                self.assertEqual(len(observed), 2, 'participant.tsv contains duplicates.')
+                self.assertListEqual(sorted(expected), sorted(observed), 'participant.tsv contains incorrect data')
+
+            with open(os.path.join(zip_dir, zip_fname, 'data', 'sample.tsv'), 'r') as fh:
+
+                expectations = [('entity:sample_id','DID_scRSq06'),
+                                ('participant_id', '7b07b9d0-cc0e-4098-9f64-f4a569f7d746'),
+                                ('cell_suspension_id', '412898c5-5b9b-4907-b07c-e9b89666e204'),
+                                ('bundle_uuid', 'aaa96233-bf27-44c7-82df-b4dc15ad4d9d'),
+                                ('bundle_version', '2018-11-02T113344.698028Z'),
+                                ('file_content_type', 'application/gzip; dcp-type=data'),
+                                ('file_name', 'SRR3562915_1.fastq.gz'),
+                                ('file_sha256', '77337cb51b2e584b5ae1b99db6c163b988cbc5b894dda2f5d22424978c3bfc7a'),
+                                ('file_size', '195142097'),
+                                ('file_uuid', '7b07f99e-4a8a-4ad0-bd4f-db0d7a00c7bb'),
+                                ('file_version', '2018-11-02T113344.698028Z'),
+                                ('file_indexed', 'False'),
+                                ('file_url', config.dss_endpoint + '/files/7b07f99e-4a8a-4ad0-bd4f-db0d7a00c7bb?'
+                                                                   'version=2018-11-02T113344.698028Z&replica=gcp')
+                ]
+
+                expected_fieldnames, expected_row = map(list, zip(*expectations))
+                samples = csv.reader(fh, delimiter='\t')
+                for row_count, row in enumerate(samples):
+                    # Assert row contains no empty strings.
+                    self.assertTrue(all(re.match(r'[^ ]', item) for item in row), 'Row has empty string.')
+                    if row_count == 0:
+                        self.assertEqual(expected_fieldnames, row, 'Manifest headers are not configured correctly')
+                    elif row_count == 1:
+                        self.assertEqual(len(row), 13, 'Incorrect number of entries in row.')
+                        self.assertEqual(row, expected_row, 'Row in sample.tsv incorrect.')
+                self.assertEqual(row_count, 2, 'Found incorrect number of files.')  # self.bundle has 2 files


### PR DESCRIPTION
Adds some of the functionality to export the manifest from
the explorer to Broad analysis platform Terra (aka FireCloud).
I used the original manifest as the base, and added four
columns to it, `participant_id`, `sample_id`, and
`cellsuspension_id` (to satisfy current Terra import
requirements), and `drs_uri` (to enable use of DRS URLs
for metadata resolution). 

The manifest is compressed as a zip file, uploaded to 
AWS S3, and a signed URL is generated to that location.

Specific changes are:
* cell_suspension_id -> cellsuspensions.document_id
* participant_id -> specimens.donor_document_id
* sample_id -> specimens.donor_biomaterial_id
* new method `_construct_bdbag` in class `ManifestResponse`
* a second HTTP parameter, `format` was added, which can
assume two values, _tsv_ and _bdbag_.
* currently the BDBag is pushed as a single part
* a new environment variable `AZUL_DRS_ENDPOINT` was added
to file `environment` 