### PR TITLE
Added `/progress` endpoint in Indexer and `api_endpoints` to `/health` endpoint (#971)

### DIFF
--- a/lambdas/indexer/app.py
+++ b/lambdas/indexer/app.py
@@ -61,21 +61,12 @@ def basic_health():
 
 @app.route('/health', methods=['GET'], cors=True)
 @app.route('/health/{key}', methods=['GET'], cors=True)
-def health(key: Optional[str]=None):
+def health(key: Optional[str] = None):
     health = Health('indexer')
     body = health.as_json(*[(key,)] if key else [])
     return Response(
         body=json.dumps(body),
         status_code=200 if body['up'] else 503
-    )
-
-
-@app.route('/progress', methods=['GET'], cors=True)
-def progress():
-    health = Health('indexer')
-    return Response(
-        body=json.dumps(health.progress),
-        status_code=200
     )
 
 

--- a/lambdas/indexer/app.py
+++ b/lambdas/indexer/app.py
@@ -68,6 +68,15 @@ def health():
     )
 
 
+@app.route('/progress', methods=['GET'], cors=True)
+def progress():
+    health = Health('indexer')
+    return Response(
+        body=json.dumps(health.progress),
+        status_code=200
+    )
+
+
 @app.route('/', cors=True)
 def hello():
     return {'Hello': 'World!'}

--- a/lambdas/indexer/app.py
+++ b/lambdas/indexer/app.py
@@ -11,7 +11,7 @@ import random
 import time
 
 from chalice import Response
-from typing import List, MutableMapping
+from typing import List, MutableMapping, Optional
 import uuid
 
 import boto3
@@ -60,11 +60,13 @@ def basic_health():
 
 
 @app.route('/health', methods=['GET'], cors=True)
-def health():
+@app.route('/health/{key}', methods=['GET'], cors=True)
+def health(key: Optional[str]=None):
     health = Health('indexer')
+    body = health.as_json(*[(key,)] if key else [])
     return Response(
-        body=json.dumps(health.as_json),
-        status_code=200 if health.up else 503
+        body=json.dumps(body),
+        status_code=200 if body['up'] else 503
     )
 
 

--- a/lambdas/service/app.py
+++ b/lambdas/service/app.py
@@ -133,7 +133,7 @@ def basic_health():
 
 @app.route('/health', methods=['GET'], cors=True)
 @app.route('/health/{key}', methods=['GET'], cors=True)
-def health(key: Optional[str]=None):
+def health(key: Optional[str] = None):
     health = Health('service')
     body = health.as_json(*[(key,)] if key else [])
     return Response(

--- a/lambdas/service/app.py
+++ b/lambdas/service/app.py
@@ -161,7 +161,7 @@ def repository_search(entity_type: str, item_id: str):
         raise NotFoundError(msg=e)
 
 
-@app.route('/repository/files', methods=['GET'], cors=True)
+@app.route('/repository/files', methods=['HEAD', 'GET'], cors=True)
 @app.route('/repository/files/{file_id}', methods=['GET'], cors=True)
 def get_data(file_id=None):
     """
@@ -208,7 +208,7 @@ def get_data(file_id=None):
     return repository_search('files', file_id)
 
 
-@app.route('/repository/samples', methods=['GET'], cors=True)
+@app.route('/repository/samples', methods=['HEAD', 'GET'], cors=True)
 @app.route('/repository/samples/{sample_id}', methods=['GET'], cors=True)
 def get_sample_data(sample_id=None):
     """
@@ -255,7 +255,7 @@ def get_sample_data(sample_id=None):
     return repository_search('samples', sample_id)
 
 
-@app.route('/repository/bundles', methods=['GET'], cors=True)
+@app.route('/repository/bundles', methods=['HEAD', 'GET'], cors=True)
 @app.route('/repository/bundles/{bundle_uuid}', methods=['GET'], cors=True)
 def get_bundle_data(bundle_uuid=None):
     """
@@ -302,7 +302,7 @@ def get_bundle_data(bundle_uuid=None):
     return repository_search('bundles', bundle_uuid)
 
 
-@app.route('/repository/projects', methods=['GET'], cors=True)
+@app.route('/repository/projects', methods=['HEAD', 'GET'], cors=True)
 @app.route('/repository/projects/{project_id}', methods=['GET'], cors=True)
 def get_project_data(project_id=None):
     """
@@ -349,7 +349,7 @@ def get_project_data(project_id=None):
     return repository_search('projects', project_id)
 
 
-@app.route('/repository/summary', methods=['GET'], cors=True)
+@app.route('/repository/summary', methods=['HEAD', 'GET'], cors=True)
 def get_summary():
     """
     Returns a summary based on the filters passed on to the call. Based on the

--- a/lambdas/service/app.py
+++ b/lambdas/service/app.py
@@ -8,6 +8,7 @@ import math
 import os
 import re
 import time
+from typing import Optional
 import urllib
 from urllib.parse import urlparse
 
@@ -131,11 +132,13 @@ def basic_health():
 
 
 @app.route('/health', methods=['GET'], cors=True)
-def health():
+@app.route('/health/{key}', methods=['GET'], cors=True)
+def health(key: Optional[str]=None):
     health = Health('service')
+    body = health.as_json(*[(key,)] if key else [])
     return Response(
-        body=json.dumps(health.as_json),
-        status_code=200 if health.up else 503
+        body=json.dumps(body),
+        status_code=200 if body['up'] else 503
     )
 
 

--- a/src/azul/health.py
+++ b/src/azul/health.py
@@ -85,17 +85,17 @@ class Health:
         status = {'up': True}
 
         for endpoint in self.endpoints:
-            response = requests.head(f'{config.service_endpoint()}{endpoint}')
+            response = requests.head(config.service_endpoint() + endpoint)
             try:
                 response.raise_for_status()
             except requests.exceptions.HTTPError as e:
-                status[endpoint] = {
+                status[config.service_endpoint() + endpoint] = {
                     'up': False,
                     'error': str(e)
                 }
                 status['up'] = False
             else:
-                status[endpoint] = {
+                status[config.service_endpoint() + endpoint] = {
                     'up': True
                 }
         return status

--- a/src/azul/health.py
+++ b/src/azul/health.py
@@ -20,8 +20,7 @@ class Health:
         'elastic_search',
         'queues',
         'api_endpoints',
-        'other_lambdas',
-        'progress'
+        'other_lambdas'
     )
 
     def as_json(self, keys=default_keys) -> JSON:
@@ -29,13 +28,13 @@ class Health:
 
     @memoized_property
     def other_lambdas(self):
-        d = {
+        response = {
             lambda_name: self._lambda(lambda_name)
             for lambda_name in config.lambda_names()
             if lambda_name != self.lambda_name
         }
-        d['up'] = all(v['up'] for v in d.values())
-        return d
+        response['up'] = all(v['up'] for v in response.values())
+        return response
 
     @memoized_property
     def queues(self):
@@ -64,7 +63,6 @@ class Health:
     @memoized_property
     def progress(self) -> JSON:
         return {
-            'up': True,
             'unindexed_bundles': sum(self.queues[config.notify_queue_name].get('messages', {}).values()),
             'unindexed_documents': sum(self.queues[config.document_queue_name].get('messages', {}).values())
         }
@@ -74,10 +72,10 @@ class Health:
         status = {'up': True}
 
         for endpoint in ('/repository/files?size=1',
-                         '/repository/projects',
-                         '/repository/samples',
-                         '/repository/bundles',
-                         '/repository/summary'):
+                         '/repository/projects?size=1',
+                         '/repository/samples?size=1',
+                         '/repository/bundles?size=1',
+                         '/repository/summary?size=1'):
 
             response = requests.head(f'{config.service_endpoint()}{endpoint}')
             try:

--- a/test/health_check_test_case.py
+++ b/test/health_check_test_case.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta
 import os
-from typing import List, Tuple
+from typing import List, Dict
 from unittest import TestSuite, mock
 
 import boto3
@@ -10,6 +10,7 @@ import responses
 
 from app_test_case import LocalAppTestCase
 from azul import config
+from azul.types import JSON
 from es_test_case import ElasticsearchTestCase
 from retorts import ResponsesHelper
 
@@ -22,6 +23,11 @@ def load_tests(loader, tests, pattern):
 
 
 class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABCMeta):
+    endpoints = ['/repository/files?size=1',
+                 '/repository/projects?size=1',
+                 '/repository/samples?size=1',
+                 '/repository/bundles?size=1',
+                 '/repository/summary?size=1']
 
     def _other_lambda_names(self) -> List[str]:
         return [
@@ -34,12 +40,8 @@ class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABC
     @mock_sqs
     def test_ok_response(self):
         self._create_mock_queues()
-        endpoints = [('/repository/files', True),
-                     ('/repository/projects', True),
-                     ('/repository/samples', True),
-                     ('/repository/bundles', True),
-                     ('/repository/summary', True)]
-        response = self._test(endpoints, lambdas_up=True)
+        endpoint_states = self._generate_endpoint_states(self.endpoints)
+        response = self._test(endpoint_states, lambdas_up=True)
         health_object = response.json()
         self.assertEqual(200, response.status_code)
         self.assertEqual({
@@ -47,35 +49,17 @@ class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABC
             'elastic_search': {
                 'up': True
             },
-            'queues': {
-                'up': True,
-                **({
-                    queue_name: {'up': True, 'messages': {'delayed': 0, 'invisible': 0, 'queued': 0}}
-                    for queue_name in config.all_queue_names
-                })
-            },
-            **({
-                lambda_name: {'up': True}
-                for lambda_name in self._other_lambda_names()
-            }),
-            'api_endpoints': {
-                'up': True,
-                **({
-                    endpoint: {'up': up} for endpoint, up in endpoints
-                })
-            },
+            **self._expected_queues(True),
+            **self._expected_other_lambdas(True),
+            **self._expected_api_endpoints(endpoint_states)
         }, health_object)
 
     @mock_sts
     @mock_sqs
     def test_other_lambda_down(self):
         self._create_mock_queues()
-        endpoints = [('/repository/files', True),
-                     ('/repository/projects', True),
-                     ('/repository/samples', True),
-                     ('/repository/bundles', True),
-                     ('/repository/summary', True)]
-        response = self._test(endpoints, lambdas_up=False)
+        endpoint_states = self._generate_endpoint_states(self.endpoints)
+        response = self._test(endpoint_states, lambdas_up=False)
         health_object = response.json()
         self.assertEqual(503, response.status_code)
         self.assertEqual({
@@ -83,34 +67,16 @@ class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABC
             'elastic_search': {
                 'up': True
             },
-            'queues': {
-                'up': True,
-                **({
-                    queue_name: {'up': True, 'messages': {'delayed': 0, 'invisible': 0, 'queued': 0}}
-                    for queue_name in config.all_queue_names
-                })
-            },
-            **({
-                lambda_name: {'up': False}
-                for lambda_name in self._other_lambda_names()
-            }),
-            'api_endpoints': {
-                'up': True,
-                **({
-                    endpoint: {'up': up} for endpoint, up in endpoints
-                })
-            }
+            **self._expected_queues(True),
+            **self._expected_other_lambdas(False),
+            **self._expected_api_endpoints(endpoint_states)
         }, health_object)
 
     @mock_sts
     @mock_sqs
     def test_queues_down(self):
-        endpoints = [('/repository/files', True),
-                     ('/repository/projects', True),
-                     ('/repository/samples', True),
-                     ('/repository/bundles', True),
-                     ('/repository/summary', True)]
-        response = self._test(endpoints, lambdas_up=True)
+        endpoint_states = self._generate_endpoint_states(self.endpoints)
+        response = self._test(endpoint_states, lambdas_up=True)
         health_object = response.json()
         self.assertEqual(503, response.status_code)
         self.assertEqual({
@@ -118,35 +84,17 @@ class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABC
             'elastic_search': {
                 'up': True
             },
-            'queues': {
-                'up': False,
-                **({
-                    queue_name: {'up': False, 'error': 'The specified queue does not exist for this wsdl version.'}
-                    for queue_name in config.all_queue_names
-                })
-            },
-            **({
-                lambda_name: {'up': True}
-                for lambda_name in self._other_lambda_names()
-            }),
-            'api_endpoints': {
-                'up': True,
-                **({
-                    endpoint: {'up': up} for endpoint, up in endpoints
-                })
-            },
+            **self._expected_queues(False),
+            **self._expected_other_lambdas(True),
+            **self._expected_api_endpoints(endpoint_states)
         }, health_object)
 
     @mock_sts
     @mock_sqs
     def test_all_api_endpoints_down(self):
         self._create_mock_queues()
-        endpoints = [('/repository/files', False),
-                     ('/repository/projects', False),
-                     ('/repository/samples', False),
-                     ('/repository/bundles', False),
-                     ('/repository/summary', False)]
-        response = self._test(endpoints, lambdas_up=True)
+        endpoint_states = self._generate_endpoint_states([], down_endpoints=self.endpoints)
+        response = self._test(endpoint_states, lambdas_up=True)
         health_object = response.json()
         self.assertEqual(503, response.status_code)
         self.assertEqual({
@@ -154,37 +102,17 @@ class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABC
             'elastic_search': {
                 'up': True
             },
-            'queues': {
-                'up': True,
-                **({
-                    queue_name: {'up': True, 'messages': {'delayed': 0, 'invisible': 0, 'queued': 0}}
-                    for queue_name in config.all_queue_names
-                })
-            },
-            **({
-                lambda_name: {'up': True}
-                for lambda_name in self._other_lambda_names()
-            }),
-            'api_endpoints': {
-                'up': False,
-                **({
-                    endpoint: {'up': up,
-                               'error': f'503 Server Error: Service Unavailable for url: '
-                                        f'{config.service_endpoint()}{endpoint}'} for endpoint, up in endpoints
-                })
-            }
+            **self._expected_queues(True),
+            **self._expected_other_lambdas(True),
+            **self._expected_api_endpoints(endpoint_states)
         }, health_object)
 
     @mock_sts
     @mock_sqs
     def test_one_api_endpoint_down(self):
         self._create_mock_queues()
-        endpoints = [('/repository/files', True),
-                     ('/repository/projects', True),
-                     ('/repository/samples', False),
-                     ('/repository/bundles', True),
-                     ('/repository/summary', True)]
-        response = self._test(endpoints, lambdas_up=True)
+        endpoint_states = self._generate_endpoint_states(self.endpoints[1:], down_endpoints=self.endpoints[:1])
+        response = self._test(endpoint_states, lambdas_up=True)
         health_object = response.json()
         self.assertEqual(503, response.status_code)
         self.assertEqual({
@@ -192,40 +120,19 @@ class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABC
             'elastic_search': {
                 'up': True
             },
-            'queues': {
-                'up': True,
-                **({
-                    queue_name: {'up': True, 'messages': {'delayed': 0, 'invisible': 0, 'queued': 0}}
-                    for queue_name in config.all_queue_names
-                })
-            },
-            **({
-                lambda_name: {'up': True}
-                for lambda_name in self._other_lambda_names()
-            }),
-            'api_endpoints': {
-                'up': False,
-                **({
-                    endpoint: {'up': up} if up else
-                              {'up': up,
-                               'error': f'503 Server Error: Service Unavailable for url: {config.service_endpoint()}'
-                                        f'{endpoint}'} for endpoint, up in endpoints
-                })
-            }
+            **self._expected_queues(True),
+            **self._expected_other_lambdas(True),
+            **self._expected_api_endpoints(endpoint_states)
         }, health_object)
 
     @mock_sts
     @mock_sqs
     def test_elasticsearch_down(self):
         self._create_mock_queues()
-        endpoints = [('/repository/files', True),
-                     ('/repository/projects', True),
-                     ('/repository/samples', True),
-                     ('/repository/bundles', True),
-                     ('/repository/summary', True)]
         mock_endpoint = ('nonexisting-index.com', 80)
+        endpoint_states = self._generate_endpoint_states(self.endpoints)
         with mock.patch.dict(os.environ, **config.es_endpoint_env(mock_endpoint)):
-            response = self._test(endpoints, lambdas_up=True)
+            response = self._test(endpoint_states, lambdas_up=True)
             health_object = response.json()
             self.assertEqual(503, response.status_code)
             documents_ = {
@@ -233,27 +140,59 @@ class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABC
                 'elastic_search': {
                     'up': False
                 },
-                'queues': {
-                    'up': True,
-                    **({
-                        queue_name: {'up': True, 'messages': {'delayed': 0, 'invisible': 0, 'queued': 0}}
-                        for queue_name in config.all_queue_names
-                    })
-                },
-                **({
-                    lambda_name: {'up': True}
-                    for lambda_name in self._other_lambda_names()
-                }),
-                'api_endpoints': {
-                    'up': True,
-                    **{
-                        endpoint: {'up': up} for endpoint, up in endpoints
-                    }
-                }
+                **self._expected_queues(True),
+                **self._expected_other_lambdas(True),
+                **self._expected_api_endpoints(endpoint_states)
             }
             self.assertEqual(documents_, health_object)
 
-    def _test(self, endpoints: List[Tuple[str, bool]], lambdas_up: bool):
+    def _expected_queues(self, up: bool) -> JSON:
+        return {
+            'queues': {
+                'up': up,
+                **({
+                    queue_name: {
+                        'up': True,
+                        'messages': {
+                            'delayed': 0, 'invisible': 0, 'queued': 0
+                        }
+                    } if up else {
+                        'up': False, 'error': 'The specified queue does not exist for this wsdl version.'
+                    }
+                    for queue_name in config.all_queue_names
+                })
+            }
+        }
+
+    def _expected_api_endpoints(self, endpoint_states: Dict[str, bool]) -> JSON:
+        return {
+            'api_endpoints': {
+                'up': all(up for endpoint, up in endpoint_states.items()),
+                **({
+                    endpoint: {
+                        'up': up
+                    } if up else {
+                        'up': up,
+                        'error': f'503 Server Error: Service Unavailable for url: {config.service_endpoint()}'
+                                 f'{endpoint}'
+                    } for endpoint, up in endpoint_states.items()
+                })
+            }
+        }
+
+    def _expected_other_lambdas(self, up: bool) -> JSON:
+        return {
+            'other_lambdas': {
+                'up': up,
+                **({
+                    lambda_name: {
+                        'up': up
+                    } for lambda_name in self._other_lambda_names()
+                })
+            }
+        }
+
+    def _test(self, endpoint_states: Dict[str, bool], lambdas_up: bool):
         with ResponsesHelper() as helper:
             helper.add_passthru(self.base_url)
             for lambda_name in self._other_lambda_names():
@@ -261,7 +200,7 @@ class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABC
                                               url=config.lambda_endpoint(lambda_name) + '/health/basic',
                                               status=200 if lambdas_up else 503,
                                               json={'up': lambdas_up}))
-            for endpoint, endpoint_up in endpoints:
+            for endpoint, endpoint_up in endpoint_states.items():
                 helper.add(responses.Response(method='HEAD',
                                               url=config.service_endpoint() + endpoint,
                                               status=200 if endpoint_up else 503,
@@ -273,3 +212,9 @@ class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABC
         sqs = boto3.resource('sqs', region_name='us-east-1')
         for queue_name in config.all_queue_names:
             sqs.create_queue(QueueName=queue_name)
+
+    def _generate_endpoint_states(self, up_endpoints: List[str], down_endpoints: List[str] = None) -> Dict[str, bool]:
+        return {
+            **({endpoint: True for endpoint in up_endpoints}),
+            **({endpoint: False for endpoint in down_endpoints} if down_endpoints else {})
+        }

--- a/test/health_check_test_case.py
+++ b/test/health_check_test_case.py
@@ -189,7 +189,7 @@ class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABC
             'api_endpoints': {
                 'up': all(up for endpoint, up in endpoint_states.items()),
                 **({
-                    endpoint: {
+                    config.service_endpoint() + endpoint: {
                         'up': up
                     } if up else {
                         'up': up,

--- a/test/health_check_test_case.py
+++ b/test/health_check_test_case.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta
 import os
-from typing import List, Dict
+from typing import List, Mapping
 from unittest import TestSuite, mock
 
 import boto3
@@ -27,7 +27,7 @@ class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABC
                  '/repository/projects?size=1',
                  '/repository/samples?size=1',
                  '/repository/bundles?size=1',
-                 '/repository/summary?size=1']
+                 '/repository/summary']
 
     def _other_lambda_names(self) -> List[str]:
         return [
@@ -40,89 +40,84 @@ class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABC
     @mock_sqs
     def test_ok_response(self):
         self._create_mock_queues()
-        endpoint_states = self._generate_endpoint_states(self.endpoints)
+        endpoint_states = self._make_endpoint_states(self.endpoints)
         response = self._test(endpoint_states, lambdas_up=True)
         health_object = response.json()
         self.assertEqual(200, response.status_code)
         self.assertEqual({
             'up': True,
-            'elastic_search': {
-                'up': True
-            },
+            **self._expected_elastic_search(True),
             **self._expected_queues(True),
             **self._expected_other_lambdas(True),
-            **self._expected_api_endpoints(endpoint_states)
+            **self._expected_api_endpoints(endpoint_states),
+            **self._expected_progress()
         }, health_object)
 
     @mock_sts
     @mock_sqs
     def test_other_lambda_down(self):
         self._create_mock_queues()
-        endpoint_states = self._generate_endpoint_states(self.endpoints)
+        endpoint_states = self._make_endpoint_states(self.endpoints)
         response = self._test(endpoint_states, lambdas_up=False)
         health_object = response.json()
         self.assertEqual(503, response.status_code)
         self.assertEqual({
             'up': False,
-            'elastic_search': {
-                'up': True
-            },
+            **self._expected_elastic_search(True),
             **self._expected_queues(True),
             **self._expected_other_lambdas(False),
-            **self._expected_api_endpoints(endpoint_states)
+            **self._expected_api_endpoints(endpoint_states),
+            **self._expected_progress()
         }, health_object)
 
     @mock_sts
     @mock_sqs
     def test_queues_down(self):
-        endpoint_states = self._generate_endpoint_states(self.endpoints)
+        endpoint_states = self._make_endpoint_states(self.endpoints)
         response = self._test(endpoint_states, lambdas_up=True)
         health_object = response.json()
         self.assertEqual(503, response.status_code)
         self.assertEqual({
             'up': False,
-            'elastic_search': {
-                'up': True
-            },
+            **self._expected_elastic_search(True),
             **self._expected_queues(False),
             **self._expected_other_lambdas(True),
-            **self._expected_api_endpoints(endpoint_states)
+            **self._expected_api_endpoints(endpoint_states),
+            **self._expected_progress()
         }, health_object)
 
     @mock_sts
     @mock_sqs
     def test_all_api_endpoints_down(self):
         self._create_mock_queues()
-        endpoint_states = self._generate_endpoint_states([], down_endpoints=self.endpoints)
+        endpoint_states = self._make_endpoint_states([], down_endpoints=self.endpoints)
         response = self._test(endpoint_states, lambdas_up=True)
         health_object = response.json()
         self.assertEqual(503, response.status_code)
         self.assertEqual({
             'up': False,
-            'elastic_search': {
-                'up': True
-            },
+            **self._expected_elastic_search(True),
             **self._expected_queues(True),
             **self._expected_other_lambdas(True),
-            **self._expected_api_endpoints(endpoint_states)
+            **self._expected_api_endpoints(endpoint_states),
+            **self._expected_progress()
         }, health_object)
 
     @mock_sts
     @mock_sqs
     def test_one_api_endpoint_down(self):
         self._create_mock_queues()
-        endpoint_states = self._generate_endpoint_states(self.endpoints[1:], down_endpoints=self.endpoints[:1])
+        endpoint_states = self._make_endpoint_states(self.endpoints[1:], down_endpoints=self.endpoints[:1])
         response = self._test(endpoint_states, lambdas_up=True)
         health_object = response.json()
         self.assertEqual(503, response.status_code)
         self.assertEqual({
             'up': False,
-            'elastic_search': {
-                'up': True
-            },
+            **self._expected_elastic_search(True),
             **self._expected_queues(True),
             **self._expected_other_lambdas(True),
-            **self._expected_api_endpoints(endpoint_states)
+            **self._expected_api_endpoints(endpoint_states),
+            **self._expected_progress()
         }, health_object)
 
     @mock_sts
@@ -130,21 +125,46 @@ class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABC
     def test_elasticsearch_down(self):
         self._create_mock_queues()
         mock_endpoint = ('nonexisting-index.com', 80)
-        endpoint_states = self._generate_endpoint_states(self.endpoints)
+        endpoint_states = self._make_endpoint_states(self.endpoints)
         with mock.patch.dict(os.environ, **config.es_endpoint_env(mock_endpoint)):
             response = self._test(endpoint_states, lambdas_up=True)
             health_object = response.json()
             self.assertEqual(503, response.status_code)
             documents_ = {
                 'up': False,
-                'elastic_search': {
-                    'up': False
-                },
+                **self._expected_elastic_search(False),
                 **self._expected_queues(True),
                 **self._expected_other_lambdas(True),
-                **self._expected_api_endpoints(endpoint_states)
+                **self._expected_api_endpoints(endpoint_states),
+                **self._expected_progress()
             }
             self.assertEqual(documents_, health_object)
+
+    @mock_sts
+    @mock_sqs
+    def test_health_endpoint_keys(self):
+        endpoint_states = self._make_endpoint_states(self.endpoints)
+        expected = {
+            key: {
+                'up': True,
+                **expected_response
+            } for key, expected_response in [('elastic_search', self._expected_elastic_search(True)),
+                                             ('queues', self._expected_queues(True)),
+                                             ('other_lambdas', self._expected_other_lambdas(True)),
+                                             ('api_endpoints', self._expected_api_endpoints(endpoint_states)),
+                                             ('progress', self._expected_progress())]
+        }
+        self._create_mock_queues()
+        for health_key, expected_response in expected.items():
+            with self.subTest(msg=health_key):
+                with ResponsesHelper() as helper:
+                    helper.add_passthru(self.base_url)
+                    self._add_helper_responses(helper, endpoint_states, True)
+                    with mock.patch.dict(os.environ, AWS_DEFAULT_REGION='us-east-1'):
+                        response = requests.get(self.base_url + '/health/' + health_key)
+                        health_object = response.json()
+                        self.assertEqual(200, response.status_code)
+                        self.assertEqual(health_object, expected_response)
 
     def _expected_queues(self, up: bool) -> JSON:
         return {
@@ -164,7 +184,7 @@ class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABC
             }
         }
 
-    def _expected_api_endpoints(self, endpoint_states: Dict[str, bool]) -> JSON:
+    def _expected_api_endpoints(self, endpoint_states: Mapping[str, bool]) -> JSON:
         return {
             'api_endpoints': {
                 'up': all(up for endpoint, up in endpoint_states.items()),
@@ -192,28 +212,47 @@ class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABC
             }
         }
 
-    def _test(self, endpoint_states: Dict[str, bool], lambdas_up: bool):
+    def _expected_progress(self) -> JSON:
+        return {
+            'progress': {
+                'up': True,
+                'unindexed_bundles': 0,
+                'unindexed_documents': 0
+            }
+        }
+
+    def _expected_elastic_search(self, up: bool) -> JSON:
+        return {
+            'elastic_search': {
+                'up': up
+            }
+        }
+
+    def _test(self, endpoint_states: Mapping[str, bool], lambdas_up: bool):
         with ResponsesHelper() as helper:
             helper.add_passthru(self.base_url)
-            for lambda_name in self._other_lambda_names():
-                helper.add(responses.Response(method='GET',
-                                              url=config.lambda_endpoint(lambda_name) + '/health/basic',
-                                              status=200 if lambdas_up else 503,
-                                              json={'up': lambdas_up}))
-            for endpoint, endpoint_up in endpoint_states.items():
-                helper.add(responses.Response(method='HEAD',
-                                              url=config.service_endpoint() + endpoint,
-                                              status=200 if endpoint_up else 503,
-                                              json={}))
+            self._add_helper_responses(helper, endpoint_states, lambdas_up)
             with mock.patch.dict(os.environ, AWS_DEFAULT_REGION='us-east-1'):
                 return requests.get(self.base_url + '/health')
+
+    def _add_helper_responses(self, helper: ResponsesHelper, endpoint_states: Mapping[str, bool], lambdas_up: bool):
+        for lambda_name in self._other_lambda_names():
+            helper.add(responses.Response(method='GET',
+                                          url=config.lambda_endpoint(lambda_name) + '/health/basic',
+                                          status=200 if lambdas_up else 503,
+                                          json={'up': lambdas_up}))
+        for endpoint, endpoint_up in endpoint_states.items():
+            helper.add(responses.Response(method='HEAD',
+                                          url=config.service_endpoint() + endpoint,
+                                          status=200 if endpoint_up else 503,
+                                          json={}))
 
     def _create_mock_queues(self):
         sqs = boto3.resource('sqs', region_name='us-east-1')
         for queue_name in config.all_queue_names:
             sqs.create_queue(QueueName=queue_name)
 
-    def _generate_endpoint_states(self, up_endpoints: List[str], down_endpoints: List[str] = None) -> Dict[str, bool]:
+    def _make_endpoint_states(self, up_endpoints: List[str], down_endpoints: List[str] = None) -> Mapping[str, bool]:
         return {
             **({endpoint: True for endpoint in up_endpoints}),
             **({endpoint: False for endpoint in down_endpoints} if down_endpoints else {})

--- a/test/indexer/test_health_check.py
+++ b/test/indexer/test_health_check.py
@@ -1,7 +1,12 @@
 import logging
+import os
+from moto import mock_sqs, mock_sts
+import requests
 import unittest
+from unittest import mock
 
 from health_check_test_case import HealthCheckTestCase
+from retorts import ResponsesHelper
 
 
 def setUpModule():
@@ -13,6 +18,21 @@ class TestHealthCheck(HealthCheckTestCase):
     @classmethod
     def lambda_name(cls) -> str:
         return 'indexer'
+
+    @mock_sts
+    @mock_sqs
+    def test_progress(self):
+        self._create_mock_queues()
+        with ResponsesHelper() as helper:
+            helper.add_passthru(self.base_url)
+            with mock.patch.dict(os.environ, AWS_DEFAULT_REGION='us-east-1'):
+                response = requests.get(self.base_url + '/progress')
+                health_object = response.json()
+                self.assertEqual(200, response.status_code)
+                self.assertEqual({
+                    'unindexed_bundles': 0,
+                    'unindexed_documents': 0
+                }, health_object)
 
 
 # FIXME: This is inelegant: https://github.com/DataBiosphere/azul/issues/652

--- a/test/indexer/test_health_check.py
+++ b/test/indexer/test_health_check.py
@@ -1,12 +1,7 @@
 import logging
-import os
-from moto import mock_sqs, mock_sts
-import requests
 import unittest
-from unittest import mock
 
 from health_check_test_case import HealthCheckTestCase
-from retorts import ResponsesHelper
 
 
 def setUpModule():
@@ -18,21 +13,6 @@ class TestHealthCheck(HealthCheckTestCase):
     @classmethod
     def lambda_name(cls) -> str:
         return 'indexer'
-
-    @mock_sts
-    @mock_sqs
-    def test_progress(self):
-        self._create_mock_queues()
-        with ResponsesHelper() as helper:
-            helper.add_passthru(self.base_url)
-            with mock.patch.dict(os.environ, AWS_DEFAULT_REGION='us-east-1'):
-                response = requests.get(self.base_url + '/progress')
-                health_object = response.json()
-                self.assertEqual(200, response.status_code)
-                self.assertEqual({
-                    'unindexed_bundles': 0,
-                    'unindexed_documents': 0
-                }, health_object)
 
 
 # FIXME: This is inelegant: https://github.com/DataBiosphere/azul/issues/652

--- a/test/local_integration_test.py
+++ b/test/local_integration_test.py
@@ -98,9 +98,16 @@ class IntegrationTest(unittest.TestCase):
         self.check_bundles_are_indexed(self.test_name, 'files')
 
     def _test_other_endpoints(self):
-        self.check_endpoint_is_working(config.indexer_endpoint(), '/health')
+        for health_key in ('',
+                           '/elastic_search',
+                           '/queues',
+                           '/api_endpoints',
+                           '/other_lambdas',
+                           '/basic',
+                           '/progress'):
+            self.check_endpoint_is_working(config.service_endpoint(), '/health' + health_key)
+            self.check_endpoint_is_working(config.indexer_endpoint(), '/health' + health_key)
         self.check_endpoint_is_working(config.service_endpoint(), '/')
-        self.check_endpoint_is_working(config.service_endpoint(), '/health')
         self.check_endpoint_is_working(config.service_endpoint(), '/version')
         self.check_endpoint_is_working(config.service_endpoint(), '/repository/summary')
         self.check_endpoint_is_working(config.service_endpoint(), '/repository/files/order')


### PR DESCRIPTION
This PR adds the `/progress` endpoint to the indexer lambda. The `/health` endpoint is also modified to include the statuses of the main service api endpoints.

The following is the new response structure of these endpoints.

**/health**
```
{
  "up": true,
  "elastic_search": {
    "up": true
  },
  "queues": {
    "up": true,
    "azul-documents-geryl": {
      "up": true,
      "messages": {
        "delayed": 0,
        "invisible": 0,
        "queued": 0
      }
    },
    "azul-documents-geryl.fifo": {
      "up": true,
      "messages": {
        "delayed": 0,
        "invisible": 0,
        "queued": 0
      }
    },
    "azul-fail-geryl": {
      "up": true,
      "messages": {
        "delayed": 0,
        "invisible": 0,
        "queued": 7
      }
    },
    "azul-fail-geryl.fifo": {
      "up": true,
      "messages": {
        "delayed": 0,
        "invisible": 0,
        "queued": 0
      }
    },
    "azul-notify-geryl": {
      "up": true,
      "messages": {
        "delayed": 0,
        "invisible": 0,
        "queued": 0
      }
    }
  },
  "indexer": {
    "up": true
  },
  "api_endpoints": {
    "up": true,
    "/repository/files": {
      "up": true
    },
    "/repository/projects": {
      "up": true
    },
    "/repository/samples": {
      "up": true
    },
    "/repository/bundles": {
      "up": true
    },
    "/repository/summary": {
      "up": true
    }
  }
}
```

**/progress**
```
{
  "unindexed_bundles": 0,
  "unindexed_documents": 0
}
```
