### PR TITLE
Replace str.format with f-strings (#1193)

### DIFF
--- a/src/azul/queues.py
+++ b/src/azul/queues.py
@@ -36,16 +36,16 @@ class Queues:
 
     def list(self):
         logger.info('Listing queues')
-        print('\n{:<35s}{:^20s}{:^20s}{:^18s}\n'.format('Queue Name',
-                                                        'Messages Available',
-                                                        'Messages in Flight',
-                                                        'Messages Delayed'))
+        print(f'\n{"Queue Name":<35s}'
+              f'{"Messages Available":^20s}'
+              f'{"Messages In Flight":^20s}'
+              f'{"Messages Delayed":^18s}\n')
         queues = self.azul_queues()
         for queue_name, queue in queues.items():
-            print('{:<35s}{:^20s}{:^20s}{:^18s}'.format(queue_name,
-                                                        queue.attributes['ApproximateNumberOfMessages'],
-                                                        queue.attributes['ApproximateNumberOfMessagesNotVisible'],
-                                                        queue.attributes['ApproximateNumberOfMessagesDelayed']))
+            print(f'{queue_name:<35s}'
+                  f'{queue.attributes["ApproximateNumberOfMessages"]:^20s}'
+                  f'{queue.attributes["ApproximateNumberOfMessagesNotVisible"]:^20s}'
+                  f'{queue.attributes["ApproximateNumberOfMessagesDelayed"]:^18s}')
 
     def dump(self, queue_name, path):
         sqs = boto3.resource('sqs')

--- a/src/azul/service/elasticsearch_service.py
+++ b/src/azul/service/elasticsearch_service.py
@@ -281,7 +281,7 @@ class ElasticsearchService(AbstractService):
         search_field = field_mapping[search_field] if search_field in field_mapping else search_field
         es_filter_query = self._create_query(filters)
         es_search = es_search.post_filter(es_filter_query)
-        es_search = es_search.query(Q('prefix', **{'{}'.format(search_field): _query}))
+        es_search = es_search.query(Q('prefix', **{str(search_field): _query}))
         return es_search
 
     def _apply_paging(self, es_search, pagination):
@@ -438,7 +438,7 @@ class ElasticsearchService(AbstractService):
         ):
             es_search.aggs.metric(
                 agg_name, 'cardinality',
-                field='{}.keyword'.format(cardinality),
+                field=cardinality + '.keyword',
                 precision_threshold="40000")
 
         self._annotate_aggs_for_translation(es_search)

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -398,8 +398,8 @@ class IntegrationTest(AlwaysTearDownTestCase):
     def _project_removed_from_index(self):
         results_empty = [len(self._get_entities_by_project(entity, self.test_name)) == 0
                          for entity in ['files', 'projects', 'samples', 'bundles']]
-        log.info("Project removed from index files: {}, projects: {}, "
-                 "specimens: {}, bundles: {}".format(*results_empty))
+        log.info('Project removed from index files: %d, projects: %d, '
+                 'specimens: %d, bundles: %d', *results_empty)
         return all(results_empty)
 
     def _get_entities_by_project(self, entity_type, project_short_name):

--- a/test/service/test_pagination.py
+++ b/test/service/test_pagination.py
@@ -91,7 +91,7 @@ class PaginationTestCase(WebServiceTestCase):
         Tests that search_after pagination works for the first returned page.
         :return:
         """
-        content = requests.get("{}?sort=entryId&order=desc".format(self.get_base_url())).content
+        content = requests.get(self.get_base_url() + '?sort=entryId&order=desc').content
         json_response = json.loads(content)
         self.assert_page1_correct(json_response)
 
@@ -101,7 +101,7 @@ class PaginationTestCase(WebServiceTestCase):
         passes from and size variables.
         :return:
         """
-        content = requests.get("{}?sort=entryId&size=10&order=desc".format(self.get_base_url())).content
+        content = requests.get(self.get_base_url() + '?sort=entryId&size=10&order=desc').content
         json_response = json.loads(content)
         self.assert_page1_correct(json_response)
 
@@ -111,16 +111,18 @@ class PaginationTestCase(WebServiceTestCase):
         :return:
         """
         # Fetch and check first page.
-        content = requests.get("{}?sort=entryId&order=desc".format(self.get_base_url())).content
+        content = requests.get(self.get_base_url() + '?sort=entryId&order=desc').content
         json_response = json.loads(content)
         self.assert_page1_correct(json_response)
 
         # Fetch the second page using search_after
         search_after = json_response['pagination']['search_after']
         search_after_uid = json_response['pagination']['search_after_uid']
-        url = "{}?sort=entryId&order=desc&search_after={}&search_after_uid={}".format(self.get_base_url(),
-                                                                                      search_after, search_after_uid)
-        content = requests.get(url).content
+        content = requests.get(self.get_base_url() +
+                               f'?sort=entryId'
+                               f'&order=desc'
+                               f'&search_after={search_after}'
+                               f'&search_after_uid={search_after_uid}').content
         json_response_second = json.loads(content)
         self.assert_page2_correct(json_response, json_response_second, "desc")
 
@@ -129,26 +131,29 @@ class PaginationTestCase(WebServiceTestCase):
         Tests that the last page returned in search_after pagination mode is correct.
         :return:
         """
-        content = requests.get("{}?sort=entryId&order=asc".format(self.get_base_url())).content
+        content = requests.get(self.get_base_url() + '?sort=entryId&order=asc').content
         json_response = json.loads(content)
         self.assert_page1_correct(json_response)
         # Store the search_after for the last result of the first page.
         search_after_lrfp = json_response['pagination']['search_after']
         search_after_lrfp_uid = json_response['pagination']['search_after_uid']
-        content = requests.get("{}?sort=entryId&order=asc&search_after={}&search_after_uid={}"
-                               .format(self.get_base_url(), search_after_lrfp, search_after_lrfp_uid)).content
+        content = requests.get(self.get_base_url() +
+                               f'?sort=entryId'
+                               f'&order=asc'
+                               f'&search_after={search_after_lrfp}'
+                               f'&search_after_uid={search_after_lrfp_uid}').content
         json_response_second = json.loads(content)
         self.assert_page2_correct(json_response, json_response_second, "asc")
 
         search_after = json_response_second['pagination']['search_before']
         search_after_uid = json_response_second['pagination']['search_before_uid']
 
-        content = requests.get(f"{self.get_base_url()}"
-                               f"?sort=entryId"
-                               f"&order=desc"
-                               f"&search_after={search_after}"
-                               f"&search_after_uid={search_after_uid}"
-                               f"&order=desc").content
+        content = requests.get(self.get_base_url() +
+                               f'?sort=entryId'
+                               f'&order=desc'
+                               f'&search_after={search_after}'
+                               f'&search_after_uid={search_after_uid}'
+                               f'&order=desc').content
         json_response = json.loads(content)
         if 'search_before' in json_response['pagination']:
             self.assertEqual(json_response['pagination']['search_before'], search_after_lrfp,
@@ -172,7 +177,7 @@ class PaginationTestCase(WebServiceTestCase):
         :return:
         """
         # Fetch and check first page.
-        content = requests.get("{}?sort=entryId&order=desc".format(self.get_base_url())).content
+        content = requests.get(self.get_base_url() + '?sort=entryId&order=desc').content
         json_response = json.loads(content)
         self.assert_page1_correct(json_response)
 

--- a/test/service/test_request_builder.py
+++ b/test/service/test_request_builder.py
@@ -48,14 +48,14 @@ class TestRequestBuilder(WebServiceTestCase):
         Print the two outputs along with a diff of the two
         """
         print("Comparing the two dictionaries built.")
-        print('{}... => {}...'.format(actual_output[:20], expected_output[:20]))
+        print(f'{actual_output[:20]}... => {expected_output[:20]}...')
         for i, s in enumerate(difflib.ndiff(actual_output, expected_output)):
             if s[0] == ' ':
                 continue
             elif s[0] == '-':
-                print(u'Delete "{}" from position {}'.format(s[-1], i))
+                print(f'Delete "{s[-1]}" from position {i}')
             elif s[0] == '+':
-                print(u'Add "{}" to position {}'.format(s[-1], i))
+                print(f'Add "{s[-1]}" to position {i}')
 
     def test_create_request(self):
         """


### PR DESCRIPTION
A few usages of `str.format` remain in cases where it seemed preferable. In these cases, the format string is not a literal and cannot reasonably be replaced with one:

https://github.com/DataBiosphere/azul/blob/21ef13a8091a6a524682e782a4afa47faa3821e3/lambdas/service/app.py#L1185

https://github.com/DataBiosphere/azul/blob/21ef13a8091a6a524682e782a4afa47faa3821e3/src/azul/__init__.py#L163

https://github.com/DataBiosphere/azul/blob/21ef13a8091a6a524682e782a4afa47faa3821e3/src/azul/__init__.py#L289

In this case, the code was deliberately designed to avoid literals to reduce redundancy: 

https://github.com/DataBiosphere/azul/blob/21ef13a8091a6a524682e782a4afa47faa3821e3/test/integration_test.py#L441