### PR TITLE
Override API Gateway's values for API documentation (#1436)

### DIFF
--- a/lambdas/service/app.py
+++ b/lambdas/service/app.py
@@ -184,19 +184,39 @@ def openapi():
                     body=spec)
 
 
-@app.route('/health', methods=['GET'], cors=True, spec={
+health_spec = {
+    'responses': {
+        '200': {
+            'description': '200 response',
+            'content': {
+                'application/json': {
+                    'schema': {'$ref': '#/components/schemas/Empty'}
+                }
+            }
+        }
+    },
+    'tags': ['Health']
+}
+
+
+@app.route('/health', methods=['GET'], cors=True, method_spec={
+    **health_spec,
+    'summary': 'List health information for webservice'
+})
+@app.route('/health/{keys}', methods=['GET'], cors=True, path_spec={
     'parameters': [
         {
-            'in': 'query',
-            'name': 'foo',
-            'description': 'This is not a real parameter',
-            'required': False,
-            'schema': {'$ref': "#/components/schemas/Empty"}
+            'name': 'keys',
+            'in': 'path',
+            'required': True,
+            'schema': {'type': 'string'}
         }
     ],
-    'tags': ['Health']
+}, method_spec={
+    **health_spec,
+    'summary': 'List health information for a specific key',
+    'description': 'List health information for a specific key, or all keys if `/health/` is used.'
 })
-@app.route('/health/{keys}', methods=['GET'], cors=True)
 def health(keys: Optional[str] = None):
     controller = HealthController(lambda_name='service',
                                   keys=keys,

--- a/src/azul/chalice.py
+++ b/src/azul/chalice.py
@@ -22,12 +22,13 @@ class AzulChaliceApp(Chalice):
         Same as method in supper class but stashes URL path a view function is bound to as an attribute of the
         function itself.
         """
-        spec = kwargs.pop('spec', None)
+        methods = kwargs.get('methods', None)
+        path_spec = kwargs.pop('path_spec', None)
+        method_spec = kwargs.pop('method_spec', None)
         decorator = super().route(path, **kwargs)
 
         def _decorator(view_func):
-            if spec is not None:
-                view_func = openapi_spec(spec)(view_func)
+            view_func = openapi_spec(path, methods, path_spec=path_spec, method_spec=method_spec)(view_func)
             view_func.path = path
             return decorator(view_func)
 

--- a/src/azul/openapi.py
+++ b/src/azul/openapi.py
@@ -50,8 +50,8 @@ def clean_specs(specs):
     Adjust specs from API Gateway so they pass linting
     """
     # Filter out 'options' since it causes linting errors
-    for path in specs['paths']:
-        specs['paths'][path].pop('options', None)
+    for path in specs['paths'].values():
+        path.pop('options', None)
     # Remove listed servers since API Gateway give false results
     specs.pop('servers')
 

--- a/test/test_openapi.py
+++ b/test/test_openapi.py
@@ -1,0 +1,88 @@
+from unittest.mock import MagicMock
+
+from azul.openapi import (
+    get_app_specs,
+    openapi_spec,
+)
+from azul_test_case import AzulTestCase
+
+
+class TestGetAppSpecs(AzulTestCase):
+
+    def test_unannotated(self):
+        # TODO: Once all endpoints are documented, this test should assert failure
+        app = self._mock_app_object([lambda x: x])
+        get_app_specs(app)
+
+    def test_just_method_spec(self):
+        route = self._annotate_func('/foo', ['GET'], method_spec={'a': 'b'})
+        app = self._mock_app_object([route])
+        specs = get_app_specs(app)
+        self.assertEqual(specs, ({}, {('/foo', 'get'): {'a': 'b'}}))
+
+    def test_just_path_spec(self):
+        route = self._annotate_func('/foo', ['GET'], path_spec={'a': 'b'})
+        app = self._mock_app_object([route])
+        specs = get_app_specs(app)
+        self.assertEqual(specs, ({'/foo': {'a': 'b'}}, {}))
+
+    def test_fully_annotated(self):
+        route = self._annotate_func('/foo', ['GET'], path_spec={'a': 'b'}, method_spec={'c': 'd'})
+        app = self._mock_app_object([route])
+        specs = get_app_specs(app)
+        self.assertEqual(specs, ({'/foo': {'a': 'b'}}, {('/foo', 'get'): {'c': 'd'}}))
+
+    def test_duplicate_method_specs(self):
+        """
+        This doesn't fail because we expect Chalice to disallow duplicate specs
+        like this inside of app.py
+        """
+
+        @openapi_spec('/foo', ['GET'], method_spec={'a': 'XXX'})
+        @openapi_spec('/foo', ['GET'], method_spec={'a': 'b'})
+        def route():
+            pass
+
+        app = self._mock_app_object([route])
+        specs = get_app_specs(app)
+        self.assertEqual(specs, ({}, {('/foo', 'get'): {'a': 'XXX'}}))
+
+    def test_duplicate_path_specs(self):
+        """
+        We have to catch this manually in get_app_specs
+        """
+
+        @openapi_spec('/foo', ['PUT'], path_spec={'a': 'XXX'})
+        def route1():
+            pass
+
+        @openapi_spec('/foo', ['GET'], path_spec={'a': 'b'})
+        def route2():
+            pass
+
+        app = self._mock_app_object([route1, route2])
+        with self.assertRaises(AssertionError):
+            get_app_specs(app)
+
+    def _annotate_func(self, route, methods, path_spec=None, method_spec=None):
+        @openapi_spec(route, methods, path_spec=path_spec, method_spec=method_spec)
+        def route():
+            pass
+
+        return route
+
+    def _mock_app_object(self, funcs):
+        """
+        Takes a list of functions and mocks the structure of an Chalice app
+        object that contains them
+        """
+        app = MagicMock()
+        mock_routes = []
+        for f in funcs:
+            route = MagicMock()
+            route.view_function = f
+            route_wrapper = MagicMock()
+            route_wrapper.values.return_value = [route]
+            mock_routes.append(route_wrapper)
+        app.routes.values.return_value = mock_routes
+        return app


### PR DESCRIPTION
Before this change, the specs were combined. But now, if any
documentation is provided, we will assume it is correct and complete.
Because of this, it should override the default values provided by API
Gateway.