### PR TITLE
Force compiling of source files during deployment (#1673)

### DIFF
--- a/environment.py
+++ b/environment.py
@@ -347,4 +347,7 @@ def env() -> Mapping[str, Optional[str]]:
 
         # HCA client caches Swagger specs downloaded from the DSS endpoint here
         'XDG_CONFIG_HOME': '{project_root}/.config',
+
+        # This is set only during integration tests. Never override this to 1.
+        'AZUL_TEST_MODE': '0',
     }

--- a/lambdas/indexer/Makefile
+++ b/lambdas/indexer/Makefile
@@ -5,11 +5,7 @@ include ../../common.mk
 include ../lambdas.mk
 
 .PHONY: package
-package: check_branch check_python check_aws config
+package: check_branch check_python check_aws config compile
 	python -m azul.changelog vendor
-	# Ensure a .pyc file is present for every .py file. Set literals will
-	# compile in a non-deterministic order unless PYTHONHASHSEED is set. For a
-	# full explanation see http://benno.id.au/blog/2013/01/15/python-determinism
-	PYTHONHASHSEED=0 python -m compileall -q --invalidation-mode checked-hash vendor vendor/azul
 	chalice package --stage $(AZUL_DEPLOYMENT_STAGE) --pkg-format terraform .chalice/terraform
 	python $(project_root)/scripts/prepare_lambda_deployment.py indexer

--- a/lambdas/indexer/Makefile
+++ b/lambdas/indexer/Makefile
@@ -2,9 +2,7 @@
 all: package
 
 include ../../common.mk
-
-.PHONY: config
-config: .chalice/config.json
+include ../lambdas.mk
 
 .PHONY: package
 package: check_branch check_python check_aws config
@@ -15,11 +13,3 @@ package: check_branch check_python check_aws config
 	PYTHONHASHSEED=0 python -m compileall -q --invalidation-mode checked-hash vendor vendor/azul
 	chalice package --stage $(AZUL_DEPLOYMENT_STAGE) --pkg-format terraform .chalice/terraform
 	python $(project_root)/scripts/prepare_lambda_deployment.py indexer
-
-.PHONY: local
-local: check_python config
-	chalice local
-
-.PHONY: clean
-clean: check_env
-	git clean -Xdf

--- a/lambdas/lambdas.mk
+++ b/lambdas/lambdas.mk
@@ -1,4 +1,33 @@
 
+# The compile target is used during packaging of lambdas. The target ensures
+# that a .pyc file is present for every .py file in the package.
+#
+# One reason to compile before deploying is to reduce lambda start-up time. But
+# more importantly, it ensures that the same files are always included in the
+# Chalice deployment package. Having a consistent, deterministic deployment
+# package allows Terraform to use the hash of the deployment package to easily
+# decide if anything new is being deployed, and skip updating the lambdas
+# otherwise.
+#
+# By default, Python embeds the modify timestamp of the source file into the
+# .pyc and uses this to determine when to re-compile, but since Gitlab clones
+# the repository each time it deploys, fresh timestamps prevented the deployment
+# package from being deterministic. With the `--invalidation-mode checked-hash`
+# option, Python embeds the hash of the source file embeded in the .pyc instead
+# of the timestamp, which is consistent regardless of when the files were
+# downloaded.
+#
+# The `-f` option forces recompilation. This is necessary because timestamp
+# style .pycs may have already been created when other deployment scripts are
+# run, and we need to overwrite them.
+#
+# Set literals will compile in a non-deterministic order unless PYTHONHASHSEED
+# is set. For a full explanation see http://benno.id.au/blog/2013/01/15/python-determinism
+#
+.PHONY: compile
+compile: check_env
+	PYTHONHASHSEED=0 python -m compileall -f -q --invalidation-mode checked-hash vendor vendor/azul
+
 .PHONY: config
 config: .chalice/config.json
 

--- a/lambdas/lambdas.mk
+++ b/lambdas/lambdas.mk
@@ -1,0 +1,11 @@
+
+.PHONY: config
+config: .chalice/config.json
+
+.PHONY: local
+local: check_python config
+	chalice local
+
+.PHONY: clean
+clean: check_env
+	git clean -Xdf

--- a/lambdas/layer/Makefile
+++ b/lambdas/layer/Makefile
@@ -2,9 +2,7 @@
 all: package
 
 include ../../common.mk
-
-.PHONY: config
-config: .chalice/config.json
+include ../lambdas.mk
 
 .PHONY: wheels
 wheels: check_env
@@ -14,7 +12,3 @@ wheels: check_env
 .PHONY: package
 package: check_branch check_python check_aws config wheels
 	python $(project_root)/scripts/stage_layer.py
-
-.PHONY: clean
-clean: check_env
-	git clean -Xdf

--- a/lambdas/service/Makefile
+++ b/lambdas/service/Makefile
@@ -2,9 +2,7 @@
 all: package
 
 include ../../common.mk
-
-.PHONY: config
-config: .chalice/config.json
+include ../lambdas.mk
 
 .PHONY: package
 package: check_branch check_python check_aws config
@@ -15,11 +13,3 @@ package: check_branch check_python check_aws config
 	PYTHONHASHSEED=0 python -m compileall -q --invalidation-mode checked-hash vendor vendor/azul
 	chalice package --stage $(AZUL_DEPLOYMENT_STAGE) --pkg-format terraform .chalice/terraform
 	python $(project_root)/scripts/prepare_lambda_deployment.py service
-
-.PHONY: local
-local: check_python config
-	chalice local
-
-.PHONY: clean
-clean: check_env
-	git clean -Xdf

--- a/lambdas/service/Makefile
+++ b/lambdas/service/Makefile
@@ -5,11 +5,7 @@ include ../../common.mk
 include ../lambdas.mk
 
 .PHONY: package
-package: check_branch check_python check_aws config
+package: check_branch check_python check_aws config compile
 	python -m azul.changelog vendor
-	# Ensure a .pyc file is present for every .py file. Set literals will
-	# compile in a non-deterministic order unless PYTHONHASHSEED is set. For a
-	# full explanation see http://benno.id.au/blog/2013/01/15/python-determinism
-	PYTHONHASHSEED=0 python -m compileall -q --invalidation-mode checked-hash vendor vendor/azul
 	chalice package --stage $(AZUL_DEPLOYMENT_STAGE) --pkg-format terraform .chalice/terraform
 	python $(project_root)/scripts/prepare_lambda_deployment.py service


### PR DESCRIPTION
We have to do "force", because if a `pyc` file is generated before the tests run, it will be generated with a timestamp for validation instead of a hash. This likely is happening when the script to generate the changelog is run. Running compileall won't override this file. The timestamp validation will change between deployments and therefore the package hash won't match between deployments.