### PR TITLE
Azul Integration deployment to point at DSS staging instance

### DIFF
--- a/deployments/integration/environment
+++ b/deployments/integration/environment
@@ -11,7 +11,7 @@
 # at the project root.
 
 _set AZUL_DEPLOYMENT_STAGE integration
-_set AZUL_DSS_ENDPOINT "https://dss.integration.data.humancellatlas.org/v1"
+_set AZUL_DSS_ENDPOINT "https://dss.staging.data.humancellatlas.org/v1"
 _set AZUL_DRS_DOMAIN_NAME "drs.integration.data.humancellatlas.org"
 
 _set azul_grafana_endpoint "https://metrics.dev.data.humancellatlas.org"

--- a/src/azul/project/hca/__init__.py
+++ b/src/azul/project/hca/__init__.py
@@ -33,14 +33,6 @@ class Plugin(azul.plugin.Plugin):
                         *(
                             [
                                 {
-                                    "range": {
-                                        "manifest.version": {
-                                            "gte": "2018-11-27"
-                                        }
-                                    }
-                                }
-                            ] if config.dss_endpoint == "https://dss.integration.data.humancellatlas.org/v1" else [
-                                {
                                     "bool": {
                                         "should": [
                                             {


### PR DESCRIPTION
Since DSS has recently deleted most of its bundles from their integration DSS instance. Azul is unable to obtain results back for a prefix query, due to the small set of bundles available. Most of the bundles available are test bundles. That is why I suggest we direct our integration environment to the DSS staging instance. 
We could also solve the issue by having special logic in our integration test when dealing with the integration DSS instance. 

@hannes-ucsc for further evaluation of this issue. 