### PR TITLE
Securely store HMAC key and google creds (#794)

### DIFF
--- a/lambdas/indexer/lambda-policy.json.template.py
+++ b/lambdas/indexer/lambda-policy.json.template.py
@@ -67,6 +67,15 @@ emit({
             "Resource": [
                 f"arn:aws:sqs:{aws.region_name}:{aws.account}:*"
             ]
-        }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "secretsmanager:GetSecretValue"
+            ],
+            "Resource": [
+                f"arn:aws:secretsmanager:{aws.region_name}:{aws.account}:secret:*"
+            ]
+        },
     ]
 })

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -5,6 +5,7 @@ locustio==0.9.0
 pytest==3.2.3
 coverage==4.0.3
 gitpython==2.1.11
+google-api-python-client==1.7.8
 moto==1.3.6
 pyyaml==3.12
 responses==0.10.2

--- a/scripts/provision_credentials.py
+++ b/scripts/provision_credentials.py
@@ -1,0 +1,169 @@
+import argparse
+import base64
+import json
+import logging
+import os
+import uuid
+from functools import partial
+
+import boto3
+import googleapiclient.discovery
+from botocore.exceptions import ClientError
+from google.oauth2 import service_account
+from googleapiclient.errors import HttpError
+
+from azul import config
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+def parse_google_key(response):
+    return base64.decodebytes(bytes(response['privateKeyData'], 'ascii')).decode()
+
+
+def get_google_service():
+    credentials = service_account.Credentials.from_service_account_file(
+        filename=os.environ['GOOGLE_APPLICATION_CREDENTIALS'],
+        scopes=['https://www.googleapis.com/auth/cloud-platform'])
+    return googleapiclient.discovery.build('iam', 'v1', credentials=credentials)
+
+
+class CredentialsProvisioner:
+
+    def __init__(self):
+        self.secrets_manager = boto3.client('secretsmanager')
+
+    def provision_google_from_args(self, args):
+        self.provision_google(args.build, args.email)
+
+    def provision_hmac_from_args(self, args):
+        self.provision_hmac(args.build)
+
+    def provision_hmac(self, build):
+        secret_name = config.secrets_manager_secret_name('indexer', 'hmac')
+        if build:
+            self._create_secret(secret_name)
+            if not self._secret_is_stored(secret_name):
+                self._write_secret_value(secret_name, self._random_hmac_key())
+        else:
+            self._destroy_aws_secrets_manager_secret(secret_name)
+
+    def provision_google(self, build, email):
+        secret_name = config.secrets_manager_secret_name('indexer', 'google_service_account')
+        if build:
+            self._create_secret(secret_name)
+            if not self._secret_is_stored(secret_name):
+                google_key = self._create_service_account_creds(email)
+                self._write_secret_value(secret_name, google_key)
+        else:
+            self._destroy_service_account_creds(email)
+            self._destroy_aws_secrets_manager_secret(secret_name)
+
+    @classmethod
+    def _random_hmac_key(cls):
+        # Even though an HMAC key can be any sequence of bytes, we restrict to base64 in order to encode as string
+        key = base64.encodebytes(os.urandom(48)).decode().replace('=', '').replace('\n', '')
+        assert len(key) == 64
+        return json.dumps({'key': key, 'key_id': str(uuid.uuid4())})
+
+    def _write_secret_value(self, name, value):
+        self.secrets_manager.put_secret_value(
+            SecretId=name,
+            SecretString=value
+        )
+        logger.info("Successfully wrote value to AWS secret '%s'.", name)
+
+    def _create_secret(self, name):
+        try:
+            self.secrets_manager.create_secret(Name=name)
+        except ClientError as e:
+            if e.response['Error']['Code'] == 'ResourceExistsException':
+                logger.info('AWS secret %s already exists.', name)
+            else:
+                raise
+        else:
+            logger.info('AWS secret %s created.', name)
+
+    def _secret_is_stored(self, name):
+        try:
+            response = self.secrets_manager.get_secret_value(SecretId=name)
+        except ClientError as e:
+            if e.response['Error']['Code'] == 'ResourceNotFoundException':
+                return False
+            else:
+                raise
+        try:
+            return response['SecretString'] != ''
+        except KeyError:
+            return False
+
+    def _create_service_account_creds(self, service_account_email):
+        service = get_google_service()
+        key = service.projects().serviceAccounts().keys().create(
+            name='projects/-/serviceAccounts/' + service_account_email, body={}
+        ).execute()
+        logger.info("Successfully created service account key for user '%s'", service_account_email)
+        return parse_google_key(key)
+
+    def _destroy_aws_secrets_manager_secret(self, secret_name):
+        try:
+            response = self.secrets_manager.delete_secret(
+                SecretId=secret_name,
+                ForceDeleteWithoutRecovery=True
+            )
+        except ClientError as e:
+            if e.response['Error']['Code'] == 'ResourceNotFoundException':
+                logger.info('AWS secret %s does not exist. No changes will be made.', secret_name)
+            else:
+                raise
+        else:
+            assert response['Name'] == secret_name
+            logger.info('Successfully deleted AWS secret %s.', secret_name)
+
+    def _destroy_service_account_creds(self, service_account_email):
+        try:
+            creds = self.secrets_manager.get_secret_value(
+                SecretId=config.secrets_manager_secret_name('indexer', 'google_service_account')
+            )
+        except ClientError as e:
+            if e.response['Error']['Code'] == 'ResourceNotFoundException':
+                logger.info('Secret already deleted, cannot get key_id for %s', service_account_email)
+                return
+            else:
+                raise
+        else:
+            key_id = json.loads(creds['SecretString'])['private_key_id']
+            service = get_google_service()
+            try:
+                service.projects().serviceAccounts().keys().delete(
+                    name='projects/-/serviceAccounts/' + service_account_email + '/keys/' + key_id).execute()
+            except HttpError as e:
+                if e.resp.reason != 'Not Found':
+                    raise
+            logger.info("Successfully deleted service account key with id '%s' for user '%s'",
+                        key_id, service_account_email)
+
+
+if __name__ == "__main__":
+    provision_parser = argparse.ArgumentParser(add_help=False)
+    group = provision_parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--build', '-b', action='store_true', dest='build',
+                       help='Create credentials instead of destroying them. This action is idempotent.')
+    group.add_argument('--destroy', '-d', action='store_false', dest='build',
+                       help='Destroy credentials instead of building them. This action is idempotent.')
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(help='Specify action', dest='action')
+    subparsers.required = True
+    google_parser = subparsers.add_parser('google-key', parents=[provision_parser],
+                                          help='Create Google service account key and store in an AWS secret.')
+    google_parser.set_defaults(func=CredentialsProvisioner.provision_google_from_args)
+    google_parser.add_argument('email', type=str,
+                               help='Email address for the Google service account '
+                                    'for which to provision credentials')
+    hmac_parser = subparsers.add_parser('hmac-key', parents=[provision_parser],
+                                        help='Create a random HMAC key and store in an AWS secret.')
+    hmac_parser.set_defaults(func=CredentialsProvisioner.provision_hmac_from_args)
+    args = parser.parse_args()
+    credentials_provisioner = CredentialsProvisioner()
+    args.func(credentials_provisioner, args)

--- a/scripts/subscribe.py
+++ b/scripts/subscribe.py
@@ -24,7 +24,7 @@ def main(argv):
 
     if options.shared:
         sm = boto3.client('secretsmanager')
-        creds = sm.get_secret_value(SecretId=config.google_service_account('indexer'))
+        creds = sm.get_secret_value(SecretId=config.secrets_manager_secret_name('indexer', 'google_service_account'))
         with tempfile.NamedTemporaryFile(mode='w+') as f:
             f.write(creds['SecretString'])
             f.flush()

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -309,8 +309,8 @@ class Config:
         require(self.term_re.fullmatch(term) is not None,
                 f"{name} is either too short, too long or contains invalid characters: '{term}'")
 
-    def google_service_account(self, lambda_name):
-        return f"dcp/azul/{self.deployment_stage}/{lambda_name}/google_service_account"
+    def secrets_manager_secret_name(self, *args):
+        return '/'.join(['dcp', 'azul', self.deployment_stage, *args])
 
     def enable_gcp(self):
         return 'GOOGLE_PROJECT' in os.environ
@@ -417,11 +417,6 @@ class Config:
             f"https://{self.deployment_stage}.data.humancellatlas.org/",
             f"{self.access_token_issuer}/userinfo"
         ]
-
-    # TODO: Generate subscription HMAC key dynamically and store it securely
-    #  https://github.com/DataBiosphere/azul/issues/794
-    hmac_key = 'São Paulo number Juan among all the numbers'
-    hmac_key_id = 'Mueto bem'
 
     @property
     def fusillade_endpoint(self) -> str:

--- a/src/azul/subscription.py
+++ b/src/azul/subscription.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from azul import config
+from azul import config, deployment
 from azul.json_freeze import freeze, thaw
 from azul.plugin import Plugin
 
@@ -17,11 +17,12 @@ def manage_subscriptions(dss_client, subscribe=True):
         plugin = Plugin.load()
         base_url = config.indexer_endpoint()
         prefix = config.dss_query_prefix
+        key, key_id = deployment.aws.get_hmac_key_and_id()
         new_subscriptions = [freeze(dict(replica='aws',
                                          es_query=query,
                                          callback_url=base_url + path,
-                                         hmac_key_id=config.hmac_key_id,
-                                         hmac_secret_key=config.hmac_key))
+                                         hmac_key_id=key_id,
+                                         hmac_secret_key=key))
                              for query, path in [(plugin.dss_subscription_query(prefix), '/'),
                                                  (plugin.dss_deletion_subscription_query(prefix), '/delete')]]
     else:


### PR DESCRIPTION
This creates a new provisioner for the Google service account that takes care of creating (and destroying) the Account credentials, generating an HMAC key, and storing them in AWS Secrets Manager secrets.

Destroying resources has some limitations. From [Terraform docs](https://www.terraform.io/docs/provisioners/index.html#destroy-time-provisioners)

> Destroy-time provisioners can only run if they remain in the configuration at the time a resource is destroyed.

This is not the case with our code. This means secrets, etc. won't be destroyed if `AZUL_SUBSCRIBE_TO_DSS` **was** set to true and then is set to false.