### PR TITLE
Grant Gitlab write access to Elasticsearch log groups (#825)

### DIFF
--- a/terraform/gitlab/gitlab.tf.json.template.py
+++ b/terraform/gitlab/gitlab.tf.json.template.py
@@ -367,7 +367,8 @@ emit({} if config.terraform_component != 'gitlab' else {
                                                             LogStream='*',
                                                             LogStreamName='*')
                                            for log_group_name in ['/aws/apigateway/azul-*',
-                                                                  '/aws/lambda/azul-*'])
+                                                                  '/aws/lambda/azul-*',
+                                                                  '/aws/aes/domains/azul-*'])
                     }
                 ]
             },


### PR DESCRIPTION
This has already been terra-formed. This is just about getting the changes into the develop branch.