### PR TITLE
Use JSON for filters (#537) (#279)

### DIFF
--- a/lambdas/service/app.py
+++ b/lambdas/service/app.py
@@ -469,9 +469,9 @@ def get_manifest():
           https://software.broadinstitute.org/firecloud/documentation/article?id=10954
     :return: A manifest that the user can use to download the files in there
     """
-    params = app.current_request.query_params
-    if params is None:  # FIXME: is this necessary?
+    if app.current_request.query_params is None:
         app.current_request.query_params = {}
+    params = app.current_request.query_params
     from azul.service import AbstractService
     filters = AbstractService.parse_filters(params.get('filters'))
     es_td = EsTd()
@@ -1268,7 +1268,7 @@ def add_all_results_to_cart(cart_id):
         raise BadRequestError('entityType must be one of files, samples, or projects')
 
     try:
-        filters = json.loads(filters)
+        filters = json.loads(filters or '{}')
     except json.JSONDecodeError:
         raise BadRequestError('Invalid filters given')
     hits, search_after = EsTd().transform_cart_item_request(entity_type, filters=filters, size=1)
@@ -1601,10 +1601,8 @@ def get_data_object(file_uuid):
     params = app.current_request.query_params or {}
     file_version = params.get('version')
     filters = {
-        "file": {
-            "fileId": {"is": [file_uuid]},
-            **({"fileVersion": {"is": [file_version]}} if file_version else {})
-        }
+        "fileId": {"is": [file_uuid]},
+        **({"fileVersion": {"is": [file_version]}} if file_version else {})
     }
     es_td = EsTd()
     pagination = _get_pagination(app.current_request, entity_type='files')

--- a/src/azul/service/__init__.py
+++ b/src/azul/service/__init__.py
@@ -1,4 +1,4 @@
-import ast
+import json
 import logging
 
 from typing import Optional
@@ -20,11 +20,11 @@ class AbstractService:
         :raises ValueError: Will raise a ValueError if token is misformatted or invalid
         :return: python literal
         """
-        default_filters = {'file': {}}
+        default_filters = {}
         if filters is None:
             return default_filters
         try:
-            filters = ast.literal_eval(filters)
+            filters = json.loads(filters or '{}')
         except ValueError as e:
             logger.error('Malformed filters parameter: {}'.format(e))
             raise BadArgumentException('Malformed filters parameter')

--- a/src/azul/service/repository.py
+++ b/src/azul/service/repository.py
@@ -39,7 +39,7 @@ class RepositoryService(AbstractService):
         return response
 
     def _get_item(self, entity_type, item_id, pagination, filters, file_url_func):
-        filters['file']['entryId'] = {"is": [item_id]}
+        filters['entryId'] = {'is': [item_id]}
         try:
             formatted_uuid = uuid.UUID(item_id)
         except ValueError:

--- a/src/azul/service/responseobjects/elastic_request_builder.py
+++ b/src/azul/service/responseobjects/elastic_request_builder.py
@@ -53,7 +53,7 @@ class ElasticTransformDump(object):
     def translate_filters(filters, field_mapping):
         """
         Function for translating the filters
-        :param filters: Raw filters from the filters /files param.
+        :param filters: Raw filters from the filters param.
         That is, in 'browserForm'
         :param field_mapping: Mapping config json with
         '{'browserKey': 'es_key'}' format
@@ -61,7 +61,7 @@ class ElasticTransformDump(object):
         """
         # Translate the fields to the appropriate ElasticSearch Index.
         # Probably can be edited later to do not just files but donors, etc.
-        # for key, value in filters['file'].items():
+        # for key, value in filters.items():
         iterate_filters = deepcopy(filters)
         for key, value in iterate_filters.items():
             if key in field_mapping:
@@ -149,7 +149,7 @@ class ElasticTransformDump(object):
         """
         This function will create an ElasticSearch request based on
         the filters and facet_config passed into the function
-        :param filters: The 'filters' parameter from '/files'.
+        :param filters: The 'filters' parameter.
         Assumes to be translated into es_key terms
         :param es_client: The ElasticSearch client object used
          to configure the Search object
@@ -355,8 +355,7 @@ class ElasticTransformDump(object):
         self.logger.debug('Getting the request_config file')
         request_config = self.open_and_return_json(request_config_path)
         if not filters:
-            filters = {"file": {}}
-        filters = filters["file"]
+            filters = {}
         # Create a request to ElasticSearch
         self.logger.info('Creating request to ElasticSearch')
         es_search = self.create_request(
@@ -458,8 +457,7 @@ class ElasticTransformDump(object):
         # FIXME: cache the json (or, even better, convert to Python module
         request_config = self.open_and_return_json(request_config_path)
         if not filters:
-            filters = {"file": {}}
-        filters = filters['file']
+            filters = {}
 
         translation = request_config['translation']
         inverse_translation = {v: k for k, v in translation.items()}
@@ -543,7 +541,6 @@ class ElasticTransformDump(object):
         config_folder = os.path.dirname(service_config.__file__)
         request_config_path = "{}/{}".format(config_folder, 'request_config.json')
         request_config = self.open_and_return_json(request_config_path)
-        filters = filters['file']
         manifest_config = request_config['manifest']
         if format == 'bdbag':
             # Terra rejects `.` in column names
@@ -621,7 +618,7 @@ class ElasticTransformDump(object):
                 json_pp(mapping_config)))
         mapping_config = mapping_config[entry_format]
         if not filters:
-            filters = {"file": {}}
+            filters = {}
 
         entity_type = 'files' if entry_format == 'file' else 'donor'
         # Create an ElasticSearch autocomplete request
@@ -683,8 +680,7 @@ class ElasticTransformDump(object):
         request_config_path = "{}/{}".format(config_folder, request_config_file)
         request_config = self.open_and_return_json(request_config_path)
         if not filters:
-            filters = {"file": {}}
-        filters = filters['file']
+            filters = {}
 
         field_mappings = request_config['translation']
         cart_item_config = request_config['cart-item']

--- a/test/service/test_cart_item_manager.py
+++ b/test/service/test_cart_item_manager.py
@@ -466,7 +466,7 @@ class TestCartItemManager(WebServiceTestCase, DynamoTestCase):
         cart_id = '123'
         write_params = {
             'entity_type': 'samples',
-            'filters': {'file': {}},
+            'filters': {},
             'cart_id': cart_id,
             'batch_size': 1000
         }
@@ -495,7 +495,7 @@ class TestCartItemManager(WebServiceTestCase, DynamoTestCase):
             'executionArn': f'arn:aws:states:us-east-1:1234567890:execution:state_machine:{execution_id}'
         }
 
-        mock_app.current_request.json_body = {'filters': '{"file": {}}', 'entityType': 'files'}
+        mock_app.current_request.json_body = {'filters': '{}', 'entityType': 'files'}
 
         user_id = '123'
         get_user_id.return_value = user_id

--- a/test/service/test_manifest_service.py
+++ b/test/service/test_manifest_service.py
@@ -46,7 +46,7 @@ class ManifestServiceTest(AzulTestCase):
             'status': 'SUCCEEDED',
             'startDate': datetime.datetime(2018, 11, 15, 18, 30, 44, 896000),
             'stopDate': datetime.datetime(2018, 11, 15, 18, 30, 59, 295000),
-            'input': '{"filters": {"file": {}}}',
+            'input': '{"filters": {}}',
             'output': json.dumps({'Location': manifest_url})
         }
         step_function_helper.describe_execution.return_value = execution_success_output
@@ -70,7 +70,7 @@ class ManifestServiceTest(AzulTestCase):
             'name': execution_id,
             'status': 'RUNNING',
             'startDate': datetime.datetime(2018, 11, 15, 18, 30, 44, 896000),
-            'input': '{"filters": {"file": {}}}'
+            'input': '{"filters": {}}'
         }
         step_function_helper.describe_execution.return_value = execution_running_output
         manifest_service = ManifestService()
@@ -96,7 +96,7 @@ class ManifestServiceTest(AzulTestCase):
             'status': 'FAILED',
             'startDate': datetime.datetime(2018, 11, 14, 16, 6, 53, 382000),
             'stopDate': datetime.datetime(2018, 11, 14, 16, 6, 55, 860000),
-            'input': '{"filters": {"file": {"organ": {"is": ["lymph node"]}}}}',
+            'input': '{"filters": {"organ": {"is": ["lymph node"]}}}',
         }
         step_function_helper.describe_execution.return_value = execution_failed_output
         manifest_service = ManifestService()

--- a/test/service/test_request_validation.py
+++ b/test/service/test_request_validation.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import sys
@@ -48,99 +49,164 @@ class FacetNameValidationTest(WebServiceTestCase):
                             self.assertEqual(response.json()['git'], expected_json)
 
     def test_bad_single_filter_facet_of_sample(self):
-        url = self.base_url + "/repository/samples?from=1&size=1&filters={'file':{'bad-facet':{'is':['fake-val']}}}"
-        response = requests.get(url)
+        url = self.base_url + '/repository/samples'
+        params = {
+            'from': 1,
+            'size': 1,
+            'filters': json.dumps({'bad-facet': {'is': ['fake-val']}}),
+        }
+        response = requests.get(url, params=params)
         self.assertEqual(400, response.status_code, response.json())
         self.assertEqual(self.filter_facet_message, response.json())
 
     def test_bad_multiple_filter_facet_of_sample(self):
-        url = self.base_url + "/repository/samples?from=1&size=1" \
-                              "&filters={'file':{'bad-facet':{'is':['fake-val']},'bad-facet2':{'is':['fake-val2']}}}"
-        response = requests.get(url)
+        url = self.base_url + '/repository/samples'
+        params = {
+            'from': 1,
+            'size': 1,
+            'filters': json.dumps({'bad-facet': {'is': ['fake-val']}, 'bad-facet2': {'is': ['fake-val2']}}),
+        }
+        response = requests.get(url, params=params)
         self.assertEqual(400, response.status_code, response.json())
         self.assertEqual(self.filter_facet_message, response.json())
 
     def test_mixed_multiple_filter_facet_of_sample(self):
-        url = self.base_url + "/repository/samples?from=1&size=1" \
-                              "&filters={'file':{'organPart':{'is':['fake-val']},'bad-facet':{'is':['fake-val']}}}"
-        response = requests.get(url)
+        url = self.base_url + '/repository/samples'
+        params = {
+            'from': 1,
+            'size': 1,
+            'filters': json.dumps({'organPart': {'is': ['fake-val']}, 'bad-facet': {'is': ['fake-val']}}),
+        }
+        response = requests.get(url, params=params)
         self.assertEqual(400, response.status_code, response.json())
         self.assertEqual(self.filter_facet_message, response.json())
 
     def test_bad_sort_facet_of_sample(self):
-        url = self.base_url + "/repository/samples?size=15&filters={}&sort=bad-facet&order=asc"
-        response = requests.get(url)
+        url = self.base_url + '/repository/samples'
+        params = {
+            'from': 1,
+            'size': 1,
+            'filters': json.dumps({}),
+            'sort': 'bad-facet',
+            'order': 'asc',
+        }
+        response = requests.get(url, params=params)
         self.assertEqual(400, response.status_code, response.json())
         self.assertEqual(self.sort_facet_message, response.json())
 
     def test_bad_sort_facet_and_filter_facet_of_sample(self):
-        url = self.base_url + "/repository/samples?size=15" \
-                              "&filters={'file':{'bad-facet':{'is':['fake-val']}}}&sort=bad-facet&order=asc"
-
-        response = requests.get(url)
+        url = self.base_url + '/repository/samples'
+        params = {
+            'size': 15,
+            'filters': json.dumps({'bad-facet': {'is': ['fake-val']}}),
+            'sort': 'bad-facet',
+            'order': 'asc',
+        }
+        response = requests.get(url, params=params)
         self.assertEqual(400, response.status_code, response.json())
         self.assertTrue(response.json() in [self.sort_facet_message, self.filter_facet_message])
 
     def test_valid_sort_facet_but_bad_filter_facet_of_sample(self):
-        url = self.base_url + "/repository/samples?size=15" \
-                              "&filters={'file':{'bad-facet':{'is':['fake-val']}}}&sort=organPart&order=asc"
-        response = requests.get(url)
+        url = self.base_url + '/repository/samples'
+        params = {
+            'size': 15,
+            'filters': json.dumps({'bad-facet': {'is': ['fake-val']}}),
+            'sort': 'organPart',
+            'order': 'asc',
+        }
+        response = requests.get(url, params=params)
         self.assertEqual(400, response.status_code, response.json())
         self.assertEqual(self.filter_facet_message, response.json())
 
     def test_bad_sort_facet_but_valid_filter_facet_of_sample(self):
-        url = self.base_url + "/repository/samples?size=15" \
-                              "&filters={'file':{'organPart':{'is':['fake-val2']}}}&sort=bad-facet&order=asc"
-        response = requests.get(url)
+        url = self.base_url + '/repository/samples'
+        params = {
+            'size': 15,
+            'filters': json.dumps({'organPart': {'is': ['fake-val2']}}),
+            'sort': 'bad-facet',
+            'order': 'asc',
+        }
+        response = requests.get(url, params=params)
         self.assertEqual(400, response.status_code, response.json())
         self.assertEqual(self.sort_facet_message, response.json())
 
     def test_bad_single_filter_facet_of_file(self):
-        url = self.base_url + "/repository/files?from=1&size=1" \
-                              "&filters={'file':{'bad-facet':{'is':['fake-val2']}}}"
-        response = requests.get(url)
+        url = self.base_url + '/repository/files'
+        params = {
+            'from': 1,
+            'size': 1,
+            'filters': json.dumps({'bad-facet': {'is': ['fake-val2']}}),
+        }
+        response = requests.get(url, params=params)
         self.assertEqual(400, response.status_code, response.json())
         self.assertEqual(self.filter_facet_message, response.json())
 
     def test_bad_multiple_filter_facet_of_file(self):
-        url = self.base_url + "/repository/files?from=1&size=1" \
-                              "&filters={'file':{'bad-facet':{'is':['fake-val']},'bad-facet2':{'is':['fake-val2']}}}"
-        response = requests.get(url)
+        url = self.base_url + '/repository/files'
+        params = {
+            'from': 1,
+            'size': 1,
+            'filters': json.dumps({'bad-facet': {'is': ['fake-val']}, 'bad-facet2': {'is': ['fake-val2']}}),
+        }
+        response = requests.get(url, params=params)
         self.assertEqual(400, response.status_code, response.json())
         self.assertEqual(self.filter_facet_message, response.json())
 
     def test_mixed_multiple_filter_facet_of_file(self):
-        url = self.base_url + "/repository/files?from=1&size=1" \
-                              "&filters={'file':{'organPart':{'is':['fake-val']},'bad-facet':{'is':['fake-val']}}}"
-        response = requests.get(url)
+        url = self.base_url + '/repository/files'
+        params = {
+            'from': 1,
+            'size': 1,
+            'filters': json.dumps({'organPart': {'is': ['fake-val']}, 'bad-facet': {'is': ['fake-val']}}),
+        }
+        response = requests.get(url, params=params)
         self.assertEqual(400, response.status_code, response.json())
         self.assertEqual(self.filter_facet_message, response.json())
 
     def test_bad_sort_facet_of_file(self):
-        url = self.base_url + "/repository/files?size=15&sort=bad-facet&order=asc" \
-                              "&filters={}"
-        response = requests.get(url)
+        url = self.base_url + '/repository/files'
+        params = {
+            'size': 15,
+            'sort': 'bad-facet',
+            'order': 'asc',
+            'filters': json.dumps({}),
+        }
+        response = requests.get(url, params=params)
         self.assertEqual(400, response.status_code, response.json())
         self.assertEqual(self.sort_facet_message, response.json())
 
     def test_bad_sort_facet_and_filter_facet_of_file(self):
-        url = self.base_url + "/repository/files?size=15" \
-                              "&filters={'file':{'bad-facet':{'is':['fake-val2']}}}"
-        response = requests.get(url)
+        url = self.base_url + '/repository/files'
+        params = {
+            'size': 15,
+            'filters': json.dumps({'bad-facet': {'is': ['fake-val2']}}),
+        }
+        response = requests.get(url, params=params)
         self.assertEqual(400, response.status_code, response.json())
         self.assertTrue(response.json() in [self.sort_facet_message, self.filter_facet_message])
 
     def test_bad_sort_facet_but_valid_filter_facet_of_file(self):
-        url = self.base_url + "/repository/files?size=15&sort=bad-facet&order=asc" \
-                              "&filters={'file':{'organ':{'is':['fake-val2']}}}"
-        response = requests.get(url)
+        url = self.base_url + '/repository/files'
+        params = {
+            'size': 15,
+            'sort': 'bad-facet',
+            'order': 'asc',
+            'filters': json.dumps({'organ': {'is': ['fake-val2']}}),
+        }
+        response = requests.get(url, params=params)
         self.assertEqual(400, response.status_code, response.json())
         self.assertEqual(self.sort_facet_message, response.json())
 
     def test_valid_sort_facet_but_bad_filter_facet_of_file(self):
-        url = self.base_url + "/repository/files?size=15&sort=organPart&order=asc" \
-                              "&filters={'file':{'bad-facet':{'is':['fake-val2']}}}"
-        response = requests.get(url)
+
+        url = self.base_url + '/repository/files'
+        params = {
+            'size': 15,
+            'sort': 'organPart',
+            'order': 'asc',
+            'filters': json.dumps({'bad-facet': {'is': ['fake-val2']}}),
+        }
+        response = requests.get(url, params=params)
         self.assertEqual(400, response.status_code, response.json())
         self.assertEqual(self.filter_facet_message, response.json())
 

--- a/test/service/test_response.py
+++ b/test/service/test_response.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import unittest
 import urllib.parse
@@ -1206,9 +1207,12 @@ class TestResponse(WebServiceTestCase):
         for test_data in test_data_sets:
             for entity_type in 'files', 'samples', 'projects', 'bundles':
                 with self.subTest(entity_type=entity_type):
-                    url = self.base_url + "/repository/" + entity_type + "?size=2" \
-                                          "&filters={'file':{'projectId':{'is':['" + test_data['id'] + "']}}}"
-                    response = requests.get(url)
+                    url = self.base_url + "/repository/" + entity_type
+                    params = {
+                        'size': 2,
+                        'filters': json.dumps({'projectId': {'is': [test_data['id']]}})
+                    }
+                    response = requests.get(url, params=params)
                     response.raise_for_status()
                     response_json = response.json()
                     for hit in response_json['hits']:


### PR DESCRIPTION
- Convert filters parameter from Python literal to JSON https://github.com/databiosphere/azul/issues/537
- Remove 'file' key from the 'filters' parameter https://github.com/databiosphere/azul/issues/279