### PR TITLE
Refined timeout conditions (#785)

### DIFF
--- a/test/local_integration_test.py
+++ b/test/local_integration_test.py
@@ -106,16 +106,15 @@ class IntegrationTest(unittest.TestCase):
             total_message_count = self.get_number_of_messages(queues)
             queue_wait_time_elapsed = (time.time() - wait_start_time)
             queue_size_history.append(total_message_count)
-            average_queue_size = sum(queue_size_history) / queue_size_history.maxlen
+            cumulative_queue_size = sum(queue_size_history)
             if queue_wait_time_elapsed > timeout:
                 logger.error('The queue(s) are NOT at the desired level.')
                 return
-            elif (average_queue_size == 0) == empty:
+            elif (cumulative_queue_size == 0) == empty:
                 logger.info('The queue(s) at the desired level.')
                 break
             else:
-                logger.info('The average size of the last %i recorded queue states is %.2f.',
-                            queue_size_history.maxlen, average_queue_size)
+                logger.info('The most recently sampled queue sizes are %r.', cumulative_queue_size)
             time.sleep(5)
 
         # Hack that removes the ResourceWarning that is caused by an unclosed SQS session

--- a/test/local_integration_test.py
+++ b/test/local_integration_test.py
@@ -1,15 +1,15 @@
+import boto3
+from collections import deque
 import logging
+from more_itertools import one
 import random
+import requests
 import time
 from typing import Any, Mapping, Set
 import unittest
 import urllib
 from urllib.parse import urlencode
 import uuid
-
-import boto3
-from more_itertools import one
-import requests
 
 from azul import config
 from azul.decorators import memoized_property
@@ -100,16 +100,22 @@ class IntegrationTest(unittest.TestCase):
         queues = {queue_name: boto3.resource('sqs').get_queue_by_name(QueueName=queue_name)
                   for queue_name in queue_names}
         wait_start_time = time.time()
+        queue_size_history = deque(maxlen=10)
 
         while True:
             total_message_count = self.get_number_of_messages(queues)
             queue_wait_time_elapsed = (time.time() - wait_start_time)
+            queue_size_history.append(total_message_count)
+            average_queue_size = sum(queue_size_history) / queue_size_history.maxlen
             if queue_wait_time_elapsed > timeout:
                 logger.error('The queue(s) are NOT at the desired level.')
                 return
-            elif (total_message_count <= 0) == empty:
+            elif (average_queue_size == 0) == empty:
                 logger.info('The queue(s) at the desired level.')
                 break
+            else:
+                logger.info('The average size of the last %i recorded queue states is %.2f.',
+                            queue_size_history.maxlen, average_queue_size)
             time.sleep(5)
 
         # Hack that removes the ResourceWarning that is caused by an unclosed SQS session
@@ -117,7 +123,7 @@ class IntegrationTest(unittest.TestCase):
             queue.meta.client._endpoint.http_session.close()
 
     def check_bundles_are_indexed(self, test_name: str, entity_type: str, indexed_bundle_fqids: Set[str]):
-        max_retries = 5
+        service_check_timeout = 600
         delay_between_retries = 5
         page_size = 100
 
@@ -134,6 +140,7 @@ class IntegrationTest(unittest.TestCase):
         logger.info('Checking if bundles are referenced by the service response ...')
         retries = 0
         found_bundle_fqids = set()
+        deadline = time.time() + service_check_timeout
 
         while True:
             response_json = self.requests.get(url).json()
@@ -144,16 +151,17 @@ class IntegrationTest(unittest.TestCase):
             search_after = response_json['pagination']['search_after']
             search_after_uid = response_json['pagination']['search_after_uid']
             total_entities = response_json['pagination']['total']
-            logger.info('Found %i/%i bundles on try #%i/%i. There are %i total hits. Current page has %i hits in %s.',
-                        len(found_bundle_fqids), num_bundles, retries + 1, max_retries, total_entities, len(hits), url)
+            logger.info('Found %i/%i bundles on try #%i. There are %i files with the project name.'
+                        ' Current page has %i hits in %s.', len(found_bundle_fqids), num_bundles, retries + 1,
+                        total_entities, len(hits), url)
 
             if search_after is None:
                 assert search_after_uid is None
                 if indexed_bundle_fqids == found_bundle_fqids:
                     logger.info('Found all bundles.')
                     break
-                elif retries >= max_retries:
-                    logger.error('Unable to find all the bundles. Retried too many (%i) times.', retries)
+                elif time.time() > deadline:
+                    logger.error('Unable to find all the bundles in under %i seconds.', service_check_timeout)
                     break
                 else:
                     time.sleep(delay_between_retries)

--- a/test/local_integration_test.py
+++ b/test/local_integration_test.py
@@ -114,7 +114,7 @@ class IntegrationTest(unittest.TestCase):
                 logger.info('The queue(s) at the desired level.')
                 break
             else:
-                logger.info('The most recently sampled queue sizes are %r.', cumulative_queue_size)
+                logger.info('The most recently sampled queue sizes are %r.', queue_size_history)
             time.sleep(5)
 
         # Hack that removes the ResourceWarning that is caused by an unclosed SQS session


### PR DESCRIPTION
IntegrationTest.wait_for_queue_level() now stops waiting if the last 10 recorded queue states have an average size of 0.

IntegrationTest.check_bundles_are_indexed() fails if 10 minutes has passed since the first api call to the service and all the test bundles aren't found. It no longer fails after checking all the pages of the service 5 times.

Improved logs and import order.