### PR TITLE
Distinguish Azul and Data Portal monitoring resources (#787)

### DIFF
--- a/deployments/sandbox/environment
+++ b/deployments/sandbox/environment
@@ -23,9 +23,14 @@ _set AZUL_SUBDOMAIN_TEMPLATE "{lambda_name}.$AZUL_DEPLOYMENT_STAGE"
 _set AZUL_URL_REDIRECT_BASE_DOMAIN_NAME "dev.url.data.humancellatlas.org"
 _set AZUL_URL_REDIRECT_FULL_DOMAIN_NAME "$AZUL_DEPLOYMENT_STAGE.$AZUL_URL_REDIRECT_BASE_DOMAIN_NAME"
 
+_set azul_grafana_endpoint "https://metrics.dev.data.humancellatlas.org"
+
 # Personal deployments and the `sandbox` share an ES domain with `dev`
 #
 _set AZUL_SHARE_ES_DOMAIN 1
 _set AZUL_ES_DOMAIN "azul-index-dev"
 
 _set azul_dss_query_prefix '42'
+
+# Ensure that monitoring and pushing to Grafana is enabled
+_set AZUL_ENABLE_MONITORING 1

--- a/terraform/cloudwatch.tf.json.template.py
+++ b/terraform/cloudwatch.tf.json.template.py
@@ -100,7 +100,7 @@ emit({
                     "statistic": "Minimum",
                     "threshold": "1.0",
                     "alarm_description": json.dumps({
-                        "slack_channel": "data-browser",
+                        "slack_channel": "azul-dev",
                         "environment": config.deployment_stage,
                         "description": f"azul-{config.deployment_stage} HealthCheckStatus alarm"
                     }),
@@ -109,7 +109,30 @@ emit({
                         f"arn:aws:sns:{aws.region_name}:{aws.account}:dcp-events"
                     ],
                     "dimensions": {
-                        "HealthCheckId": "${aws_route53_health_check.composite.id}",
+                        "HealthCheckId": "${aws_route53_health_check.composite-azul.id}",
+                    }
+                },
+                "data_portal_health": {
+                    "alarm_name": f"data-browser-{config.deployment_stage}",
+                    "actions_enabled": True,
+                    "comparison_operator": "LessThanThreshold",
+                    "evaluation_periods": "1",
+                    "metric_name": "HealthCheckStatus",
+                    "namespace": "AWS/Route53",
+                    "period": "120",
+                    "statistic": "Minimum",
+                    "threshold": "1.0",
+                    "alarm_description": json.dumps({
+                        "slack_channel": "data-browser",
+                        "environment": config.deployment_stage,
+                        "description": f"data-browser-{config.deployment_stage} HealthCheckStatus alarm"
+                    }),
+                    "alarm_actions": [
+                        f"arn:aws:sns:{aws.region_name}:{aws.account}:cloudwatch-alarms",
+                        f"arn:aws:sns:{aws.region_name}:{aws.account}:dcp-events"
+                    ],
+                    "dimensions": {
+                        "HealthCheckId": "${aws_route53_health_check.composite-portal.id}",
                     }
                 }
             }

--- a/terraform/grafana_dashboard.tf.json.template.py
+++ b/terraform/grafana_dashboard.tf.json.template.py
@@ -91,7 +91,7 @@ emit({
                              {
                                  "dimensions": {
                                      "HealthCheckId":
-                                         "${aws_route53_health_check.composite.id}",
+                                         "${aws_route53_health_check.composite-azul.id}",
                                  },
                                  "highResolution": False,
                                  "metricName": "HealthCheckStatus",

--- a/terraform/route53_health_check.tf.json.template.py
+++ b/terraform/route53_health_check.tf.json.template.py
@@ -36,6 +36,25 @@ emit(None if not config.enable_monitoring else {
         },
         {
             "aws_route53_health_check": {
+                "composite-azul": {
+                    # NOTE: There is a 64 character limit on reference name. Terraform adds long string at the end so
+                    #  we must be economical about what we add.
+                    "reference_name": f"azul-{config.deployment_stage}",
+                    "type": "CALCULATED",
+                    "child_health_threshold": 2,
+                    "child_healthchecks": [
+                        "${aws_route53_health_check." + "indexer" + ".id}",
+                        "${aws_route53_health_check." + "service" + ".id}"
+                    ],
+                    "cloudwatch_alarm_region": aws.region_name,
+                    "tags": {
+                        "Name": f"azul-composite-{config.deployment_stage}"
+                    }
+                }
+            }
+        },
+        {
+            "aws_route53_health_check": {
                 "data-browser": {
                     "fqdn": config.data_browser_domain,
                     "port": 443,
@@ -66,19 +85,17 @@ emit(None if not config.enable_monitoring else {
         },
         {
             "aws_route53_health_check": {
-                "composite": {
-                    "reference_name": f"azul-composite-{config.deployment_stage} ",
+                "composite-portal": {
+                    "reference_name": f"portal-{config.deployment_stage}",
                     "type": "CALCULATED",
-                    "child_health_threshold": 3,
+                    "child_health_threshold": 2,
                     "child_healthchecks": [
-                        "${aws_route53_health_check." + "indexer" + ".id}",
-                        "${aws_route53_health_check." + "service" + ".id}",
                         "${aws_route53_health_check." + "data-browser" + ".id}",
                         "${aws_route53_health_check." + "data-portal" + ".id}"
                     ],
                     "cloudwatch_alarm_region": aws.region_name,
                     "tags": {
-                        "Name": f"azul-composite-{config.deployment_stage}"
+                        "Name": f"azul-portal-composite-{config.deployment_stage}"
                     }
                 }
             }


### PR DESCRIPTION
Fixes health_check id extraction from Terraform to be used in Grafana. 