### PR TITLE
BDBag TSV with multiple files in row (#866)

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -13,6 +13,13 @@ meta:
                    deployments may need to be updated
 
 changes:
+  - title: Add support for multiple file columns in BDBag TSV row
+    issues:
+      - https://github.com/DataBiosphere/azul/issues/866
+    upgrade:
+      - reindex
+    notes: BDBag payload contains one file, `bundle.tsv`, with the bundle UUID as primary key. The attributes
+           `read_index` and `file_format` were added to the BDBag section of `request_config.json`.
 
   - title: Add non-fetch variant of DSS proxy; add server-side wait
     issues:

--- a/lambdas/service/app.py
+++ b/lambdas/service/app.py
@@ -443,8 +443,8 @@ def start_manifest_generation():
           type: string
           description: The desired format of the output. Possible values are `tsv` (the default) for a tab-separated
           manifest and `bdbag` for a manifest in the format documented `http://bd2k.ini.usc.edu/tools/bdbag/. The
-          latter is essentially a ZIP file containing two manifests: one for participants (aka Donors) and one for
-          samples (aka specimens). The format of the manifests inside the BDBag is documented here:
+          latter is essentially a ZIP file containing a manifest where one row represents all metadata files in one
+          bundle. The format of the manifests inside the BDBag is documented here:
           https://software.broadinstitute.org/firecloud/documentation/article?id=10954
         - name: token
           in: query
@@ -482,8 +482,8 @@ def start_manifest_generation_fetch():
           type: string
           description: The desired format of the output. Possible values are `tsv` (the default) for a tab-separated
           manifest and `bdbag` for a manifest in the format documented `http://bd2k.ini.usc.edu/tools/bdbag/. The
-          latter is essentially a ZIP file containing two manifests: one for participants (aka Donors) and one for
-          samples (aka specimens). The format of the manifests inside the BDBag is documented here:
+          latter is essentially a ZIP file containing a manifest where one row represents all metadata files in one
+          bundle. The format of the manifests inside the BDBag is documented here:
           https://software.broadinstitute.org/firecloud/documentation/article?id=10954
         - name: token
           in: query

--- a/src/azul/service/service_config/request_config.json
+++ b/src/azul/service/service_config/request_config.json
@@ -97,13 +97,10 @@
       "specimen_from_organism.preservation_storage.preservation_method": "preservation_method"
     }
   },
-    "bdbag": {
-    "contents.cell_suspensions": {
-      "cell_suspension_id": "document_id"
-    },
-    "contents.specimens": {
-      "entity:sample_id": "document_id",
-      "participant_id": "donor_document_id"
+  "bdbag": {
+    "bundles": {
+      "bundle_fqid": "uuid",
+      "bundle_version": "version"
     },
     "contents.files": {
       "file_content_type": "content-type",
@@ -112,11 +109,16 @@
       "file_size": "size",
       "file_uuid": "uuid",
       "file_version": "version",
-      "file_indexed": "indexed"
+      "file_indexed": "indexed",
+      "file_read_index": "read_index",
+      "file_format": "file_format"
     },
-    "bundles": {
-      "bundle_uuid": "uuid",
-      "bundle_version": "version"
+    "contents.cell_suspensions": {
+      "cell_suspension_id": "document_id"
+    },
+    "contents.specimens": {
+      "specimen_id": "document_id",
+      "specimen_donor_id": "donor_document_id"
     }
   },
   "cart-item": {

--- a/test/local_integration_test.py
+++ b/test/local_integration_test.py
@@ -129,13 +129,13 @@ class IntegrationTest(unittest.TestCase):
     def check_bdbag(self, response: bytes):
         with ZipFile(BytesIO(response)) as zip_fh:
             data_path = os.path.join(os.path.dirname(first(zip_fh.namelist())), 'data')
-            tsv_files = {filename: os.path.join(data_path, filename) for filename in ['participants.tsv', 'samples.tsv']}
-            for file_name, file_path in tsv_files.items():
-                with zip_fh.open(file_path) as bytesfile:
-                    text = TextIOWrapper(bytesfile, encoding='utf-8')
-                    num_rows = len(list(csv.reader(text, delimiter='\t')))
-                    self.assertTrue(num_rows > 1)
-                    logger.info(f'BDBag file {file_name} contains {num_rows} rows.')
+            file_name = 'bundle.tsv'
+            file_path = os.path.join(data_path, file_name)
+            with zip_fh.open(file_path) as bytesfile:
+                text = TextIOWrapper(bytesfile, encoding='utf-8')
+                num_rows = len(list(csv.reader(text, delimiter='\t')))
+                self.assertTrue(num_rows > 1)
+                logger.info(f'BDBag file {file_name} contains {num_rows} rows.')
 
     def download_file_from_drs_response(self, response: bytes):
         json_data = json.loads(response)['data_object']


### PR DESCRIPTION
* added read_index and file_format to request_config.json
* iterate over bundles from ES search result, and create
one row per bundle in a TSV file
* bundle_uuid is the primary key of that TSV file
* a row can contain metadata of multiple files (all of which
are part of the same bundle UUID)
* create a BDBag containing that TSV as payload
* added changelog entry
* updated comments on BDBag in app.py
* code only considers files in first bundle encountered if
file is represented in more than one bundle
* updated local integration test