### PR TITLE
Refactor azul.config so that `azul` doesn't import `azul.deployment`

### DIFF
--- a/lambdas/indexer/.chalice/config.json.template.py
+++ b/lambdas/indexer/.chalice/config.json.template.py
@@ -11,7 +11,7 @@ emit({
     "api_gateway_stage": config.deployment_stage,
     "manage_iam_role": False,
     "iam_role_arn": f"arn:aws:iam::{aws.account}:role/{config.indexer_name}",
-    "environment_variables": config.lambda_env,
+    "environment_variables": aws.lambda_env,
     "lambda_timeout": config.lambda_timeout,
     "lambda_memory_size": 256,
     "reserved_concurrency": config.indexer_concurrency,

--- a/lambdas/indexer/app.py
+++ b/lambdas/indexer/app.py
@@ -45,7 +45,7 @@ plugin = Plugin.load()
 def version():
     from azul.changelog import compact_changes
     return {
-        'git': config.git_status,
+        'git': config.lambda_git_status,
         'changes': compact_changes(limit=10)
     }
 

--- a/lambdas/service/.chalice/config.json.template.py
+++ b/lambdas/service/.chalice/config.json.template.py
@@ -11,7 +11,7 @@ emit({
     'api_gateway_stage': config.deployment_stage,
     'manage_iam_role': False,
     'iam_role_arn': f'arn:aws:iam::{aws.account}:role/{config.service_name}',
-    'environment_variables': config.lambda_env,
+    'environment_variables': aws.lambda_env,
     'lambda_timeout': 31,
     'lambda_memory_size': 1024,
     'stages': {

--- a/lambdas/service/app.py
+++ b/lambdas/service/app.py
@@ -139,7 +139,7 @@ def health():
 def version():
     from azul.changelog import compact_changes
     return {
-        'git': config.git_status,
+        'git': config.lambda_git_status,
         'changes': compact_changes(limit=10)
     }
 

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -356,9 +356,7 @@ class Config:
         return (self.token_queue_name, self.document_queue_name, self.fail_queue_name,
                 self.fail_fifo_queue_name, self.notify_queue_name)
 
-    @property
-    def manifest_lambda_basename(self):
-        return 'manifest'
+    manifest_lambda_basename = 'manifest'
 
     @property
     def manifest_state_machine_name(self):
@@ -368,9 +366,7 @@ class Config:
     def test_mode(self) -> bool:
         return self._boolean(os.environ.get('TEST_MODE', '0'))
 
-    @property
-    def url_shortener_whitelist(self):
-        return [r'.*humancellatlas\.org']
+    url_shortener_whitelist = [r'.*humancellatlas\.org']
 
     @property
     def es_refresh_interval(self) -> int:
@@ -391,9 +387,7 @@ class Config:
     def dynamo_cart_item_table_name(self):
         return self.qualified_resource_name('cartitems')
 
-    @property
-    def cart_item_write_lambda_basename(self):
-        return 'cartitemwrite'
+    cart_item_write_lambda_basename= 'cartitemwrite'
 
     @property
     def cart_item_state_machine_name(self):
@@ -411,13 +405,9 @@ class Config:
     def cart_export_state_machine_name(self):
         return self.qualified_resource_name('cartexport')
 
-    @property
-    def cart_export_dss_push_lambda_basename(self):
-        return 'cartexportpush'
+    cart_export_dss_push_lambda_basename= 'cartexportpush'
 
-    @property
-    def access_token_issuer(self):
-        return "https://humancellatlas.auth0.com"
+    access_token_issuer = "https://humancellatlas.auth0.com"
 
     @property
     def access_token_audience_list(self):

--- a/src/azul/es.py
+++ b/src/azul/es.py
@@ -14,7 +14,7 @@ class ESClientFactory:
 
     @classmethod
     def get(cls):
-        host, port = config.es_endpoint
+        host, port = config.es_endpoint or aws.es_endpoint
         return cls._create_client(host, port, config.es_timeout)
 
     @classmethod

--- a/terraform/grafana_dashboard.tf.json.template.py
+++ b/terraform/grafana_dashboard.tf.json.template.py
@@ -1,6 +1,7 @@
 import json
 
-from azul import config, aws
+from azul import config
+from azul.deployment import aws
 from azul.template import emit
 
 emit({

--- a/terraform/route53_health_check.tf.json.template.py
+++ b/terraform/route53_health_check.tf.json.template.py
@@ -1,7 +1,8 @@
+from azul.deployment import aws
 from azul.template import emit
-from azul import config, aws
+from azul import config
 
-emit({
+emit(None if not config.enable_monitoring else {
     "resource": [
         {
             "aws_route53_health_check": {
@@ -83,4 +84,4 @@ emit({
             }
         }
     ]
-} if config.enable_monitoring else None)
+})

--- a/terraform/step_function.tf.json.template.py
+++ b/terraform/step_function.tf.json.template.py
@@ -1,6 +1,7 @@
 import json
 
 from azul import config
+from azul.deployment import aws
 from azul.template import emit
 
 
@@ -8,7 +9,7 @@ def cart_item_states():
     return {
         "WriteBatch": {
             "Type": "Task",
-            "Resource": config.get_lambda_arn(config.service_name, config.cart_item_write_lambda_basename),
+            "Resource": aws.get_lambda_arn(config.service_name, config.cart_item_write_lambda_basename),
             "Next": "NextBatch",
             "ResultPath": "$.write_result"
         },
@@ -18,7 +19,7 @@ def cart_item_states():
                 {
                     "Variable": "$.write_result.count",
                     "NumericEquals": 0,
-                    "Next": "SuccessState"
+                    "Next": "SuccessState",
                 }
             ],
             "Default": "WriteBatch"
@@ -62,9 +63,9 @@ emit({
                                 "lambda:InvokeFunction"
                             ],
                             "Resource": [
-                                config.get_lambda_arn(config.service_name, config.manifest_lambda_basename),
-                                config.get_lambda_arn(config.service_name, config.cart_item_write_lambda_basename),
-                                config.get_lambda_arn(config.service_name, config.cart_export_dss_push_lambda_basename)
+                                aws.get_lambda_arn(config.service_name, config.manifest_lambda_basename),
+                                aws.get_lambda_arn(config.service_name, config.cart_item_write_lambda_basename),
+                                aws.get_lambda_arn(config.service_name, config.cart_export_dss_push_lambda_basename)
                             ]
                         }
                     ]
@@ -80,7 +81,7 @@ emit({
                     "States": {
                         "WriteManifest": {
                             "Type": "Task",
-                            "Resource": config.get_lambda_arn(config.service_name, config.manifest_lambda_basename),
+                            "Resource": aws.get_lambda_arn(config.service_name, config.manifest_lambda_basename),
                             "End": True
                         }
                     }
@@ -102,8 +103,8 @@ emit({
                     "States": {
                         "SendToCollectionAPI": {
                             "Type": "Task",
-                            "Resource": config.get_lambda_arn(config.service_name,
-                                                              config.cart_export_dss_push_lambda_basename),
+                            "Resource": aws.get_lambda_arn(config.service_name,
+                                                           config.cart_export_dss_push_lambda_basename),
                             "Next": "NextBatch",
                             "ResultPath": "$"
                         },

--- a/test/docker_container_test_case.py
+++ b/test/docker_container_test_case.py
@@ -1,10 +1,10 @@
 import logging
 import os
-from typing import Tuple
 
 import docker
 from more_itertools import one
 
+from azul import Netloc
 from azul_test_case import AzulTestCase
 
 logger = logging.getLogger(__name__)
@@ -19,7 +19,7 @@ class DockerContainerTestCase(AzulTestCase):
     _containers = []
 
     @classmethod
-    def _create_container(cls, image: str, container_port: int, **kwargs) -> Tuple[str, int]:
+    def _create_container(cls, image: str, container_port: int, **kwargs) -> Netloc:
         """
         Create a Docker container from the given image, exposing the given container port on a interface that is
         within reach of the current process.

--- a/test/health_check_test_case.py
+++ b/test/health_check_test_case.py
@@ -114,7 +114,8 @@ class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABC
     @mock_sqs
     def test_elasticsearch_down(self):
         self._create_mock_queues()
-        with mock.patch.dict(os.environ, AZUL_ES_ENDPOINT='nonexisting-index.com:80'):
+        mock_endpoint = ('nonexisting-index.com', 80)
+        with mock.patch.dict(os.environ, **config.es_endpoint_env(mock_endpoint)):
             response = self._test(up=True)
             health_object = response.json()
             self.assertEqual(503, response.status_code)


### PR DESCRIPTION
Also consolidates references to AZUL_ES_ENDPOINT.
