### PR TITLE
Refactor HCA transformer

### DIFF
--- a/src/azul/project/hca/transformers.py
+++ b/src/azul/project/hca/transformers.py
@@ -1,7 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from collections import Counter
 import logging
-from dataclasses import dataclass
 from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Set, Union
 
 from humancellatlas.data.metadata import api
@@ -332,7 +331,7 @@ class Transformer(AggregatingTransformer, metaclass=ABCMeta):
         }
 
     def _protocol(self, protocol: api.Protocol) -> JSON:
-        protocol_ = {"document_id": protocol.document_id}
+        protocol_ = {'document_id': protocol.document_id}
         if isinstance(protocol, api.LibraryPreparationProtocol):
             protocol_['library_construction_approach'] = protocol.library_construction_approach
         elif isinstance(protocol, api.SequencingProtocol):

--- a/src/azul/project/hca/transformers.py
+++ b/src/azul/project/hca/transformers.py
@@ -261,8 +261,6 @@ class Transformer(AggregatingTransformer, metaclass=ABCMeta):
     def _contribution(self, bundle: api.Bundle, contents: JSON, entity_id: api.UUID4) -> Contribution:
         entity_reference = EntityReference(entity_type=self.entity_type(),
                                            entity_id=str(entity_id))
-        # noinspection PyArgumentList
-        # https://youtrack.jetbrains.com/issue/PY-28506
         return Contribution(entity=entity_reference,
                             version=None,
                             contents=contents,

--- a/src/azul/project/hca/transformers.py
+++ b/src/azul/project/hca/transformers.py
@@ -27,206 +27,6 @@ log = logging.getLogger(__name__)
 Sample = Union[api.CellLine, api.Organoid, api.SpecimenFromOrganism]
 
 
-def _contact_dict(p: api.ProjectContact):
-    return {
-        "contact_name": p.contact_name,
-        "corresponding_contributor": p.corresponding_contributor,
-        "email": p.email,
-        "institution": p.institution,
-        "laboratory": p.laboratory,
-        "project_role": p.project_role
-    }
-
-
-def _publication_dict(p: api.ProjectPublication):
-    return {
-        "publication_title": p.publication_title,
-        "publication_url": p.publication_url
-    }
-
-
-def _project_dict(project: api.Project) -> JSON:
-    # Store lists of all values of each of these facets to allow facet filtering
-    # and term counting on the webservice
-    laboratories: Set[str] = set()
-    institutions: Set[str] = set()
-    contact_names: Set[str] = set()
-    publication_titles: Set[str] = set()
-
-    for contributor in project.contributors:
-        if contributor.laboratory:
-            laboratories.add(contributor.laboratory)
-        if contributor.contact_name:
-            contact_names.add(contributor.contact_name)
-        if contributor.institution:
-            institutions.add(contributor.institution)
-
-    for publication in project.publications:
-        if publication.publication_title:
-            publication_titles.add(publication.publication_title)
-
-    return {
-        'project_title': project.project_title,
-        'project_description': project.project_description,
-        'project_shortname': project.project_short_name,
-        'laboratory': list(laboratories),
-        'institutions': list(institutions),
-        'contact_names': list(contact_names),
-        'contributors': [_contact_dict(c) for c in project.contributors],
-        'document_id': str(project.document_id),
-        'publication_titles': list(publication_titles),
-        'publications': [_publication_dict(p) for p in project.publications],
-        'insdc_project_accessions': list(project.insdc_project_accessions),
-        'geo_series_accessions': list(project.geo_series_accessions),
-        'array_express_accessions': list(project.array_express_accessions),
-        'insdc_study_accessions': list(project.insdc_study_accessions),
-        '_type': 'project'
-    }
-
-
-def _specimen_dict(specimen: api.SpecimenFromOrganism) -> JSON:
-    return {
-        'has_input_biomaterial': specimen.has_input_biomaterial,
-        '_source': api.schema_names[type(specimen)],
-        'document_id': str(specimen.document_id),
-        'biomaterial_id': specimen.biomaterial_id,
-        'disease': list(specimen.diseases),
-        'organ': specimen.organ,
-        'organ_part': list(specimen.organ_parts),
-        'storage_method': specimen.storage_method,
-        'preservation_method': specimen.preservation_method,
-        '_type': 'specimen',
-    }
-
-def _cell_suspension_dict(cell_suspension: api.CellSuspension) -> JSON:
-    organs = set()
-    organ_parts = set()
-    samples: MutableMapping[str, Sample] = dict()
-    SampleTransformer.get_ancestor_samples(cell_suspension, samples)
-    for sample in samples.values():
-        if isinstance(sample, api.SpecimenFromOrganism):
-            organs.add(sample.organ)
-            organ_parts.update(sample.organ_parts)
-        elif isinstance(sample, api.CellLine):
-            organs.add(sample.model_organ)
-            organ_parts.add(None)
-        elif isinstance(sample, api.Organoid):
-            organs.add(sample.model_organ)
-            organ_parts.add(sample.model_organ_part)
-        else:
-            assert False
-    return {
-        'document_id': str(cell_suspension.document_id),
-        'total_estimated_cells': cell_suspension.estimated_cell_count,
-        'selected_cell_type': list( cell_suspension.selected_cell_types),
-        'organ': list(organs),
-        'organ_part': list(organ_parts),
-    }
-
-
-def _cell_line_dict(cell_line: api.CellLine) -> JSON:
-    return {
-        'document_id': str(cell_line.document_id),
-        'biomaterial_id': cell_line.biomaterial_id,
-        'cell_line_type': cell_line.cell_line_type,
-        'model_organ': cell_line.model_organ
-    }
-
-
-def _donor_dict(donor: api.DonorOrganism) -> JSON:
-    return {
-        'document_id': str(donor.document_id),
-        'biomaterial_id': donor.biomaterial_id,
-        'biological_sex': donor.sex,
-        'genus_species': list(donor.genus_species),
-        'diseases': list(donor.diseases),
-        'organism_age': donor.organism_age,
-        'organism_age_unit': donor.organism_age_unit,
-        **(
-            {
-                'min_organism_age_in_seconds': donor.organism_age_in_seconds.min,
-                'max_organism_age_in_seconds': donor.organism_age_in_seconds.max,
-            } if donor.organism_age_in_seconds else {
-            }
-        ),
-    }
-
-
-def _organoid_dict(organoid: api.Organoid) -> JSON:
-    return {
-        'document_id': str(organoid.document_id),
-        'biomaterial_id': organoid.biomaterial_id,
-        'model_organ': organoid.model_organ,
-        'model_organ_part': organoid.model_organ_part,
-    }
-
-
-def _file_dict(file: api.File) -> JSON:
-    return {
-        'content-type': file.manifest_entry.content_type,
-        'indexed': file.manifest_entry.indexed,
-        'name': file.manifest_entry.name,
-        'sha256': file.manifest_entry.sha256,
-        'size': file.manifest_entry.size,
-        'uuid': file.manifest_entry.uuid,
-        'version': file.manifest_entry.version,
-        'document_id': str(file.document_id),
-        'file_format': file.file_format,
-        '_type': 'file',
-        **(
-            {
-                'read_index': file.read_index,
-                'lane_index': file.lane_index
-            } if isinstance(file, api.SequenceFile) else {
-            }
-        )
-    }
-
-
-def _protocol_dict(protocol: api.Protocol) -> JSON:
-    protocol_dict = {"document_id": protocol.document_id}
-    if isinstance(protocol, api.LibraryPreparationProtocol):
-        protocol_dict['library_construction_approach'] = protocol.library_construction_approach
-    elif isinstance(protocol, api.SequencingProtocol):
-        protocol_dict['instrument_manufacturer_model'] = protocol.instrument_manufacturer_model
-        protocol_dict['paired_end'] = protocol.paired_end
-    elif isinstance(protocol, api.AnalysisProtocol):
-        protocol_dict['workflow'] = protocol.protocol_id
-    elif isinstance(protocol, api.ImagingProtocol):
-        protocol_dict['assay_type'] = dict(Counter(target.assay_type for target in protocol.target))
-    else:
-        assert False
-    return protocol_dict
-
-
-# map Sample api.schema_names to keys in the contents dict
-sample_entity_types = {
-    'cell_line': 'cell_lines',
-    'organoid': 'organoids',
-    'specimen_from_organism': 'specimens',
-}
-
-# map Sample api.schema_names to the related ..._dict function
-sample_entity_dict_functions = {
-    'cell_line': _cell_line_dict,
-    'organoid': _organoid_dict,
-    'specimen_from_organism': _specimen_dict,
-}
-
-
-def _sample_dict(sample: api.Biomaterial) -> JSON:
-    schema_type = api.schema_names[type(sample)]
-    sample_dict = {
-        'entity_type': sample_entity_types[schema_type],
-        **sample_entity_dict_functions[schema_type](sample)
-    }
-    assert hasattr(sample, 'organ') != hasattr(sample, 'model_organ')
-    sample_dict['effective_organ'] = sample.organ if hasattr(sample, 'organ') else sample.model_organ
-    assert sample_dict['document_id'] == str(sample.document_id)
-    assert sample_dict['biomaterial_id'] == sample.biomaterial_id
-    return sample_dict
-
-
 class TransformerVisitor(api.EntityVisitor):
     # Entities are tracked by ID to ensure uniqueness if an entity is visited twice while descending the entity DAG
     specimens: MutableMapping[api.UUID4, api.SpecimenFromOrganism]
@@ -382,6 +182,205 @@ class Transformer(AggregatingTransformer, metaclass=ABCMeta):
             return ProtocolAggregator()
         else:
             return super().get_aggregator(entity_type)
+
+    def _contact_dict(p: api.ProjectContact):
+        return {
+            "contact_name": p.contact_name,
+            "corresponding_contributor": p.corresponding_contributor,
+            "email": p.email,
+            "institution": p.institution,
+            "laboratory": p.laboratory,
+            "project_role": p.project_role
+        }
+
+
+    def _publication_dict(p: api.ProjectPublication):
+        return {
+            "publication_title": p.publication_title,
+            "publication_url": p.publication_url
+        }
+
+
+    def _project_dict(project: api.Project) -> JSON:
+        # Store lists of all values of each of these facets to allow facet filtering
+        # and term counting on the webservice
+        laboratories: Set[str] = set()
+        institutions: Set[str] = set()
+        contact_names: Set[str] = set()
+        publication_titles: Set[str] = set()
+
+        for contributor in project.contributors:
+            if contributor.laboratory:
+                laboratories.add(contributor.laboratory)
+            if contributor.contact_name:
+                contact_names.add(contributor.contact_name)
+            if contributor.institution:
+                institutions.add(contributor.institution)
+
+        for publication in project.publications:
+            if publication.publication_title:
+                publication_titles.add(publication.publication_title)
+
+        return {
+            'project_title': project.project_title,
+            'project_description': project.project_description,
+            'project_shortname': project.project_short_name,
+            'laboratory': list(laboratories),
+            'institutions': list(institutions),
+            'contact_names': list(contact_names),
+            'contributors': [_contact_dict(c) for c in project.contributors],
+            'document_id': str(project.document_id),
+            'publication_titles': list(publication_titles),
+            'publications': [_publication_dict(p) for p in project.publications],
+            'insdc_project_accessions': list(project.insdc_project_accessions),
+            'geo_series_accessions': list(project.geo_series_accessions),
+            'array_express_accessions': list(project.array_express_accessions),
+            'insdc_study_accessions': list(project.insdc_study_accessions),
+            '_type': 'project'
+        }
+
+
+    def _specimen_dict(specimen: api.SpecimenFromOrganism) -> JSON:
+        return {
+            'has_input_biomaterial': specimen.has_input_biomaterial,
+            '_source': api.schema_names[type(specimen)],
+            'document_id': str(specimen.document_id),
+            'biomaterial_id': specimen.biomaterial_id,
+            'disease': list(specimen.diseases),
+            'organ': specimen.organ,
+            'organ_part': list(specimen.organ_parts),
+            'storage_method': specimen.storage_method,
+            'preservation_method': specimen.preservation_method,
+            '_type': 'specimen',
+        }
+
+    def _cell_suspension_dict(cell_suspension: api.CellSuspension) -> JSON:
+        organs = set()
+        organ_parts = set()
+        samples: MutableMapping[str, Sample] = dict()
+        SampleTransformer.get_ancestor_samples(cell_suspension, samples)
+        for sample in samples.values():
+            if isinstance(sample, api.SpecimenFromOrganism):
+                organs.add(sample.organ)
+                organ_parts.update(sample.organ_parts)
+            elif isinstance(sample, api.CellLine):
+                organs.add(sample.model_organ)
+                organ_parts.add(None)
+            elif isinstance(sample, api.Organoid):
+                organs.add(sample.model_organ)
+                organ_parts.add(sample.model_organ_part)
+            else:
+                assert False
+        return {
+            'document_id': str(cell_suspension.document_id),
+            'total_estimated_cells': cell_suspension.estimated_cell_count,
+            'selected_cell_type': list( cell_suspension.selected_cell_types),
+            'organ': list(organs),
+            'organ_part': list(organ_parts),
+        }
+
+
+    def _cell_line_dict(cell_line: api.CellLine) -> JSON:
+        return {
+            'document_id': str(cell_line.document_id),
+            'biomaterial_id': cell_line.biomaterial_id,
+            'cell_line_type': cell_line.cell_line_type,
+            'model_organ': cell_line.model_organ
+        }
+
+
+    def _donor_dict(donor: api.DonorOrganism) -> JSON:
+        return {
+            'document_id': str(donor.document_id),
+            'biomaterial_id': donor.biomaterial_id,
+            'biological_sex': donor.sex,
+            'genus_species': list(donor.genus_species),
+            'diseases': list(donor.diseases),
+            'organism_age': donor.organism_age,
+            'organism_age_unit': donor.organism_age_unit,
+            **(
+                {
+                    'min_organism_age_in_seconds': donor.organism_age_in_seconds.min,
+                    'max_organism_age_in_seconds': donor.organism_age_in_seconds.max,
+                } if donor.organism_age_in_seconds else {
+                }
+            ),
+        }
+
+
+    def _organoid_dict(organoid: api.Organoid) -> JSON:
+        return {
+            'document_id': str(organoid.document_id),
+            'biomaterial_id': organoid.biomaterial_id,
+            'model_organ': organoid.model_organ,
+            'model_organ_part': organoid.model_organ_part,
+        }
+
+
+    def _file_dict(file: api.File) -> JSON:
+        return {
+            'content-type': file.manifest_entry.content_type,
+            'indexed': file.manifest_entry.indexed,
+            'name': file.manifest_entry.name,
+            'sha256': file.manifest_entry.sha256,
+            'size': file.manifest_entry.size,
+            'uuid': file.manifest_entry.uuid,
+            'version': file.manifest_entry.version,
+            'document_id': str(file.document_id),
+            'file_format': file.file_format,
+            '_type': 'file',
+            **(
+                {
+                    'read_index': file.read_index,
+                    'lane_index': file.lane_index
+                } if isinstance(file, api.SequenceFile) else {
+                }
+            )
+        }
+
+
+    def _protocol_dict(protocol: api.Protocol) -> JSON:
+        protocol_dict = {"document_id": protocol.document_id}
+        if isinstance(protocol, api.LibraryPreparationProtocol):
+            protocol_dict['library_construction_approach'] = protocol.library_construction_approach
+        elif isinstance(protocol, api.SequencingProtocol):
+            protocol_dict['instrument_manufacturer_model'] = protocol.instrument_manufacturer_model
+            protocol_dict['paired_end'] = protocol.paired_end
+        elif isinstance(protocol, api.AnalysisProtocol):
+            protocol_dict['workflow'] = protocol.protocol_id
+        elif isinstance(protocol, api.ImagingProtocol):
+            protocol_dict['assay_type'] = dict(Counter(target.assay_type for target in protocol.target))
+        else:
+            assert False
+        return protocol_dict
+
+
+    # map Sample api.schema_names to keys in the contents dict
+    sample_entity_types = {
+        'cell_line': 'cell_lines',
+        'organoid': 'organoids',
+        'specimen_from_organism': 'specimens',
+    }
+
+    # map Sample api.schema_names to the related ..._dict function
+    sample_entity_dict_functions = {
+        'cell_line': _cell_line_dict,
+        'organoid': _organoid_dict,
+        'specimen_from_organism': _specimen_dict,
+    }
+
+
+    def _sample_dict(sample: api.Biomaterial) -> JSON:
+        schema_type = api.schema_names[type(sample)]
+        sample_dict = {
+            'entity_type': sample_entity_types[schema_type],
+            **sample_entity_dict_functions[schema_type](sample)
+        }
+        assert hasattr(sample, 'organ') != hasattr(sample, 'model_organ')
+        sample_dict['effective_organ'] = sample.organ if hasattr(sample, 'organ') else sample.model_organ
+        assert sample_dict['document_id'] == str(sample.document_id)
+        assert sample_dict['biomaterial_id'] == sample.biomaterial_id
+        return sample_dict
 
     def _get_project(self, bundle) -> api.Project:
         project, *additional_projects = bundle.projects.values()

--- a/src/azul/project/hca/transformers.py
+++ b/src/azul/project/hca/transformers.py
@@ -51,6 +51,7 @@ class Transformer(AggregatingTransformer, metaclass=ABCMeta):
             return super().get_aggregator(entity_type)
 
     def _contact(self, p: api.ProjectContact):
+        # noinspection PyDeprecation
         return {
             "contact_name": p.contact_name,
             "corresponding_contributor": p.corresponding_contributor,
@@ -61,6 +62,7 @@ class Transformer(AggregatingTransformer, metaclass=ABCMeta):
         }
 
     def _publication(self, p: api.ProjectPublication):
+        # noinspection PyDeprecation
         return {
             "publication_title": p.publication_title,
             "publication_url": p.publication_url
@@ -77,13 +79,17 @@ class Transformer(AggregatingTransformer, metaclass=ABCMeta):
         for contributor in project.contributors:
             if contributor.laboratory:
                 laboratories.add(contributor.laboratory)
+            # noinspection PyDeprecation
             if contributor.contact_name:
+                # noinspection PyDeprecation
                 contact_names.add(contributor.contact_name)
             if contributor.institution:
                 institutions.add(contributor.institution)
 
         for publication in project.publications:
+            # noinspection PyDeprecation
             if publication.publication_title:
+                # noinspection PyDeprecation
                 publication_titles.add(publication.publication_title)
 
         return {
@@ -144,6 +150,7 @@ class Transformer(AggregatingTransformer, metaclass=ABCMeta):
         }
 
     def _cell_line(self, cell_line: api.CellLine) -> JSON:
+        # noinspection PyDeprecation
         return {
             'document_id': str(cell_line.document_id),
             'biomaterial_id': cell_line.biomaterial_id,
@@ -178,6 +185,7 @@ class Transformer(AggregatingTransformer, metaclass=ABCMeta):
         }
 
     def _file(self, file: api.File) -> JSON:
+        # noinspection PyDeprecation
         return {
             'content-type': file.manifest_entry.content_type,
             'indexed': file.manifest_entry.indexed,
@@ -201,6 +209,7 @@ class Transformer(AggregatingTransformer, metaclass=ABCMeta):
     def _protocol(self, protocol: api.Protocol) -> JSON:
         protocol_ = {'document_id': protocol.document_id}
         if isinstance(protocol, api.LibraryPreparationProtocol):
+            # noinspection PyDeprecation
             protocol_['library_construction_approach'] = protocol.library_construction_approach
         elif isinstance(protocol, api.SequencingProtocol):
             protocol_['instrument_manufacturer_model'] = protocol.instrument_manufacturer_model
@@ -286,6 +295,7 @@ class TransformerVisitor(api.EntityVisitor):
                                          api.ImagingProtocol)):
                     self.protocols[protocol.document_id] = protocol
         elif isinstance(entity, api.File):
+            # noinspection PyDeprecation
             if entity.file_format == 'unknown' and '.zarr!' in entity.manifest_entry.name:
                 # FIXME: Remove once https://github.com/HumanCellAtlas/metadata-schema/issues/579 is resolved
                 #
@@ -310,6 +320,7 @@ class FileTransformer(Transformer):
                             metadata_files=metadata_files)
         project = self._get_project(bundle)
         for file in bundle.files.values():
+            # noinspection PyDeprecation
             if file.file_format == 'unknown' and '.zarr!' in file.manifest_entry.name:
                 # FIXME: Remove once https://github.com/HumanCellAtlas/metadata-schema/issues/579 is resolved
                 #

--- a/src/azul/project/hca/transformers.py
+++ b/src/azul/project/hca/transformers.py
@@ -13,10 +13,10 @@ from azul.transformer import (Accumulator,
                               DistinctAccumulator,
                               Document,
                               EntityReference,
+                              FrequencySetAccumulator,
                               GroupingAggregator,
                               ListAccumulator,
                               SetAccumulator,
-                              FrequencySetAccumulator,
                               SimpleAggregator,
                               SumAccumulator)
 from azul.types import JSON

--- a/src/azul/project/hca/transformers.py
+++ b/src/azul/project/hca/transformers.py
@@ -24,6 +24,8 @@ from azul.types import JSON
 log = logging.getLogger(__name__)
 
 Sample = Union[api.CellLine, api.Organoid, api.SpecimenFromOrganism]
+sample_types = api.CellLine, api.Organoid, api.SpecimenFromOrganism
+assert Sample.__args__ == sample_types  # since we can't use * in generic types
 
 
 class Transformer(AggregatingTransformer, metaclass=ABCMeta):
@@ -389,7 +391,7 @@ class SampleTransformer(Transformer):
         """
         Fill samples dict with the first Sample found up each ancestor tree
         """
-        if isinstance(entity, Sample.__args__):
+        if isinstance(entity, sample_types):
             samples[str(entity.document_id)] = entity
         else:
             for parent in entity.parents.values():
@@ -497,7 +499,7 @@ class BundleTransformer(BundleProjectTransformer):
                   uuid: str,
                   version: str,
                   manifest: List[JSON],
-                  metadata_files: Iterable[JSON]
+                  metadata_files: Mapping[str, JSON]
                   ) -> Sequence[Document]:
         for contrib in super().transform(uuid, version, manifest, metadata_files):
             # noinspection PyArgumentList


### PR DESCRIPTION
* Make …_dict functions methods of the Transformer class
* Reorder classes in HCA transformers module  such that Transformers precede Visitors and Aggregators
* Eliminate type check warnings
* Suppress deprecation warnings