### PR TITLE
Log transaction IDs during remote reindex (#1030)

### DIFF
--- a/src/azul/azulclient.py
+++ b/src/azul/azulclient.py
@@ -62,7 +62,7 @@ class AzulClient(object):
         return {
             "query": self.query(),
             "subscription_id": 'feeb0f2b-c16f-48f8-bac0-e6fd09b92320',
-            "transaction_id": 'feeb0f2b-c16f-48f8-bac0-e6fd09b92320',
+            "transaction_id": str(uuid.uuid4()),
             "match": {
                 "bundle_uuid": bundle_uuid,
                 "bundle_version": bundle_version
@@ -235,6 +235,9 @@ class AzulClient(object):
         num_messages = 0
         for batch in chunked(messages, 10):
             if not self.dryrun:
+                if logger.isEnabledFor(logging.DEBUG):
+                    for message in batch:
+                        logger.debug('Sending message %r', message)
                 notify_queue.send_messages(Entries=[dict(Id=str(i), MessageBody=json.dumps(message))
                                                     for i, message in enumerate(batch)])
             num_messages += len(batch)


### PR DESCRIPTION
This will make debugging duplicate notifications easier because it will allow you to search the logs for a single transaction ID.

This should be reviewed with fix for #995 (i.e. not yet).