### PR TITLE
Fix bdbag upload to S3 (#743)

### DIFF
--- a/src/azul/service/responseobjects/hca_response_v5.py
+++ b/src/azul/service/responseobjects/hca_response_v5.py
@@ -237,8 +237,11 @@ class ManifestResponse(AbstractResponse):
             return self.storage_service.put(**parameters)
         elif self.format == 'bdbag':
             file_name = self._construct_bdbag()
-            object_key = f'manifests/{uuid4()}.zip'
-            return self.storage_service.upload(file_name, object_key)
+            try:
+                object_key = f'manifests/{uuid4()}.zip'
+                return self.storage_service.upload(file_name, object_key)
+            finally:
+                os.remove(file_name)
         else:
             assert False
 

--- a/src/azul/service/responseobjects/hca_response_v5.py
+++ b/src/azul/service/responseobjects/hca_response_v5.py
@@ -231,16 +231,16 @@ class ManifestResponse(AbstractResponse):
             data = self._construct_tsv_content().encode()
             content_type = 'text/tab-separated-values'
             object_key = f'manifests/{uuid4()}.tsv'
+            parameters = dict(object_key=object_key,
+                              data=data,
+                              content_type=content_type)
+            return self.storage_service.put(**parameters)
         elif self.format == 'bdbag':
-            data = self._construct_bdbag()
-            content_type = 'application/zip'
+            file_name = self._construct_bdbag()
             object_key = f'manifests/{uuid4()}.zip'
+            return self.storage_service.upload(file_name, object_key)
         else:
             assert False
-        parameters = dict(object_key=object_key,
-                          data=data,
-                          content_type=content_type)
-        return self.storage_service.put(**parameters)
 
     def _construct_tsv_content(self):
         es_search = self.es_search

--- a/src/azul/service/responseobjects/storage_service.py
+++ b/src/azul/service/responseobjects/storage_service.py
@@ -38,12 +38,9 @@ class StorageService:
         return object_key
 
     def upload(self, file_name, object_key):
-        aws_profile = os.getenv('AWS_PROFILE')
-        session = boto3.Session(profile_name=aws_profile)
-        s3 = session.resource('s3')
-        s3.meta.client.upload_file(Filename=file_name,
-                                   Bucket=self.bucket_name,
-                                   Key=object_key)
+        self.client.upload_file(Filename=file_name,
+                                Bucket=self.bucket_name,
+                                Key=object_key)
         return object_key
 
     def get_presigned_url(self, key: str, file_name: Optional[str] = None) -> str:

--- a/src/azul/service/responseobjects/storage_service.py
+++ b/src/azul/service/responseobjects/storage_service.py
@@ -4,6 +4,7 @@ from functools import lru_cache
 from logging import getLogger
 from typing import Optional
 import boto3
+import os
 from azul import config
 
 logger = getLogger(__name__)
@@ -34,6 +35,15 @@ class StorageService:
 
         self.client.put_object(**params)
 
+        return object_key
+
+    def upload(self, file_name, object_key):
+        aws_profile = os.getenv('AWS_PROFILE')
+        session = boto3.Session(profile_name=aws_profile)
+        s3 = session.resource('s3')
+        s3.meta.client.upload_file(Filename=file_name,
+                                   Bucket=self.bucket_name,
+                                   Key=object_key)
         return object_key
 
     def get_presigned_url(self, key: str, file_name: Optional[str] = None) -> str:


### PR DESCRIPTION
* as BDBag format requires upload of a zipped file it cannot use the
same upload function as a TSV file
* depending on the manifest format, def _push_content_single_part will
call a specific function to upload to S3
* added def `upload` to StorageService to upload the zipped BDBag using
the upload_file function
* changed how zipfile name is obtained