### PR TITLE
Add health check for data portal

### DIFF
--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -78,6 +78,10 @@ class Config:
         return f'{self._resource_prefix}-data-browser-{self.deployment_stage}'
 
     @property
+    def data_portal_name(self):
+        return f'{self._resource_prefix}-data-portal-{self.deployment_stage}'
+
+    @property
     def dss_endpoint(self) -> str:
         return os.environ['AZUL_DSS_ENDPOINT']
 

--- a/terraform/route53_health_check.tf.json.template.py
+++ b/terraform/route53_health_check.tf.json.template.py
@@ -39,11 +39,26 @@ emit({
                     "fqdn": config.data_browser_domain,
                     "port": 443,
                     "type": "HTTPS",
-                    "resource_path": "/health",
+                    "resource_path": "/explore",
                     "failure_threshold": "3",
                     "request_interval": "30",
                     "tags": {
                         "Name": config.data_browser_name
+                    }
+                }
+            }
+        },
+        {
+            "aws_route53_health_check": {
+                "data-portal": {
+                    "fqdn": config.data_browser_domain,
+                    "port": 443,
+                    "type": "HTTPS",
+                    "resource_path": "/",
+                    "failure_threshold": "3",
+                    "request_interval": "30",
+                    "tags": {
+                        "Name": config.data_portal_name
                     }
                 }
             }
@@ -57,7 +72,8 @@ emit({
                     "child_healthchecks": [
                         "${aws_route53_health_check." + "indexer" + ".id}",
                         "${aws_route53_health_check." + "service" + ".id}",
-                        "${aws_route53_health_check." + "data-browser" + ".id}"
+                        "${aws_route53_health_check." + "data-browser" + ".id}",
+                        "${aws_route53_health_check." + "data-portal" + ".id}"
                     ],
                     "cloudwatch_alarm_region": aws.region_name,
                     "tags": {


### PR DESCRIPTION
This resolves https://github.com/HumanCellAtlas/data-portal/issues/311

All health checks are bundled into a single alarm that is currently set to trigger posts in the data-browser Slack channel.