### PR TITLE
 Support duplicate notifications (#947)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ deploy:
 subscribe: check_branch
 	if [[ $$AZUL_SUBSCRIBE_TO_DSS != 0 ]]; then python scripts/subscribe.py --shared; fi
 
+unsubscribe:
+	python scripts/subscribe.py --unsubscribe --shared
+
 reindex: check_branch
 	python scripts/reindex.py --delete --partition-prefix-length=2
 

--- a/lambdas/indexer/app.py
+++ b/lambdas/indexer/app.py
@@ -308,9 +308,10 @@ def write(event: chalice.app.SQSEvent):
 
 
 def _create_index_writer():
-    # The should be no conflicts because we use SQS FIFO message group per entity.
+    # We allow one conflict retry in the case of duplicate notifications and switch from 'add' to 'update'.
+    # After that, there should be no conflicts because we use an SQS FIFO message group per entity.
     # For other errors we use SQS message redelivery to take care of the retries.
-    index_writer = IndexWriter(refresh=False, conflict_retry_limit=0, error_retry_limit=0)
+    index_writer = IndexWriter(refresh=False, conflict_retry_limit=1, error_retry_limit=0)
     return index_writer
 
 

--- a/scripts/subscribe.py
+++ b/scripts/subscribe.py
@@ -18,7 +18,10 @@ def main(argv):
     import argparse
     parser = argparse.ArgumentParser(description='Subscribe indexer lambda to bundle events from DSS')
     parser.add_argument('--unsubscribe', '-U', dest='subscribe', action='store_false', default=True)
-    parser.add_argument('--shared', '-s', dest='shared', action='store_true', default=False)
+    parser.add_argument('--shared', '-s', dest='shared', action='store_true', default=False,
+                        help='Fetch credentials to a shared Google service account from AWS Secrets Manager. This '
+                             'option allows you to not have Google Cloud access as long as someone else with access '
+                             'provisions the credentials for you.')
     options = parser.parse_args(argv)
     dss_client = config.dss_client()
 

--- a/src/azul/azulclient.py
+++ b/src/azul/azulclient.py
@@ -74,7 +74,7 @@ class AzulClient(object):
         bundle_fqids = self._post_dss_search()
         logger.info("Bundle FQIDs to index: %i", len(bundle_fqids))
         notifications = [self._make_notification(fqid) for fqid in bundle_fqids]
-        self._reindex(notifications, sync=sync)
+        self._index(notifications, sync=sync)
 
     def test_notifications(self, test_name: str, test_uuid: str) -> Tuple[List[dict], Set[str]]:
         logger.info('Querying DSS using %s', json.dumps(self.query(), indent=4))
@@ -93,7 +93,7 @@ class AzulClient(object):
             notifications.append(notification)
         return notifications, effective_bundle_fqids
 
-    def _reindex(self, notifications: Iterable, sync: bool = False):
+    def _index(self, notifications: Iterable, sync: bool = False):
         errors = defaultdict(int)
         missing = []
         indexed = 0

--- a/src/azul/indexer.py
+++ b/src/azul/indexer.py
@@ -21,8 +21,7 @@ from azul.transformer import (Aggregate,
                               DocumentCoordinates,
                               EntityReference,
                               Transformer,
-                              BundleUUID,
-                              BundleVersion)
+                              BundleUUID)
 from azul.types import JSON
 
 log = logging.getLogger(__name__)

--- a/src/azul/indexer.py
+++ b/src/azul/indexer.py
@@ -160,12 +160,12 @@ class BaseIndexer(ABC):
         """
         while True:
             # Read the aggregates
-            old_aggregates = self._read_aggregates(entity for entity in tallies.keys())
-            absolute_tallies = Counter(tallies)
-            absolute_tallies.update({old_aggregate.entity: old_aggregate.num_contributions
+            old_aggregates = self._read_aggregates(tallies)
+            total_tallies = Counter(tallies)
+            total_tallies.update({old_aggregate.entity: old_aggregate.num_contributions
                                      for old_aggregate in old_aggregates.values()})
             # Read all contributions from Elasticsearch
-            contributions = self._read_contributions(absolute_tallies)
+            contributions = self._read_contributions(total_tallies)
             actual_tallies = Counter(contribution.entity for contribution in contributions)
             assert len(tallies) == len(actual_tallies)
             assert all(tallies[entity] <= actual_tally for entity, actual_tally in actual_tallies.items())

--- a/src/azul/indexer.py
+++ b/src/azul/indexer.py
@@ -157,6 +157,12 @@ class BaseIndexer(ABC):
         """
         Read all contributions to the entities listed in the given tallies from the index, aggregate the
         contributions into one aggregate per entity and write the resulting aggregates to the index.
+
+        Normally there is a 1 to 1 correspondence between number of contributions for an entity and the value for a
+        tally, however tallies are not counted for updates. This means, in the case of a duplicate notification or
+        writing over an already populated index, it's possible to receive a tally with a value of 0. We still need to
+        aggregate (if the indexed format changed for example) but tallies will not serve as an accurate guide for how
+        to read from contributions.
         """
         while True:
             # Read the aggregates

--- a/src/azul/project/hca/indexer.py
+++ b/src/azul/project/hca/indexer.py
@@ -1,7 +1,11 @@
 from typing import Iterable
 
 from azul.indexer import BaseIndexer
-from azul.project.hca.transformers import FileTransformer, CellSuspensionTransformer, SampleTransformer, ProjectTransformer, BundleTransformer
+from azul.project.hca.transformers import (FileTransformer,
+                                           CellSuspensionTransformer,
+                                           SampleTransformer,
+                                           ProjectTransformer,
+                                           BundleTransformer)
 from azul.transformer import Transformer
 from azul.types import JSON
 
@@ -67,7 +71,11 @@ class Indexer(BaseIndexer):
         }
 
     def transformers(self) -> Iterable[Transformer]:
-        return FileTransformer(), CellSuspensionTransformer(), SampleTransformer(), ProjectTransformer(), BundleTransformer()
+        return (FileTransformer(),
+                CellSuspensionTransformer(),
+                SampleTransformer(),
+                ProjectTransformer(),
+                BundleTransformer())
 
     def entities(self) -> Iterable[str]:
         return ['files', 'cell_suspensions', 'samples', 'projects', 'bundles']

--- a/src/azul/types.py
+++ b/src/azul/types.py
@@ -1,6 +1,7 @@
 from typing import Union, Mapping, Any, List
 
-AnyJSON2 = Union[str, int, float, bool, None, Mapping[str, Any], List[Any]]
+AnyJSON3 = Union[str, int, float, bool, None, Mapping[str, Any], List[Any]]
+AnyJSON2 = Union[str, int, float, bool, None, Mapping[str, AnyJSON3], List[AnyJSON3]]
 AnyJSON1 = Union[str, int, float, bool, None, Mapping[str, AnyJSON2], List[AnyJSON2]]
 AnyJSON = Union[str, int, float, bool, None, Mapping[str, AnyJSON1], List[AnyJSON1]]
 JSON = Mapping[str, AnyJSON]

--- a/test/indexer/__init__.py
+++ b/test/indexer/__init__.py
@@ -113,7 +113,7 @@ class IndexerTestCase(ElasticsearchTestCase):
         notification = cls._make_fake_notification(bundle_fqid)
         with patch('azul.DSSClient'):
             with patch.object(indexer, '_get_bundle', new=mocked_get_bundle):
-                contributions = indexer.transform(notification)
+                contributions = indexer.transform(notification, delete=False)
                 return indexer.contribute(index_writer, contributions)
 
     @classmethod

--- a/test/indexer/__init__.py
+++ b/test/indexer/__init__.py
@@ -12,6 +12,7 @@ from azul.plugin import Plugin
 from azul.project.hca import Indexer
 from azul.types import JSON
 from es_test_case import ElasticsearchTestCase
+from lambdas.indexer.app import _create_index_writer
 
 
 class IndexerTestCase(ElasticsearchTestCase):
@@ -118,7 +119,9 @@ class IndexerTestCase(ElasticsearchTestCase):
 
     @classmethod
     def _create_index_writer(cls) -> IndexWriter:
+        writer = _create_index_writer()
         # With a single client thread, refresh=True is faster than refresh="wait_for". The latter would limit the
         # request rate to 1/refresh_interval. That's only one request per second with refresh_interval being 1s.
-        return IndexWriter(refresh=True, conflict_retry_limit=2, error_retry_limit=0)
+        writer.refresh = True
+        return writer
 

--- a/test/indexer/test_hca_indexer.py
+++ b/test/indexer/test_hca_indexer.py
@@ -1,4 +1,5 @@
 import os
+import re
 from collections import Counter, defaultdict
 from concurrent.futures import ThreadPoolExecutor
 import logging


### PR DESCRIPTION
This assertion
```
assert all(tallies[entity] <= actual_tally for entity, actual_tally in contribution_counts.items()
```
Fails for duplicate notifications. was the *actual* cause for duplicate notifications failing. Duplicate
notifications (or a notification and its deletion) would both add to the tally count but would both overwrite the same contribution. Thus the counts would be different. (Note that the overwritting behavior with deletions will change in #1011)