### PR TITLE
Use qualified_resource_name for object version table name (#1944)

### DIFF
--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -311,6 +311,13 @@ class Config:
         ...
         azul.RequirementError
 
+        >>> config.unqualified_resource_name('azul-object_versions-dev')
+        ('object_versions', 'dev')
+
+        >>> config.unqualified_resource_name('azul-object-versions-dev')
+        Traceback (most recent call last):
+        ...
+        azul.RequirementError
 
         :param qualified_resource_name:
         :param suffix:
@@ -730,7 +737,7 @@ class Config:
 
     @property
     def dynamo_object_version_table_name(self) -> str:
-        return f'azul-{self.deployment_stage}-object-versions'
+        return self.qualified_resource_name('object_versions')
 
     terms_aggregation_size = 99999
 


### PR DESCRIPTION
As requested during standup, I've confirmed that this change results in the DynamoDB table being replaced entirely.

```console
$ make package && make deploy
$ # Apply changes
$ make package && make deploy
...
  # aws_dynamodb_table.versions_table must be replaced
-/+ resource "aws_dynamodb_table" "versions_table" {
      ~ arn              = "arn:aws:dynamodb:us-east-1:122796619775:table/azul-natan-object-versions" -> (known after apply)
        billing_mode     = "PAY_PER_REQUEST"
        hash_key         = "object_url"
      ~ id               = "azul-natan-object-versions" -> (known after apply)
      ~ name             = "azul-natan-object-versions" -> "azul-object_versions-natan" # forces replacement
      - read_capacity    = 0 -> null
      + stream_arn       = (known after apply)
      - stream_enabled   = false -> null
      + stream_label     = (known after apply)
      + stream_view_type = (known after apply)
      - tags             = {} -> null
      - write_capacity   = 0 -> null

        attribute {
            name = "object_url"
            type = "S"
        }

      ~ point_in_time_recovery {
          ~ enabled = false -> (known after apply)
        }

      + server_side_encryption {
          + enabled     = (known after apply)
          + kms_key_arn = (known after apply)
        }

      - ttl {
          - enabled = false -> null
        }
    }
...
```