### PR TITLE
Add deletion to integration test (#838)

### DIFF
--- a/src/azul/azulclient.py
+++ b/src/azul/azulclient.py
@@ -57,13 +57,6 @@ class AzulClient(object):
         response.raise_for_status()
         return response.content
 
-    def _make_test_notification(self, bundle_fqid, new_bundle_uuid, test_name, test_uuid):
-        notification = self._make_notification(bundle_fqid)
-        notification["test_bundle_uuid"] = new_bundle_uuid
-        notification["test_name"] = test_name
-        notification["test_uuid"] = test_uuid
-        return notification
-
     def _make_notification(self, bundle_fqid):
         bundle_uuid, _, bundle_version = bundle_fqid.partition('.')
         return {
@@ -93,7 +86,11 @@ class AzulClient(object):
             new_bundle_uuid = str(uuid.uuid4())
             _, _, version = bundle_fqid.partition('.')
             effective_bundle_fqids.add(new_bundle_uuid + '.' + version)
-            notifications.append(self._make_test_notification(bundle_fqid, new_bundle_uuid, test_name, test_uuid))
+            notification = dict(self._make_notification(bundle_fqid),
+                                test_bundle_uuid=new_bundle_uuid,
+                                test_name=test_name,
+                                test_uuid=test_uuid)
+            notifications.append(notification)
         self._reindex(notifications, sync=sync)
         return effective_bundle_fqids
 

--- a/src/azul/indexer.py
+++ b/src/azul/indexer.py
@@ -84,7 +84,10 @@ class BaseIndexer(ABC):
         bundle_uuid = dss_notification['match']['bundle_uuid']
         bundle_version = dss_notification['match']['bundle_version']
         manifest, metadata_files = self._get_bundle(bundle_uuid, bundle_version)
-        self._add_test_modifications(manifest, metadata_files, dss_notification)
+        # If indexing a test bundle we want to change the uuid so that we can delete the bundle after
+        test_bundle_uuid = self._add_test_modifications(manifest, metadata_files, dss_notification)
+        if test_bundle_uuid:
+            bundle_uuid = test_bundle_uuid
 
         # FIXME: this seems out of place. Consider creating indices at deploy time and avoid the mostly
         # redundant requests for every notification (https://github.com/DataBiosphere/azul/issues/427)
@@ -121,12 +124,16 @@ class BaseIndexer(ABC):
         if integration_test_name is not None:
             for dss_file in manifest:
                 if 'project_0.json' in dss_file['name']:
-                    dss_file['uuid'] = integration_test_name.split('_')[1]
+                    dss_file['uuid'] = dss_notification['test_uuid']
                     metadata_files['project_0.json']['project_core']['project_short_name'] = integration_test_name
-                    metadata_files['project_0.json']['provenance']['document_id'] = integration_test_name.split('_')[1]
+                    metadata_files['project_0.json']['provenance']['document_id'] = dss_notification['test_uuid']
+
                     break
             else:
                 assert False, "project_0.json doesn't exist for this bundle."
+            return dss_notification['test_bundle_uuid']
+        else:
+            return None
 
     def contribute(self, writer: 'IndexWriter', contributions: List[Contribution]) -> Tallies:
         """


### PR DESCRIPTION
The fix works by changing the test reindexing to also assign a new
uuid for the test bundles. These new uuids are then searched in the
index to make sure that indexing was successful. Finally deletions for
all of the relevant bundles that were found in the index are sent to
Azul