### PR TITLE
Apply orange label to pull requests using new DataBiosphere repo (#1540)

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,10 +1,10 @@
-name: Add `orange` label to new issues
-on: [issues]
+name: Add `orange` label to new issues and PR's
+on: [issues, pull_request]
 jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-    - uses: HumanCellAtlas/azul-github-labeler-action@releases/v2
+    - uses: DataBiosphere/azul-github-labeler-action@releases/v4
       with:
         repo-token: "${{secrets.GITHUB_TOKEN}}"
         label: orange


### PR DESCRIPTION
Labeler repo has been migrated to DataBiosphere. Other repos not yet affected. Issue probably should not be closed until PRs are filed for other repos using orange label.