### PR TITLE
Display Swagger UI with docs from app.py (#1163)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ generic with minimal need for project-specific behavior.
     - [8.7 The Gitlab Build Environment](#87-the-gitlab-build-environment)
 - [9. Kibana](#9-kibana)
 - [10. Making wheels](#10-making-wheels)
+- [11. Development tools](#11-development-tools)
+    - [11.1 OpenAPI development](#111-openapi-development)
 
 
 The Azul project contains the components that together serve as the backend to
@@ -1205,3 +1207,28 @@ Then modify the `wheels` target in `lambdas/*/Makefile` to unzip the wheel into
 the corresponding vendor directory.
 
 Also see https://chalice.readthedocs.io/en/latest/topics/packaging.html
+
+# 11. Development tools
+
+## 11.1 OpenAPI development
+
+To assist with adding documentation to the Azul Service OpenAPI page
+(https://service.dev.explore.data.humancellatlas.org/), we use a script that
+validates the specifications.
+
+To run the script, activate your virtual environment, then run
+```
+python scripts/apidev.py
+```
+The script gives you a url where your current version of the documentation
+is visible. Change the docs in `azul/service/app.py`, save, and refresh the page and
+your changes will appear immediately along with any warnings or errors they introduce.
+
+The script pulls the skeleton for what it displays from the currently activated
+deployment. If you add new endpoints or change endpoint parameters, this won't be
+reflected nor validated by the script. To remedy this run
+```
+make -C lambdas/service deploy  # deploy to service only
+```
+with your personal deployment selected. Then refresh the web page from the
+script.

--- a/lambdas/indexer/.chalice/config.json.template.py
+++ b/lambdas/indexer/.chalice/config.json.template.py
@@ -11,7 +11,7 @@ emit({
     "api_gateway_stage": config.deployment_stage,
     "manage_iam_role": False,
     "iam_role_arn": f"arn:aws:iam::{aws.account}:role/{config.indexer_name}",
-    "environment_variables": aws.lambda_env,
+    "environment_variables": aws.lambda_env(config.indexer_name),
     'lambda_timeout': config.api_gateway_timeout + config.api_gateway_timeout_padding,
     "lambda_memory_size": 128,
     "reserved_concurrency": config.indexer_concurrency,

--- a/lambdas/service/.chalice/config.json.template.py
+++ b/lambdas/service/.chalice/config.json.template.py
@@ -11,7 +11,7 @@ emit({
     'api_gateway_stage': config.deployment_stage,
     'manage_iam_role': False,
     'iam_role_arn': f'arn:aws:iam::{aws.account}:role/{config.service_name}',
-    'environment_variables': aws.lambda_env,
+    'environment_variables': aws.lambda_env(config.service_name),
     'lambda_timeout': config.api_gateway_timeout + config.api_gateway_timeout_padding,
     'lambda_memory_size': 1024,
     'stages': {

--- a/lambdas/service/.gitignore
+++ b/lambdas/service/.gitignore
@@ -5,3 +5,4 @@
 /lambda-policy.json
 /vendor/*
 !/vendor/azul
+!/vendor/static

--- a/lambdas/service/lambda-policy.json.template.py
+++ b/lambdas/service/lambda-policy.json.template.py
@@ -136,6 +136,16 @@ emit({
                 f"arn:aws:states:{aws.region_name}:{aws.account}:execution:{config.cart_item_state_machine_name}:*",
                 f"arn:aws:states:{aws.region_name}:{aws.account}:execution:{config.cart_export_state_machine_name}"
             ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "apigateway:GET"
+            ],
+            "Resource": [
+                f"arn:aws:apigateway:{aws.region_name}::"
+                f"/restapis/{aws.api_gateway_id(config.service_name)}/stages/{config.deployment_stage}/exports/oas30"
+            ]
         }
     ]
 })

--- a/lambdas/service/vendor/static/swagger-ui.html
+++ b/lambdas/service/vendor/static/swagger-ui.html
@@ -1,0 +1,53 @@
+<!-- HTML for static distribution bundle build -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Swagger UI</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.23.4/swagger-ui.css" integrity="sha384-cxoOmCOFJb4rLogOBOvhasLk6veYZbG7YJ2H5GaDdQ9Obb69ThaKI+kVWlOhwsC8" crossorigin="anonymous">
+    <style>
+      html
+      {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+      }
+      *,
+      *:before,
+      *:after
+      {
+        box-sizing: inherit;
+      }
+      body
+      {
+        margin:0;
+        background: #fafafa;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="swagger-ui"></div>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.23.4/swagger-ui-bundle.js" integrity="sha384-JbzjdGH/8EZqLOpcMFS/MXcq75e5nV8v1zvKkLZI++muepUwRk+8wqyEA4pK+MMk" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.23.4/swagger-ui-standalone-preset.js" integrity="sha384-z/VXOloA3CoJO8uNNRCD2j/upTpSyyXg/3+kYqvichype5Xf1iya2rS7ZyqgGDGq" crossorigin="anonymous"></script>
+    <script>
+    window.onload = function() {
+      // Begin Swagger UI call region
+      const ui = SwaggerUIBundle({
+        url: "openapi",
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        presets: [
+          SwaggerUIBundle.presets.apis,
+        ],
+        plugins: [
+          SwaggerUIBundle.plugins.DownloadUrl
+        ],
+      })
+      // End Swagger UI call region
+      window.ui = ui
+    }
+  </script>
+  </body>
+</html>

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -11,4 +11,5 @@ pyyaml==3.12
 responses==0.10.2
 furl==2.0.0
 PyGithub==1.43.5
+openapi-spec-validator==0.2.8
 -r requirements.txt

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -12,4 +12,5 @@ responses==0.10.2
 furl==2.0.0
 PyGithub==1.43.5
 openapi-spec-validator==0.2.8
+watchdog==0.9.0
 -r requirements.txt

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,2 @@
+# This file is created while running apidev.py
+openapi.json

--- a/scripts/apidev.py
+++ b/scripts/apidev.py
@@ -1,0 +1,61 @@
+import json
+import os
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+
+from azul import config
+from azul.deployment import aws
+from azul.modules import load_app_module
+from azul.openapi import annotated_specs
+
+spec_file = 'openapi.json'
+parent_dir = os.path.realpath(os.path.dirname(__file__))
+
+
+def write_specs(gateway_id, app, openapi_spec):
+    specs = annotated_specs(gateway_id, app, openapi_spec)
+    with open(os.path.join(parent_dir, spec_file), 'w') as f:
+        json.dump(specs, f)
+
+
+def main():
+    static_dir = os.path.join(parent_dir, 'apidev_static')
+    web_page = os.path.join(static_dir, 'swagger-editor.html')
+
+    host, port = 'localhost', 8787
+    server_url = f"http://{host}:{port}"
+    httpd = HTTPServer((host, port), SimpleHTTPRequestHandler)
+    address = f"{server_url}/{os.path.relpath(web_page)}?url={server_url}/{os.path.relpath(parent_dir)}/{spec_file}"
+    print(f'Open {address} in browser to validate changes.')
+    print('If you changed/added any routes, make sure to deploy afterwords (also update API version)!')
+    print('This is because the specs are pulled from API Gateway which needs '
+          'to be up to date with any new routes')
+
+    service = load_app_module('service')
+    gateway_id = aws.api_gateway_id(config.service_name, validate=True)
+    event_handler = UpdateHandler(service, gateway_id)
+    observer = Observer()
+    observer.schedule(event_handler, path=os.path.dirname(service.__file__), recursive=False)
+    observer.start()
+
+    write_specs(gateway_id, service.app, service.openapi_spec)
+    httpd.serve_forever()
+
+
+class UpdateHandler(FileSystemEventHandler):
+    def __init__(self, service, gateway_id):
+        self.service = service
+        self.gateway_id = gateway_id
+        self.tracked_file = os.path.join(os.path.dirname(service.__file__), 'app.py')
+
+    def on_modified(self, event):
+        if event.src_path == self.tracked_file:
+            self.service = load_app_module('service')
+            write_specs(self.gateway_id, self.service.app, self.service.api_info)
+            print('Spec updated')
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/apidev_static/swagger-editor.html
+++ b/scripts/apidev_static/swagger-editor.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<!-- HTML for static distribution bundle build -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Swagger Editor</title>
+  <style>
+  * {
+    box-sizing: border-box;
+  }
+  body {
+    font-family: Roboto,sans-serif;
+    font-size: 9px;
+    line-height: 1.42857143;
+    color: #444;
+    margin: 0px;
+  }
+
+  #swagger-editor {
+    font-size: 1.3em;
+  }
+
+  .container {
+    height: 100%;
+    max-width: 880px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  #editor-wrapper {
+    height: 100%;
+    border:1em solid #000;
+    border:none;
+  }
+
+  .Pane2 {
+    overflow-y: scroll;
+  }
+
+  </style>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/swagger-api/swagger-editor/dist/swagger-editor.css" integrity="sha384-aCldT17rjjsR6S5mbExNY+OMqoGyVU0Um8aiZVfqviGGVPbCpczpo9yj292JyXSZ" crossorigin="anonymous">
+  <link rel="icon" type="image/png" href="https://cdn.jsdelivr.net/gh/swagger-api/swagger-editor/dist/favicon-32x32.png" sizes="32x32" integrity="sha384-hXkYX0sxBdWEtT/7FmPJG6TNr14mXf42PGd+R7r0/+xwayRTAniji8SRLNqG0y4i"/>
+</head>
+
+<body>
+  <div id="swagger-editor"></div>
+  <script src="https://cdn.jsdelivr.net/gh/swagger-api/swagger-editor/dist/swagger-editor-bundle.js" integrity="sha384-cwhESfubJtm1ozw6Rrzm49Q8/BA2XZcJ4offFa/bHEts8ifnnKnNJGMVeTdXuQ1h" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/gh/swagger-api/swagger-editor/dist/swagger-editor-standalone-preset.js" integrity="sha384-ApSagJ9tdyRiB0/BJUz47nDAkuzESW5JHSOmjSPe1welUGiFHZTWSdSH+1N2auJS" crossorigin="anonymous"></script>  <script>
+  window.onload = function() {
+    // Build a system
+    const editor = SwaggerEditorBundle({
+      dom_id: '#swagger-editor',
+      layout: 'StandaloneLayout',
+      presets: [
+        SwaggerEditorStandalonePreset
+      ]
+    })
+
+    window.editor = editor
+  }
+  </script>
+
+  <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0">
+    <defs>
+      <symbol viewBox="0 0 20 20" id="unlocked">
+            <path d="M15.8 8H14V5.6C14 2.703 12.665 1 10 1 7.334 1 6 2.703 6 5.6V6h2v-.801C8 3.754 8.797 3 10 3c1.203 0 2 .754 2 2.199V8H4c-.553 0-1 .646-1 1.199V17c0 .549.428 1.139.951 1.307l1.197.387C5.672 18.861 6.55 19 7.1 19h5.8c.549 0 1.428-.139 1.951-.307l1.196-.387c.524-.167.953-.757.953-1.306V9.199C17 8.646 16.352 8 15.8 8z"></path>
+      </symbol>
+
+      <symbol viewBox="0 0 20 20" id="locked">
+        <path d="M15.8 8H14V5.6C14 2.703 12.665 1 10 1 7.334 1 6 2.703 6 5.6V8H4c-.553 0-1 .646-1 1.199V17c0 .549.428 1.139.951 1.307l1.197.387C5.672 18.861 6.55 19 7.1 19h5.8c.549 0 1.428-.139 1.951-.307l1.196-.387c.524-.167.953-.757.953-1.306V9.199C17 8.646 16.352 8 15.8 8zM12 8H8V5.199C8 3.754 8.797 3 10 3c1.203 0 2 .754 2 2.199V8z"/>
+      </symbol>
+
+      <symbol viewBox="0 0 20 20" id="close">
+        <path d="M14.348 14.849c-.469.469-1.229.469-1.697 0L10 11.819l-2.651 3.029c-.469.469-1.229.469-1.697 0-.469-.469-.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-.469-.469-.469-1.228 0-1.697.469-.469 1.228-.469 1.697 0L10 8.183l2.651-3.031c.469-.469 1.228-.469 1.697 0 .469.469.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c.469.469.469 1.229 0 1.698z"/>
+      </symbol>
+
+      <symbol viewBox="0 0 20 20" id="large-arrow">
+        <path d="M13.25 10L6.109 2.58c-.268-.27-.268-.707 0-.979.268-.27.701-.27.969 0l7.83 7.908c.268.271.268.709 0 .979l-7.83 7.908c-.268.271-.701.27-.969 0-.268-.269-.268-.707 0-.979L13.25 10z"/>
+      </symbol>
+
+      <symbol viewBox="0 0 20 20" id="large-arrow-down">
+        <path d="M17.418 6.109c.272-.268.709-.268.979 0s.271.701 0 .969l-7.908 7.83c-.27.268-.707.268-.979 0l-7.908-7.83c-.27-.268-.27-.701 0-.969.271-.268.709-.268.979 0L10 13.25l7.418-7.141z"/>
+      </symbol>
+
+
+      <symbol viewBox="0 0 24 24" id="jump-to">
+        <path d="M19 7v4H5.83l3.58-3.59L8 6l-6 6 6 6 1.41-1.41L5.83 13H21V7z"/>
+      </symbol>
+
+      <symbol viewBox="0 0 24 24" id="expand">
+        <path d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"/>
+      </symbol>
+
+    </defs>
+  </svg>
+
+</body>
+
+</html>

--- a/src/azul/chalice.py
+++ b/src/azul/chalice.py
@@ -1,5 +1,6 @@
 from chalice import Chalice
 
+from azul.openapi import openapi_spec
 from azul.types import LambdaContext
 
 
@@ -13,9 +14,12 @@ class AzulChaliceApp(Chalice):
         Same as method in supper class but stashes URL path a view function is bound to as an attribute of the
         function itself.
         """
+        spec = kwargs.pop('spec', None)
         decorator = super().route(path, **kwargs)
 
         def _decorator(view_func):
+            if spec is not None:
+                view_func = openapi_spec(spec)(view_func)
             view_func.path = path
             return decorator(view_func)
 

--- a/src/azul/deployment.py
+++ b/src/azul/deployment.py
@@ -74,7 +74,7 @@ class AWS:
                     return None
             return api_gateway_id
 
-    def api_getway_endpoint(self, function_name: str, api_gateway_stage: str) -> Optional[str]:
+    def api_gateway_endpoint(self, function_name: str, api_gateway_stage: str) -> Optional[str]:
         api_gateway_id = self.api_gateway_id(function_name)
         if api_gateway_id is None:
             return None
@@ -91,7 +91,7 @@ class AWS:
         return config.lambda_env(self.es_endpoint)
 
     def get_lambda_arn(self, function_name, suffix):
-        return f"arn:aws:lambda:{aws.region_name}:{aws.account}:function:{function_name}-{suffix}"
+        return f"arn:aws:lambda:{self.region_name}:{self.account}:function:{function_name}-{suffix}"
 
     @memoized_property
     def permissions_boundary_arn(self) -> str:

--- a/src/azul/modules.py
+++ b/src/azul/modules.py
@@ -1,4 +1,7 @@
 import importlib.util
+import os
+
+from azul import config
 
 
 def load_module(path: str, module_name: str):
@@ -17,3 +20,8 @@ def load_module(path: str, module_name: str):
     assert path == module.__file__
     assert module.__name__ == module_name
     return module
+
+
+def load_app_module(lambda_name):
+    path = os.path.join(config.project_root, 'lambdas', lambda_name, 'app.py')
+    return load_module(path, '__main__')

--- a/src/azul/openapi.py
+++ b/src/azul/openapi.py
@@ -1,0 +1,125 @@
+import copy
+from typing import List
+
+from azul.deployment import aws
+from azul.types import JSON, MutableJSON
+
+
+def openapi_spec(description: JSON):
+    """
+    Add description to decorated function
+
+    >>> @openapi_spec({'a': 'b'})
+    ... def foo():
+    ...     pass
+    ...
+    >>> foo.api_spec == {'a': 'b'}
+    True
+    """
+
+    def spec_adder(func):
+        func.api_spec = description
+        return func
+    return spec_adder
+
+
+def annotated_specs(gateway_id, app, toplevel_spec) -> JSON:
+    """
+    Finds all routes in app that are decorated with @openapi_spec and adds this information
+    into the api spec downloaded from API Gateway.
+
+    :param gateway_id: API Gateway ID corresponding to the Chalice app
+    :param app: App with annotated routes
+    :param toplevel_spec: Top level OpenAPI info, definitions, etc.
+    :return: The annotated specifications
+    """
+    specs = aws.api_gateway_export(gateway_id)
+    clean_specs(specs)
+    specs = merge_dicts(specs, toplevel_spec, override=True)
+    docs = get_doc_specs(app)
+    for path, doc_spec in docs.items():
+        for verb, description in specs['paths'][path].items():
+            description = merge_dicts(description, doc_spec)
+            specs['paths'][path][verb] = description
+    return specs
+
+
+def clean_specs(specs):
+    """
+    Adjust specs from API Gateway so they pass linting
+    """
+    # Filter out 'options' since it causes linting errors
+    for path in specs['paths']:
+        specs['paths'][path].pop('options', None)
+
+
+def get_doc_specs(app):
+    docs = {}
+    for route, entries in app.routes.items():
+        func = next(iter(entries.values())).view_function
+        if hasattr(func, 'api_spec'):
+            docs[route] = func.api_spec
+    return docs
+
+
+def merge_dicts(d1: JSON, d2: JSON, override: bool = False) -> JSON:
+    """
+    Merge two dictionaries deeply such that:
+
+    - collisions raise an error,
+    - lists are appended, and
+    - child dictionaries are recursively merged
+
+    Know that the returned dictionary will share references in d1 and d2.
+
+    :param d1: Dictionary into which d2 is merged
+    :param d2: Dictionary merged into d1
+    :param override: Override collisions with values from d2
+    :return: A reference to d1 which has been modified by the merge
+
+    >>> merge_dicts({'a': 'b'}, {'z': 'b'})
+    {'a': 'b', 'z': 'b'}
+
+    >>> merge_dicts({'a': 1}, {'a': 2})
+    Traceback (most recent call last):
+    ...
+    ValueError: Cannot merge path 'a' with values: 1, 2
+
+    >>> merge_dicts({'a': 1}, {'a': 2}, override=True)
+    {'a': 2}
+
+    >>> merge_dicts({'a': [1, 2]}, {'a': [2, 3]})
+    {'a': [1, 2, 2, 3]}
+
+    >>> merge_dicts({'a': {'b': 'z', 'd': [1]}}, {'a': {'c': 'y', 'd': [2]}})
+    {'a': {'b': 'z', 'd': [1, 2], 'c': 'y'}}
+
+    >>> merge_dicts({'a': {'b': 'z'}}, {'a': {'b': 'y'}})
+    Traceback (most recent call last):
+    ...
+    ValueError: Cannot merge path 'a.b' with values: z, y
+
+    >>> merge_dicts({'a': {'b': 'z'}}, {'a': {'b': 'y'}}, override=True)
+    {'a': {'b': 'y'}}
+    """
+    return _recursive_merge_dicts(d1, d2, [], override)
+
+
+def _recursive_merge_dicts(d1: JSON, d2: JSON, path: List[str], override: bool) -> JSON:
+    merged = dict(copy.copy(d1))
+    for k, v in d2.items():
+        sub_path = path + [k]
+        if k not in merged:
+            merged[k] = v
+        else:
+            if type(merged[k]) == type(v) == list:
+                merged[k].extend(v)
+            elif type(merged[k]) == type(v) == dict:
+                merged[k] = _recursive_merge_dicts(merged[k], v, sub_path, override)
+            else:
+                if override:
+                    merged[k] = v
+                else:
+                    path_str = '.'.join(map(str, sub_path))
+                    raise ValueError(f"Cannot merge path '{path_str}' with values: {merged[k]}, {v}")
+    return merged

--- a/test/app_test_case.py
+++ b/test/app_test_case.py
@@ -10,8 +10,7 @@ from chalice.config import Config as ChaliceConfig
 from chalice.local import LocalDevServer
 import requests
 
-from azul import config
-from azul.modules import load_module
+from azul.modules import load_app_module
 from azul_test_case import AzulTestCase
 from retorts import TestKeyManager
 
@@ -68,8 +67,7 @@ class LocalAppTestCase(AzulTestCase, metaclass=ABCMeta):
         # Load the application module without modifying `sys.path` and without adding it to `sys.modules`. This
         # simplifies tear down and isolates the app modules from different lambdas loaded by different concrete
         # subclasses. It does, however, violate this one invariant: `sys.modules[module.__name__] == module`
-        path = os.path.join(config.project_root, 'lambdas', cls.lambda_name(), 'app.py')
-        cls.app_module = load_module(path, '__main__')
+        cls.app_module = load_app_module(cls.lambda_name())
 
     @classmethod
     def tearDownClass(cls):

--- a/test/app_test_case.py
+++ b/test/app_test_case.py
@@ -92,7 +92,7 @@ class LocalAppTestCase(AzulTestCase, metaclass=ABCMeta):
                 break
 
     def _ping(self):
-        return requests.get(self.base_url)
+        return requests.get(f"{self.base_url}/health/basic")
 
     def chalice_config(self):
         return ChaliceConfig()

--- a/test/health_check_test_case.py
+++ b/test/health_check_test_case.py
@@ -90,7 +90,7 @@ class HealthCheckTestCase(LocalAppTestCase, ElasticsearchTestCase, metaclass=ABC
         with ResponsesHelper() as helper:
             helper.add_passthru(self.base_url)
             self._mock_other_lambdas(helper, up=True)
-            # If Health werent't lazy, it would fail due the lack of mocks for SQS.
+            # If Health weren't lazy, it would fail due the lack of mocks for SQS.
             response = requests.get(self.base_url + '/health/other_lambdas')
             # The use of subTests ensures that we see the result of both
             # assertions. In the case of the health endpoint, the body of a 503

--- a/test/local_integration_test.py
+++ b/test/local_integration_test.py
@@ -21,6 +21,7 @@ from more_itertools import one, first
 from io import BytesIO, TextIOWrapper
 from zipfile import ZipFile
 
+from openapi_spec_validator import validate_spec
 from requests import HTTPError
 
 from azul import config
@@ -116,6 +117,7 @@ class IntegrationTest(unittest.TestCase):
             for endpoint in config.service_endpoint(), config.indexer_endpoint():
                 self.check_endpoint_is_working(endpoint, '/health' + health_key)
         self.check_endpoint_is_working(config.service_endpoint(), '/')
+        self.check_endpoint_is_working(config.service_endpoint(), '/openapi')
         self.check_endpoint_is_working(config.service_endpoint(), '/version')
         self.check_endpoint_is_working(config.service_endpoint(), '/repository/summary')
         self.check_endpoint_is_working(config.service_endpoint(), '/repository/files/order')
@@ -339,6 +341,21 @@ class IntegrationTest(unittest.TestCase):
             params['search_after'] = search_after
             params['search_after_uid'] = pagination['search_after_uid']
         return entities
+
+
+class OpenAPIIntegrationTest(unittest.TestCase):
+
+    def test_openapi(self):
+        service = config.service_endpoint()
+        response = requests.get(service + '/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers['content-type'], 'text/html')
+        self.assertGreater(len(response.content), 0)
+        # validate OpenAPI spec
+        response = requests.get(service + '/openapi')
+        response.raise_for_status()
+        spec = response.json()
+        validate_spec(spec)
 
 
 class DSSIntegrationTest(unittest.TestCase):

--- a/test/test_doctests.py
+++ b/test/test_doctests.py
@@ -6,6 +6,7 @@ import azul.azulclient
 import azul.collections
 import azul.json_freeze
 from azul.modules import load_module
+import azul.openapi
 import azul.service.responseobjects.elastic_request_builder
 import azul.strings
 import azul.threads
@@ -19,6 +20,7 @@ def load_tests(loader, tests, ignore):
     tests.addTests(doctest.DocTestSuite(azul))
     tests.addTests(doctest.DocTestSuite(azul.collections))
     tests.addTests(doctest.DocTestSuite(azul.json_freeze))
+    tests.addTests(doctest.DocTestSuite(azul.openapi))
     tests.addTests(doctest.DocTestSuite(azul.strings))
     tests.addTests(doctest.DocTestSuite(azul.threads))
     tests.addTests(doctest.DocTestSuite(azul.time))


### PR DESCRIPTION
Things outstanding:
- The docs are very much incomplete. This need to be done in a follow-up ticket.
- We need to decide how to deal with/display API versioning

I have a script that somewhat improves the development process for writing the docs by rendering them, unfortunately I cannot figure out how to display validation. I'm unsure whether or not to include it.

For an example of what this looks like, check out https://service.jesse0.dev.explore.data.humancellatlas.org/