### PR TITLE
Remove tsv and bdbag manifest format names (#1342)

### DIFF
--- a/lambdas/service/app.py
+++ b/lambdas/service/app.py
@@ -920,7 +920,7 @@ def handle_manifest_generation_request():
         format_ = query_params['format']
     except KeyError:
         format_ = 'compact'
-    if format_ not in ('compact', 'tsv', 'terra.bdbag', 'bdbag', 'full'):
+    if format_ not in ('compact', 'terra.bdbag', 'full'):
         raise BadRequestError(f'{format_} is not a valid manifest format.')
     token = query_params.get('token')
     retry_url = self_url()

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -324,11 +324,11 @@ class ManifestGenerator(metaclass=ABCMeta):
         :return: a ManifestGenerator instance. Note that the protocol used for
                  consuming the generator output is defined in subclasses.
         """
-        if format_ in ('tsv', 'compact'):
+        if format_ == 'compact':
             return CompactManifestGenerator(service, filters)
         elif format_ == 'full':
             return FullManifestGenerator(service, filters)
-        elif format_ in ('terra.bdbag', 'bdbag'):
+        elif format_ == 'terra.bdbag':
             return BDBagManifestGenerator(service, filters)
         else:
             assert False

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -181,10 +181,8 @@ class IntegrationTest(AlwaysTearDownTestCase):
         manifest_filter = json.dumps({'project': {'is': [self.test_name]}})
         for format_, validator in [
             (None, self._check_manifest),
-            ('tsv', self._check_manifest),
             ('compact', self._check_manifest),
             ('full', self._check_manifest),
-            ('bdbag', self._check_terra_bdbag),
             ('terra.bdbag', self._check_terra_bdbag)
         ]:
             with self.subTest(format=format_, filter=manifest_filter):

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -218,7 +218,7 @@ class TestManifestEndpoints(WebServiceTestCase):
             for single_part in False, True:
                 with self.subTest(is_single_part=single_part):
                     with mock.patch.object(type(config), 'disable_multipart_manifests', single_part):
-                        response = self._get_manifest('tsv', filters)
+                        response = self._get_manifest('compact', filters)
                         self.assertEqual(200, response.status_code, 'Unable to download manifest')
                         # Cannot use response.iter_lines() because of https://github.com/psf/requests/issues/3980
                         lines = response.content.decode('utf-8').splitlines()


### PR DESCRIPTION
Fairly certain all references to manifest formats "tsv" and "bdbag" have been removed. Many seem to have been refactored out since the commit that added support for the new formats.