### PR TITLE
Allow personal deployment from any branch (#1715)

### DIFF
--- a/scripts/check_branch.py
+++ b/scripts/check_branch.py
@@ -21,9 +21,8 @@ def check_branch(branch: Optional[str], stage: str) -> None:
     RuntimeError: Non-protected branch 'feature/foo' can't be deployed to main deployment 'prod'
 
     >>> check_branch('staging', 'hannes.local')
-    Traceback (most recent call last):
-    ...
-    RuntimeError: Protected branch 'staging' should be deployed to 'staging', not 'hannes.local'
+
+    >>> check_branch('develop', 'hannes.local')
 
     >>> check_branch('staging', 'integration')
     Traceback (most recent call last):
@@ -47,7 +46,7 @@ def check_branch(branch: Optional[str], stage: str) -> None:
             )
     else:
         assert branch is not None
-        if stage != expected_stage:
+        if stage != expected_stage and config.is_main_deployment(stage):
             raise RuntimeError(f"Protected branch '{branch}' should be deployed to '{expected_stage}', not '{stage}'")
 
 

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -465,9 +465,10 @@ class Config:
         'prod': 'prod'
     }
 
-    @property
-    def is_main_deployment(self):
-        return self.deployment_stage in self.main_deployments_by_branch.values()
+    def is_main_deployment(self, stage=None):
+        if stage is None:
+            stage = self.deployment_stage
+        return stage in self.main_deployments_by_branch.values()
 
     @property
     def _git_status(self) -> Mapping[str, str]:

--- a/terraform/s3.tf.json.template.py
+++ b/terraform/s3.tf.json.template.py
@@ -20,7 +20,7 @@ emit_tf({
                 },
                 "url_bucket": {
                     "bucket": config.url_redirect_full_domain_name,
-                    "force_destroy": not config.is_main_deployment,
+                    "force_destroy": not config.is_main_deployment(),
                     "acl": "public-read",
                     "website": {
                         # index_document is required; pointing to a non-existent file to return a 404

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -446,7 +446,7 @@ class IntegrationTest(AzulTestCase, AlwaysTearDownTestCase):
         notifications = [invalid_notification]
         self.assertRaises(AzulClientNotificationError, self.azul_client._index, notifications)
 
-    @unittest.skipIf(config.is_main_deployment, 'Test would pollute portal DB')
+    @unittest.skipIf(config.is_main_deployment(), 'Test would pollute portal DB')
     def test_concurrent_portal_db_crud(self):
         """
         Use multithreading to simulate multiple users simultaneously modifying


### PR DESCRIPTION
Changes the behavior of check_branch to permit deploying protected
branches to a personal stage. A deployment to an improper protected
stage will still fail (e.g., trying to deploy `develop` to `prod`, or
something unfortunate like that).