### PR TITLE
Update metadata-api dependency to point to DataBiosphere fork (#1518)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ Faker==0.8.11
 future==0.16.0
 hca==6.4.0
 git+git://github.com/hannes-ucsc/jmespath.py@hannes-fix-cache-race#egg=jmespath
-git+git://github.com/HumanCellAtlas/metadata-api@release/1.0b22#egg=hca-metadata-api
+git+git://github.com/DataBiosphere/hca-metadata-api@release/1.0b22#egg=hca-metadata-api
 pyasn1==0.4.4
 pyasn1-modules==0.2.2
 PyJWT==1.6.4


### PR DESCRIPTION
Created a new PR for this issue. The old PRs (https://github.com/DataBiosphere/azul/pull/1535, https://github.com/DataBiosphere/azul/pull/1542) closed/merged itself after changing base branches. 