### PR TITLE
Link to /dss/files for response description (#1642)

### DIFF
--- a/lambdas/service/app.py
+++ b/lambdas/service/app.py
@@ -1134,17 +1134,19 @@ def dss_files(uuid):
     'responses': {
         '200': {
             'description': format_description('''
-                DSS checkout with status report, emulating the response code and
-                headers of the `/dss/files/` endpoint. Note that the actual HTTP
-                response will have status 200 while the `Status` field of the
-                body will be 301 or 302. The intent is to emulate HTTP while
-                bypassing the default client behavior, which (in most web
-                browsers) is to ignore `Retry-After`. The response described
-                here is intended to be processed by client-side Javascript such
-                that the recommended delay in `Retry-After` can be handled in
-                Javascript rather that relying on the native implementation by
-                the web browser. See `/dss/files` for the meaning of the
-                response elements.
+                Emulates the response code and headers of the
+                [`/dss/files/`](#operations-DSS-get_dss_files__uuid_) endpoint
+                using JSON (response elements are documented there). Note that
+                the actual HTTP response will have status 200 while the `Status`
+                field of the body will be 301 or 302.
+
+                The intent behind this dual-endpoint scheme is to emulate HTTP
+                while bypassing the default client behavior, which (in most web
+                browsers) is to ignore the `Retry-After` header. The response
+                described here is intended to be processed by client-side
+                Javascript such that the recommended delay in `Retry-After` can
+                be handled in Javascript rather than relying on the native
+                implementation by the web browser.
             '''),
             'content': {
                 'application/json': {


### PR DESCRIPTION
Note that anchor links do not work within the swagger editor. To observe the new functionality, use [my personal deployment](https://service.nadove.dev.singlecell.gi.ucsc.edu/).

Also note that the link opens in a new tab. This is obviously gross but there doesn't seem to be any way around it, although I'd be happy to be proven wrong.