### PR TITLE
Reducing api calls in `health/progress`

### DIFF
--- a/lambdas/service/app.py
+++ b/lambdas/service/app.py
@@ -139,7 +139,7 @@ def health(keys: Optional[str] = None):
     body = health.as_json(**kwargs)
     return Response(
         body=json.dumps(body),
-        status_code=200 if body['up'] else 503
+        status_code=200 if body.get('up', True) else 503
     )
 
 

--- a/src/azul/health.py
+++ b/src/azul/health.py
@@ -36,6 +36,8 @@ class Health:
         json = {k: getattr(self, k) for k in keys if k in self.default_keys}
         if len(keys) != 1:
             json['up'] = all(v['up'] for v in json.values())
+        else:
+            json['up'] = True
         return json
 
     @memoized_property

--- a/src/azul/health.py
+++ b/src/azul/health.py
@@ -34,7 +34,8 @@ class Health:
 
     def as_json(self, keys=default_keys) -> JSON:
         json = {k: getattr(self, k) for k in keys if k in self.default_keys}
-        json['up'] = all(v['up'] for v in json.values())
+        if len(keys) != 1:
+            json['up'] = all(v['up'] for v in json.values())
         return json
 
     @memoized_property


### PR DESCRIPTION
Testing if the dev deployment slow down due to `health/progress` making too many api calls to the service