### PR TITLE
Fix test query filter for samples tab changes

### DIFF
--- a/test/local_integration_test.py
+++ b/test/local_integration_test.py
@@ -74,7 +74,7 @@ class IntegrationTest(unittest.TestCase):
             # only subset of indexed metadata, use unrestricted filter
             manifest_filter = {"file": {}}
         else:
-            manifest_filter = {"file": {"organ": {"is": ["brain", "Brain"]}, "fileFormat": {"is": ["bai"]}}}
+            manifest_filter = {"file": {"modelOrgan": {"is": ["brain", "Brain"]}, "fileFormat": {"is": ["bai"]}}}
 
         for format_, validator in [
             (None, self.check_manifest),


### PR DESCRIPTION
Fix query filters used in test to reflect changes caused by new samples tab. Change "organ" to "modelOrgan"

```
======================================================================
FAIL: test_webservice_and_indexer (local_integration_test.IntegrationTest) (filter={'file': {'organ': {'is': ['brain', 'Brain']}, 'fileFormat': {'is': ['bai']}}}, format=None, path='/repository/files/export')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/builds/azul/azul/test/local_integration_test.py", line 90, in test_webservice_and_indexer
    validator(response)
  File "/builds/azul/azul/test/local_integration_test.py", line 123, in check_manifest
    self._check_manifest(BytesIO(response), 'bundle_uuid')
  File "/builds/azul/azul/test/local_integration_test.py", line 137, in _check_manifest
    self.assertGreater(len(rows), 0)
AssertionError: 0 not greater than 0
```