### PR TITLE
Fix: OpenAPI UI renders incorrect server URL (#1262)

### DIFF
--- a/lambdas/service/app.py
+++ b/lambdas/service/app.py
@@ -92,6 +92,9 @@ openapi_spec = {
             'name': 'Health',
             'description': 'For checking on service health'
         }
+    ],
+    'servers': [
+        {'url': config.service_endpoint()}
     ]
 }
 

--- a/src/azul/openapi.py
+++ b/src/azul/openapi.py
@@ -36,7 +36,7 @@ def annotated_specs(gateway_id, app, toplevel_spec) -> JSON:
     """
     specs = aws.api_gateway_export(gateway_id)
     clean_specs(specs)
-    specs = merge_dicts(specs, toplevel_spec, override=True)
+    specs = merge_dicts(toplevel_spec, specs, override=True)
     docs = get_doc_specs(app)
     for path, doc_spec in docs.items():
         for verb, description in specs['paths'][path].items():
@@ -52,6 +52,8 @@ def clean_specs(specs):
     # Filter out 'options' since it causes linting errors
     for path in specs['paths']:
         specs['paths'][path].pop('options', None)
+    # Remove listed servers since API Gateway give false results
+    specs.pop('servers')
 
 
 def get_doc_specs(app):


### PR DESCRIPTION
Even though API Gateway is configured with multiple (namely 2) different
server domains, when requesting the OpenAPI spec from AWS only 1 is
returned. My guess is that because OpenAPI v2 only supported one "host"
entry, AWS doesn't preserve this information for when the spec is
generated, even if v3 is requested. Probably, behind the scenes, they
just convert their v2 spec to v3.

To solve this, I hard coded the URL in the OpenAPI template. and removed
from the spec any servers that are API Gateway lists.