### PR TITLE
Fix broken IT in staging

### DIFF
--- a/test/local_integration_test.py
+++ b/test/local_integration_test.py
@@ -89,7 +89,7 @@ class IntegrationTest(unittest.TestCase):
                     response = self.check_endpoint_is_working(config.service_endpoint(), path, query)
                     validator(response)
 
-        filters = {"file":{"organ":{"is":["brain"]},"fileFormat":{"is":["fastq.gz"]}}}
+        filters = {"file": {"organ": {"is": ["brain", "Brain"]}, "fileFormat": {"is": ["fastq.gz"]}}}
         response_with_file_uuid = self.check_endpoint_is_working(endpoint=config.service_endpoint(),
                                                                  path='/repository/files',
                                                                  query={'filters': filters, 'size': 15,

--- a/test/local_integration_test.py
+++ b/test/local_integration_test.py
@@ -74,7 +74,7 @@ class IntegrationTest(unittest.TestCase):
             # only subset of indexed metadata, use unrestricted filter
             manifest_filter = {"file": {}}
         else:
-            manifest_filter = {"file": {"organ": {"is": ["brain"]}, "fileFormat": {"is": ["bai"]}}}
+            manifest_filter = {"file": {"organ": {"is": ["brain", "Brain"]}, "fileFormat": {"is": ["bai"]}}}
 
         for format_, validator in [
             (None, self.check_manifest),


### PR DESCRIPTION
There is a comment that indicates to 
```
"""Assert that manifest contains at least one row of metadata."""
```
But the logic for the check was not an inclusive bound. Therefore checking for at least two rows.
This PR fixes that issue shifting the lower bound to 0, non inclusive.  