### PR TITLE
Reduce load from health endpoint (#1124)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ WORKDIR /build
 
 RUN mkdir terraform \
     && (cd terraform \
-        && wget --quiet https://releases.hashicorp.com/terraform/0.11.11/terraform_0.11.11_linux_amd64.zip \
-        && unzip terraform_0.11.11_linux_amd64.zip \
+        && wget --quiet https://releases.hashicorp.com/terraform/0.12.5/terraform_0.12.5_linux_amd64.zip \
+        && unzip terraform_0.12.5_linux_amd64.zip \
         && mv terraform /usr/local/bin/) \
     ; rm -rf terraform
 

--- a/src/azul/health.py
+++ b/src/azul/health.py
@@ -15,19 +15,19 @@ from azul.types import JSON
 class Health:
     keys = {
         'all': (
-            'elastic_search',
+            'elasticsearch',
             'queues',
             'progress',
             'api_endpoints',
             'other_lambdas',
         ),
         'indexer': (
-            'elastic_search',
+            'elasticsearch',
             'queues',
             'progress'
         ),
         'service': (
-            'elastic_search',
+            'elasticsearch',
             'api_endpoints',
         )
     }
@@ -107,7 +107,7 @@ class Health:
         return status
 
     @memoized_property
-    def elastic_search(self):
+    def elasticsearch(self):
         return {
             'up': ESClientFactory.get().ping(),
         }

--- a/src/azul/health.py
+++ b/src/azul/health.py
@@ -91,12 +91,10 @@ class Health:
 
     @memoized_property
     def api_endpoints(self):
-        if False:
-            endpoints = self.endpoints
-            with ThreadPoolExecutor(len(endpoints)) as tpe:
-                status = dict(tpe.map(self._api_endpoint, endpoints))
-            status['up'] = all(v['up'] for v in status.values())
-        status = {'up': True}
+        endpoints = self.endpoints
+        with ThreadPoolExecutor(len(endpoints)) as tpe:
+            status = dict(tpe.map(self._api_endpoint, endpoints))
+        status['up'] = all(v['up'] for v in status.values())
         return status
 
     @memoized_property

--- a/src/azul/health.py
+++ b/src/azul/health.py
@@ -13,27 +13,36 @@ from azul.types import JSON
 
 
 class Health:
+    keys = {
+        'all': (
+            'elastic_search',
+            'queues',
+            'progress',
+            'api_endpoints',
+            'other_lambdas',
+        ),
+        'indexer': (
+            'elastic_search',
+            'queues',
+            'progress'
+        ),
+        'service': (
+            'elastic_search',
+            'api_endpoints',
+        )
+    }
+    endpoints = [f'/repository/{entity_type}?size=1'
+                 for entity_type in ('projects', 'samples', 'files', 'bundles')]
 
     def __init__(self, lambda_name):
         self.lambda_name = lambda_name
 
-    default_keys = (
-        'elastic_search',
-        'queues',
-        'api_endpoints',
-        'other_lambdas',
-        'progress'
-    )
-
-    endpoints = (
-        '/repository/summary', *(
-            f'/repository/{entity_type}?size=1'
-            for entity_type in ('projects', 'samples', 'files', 'bundles')
-        )
-    )
-
-    def as_json(self, keys=default_keys) -> JSON:
-        json = {k: getattr(self, k) for k in keys if k in self.default_keys}
+    def as_json(self, keys=None) -> JSON:
+        if keys is None:
+            keys = self.keys[self.lambda_name]
+        elif keys == ['all']:
+            keys = self.keys['all']
+        json = {k: getattr(self, k) for k in keys if k in self.keys['all']}
         json['up'] = all(v['up'] for v in json.values())
         return json
 

--- a/terraform/authentication.tf.json.template.py
+++ b/terraform/authentication.tf.json.template.py
@@ -22,7 +22,7 @@ emit({
                                     config.project_root + "/scripts/provision_credentials.py",
                                     "google-key",
                                     "--build",
-                                    "${google_service_account.indexer.email}",
+                                    "${google_service_account.indexer[0].email}",
                                 ]))
                             }
                         }, {
@@ -33,7 +33,7 @@ emit({
                                     config.project_root + "/scripts/provision_credentials.py",
                                     "google-key",
                                     "--destroy",
-                                    "${google_service_account.indexer.email}",
+                                    "${google_service_account.indexer[0].email}",
                                 ]))
                             }
                         }

--- a/terraform/providers.tf.json.template.py
+++ b/terraform/providers.tf.json.template.py
@@ -4,6 +4,11 @@ from azul.template import emit
 emit({
     "provider": [
         {
+            "null": {
+                'version': "~> 2.1"
+            }
+        },
+        {
             "google": {
                 'version': "~> 1.18"
             }

--- a/terraform/providers.tf.json.template.py
+++ b/terraform/providers.tf.json.template.py
@@ -10,12 +10,12 @@ emit({
         },
         {
             "google": {
-                'version': "~> 1.18"
+                'version': "~> 2.10"
             }
         },
         *({
             "aws": {
-                'version': "~> 1.52",
+                'version': "~> 2.20",
                 **(
                     {
                         'region': region,

--- a/terraform/route53_health_check.tf.json.template.py
+++ b/terraform/route53_health_check.tf.json.template.py
@@ -17,7 +17,13 @@ emit(None if not config.enable_monitoring else {
                         "tags": {
                             "Name": full_name
                         },
-                    }
+                        "regions": ['us-west-2', 'us-east-1', 'eu-west-1'],
+                        # This is necessary only because of a Terraform bug:
+                        # https://github.com/hashicorp/terraform/issues/22171
+                        "lifecycle": {
+                            "create_before_destroy": True
+                        }
+                    },
                 }
             } for name, full_name in (('indexer', config.indexer_name),
                                       ('service', config.service_name))

--- a/terraform/route53_health_check.tf.json.template.py
+++ b/terraform/route53_health_check.tf.json.template.py
@@ -4,36 +4,24 @@ from azul import config
 
 emit(None if not config.enable_monitoring else {
     "resource": [
-        {
-            "aws_route53_health_check": {
-                "indexer": {
-                    "fqdn": config.api_lambda_domain('indexer'),
-                    "port": 443,
-                    "type": "HTTPS",
-                    "resource_path": "/health",
-                    "failure_threshold": "3",
-                    "request_interval": "30",
-                    "tags": {
-                        "Name": config.indexer_name
+        *[
+            {
+                "aws_route53_health_check": {
+                    name: {
+                        "fqdn": config.api_lambda_domain(name),
+                        "port": 443,
+                        "type": "HTTPS",
+                        "resource_path": "/health",
+                        "failure_threshold": "3",
+                        "request_interval": "30",
+                        "tags": {
+                            "Name": full_name
+                        },
                     }
                 }
-            }
-        },
-        {
-            "aws_route53_health_check": {
-                "service": {
-                    "fqdn": config.api_lambda_domain('service'),
-                    "port": 443,
-                    "type": "HTTPS",
-                    "resource_path": "/health",
-                    "failure_threshold": "3",
-                    "request_interval": "30",
-                    "tags": {
-                        "Name": config.service_name
-                    }
-                }
-            }
-        },
+            } for name, full_name in (('indexer', config.indexer_name),
+                                      ('service', config.service_name))
+        ],
         {
             "aws_route53_health_check": {
                 "composite-azul": {
@@ -53,36 +41,26 @@ emit(None if not config.enable_monitoring else {
                 }
             }
         },
-        {
-            "aws_route53_health_check": {
-                "data-browser": {
-                    "fqdn": config.data_browser_domain,
-                    "port": 443,
-                    "type": "HTTPS",
-                    "resource_path": "/explore",
-                    "failure_threshold": "3",
-                    "request_interval": "30",
-                    "tags": {
-                        "Name": config.data_browser_name
+        *[
+            {
+                "aws_route53_health_check": {
+                    name: {
+                        "fqdn": domain,
+                        "port": 443,
+                        "type": "HTTPS",
+                        "resource_path": path,
+                        "failure_threshold": "3",
+                        "request_interval": "30",
+                        "tags": {
+                            "Name": full_name
+                        }
                     }
                 }
-            }
-        },
-        {
-            "aws_route53_health_check": {
-                "data-portal": {
-                    "fqdn": config.data_browser_domain,
-                    "port": 443,
-                    "type": "HTTPS",
-                    "resource_path": "/",
-                    "failure_threshold": "3",
-                    "request_interval": "30",
-                    "tags": {
-                        "Name": config.data_portal_name
-                    }
-                }
-            }
-        },
+            } for name, domain, full_name, path in (
+                ("data-browser", config.data_browser_domain, config.data_browser_name, '/explore'),
+                ("data-portal", config.data_browser_domain, config.data_portal_name, '/')
+            )
+        ],
         {
             "aws_route53_health_check": {
                 "composite-portal": {

--- a/test/health_check_test_case.py
+++ b/test/health_check_test_case.py
@@ -45,7 +45,7 @@ class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABC
         self.assertEqual(200, response.status_code)
         self.assertEqual({
             'up': True,
-            **self._expected_elastic_search(True),
+            **self._expected_elasticsearch(True),
             **self._expected_queues(True),
             **self._expected_other_lambdas(True),
             **self._expected_api_endpoints(endpoint_states),
@@ -61,7 +61,7 @@ class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABC
                 'up': True,
                 **expected_response
             } for keys, expected_response in [
-                ('elastic_search', self._expected_elastic_search(True)),
+                ('elasticsearch', self._expected_elasticsearch(True)),
                 ('queues', self._expected_queues(True)),
                 ('other_lambdas', self._expected_other_lambdas(True)),
                 ('api_endpoints', self._expected_api_endpoints(endpoint_states)),
@@ -146,9 +146,9 @@ class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABC
             }
         }
 
-    def _expected_elastic_search(self, up: bool) -> JSON:
+    def _expected_elasticsearch(self, up: bool) -> JSON:
         return {
-            'elastic_search': {
+            'elasticsearch': {
                 'up': up
             }
         }

--- a/test/health_check_test_case.py
+++ b/test/health_check_test_case.py
@@ -93,10 +93,9 @@ class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABC
         endpoint_states = self._make_endpoint_states([], down_endpoints=self.endpoints)
         response = self._test(endpoint_states, lambdas_up=True)
         health_object = response.json()
-        # FIXME https://github.com/DataBiosphere/azul/issues/1124 503 <- 200
-        self.assertEqual(200, response.status_code)
+        self.assertEqual(503, response.status_code)
         self.assertEqual({
-            'up': True,
+            'up': False,
             **self._expected_elastic_search(True),
             **self._expected_queues(True),
             **self._expected_other_lambdas(True),
@@ -111,10 +110,9 @@ class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABC
         endpoint_states = self._make_endpoint_states(self.endpoints[1:], down_endpoints=self.endpoints[:1])
         response = self._test(endpoint_states, lambdas_up=True)
         health_object = response.json()
-        # FIXME https://github.com/DataBiosphere/azul/issues/1124 503 <- 200
-        self.assertEqual(200, response.status_code)
+        self.assertEqual(503, response.status_code)
         self.assertEqual({
-            'up': True,
+            'up': False,
             **self._expected_elastic_search(True),
             **self._expected_queues(True),
             **self._expected_other_lambdas(True),
@@ -201,10 +199,17 @@ class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABC
         }
 
     def _expected_api_endpoints(self, endpoint_states: Mapping[str, bool]) -> JSON:
-        # FIXME https://github.com/DataBiosphere/azul/issues/1124
         return {
             'api_endpoints': {
-                'up': True
+                'up': all(up for endpoint, up in endpoint_states.items()),
+                **({
+                    config.service_endpoint() + endpoint: {
+                        'up': up
+                    } if up else {
+                        'up': up,
+                        'error': f'503 Server Error: Service Unavailable for url: {config.service_endpoint()}{endpoint}'
+                    } for endpoint, up in endpoint_states.items()
+                })
             }
         }
 

--- a/test/indexer/test_health_check.py
+++ b/test/indexer/test_health_check.py
@@ -1,6 +1,11 @@
 import logging
+import os
 import unittest
+from unittest import mock
 
+from moto import mock_sts, mock_sqs
+
+from azul import config
 from health_check_test_case import HealthCheckTestCase
 
 
@@ -8,11 +13,61 @@ def setUpModule():
     logging.basicConfig(level=logging.INFO)
 
 
-class TestHealthCheck(HealthCheckTestCase):
+class TestIndexerHealthCheck(HealthCheckTestCase):
 
     @classmethod
     def lambda_name(cls) -> str:
         return 'indexer'
+
+    @mock_sts
+    @mock_sqs
+    def test_elasticsearch_down(self):
+        self._create_mock_queues()
+        mock_endpoint = ('nonexisting-index.com', 80)
+        endpoint_states = self._make_endpoint_states(self.endpoints)
+        with mock.patch.dict(os.environ, **config.es_endpoint_env(mock_endpoint)):
+            response = self._test(endpoint_states, lambdas_up=True)
+            health_object = response.json()
+            self.assertEqual(503, response.status_code)
+            documents_ = {
+                'up': False,
+                **self._expected_elastic_search(False),
+                **self._expected_queues(True),
+                **self._expected_progress()
+            }
+            self.assertEqual(documents_, health_object)
+
+    @mock_sts
+    @mock_sqs
+    def test_queues_down(self):
+        endpoint_states = self._make_endpoint_states(self.endpoints)
+        response = self._test(endpoint_states, lambdas_up=True)
+        health_object = response.json()
+        self.assertEqual(503, response.status_code)
+        self.assertEqual({
+            'up': False,
+            **self._expected_elastic_search(True),
+            **self._expected_queues(False),
+            **self._expected_progress()
+        }, health_object)
+
+    @mock_sts
+    @mock_sqs
+    def test_elasticsearch_down(self):
+        self._create_mock_queues()
+        mock_endpoint = ('nonexisting-index.com', 80)
+        endpoint_states = self._make_endpoint_states(self.endpoints)
+        with mock.patch.dict(os.environ, **config.es_endpoint_env(mock_endpoint)):
+            response = self._test(endpoint_states, lambdas_up=True)
+            health_object = response.json()
+            self.assertEqual(503, response.status_code)
+            documents_ = {
+                'up': False,
+                **self._expected_elastic_search(False),
+                **self._expected_queues(True),
+                **self._expected_progress()
+            }
+            self.assertEqual(documents_, health_object)
 
 
 # FIXME: This is inelegant: https://github.com/DataBiosphere/azul/issues/652

--- a/test/indexer/test_health_check.py
+++ b/test/indexer/test_health_check.py
@@ -31,7 +31,7 @@ class TestIndexerHealthCheck(HealthCheckTestCase):
             self.assertEqual(503, response.status_code)
             documents_ = {
                 'up': False,
-                **self._expected_elastic_search(False),
+                **self._expected_elasticsearch(False),
                 **self._expected_queues(True),
                 **self._expected_progress()
             }
@@ -46,7 +46,7 @@ class TestIndexerHealthCheck(HealthCheckTestCase):
         self.assertEqual(503, response.status_code)
         self.assertEqual({
             'up': False,
-            **self._expected_elastic_search(True),
+            **self._expected_elasticsearch(True),
             **self._expected_queues(False),
             **self._expected_progress()
         }, health_object)
@@ -63,7 +63,7 @@ class TestIndexerHealthCheck(HealthCheckTestCase):
             self.assertEqual(503, response.status_code)
             documents_ = {
                 'up': False,
-                **self._expected_elastic_search(False),
+                **self._expected_elasticsearch(False),
                 **self._expected_queues(True),
                 **self._expected_progress()
             }

--- a/test/service/test_health_check.py
+++ b/test/service/test_health_check.py
@@ -29,7 +29,7 @@ class TestServiceHealthCheck(HealthCheckTestCase):
         self.assertEqual(503, response.status_code)
         self.assertEqual({
             'up': False,
-            **self._expected_elastic_search(True),
+            **self._expected_elasticsearch(True),
             **self._expected_api_endpoints(endpoint_states),
         }, health_object)
 
@@ -43,7 +43,7 @@ class TestServiceHealthCheck(HealthCheckTestCase):
         self.assertEqual(503, response.status_code)
         self.assertEqual({
             'up': False,
-            **self._expected_elastic_search(True),
+            **self._expected_elasticsearch(True),
             **self._expected_api_endpoints(endpoint_states),
         }, health_object)
 
@@ -59,7 +59,7 @@ class TestServiceHealthCheck(HealthCheckTestCase):
             self.assertEqual(503, response.status_code)
             documents_ = {
                 'up': False,
-                **self._expected_elastic_search(False),
+                **self._expected_elasticsearch(False),
                 **self._expected_api_endpoints(endpoint_states),
             }
             self.assertEqual(documents_, health_object)


### PR DESCRIPTION
Several changes are in here that reduce the load on Azul caused by the health endpoint.

Restricting the health checker regions will probably make the biggest impact since this will reduce the number of request made by each health check by more than half. Removing the summary endpoint should also reduce the effect on Elasticsearch of calling health by a factor of two. Finally, removing the redundancy between the /health endpoints for the service and the indexer will reduce the number of Elasticsearch requests by 2 again.

My back of the napkin math says at least 8 times in reduction of Elasticsearch load from the health checker. 