### PR TITLE
Changed column name format to be consistent with Metadata TSV files (#792)

### DIFF
--- a/src/azul/service/service_config/request_config.json
+++ b/src/azul/service/service_config/request_config.json
@@ -87,7 +87,7 @@
       "specimen_from_organism.diseases": "disease",
       "specimen_from_organism.biomaterial_core.biomaterial_id": "donor_biomaterial_id",
       "donor_organism.provenance.document_id": "donor_document_id",
-      "specimen_from_organism.genus_species": "genus_species",
+      "donor_organism.genus_species": "genus_species",
       "specimen_from_organism.organ": "organ",
       "specimen_from_organism.organ_part": "organ_part",
       "donor_organism.organism_age": "organism_age",

--- a/src/azul/service/service_config/request_config.json
+++ b/src/azul/service/service_config/request_config.json
@@ -53,46 +53,46 @@
   },
   "manifest": {
     "bundles": {
-      "bundle.uuid": "uuid",
-      "bundle.version": "version"
+      "bundle_uuid": "uuid",
+      "bundle_version": "version"
     },
     "contents.files": {
-      "file.content_type": "content-type",
-      "file.name": "name",
-      "file.sha256": "sha256",
-      "file.size": "size",
-      "file.uuid": "uuid",
-      "file.version": "version",
-      "file.indexed": "indexed",
-      "file.format": "file_format"
+      "file_content_type": "content-type",
+      "file_name": "name",
+      "file_sha256": "sha256",
+      "file_size": "size",
+      "file_uuid": "uuid",
+      "file_version": "version",
+      "file_indexed": "indexed",
+      "file_format": "file_format"
     },
     "contents.cell_suspensions": {
       "cell_suspension.estimated_cell_count": "total_estimated_cells"
     },
     "contents.protocols": {
-      "protocol.instrument_manufacturer_model": "instrument_manufacturer_model",
-      "protocol.library_construction_method": "library_construction_approach"
+      "sequencing_protocol.instrument_manufacturer_model": "instrument_manufacturer_model",
+      "library_preparation_protocol.library_construction_approach": "library_construction_approach"
     },
     "contents.projects": {
-      "project.document_id": "document_id",
-      "project.institutions": "institutions",
-      "project.laboratory": "laboratory",
-      "project.project_short_name": "project_shortname",
-      "project.project_title": "project_title"
+      "project.provenance.document_id": "document_id",
+      "project.contributors.institution": "institutions",
+      "project.contributors.laboratory": "laboratory",
+      "project.project_core.project_short_name": "project_shortname",
+      "project.project_core.project_title": "project_title"
     },
     "contents.specimens": {
-      "specimen.sex": "biological_sex",
-      "specimen.biomaterial_id": "biomaterial_id",
-      "specimen.document_id": "document_id",
-      "specimen.diseases": "disease",
-      "specimen.donor_biomaterial_id": "donor_biomaterial_id",
-      "specimen.donor_document_id": "donor_document_id",
-      "specimen.genus_species": "genus_species",
-      "specimen.organ": "organ",
-      "specimen.organ_parts": "organ_part",
-      "specimen.organism_age": "organism_age",
-      "specimen.organism_age_unit": "organism_age_unit",
-      "specimen.preservation_method": "preservation_method"
+      "donor_organism.sex": "biological_sex",
+      "donor_organism.biomaterial_core.biomaterial_id": "biomaterial_id",
+      "specimen_from_organism.provenance.document_id": "document_id",
+      "specimen_from_organism.diseases": "disease",
+      "specimen_from_organism.biomaterial_core.biomaterial_id": "donor_biomaterial_id",
+      "donor_organism.provenance.document_id": "donor_document_id",
+      "specimen_from_organism.genus_species": "genus_species",
+      "specimen_from_organism.organ": "organ",
+      "specimen_from_organism.organ_part": "organ_part",
+      "donor_organism.organism_age": "organism_age",
+      "donor_organism.organism_age_unit": "organism_age_unit",
+      "specimen_from_organism.preservation_storage.preservation_method": "preservation_method"
     }
   },
     "bdbag": {

--- a/src/azul/service/service_config/request_config.json
+++ b/src/azul/service/service_config/request_config.json
@@ -53,46 +53,46 @@
   },
   "manifest": {
     "bundles": {
-      "bundle_uuid": "uuid",
-      "bundle_version": "version"
+      "bundle.uuid": "uuid",
+      "bundle.version": "version"
     },
     "contents.files": {
-      "file_content_type": "content-type",
-      "file_name": "name",
-      "file_sha256": "sha256",
-      "file_size": "size",
-      "file_uuid": "uuid",
-      "file_version": "version",
-      "file_indexed": "indexed",
-      "file_format": "file_format"
+      "file.content_type": "content-type",
+      "file.name": "name",
+      "file.sha256": "sha256",
+      "file.size": "size",
+      "file.uuid": "uuid",
+      "file.version": "version",
+      "file.indexed": "indexed",
+      "file.format": "file_format"
     },
     "contents.cell_suspensions": {
-      "total_estimated_cells": "total_estimated_cells"
+      "cell_suspension.estimated_cell_count": "total_estimated_cells"
     },
     "contents.protocols": {
-      "instrument_manufacturer_model": "instrument_manufacturer_model",
-      "library_construction_approach": "library_construction_approach"
+      "protocol.instrument_manufacturer_model": "instrument_manufacturer_model",
+      "protocol.library_construction_method": "library_construction_approach"
     },
     "contents.projects": {
-      "document_id": "document_id",
-      "institutions": "institutions",
-      "laboratory": "laboratory",
-      "project_shortname": "project_shortname",
-      "project_title": "project_title"
+      "project.document_id": "document_id",
+      "project.institutions": "institutions",
+      "project.laboratory": "laboratory",
+      "project.project_short_name": "project_shortname",
+      "project.project_title": "project_title"
     },
     "contents.specimens": {
-      "biological_sex": "biological_sex",
-      "specimen_id": "biomaterial_id",
-      "specimen_document_id": "document_id",
-      "disease": "disease",
-      "donor_biomaterial_id": "donor_biomaterial_id",
-      "donor_document_id": "donor_document_id",
-      "genus_species": "genus_species",
-      "organ": "organ",
-      "organ_part": "organ_part",
-      "organism_age": "organism_age",
-      "organism_age_unit": "organism_age_unit",
-      "preservation_method": "preservation_method"
+      "specimen.sex": "biological_sex",
+      "specimen.biomaterial_id": "biomaterial_id",
+      "specimen.document_id": "document_id",
+      "specimen.diseases": "disease",
+      "specimen.donor_biomaterial_id": "donor_biomaterial_id",
+      "specimen.donor_document_id": "donor_document_id",
+      "specimen.genus_species": "genus_species",
+      "specimen.organ": "organ",
+      "specimen.organ_parts": "organ_part",
+      "specimen.organism_age": "organism_age",
+      "specimen.organism_age_unit": "organism_age_unit",
+      "specimen.preservation_method": "preservation_method"
     }
   },
     "bdbag": {

--- a/test/service/test_request_validation.py
+++ b/test/service/test_request_validation.py
@@ -219,7 +219,7 @@ class FacetNameValidationTest(WebServiceTestCase):
                             ('specimen_from_organism.diseases', '', ''),
                             ('specimen_from_organism.biomaterial_core.biomaterial_id', '', '1209'),
                             ('donor_organism.provenance.document_id', '', '89b50434-f831-4e15-a8c0-0d57e6baa94c'),
-                            ('specimen_from_organism.genus_species', '', 'Mus musculus'),
+                            ('donor_organism.genus_species', '', 'Mus musculus'),
                             ('specimen_from_organism.organ', '', 'brain || tumor'),
                             ('specimen_from_organism.organ_part', '', ''),
                             ('donor_organism.organism_age', '', '6-12'),

--- a/test/service/test_request_validation.py
+++ b/test/service/test_request_validation.py
@@ -183,48 +183,48 @@ class FacetNameValidationTest(WebServiceTestCase):
                         self.assertEqual(200, response.status_code, 'Unable to download manifest')
 
                         expected = [
-                            ('bundle_uuid', 'f79257a7-dfc6-46d6-ae00-ba4b25313c10',
+                            ('bundle.uuid', 'f79257a7-dfc6-46d6-ae00-ba4b25313c10',
                              'f79257a7-dfc6-46d6-ae00-ba4b25313c10'),
-                            ('bundle_version', '2018-09-14T133314.453337Z', '2018-09-14T133314.453337Z'),
-                            ('file_content_type', 'application/pdf; dcp-type=data', 'application/gzip; dcp-type=data'),
-                            ('file_name', 'SmartSeq2_RTPCR_protocol.pdf', '22028_5#300_1.fastq.gz'),
-                            ('file_sha256', '2f6866c4ede92123f90dd15fb180fac56e33309b8fd3f4f52f263ed2f8af2f16',
+                            ('bundle.version', '2018-09-14T133314.453337Z', '2018-09-14T133314.453337Z'),
+                            ('file.content_type', 'application/pdf; dcp-type=data', 'application/gzip; dcp-type=data'),
+                            ('file.name', 'SmartSeq2_RTPCR_protocol.pdf', '22028_5#300_1.fastq.gz'),
+                            ('file.sha256', '2f6866c4ede92123f90dd15fb180fac56e33309b8fd3f4f52f263ed2f8af2f16',
                              '3125f2f86092798b85be93fbc66f4e733e9aec0929b558589c06929627115582'),
-                            ('file_size', '29230', '64718465'),
-                            ('file_uuid', '5f9b45af-9a26-4b16-a785-7f2d1053dd7c',
+                            ('file.size', '29230', '64718465'),
+                            ('file.uuid', '5f9b45af-9a26-4b16-a785-7f2d1053dd7c',
                              'f2b6c6f0-8d25-4aae-b255-1974cc110cfe'),
-                            ('file_version', '2018-09-14T123347.012715Z', '2018-09-14T123343.720332Z'),
-                            ('file_indexed', 'False', 'False'),
-                            ('file_format', 'pdf', 'fastq.gz'),
-                            ('total_estimated_cells', '', '9001'),
-                            ('instrument_manufacturer_model', '', 'Illumina HiSeq 2500'),
-                            ('library_construction_approach', '', 'Smart-seq2'),
-                            ('document_id', '67bc798b-a34a-4104-8cab-cad648471f69',
+                            ('file.version', '2018-09-14T123347.012715Z', '2018-09-14T123343.720332Z'),
+                            ('file.indexed', 'False', 'False'),
+                            ('file.format', 'pdf', 'fastq.gz'),
+                            ('cell_suspension.estimated_cell_count', '', '9001'),
+                            ('protocol.instrument_manufacturer_model', '', 'Illumina HiSeq 2500'),
+                            ('protocol.library_construction_method', '', 'Smart-seq2'),
+                            ('project.document_id', '67bc798b-a34a-4104-8cab-cad648471f69',
                              '67bc798b-a34a-4104-8cab-cad648471f69'),
-                            ('institutions', 'DKFZ German Cancer Research Center || EMBL-EBI || University of Cambridge'
+                            ('project.institutions', 'DKFZ German Cancer Research Center || EMBL-EBI || University of Cambridge'
                                              ' || University of Helsinki || Wellcome Trust Sanger Institute',
                              'DKFZ German Cancer Research Center || EMBL-EBI || University of Cambridge'
                              ' || University of Helsinki || Wellcome Trust Sanger Institute'),
-                            ('laboratory', 'Human Cell Atlas Data Coordination Platform || MRC Cancer Unit'
+                            ('project.laboratory', 'Human Cell Atlas Data Coordination Platform || MRC Cancer Unit'
                                            ' || Sarah Teichmann',
                              'Human Cell Atlas Data Coordination Platform || MRC Cancer Unit'
                              ' || Sarah Teichmann'),
-                            ('project_shortname', 'Mouse Melanoma', 'Mouse Melanoma'),
-                            ('project_title', 'Melanoma infiltration of stromal and immune cells',
+                            ('project.project_short_name', 'Mouse Melanoma', 'Mouse Melanoma'),
+                            ('project.project_title', 'Melanoma infiltration of stromal and immune cells',
                              'Melanoma infiltration of stromal and immune cells'),
-                            ('biological_sex', '', 'female'),
-                            ('specimen_id', '', '1209_T || 1210_T'),
-                            ('specimen_document_id', '', 'aaaaaaaa-7bab-44ba-a81d-3d8cb3873244'
+                            ('specimen.sex', '', 'female'),
+                            ('specimen.biomaterial_id', '', '1209_T || 1210_T'),
+                            ('specimen.document_id', '', 'aaaaaaaa-7bab-44ba-a81d-3d8cb3873244'
                                                          ' || b4e55fe1-7bab-44ba-a81d-3d8cb3873244'),
-                            ('disease', '', ''),
-                            ('donor_biomaterial_id', '', '1209'),
-                            ('donor_document_id', '', '89b50434-f831-4e15-a8c0-0d57e6baa94c'),
-                            ('genus_species', '', 'Mus musculus'),
-                            ('organ', '', 'brain || tumor'),
-                            ('organ_part', '', ''),
-                            ('organism_age', '', '6-12'),
-                            ('organism_age_unit', '', 'week'),
-                            ('preservation_method', '', '')
+                            ('specimen.diseases', '', ''),
+                            ('specimen.donor_biomaterial_id', '', '1209'),
+                            ('specimen.donor_document_id', '', '89b50434-f831-4e15-a8c0-0d57e6baa94c'),
+                            ('specimen.genus_species', '', 'Mus musculus'),
+                            ('specimen.organ', '', 'brain || tumor'),
+                            ('specimen.organ_parts', '', ''),
+                            ('specimen.organism_age', '', '6-12'),
+                            ('specimen.organism_age_unit', '', 'week'),
+                            ('specimen.preservation_method', '', '')
                         ]
 
                         expected_fieldnames, expected_pdf_row, expected_fastq_row = map(list, zip(*expected))

--- a/test/service/test_request_validation.py
+++ b/test/service/test_request_validation.py
@@ -183,48 +183,48 @@ class FacetNameValidationTest(WebServiceTestCase):
                         self.assertEqual(200, response.status_code, 'Unable to download manifest')
 
                         expected = [
-                            ('bundle.uuid', 'f79257a7-dfc6-46d6-ae00-ba4b25313c10',
+                            ('bundle_uuid', 'f79257a7-dfc6-46d6-ae00-ba4b25313c10',
                              'f79257a7-dfc6-46d6-ae00-ba4b25313c10'),
-                            ('bundle.version', '2018-09-14T133314.453337Z', '2018-09-14T133314.453337Z'),
-                            ('file.content_type', 'application/pdf; dcp-type=data', 'application/gzip; dcp-type=data'),
-                            ('file.name', 'SmartSeq2_RTPCR_protocol.pdf', '22028_5#300_1.fastq.gz'),
-                            ('file.sha256', '2f6866c4ede92123f90dd15fb180fac56e33309b8fd3f4f52f263ed2f8af2f16',
+                            ('bundle_version', '2018-09-14T133314.453337Z', '2018-09-14T133314.453337Z'),
+                            ('file_content_type', 'application/pdf; dcp-type=data', 'application/gzip; dcp-type=data'),
+                            ('file_name', 'SmartSeq2_RTPCR_protocol.pdf', '22028_5#300_1.fastq.gz'),
+                            ('file_sha256', '2f6866c4ede92123f90dd15fb180fac56e33309b8fd3f4f52f263ed2f8af2f16',
                              '3125f2f86092798b85be93fbc66f4e733e9aec0929b558589c06929627115582'),
-                            ('file.size', '29230', '64718465'),
-                            ('file.uuid', '5f9b45af-9a26-4b16-a785-7f2d1053dd7c',
+                            ('file_size', '29230', '64718465'),
+                            ('file_uuid', '5f9b45af-9a26-4b16-a785-7f2d1053dd7c',
                              'f2b6c6f0-8d25-4aae-b255-1974cc110cfe'),
-                            ('file.version', '2018-09-14T123347.012715Z', '2018-09-14T123343.720332Z'),
-                            ('file.indexed', 'False', 'False'),
-                            ('file.format', 'pdf', 'fastq.gz'),
+                            ('file_version', '2018-09-14T123347.012715Z', '2018-09-14T123343.720332Z'),
+                            ('file_indexed', 'False', 'False'),
+                            ('file_format', 'pdf', 'fastq.gz'),
                             ('cell_suspension.estimated_cell_count', '', '9001'),
-                            ('protocol.instrument_manufacturer_model', '', 'Illumina HiSeq 2500'),
-                            ('protocol.library_construction_method', '', 'Smart-seq2'),
-                            ('project.document_id', '67bc798b-a34a-4104-8cab-cad648471f69',
+                            ('sequencing_protocol.instrument_manufacturer_model', '', 'Illumina HiSeq 2500'),
+                            ('library_preparation_protocol.library_construction_approach', '', 'Smart-seq2'),
+                            ('project.provenance.document_id', '67bc798b-a34a-4104-8cab-cad648471f69',
                              '67bc798b-a34a-4104-8cab-cad648471f69'),
-                            ('project.institutions', 'DKFZ German Cancer Research Center || EMBL-EBI || University of Cambridge'
+                            ('project.contributors.institution', 'DKFZ German Cancer Research Center || EMBL-EBI || University of Cambridge'
                                              ' || University of Helsinki || Wellcome Trust Sanger Institute',
                              'DKFZ German Cancer Research Center || EMBL-EBI || University of Cambridge'
                              ' || University of Helsinki || Wellcome Trust Sanger Institute'),
-                            ('project.laboratory', 'Human Cell Atlas Data Coordination Platform || MRC Cancer Unit'
+                            ('project.contributors.laboratory', 'Human Cell Atlas Data Coordination Platform || MRC Cancer Unit'
                                            ' || Sarah Teichmann',
                              'Human Cell Atlas Data Coordination Platform || MRC Cancer Unit'
                              ' || Sarah Teichmann'),
-                            ('project.project_short_name', 'Mouse Melanoma', 'Mouse Melanoma'),
-                            ('project.project_title', 'Melanoma infiltration of stromal and immune cells',
+                            ('project.project_core.project_short_name', 'Mouse Melanoma', 'Mouse Melanoma'),
+                            ('project.project_core.project_title', 'Melanoma infiltration of stromal and immune cells',
                              'Melanoma infiltration of stromal and immune cells'),
-                            ('specimen.sex', '', 'female'),
-                            ('specimen.biomaterial_id', '', '1209_T || 1210_T'),
-                            ('specimen.document_id', '', 'aaaaaaaa-7bab-44ba-a81d-3d8cb3873244'
+                            ('donor_organism.sex', '', 'female'),
+                            ('donor_organism.biomaterial_core.biomaterial_id', '', '1209_T || 1210_T'),
+                            ('specimen_from_organism.provenance.document_id', '', 'aaaaaaaa-7bab-44ba-a81d-3d8cb3873244'
                                                          ' || b4e55fe1-7bab-44ba-a81d-3d8cb3873244'),
-                            ('specimen.diseases', '', ''),
-                            ('specimen.donor_biomaterial_id', '', '1209'),
-                            ('specimen.donor_document_id', '', '89b50434-f831-4e15-a8c0-0d57e6baa94c'),
-                            ('specimen.genus_species', '', 'Mus musculus'),
-                            ('specimen.organ', '', 'brain || tumor'),
-                            ('specimen.organ_parts', '', ''),
-                            ('specimen.organism_age', '', '6-12'),
-                            ('specimen.organism_age_unit', '', 'week'),
-                            ('specimen.preservation_method', '', '')
+                            ('specimen_from_organism.diseases', '', ''),
+                            ('specimen_from_organism.biomaterial_core.biomaterial_id', '', '1209'),
+                            ('donor_organism.provenance.document_id', '', '89b50434-f831-4e15-a8c0-0d57e6baa94c'),
+                            ('specimen_from_organism.genus_species', '', 'Mus musculus'),
+                            ('specimen_from_organism.organ', '', 'brain || tumor'),
+                            ('specimen_from_organism.organ_part', '', ''),
+                            ('donor_organism.organism_age', '', '6-12'),
+                            ('donor_organism.organism_age_unit', '', 'week'),
+                            ('specimen_from_organism.preservation_storage.preservation_method', '', '')
                         ]
 
                         expected_fieldnames, expected_pdf_row, expected_fastq_row = map(list, zip(*expected))


### PR DESCRIPTION
Changed manifest column names to match period separated formatting used in the TSV columns outputted by the script in https://github.com/HumanCellAtlas/hca_bundles_to_csv. 

Also, the newer non-deprecated versions of the fields names are used. 