### PR TITLE
Hot Fix: Exclude API endpoints call from health check to reduce load

### DIFF
--- a/src/azul/health.py
+++ b/src/azul/health.py
@@ -91,10 +91,12 @@ class Health:
 
     @memoized_property
     def api_endpoints(self):
-        endpoints = self.endpoints
-        with ThreadPoolExecutor(len(endpoints)) as tpe:
-            status = dict(tpe.map(self._api_endpoint, endpoints))
-        status['up'] = all(v['up'] for v in status.values())
+        if False:
+            endpoints = self.endpoints
+            with ThreadPoolExecutor(len(endpoints)) as tpe:
+                status = dict(tpe.map(self._api_endpoint, endpoints))
+            status['up'] = all(v['up'] for v in status.values())
+        status = {'up': True}
         return status
 
     @memoized_property

--- a/test/health_check_test_case.py
+++ b/test/health_check_test_case.py
@@ -93,9 +93,10 @@ class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABC
         endpoint_states = self._make_endpoint_states([], down_endpoints=self.endpoints)
         response = self._test(endpoint_states, lambdas_up=True)
         health_object = response.json()
-        self.assertEqual(503, response.status_code)
+        # FIXME https://github.com/DataBiosphere/azul/issues/1124 503 <- 200
+        self.assertEqual(200, response.status_code)
         self.assertEqual({
-            'up': False,
+            'up': True,
             **self._expected_elastic_search(True),
             **self._expected_queues(True),
             **self._expected_other_lambdas(True),
@@ -110,9 +111,10 @@ class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABC
         endpoint_states = self._make_endpoint_states(self.endpoints[1:], down_endpoints=self.endpoints[:1])
         response = self._test(endpoint_states, lambdas_up=True)
         health_object = response.json()
-        self.assertEqual(503, response.status_code)
+        # FIXME https://github.com/DataBiosphere/azul/issues/1124 503 <- 200
+        self.assertEqual(200, response.status_code)
         self.assertEqual({
-            'up': False,
+            'up': True,
             **self._expected_elastic_search(True),
             **self._expected_queues(True),
             **self._expected_other_lambdas(True),
@@ -199,17 +201,10 @@ class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABC
         }
 
     def _expected_api_endpoints(self, endpoint_states: Mapping[str, bool]) -> JSON:
+        # FIXME https://github.com/DataBiosphere/azul/issues/1124
         return {
             'api_endpoints': {
-                'up': all(up for endpoint, up in endpoint_states.items()),
-                **({
-                    config.service_endpoint() + endpoint: {
-                        'up': up
-                    } if up else {
-                        'up': up,
-                        'error': f'503 Server Error: Service Unavailable for url: {config.service_endpoint()}{endpoint}'
-                    } for endpoint, up in endpoint_states.items()
-                })
+                'up': True
             }
         }
 


### PR DESCRIPTION
Removes the call to API endpoints, and returns an overall up message.  Alters test to reflect positive response from API endpoints. 