### PR TITLE
Fix typo in CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -542,7 +542,7 @@ Pull Requests
 
 * … we don't eagerly squash them. Changes that address the outcome of a review
   should appear as separate commit. We prefix the title of those commits with
-  ``fixup! `` and follow that with the title of an earlier commit that the
+  ``fixup! `` and follow that with the title of an earlier commit that the
   current commit should be squashed with. A convenient way to create those
   commits is by using the ``--fixup`` option to ``git commit``.
   

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -325,7 +325,7 @@ Code Hygiene
 
 
   While neither ``else`` nor ``pass`` are semantically required, including them
-  anyway expresses the author's intend more strongly, eliminating all doubt in
+  anyway expresses the author's intent more strongly, eliminating all doubt in
   a potential reviewer about whether the author considered the case in which
   the condition is false.
   


### PR DESCRIPTION
Fixes a couple of typos in CONTRIBUTING.rst.

Sorry, this doesn't match the branch naming conventions because I did this from the web interface. But it's on a fork and the changes are really small so I figured it doesn't matter too much.