### PR TITLE
Use multithreading when reading TDR bigquery tables (#2021)

### DIFF
--- a/environment.py
+++ b/environment.py
@@ -230,9 +230,9 @@ def env() -> Mapping[str, Optional[str]]:
         #
         'AZUL_VERSIONED_BUCKET': 'edu-ucsc-gi-singlecell-azul-config-dev.{AWS_DEFAULT_REGION}',
 
-        # The number of workers pulling files from DSS. There is one such set of DSS
-        # workers per index worker!
-        'AZUL_DSS_WORKERS': '8',
+        # The number of workers pulling files from the repository (DSS or TDR).
+        # There is one such set of repository workers per index worker!
+        'AZUL_REPO_WORKERS': '8',
 
         # Whether to create a subscription to DSS during deployment. Set this
         # variable to 1 to enable `make subscribe` to subscribe the indexer in

--- a/scripts/can-bundle.py
+++ b/scripts/can-bundle.py
@@ -59,12 +59,12 @@ def main(argv):
     args = parser.parse_args(argv)
 
     dss_client = azul.dss.direct_access_client(dss_endpoint=args.dss_url,
-                                               num_workers=config.num_dss_workers)
+                                               num_workers=config.num_repo_workers)
     version, manifest, metadata_files = download_bundle_metadata(client=dss_client,
                                                                  replica=args.replica,
                                                                  uuid=args.uuid,
                                                                  version=args.version,
-                                                                 num_workers=config.num_dss_workers)
+                                                                 num_workers=config.num_repo_workers)
     logger.info('Downloaded bundle %s version %s from replica %s.', args.uuid, version, args.replica)
 
     api_json = as_json(Bundle(args.uuid, version, manifest, metadata_files)) if args.api_json else None

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -217,8 +217,8 @@ class Config:
                 return role_arn
 
     @property
-    def num_dss_workers(self) -> int:
-        return int(os.environ['AZUL_DSS_WORKERS'])
+    def num_repo_workers(self) -> int:
+        return int(os.environ['AZUL_REPO_WORKERS'])
 
     @property
     def external_lambda_role_assumptors(self) -> MutableMapping[str, List[str]]:

--- a/src/azul/plugins/repository/dss/__init__.py
+++ b/src/azul/plugins/repository/dss/__init__.py
@@ -72,13 +72,13 @@ class Plugin(RepositoryPlugin):
         now = time.time()
         # One client per invocation. That's OK because the client will be used
         # for many requests and a typical lambda invocation calls this only once.
-        dss_client = direct_access_client(num_workers=config.num_dss_workers)
+        dss_client = direct_access_client(num_workers=config.num_repo_workers)
         version, manifest, metadata_files = download_bundle_metadata(
             client=dss_client,
             replica='aws',
             uuid=bundle_fqid.uuid,
             version=bundle_fqid.version,
-            num_workers=config.num_dss_workers
+            num_workers=config.num_repo_workers
         )
         bundle = Bundle.for_fqid(
             bundle_fqid,

--- a/src/azul/tdr.py
+++ b/src/azul/tdr.py
@@ -299,9 +299,9 @@ class AzulTDRClient:
             link_type = link['link_type']
             if link_type == 'process_link':
                 entities[link['process_type']].add(link['process_id'])
-                for catgeory in ('input', 'output', 'protocol'):
-                    for entity_ref in link[catgeory + 's']:
-                        entities[entity_ref[catgeory + '_type']].add(entity_ref[catgeory + '_id'])
+                for category in ('input', 'output', 'protocol'):
+                    for entity_ref in link[category + 's']:
+                        entities[entity_ref[category + '_type']].add(entity_ref[category + '_id'])
             elif link_type == 'supplementary_file_link':
                 # For MVP, only project entities can have associated supplementary files.
                 entity = link['entity']

--- a/src/azul/tdr.py
+++ b/src/azul/tdr.py
@@ -109,17 +109,17 @@ class ManifestEntry(NamedTuple):
     @property
     def entry(self):
         return {
-            "name": self.name,
-            "uuid": self.uuid,
-            "version": self.version,
-            "content-type": f"{self.content_type}; dcp-type={self.dcp_type}",
-            "size": self.size,
+            'name': self.name,
+            'uuid': self.uuid,
+            'version': self.version,
+            'content-type': f'{self.content_type}; dcp-type={self.dcp_type}',
+            'size': self.size,
             **(
                 {
-                    "indexed": False,
+                    'indexed': False,
                     **self.checksums.asdict()
                 } if self.dcp_type == 'data' else {
-                    "indexed": True,
+                    'indexed': True,
                     **Checksums.without_values()
                 }
             )
@@ -140,7 +140,7 @@ class ManifestBundler:
                                            version=entity_row['version'].strftime(AzulTDRClient.timestamp_format),
                                            size=entity_row['content_size'],
                                            content_type='application/json',
-                                           dcp_type=f'\"metadata/{content_type}\"',
+                                           dcp_type=f'"metadata/{content_type}"',
                                            checksums=None).entry)
         if entity_type.endswith('_file'):
             descriptor = json.loads(entity_row['descriptor'])
@@ -259,7 +259,7 @@ class AzulTDRClient:
         current_bundles = self._query_latest_version(f'''
             SELECT links_id, version
             FROM {self.target.name}.links
-            WHERE STARTS_WITH(links_id, "{prefix}")
+            WHERE STARTS_WITH(links_id, '{prefix}')
         ''', group_by='links_id')
         return [BundleFQID(uuid=row['links_id'],
                            version=row['version'].strftime(self.timestamp_format))
@@ -286,8 +286,8 @@ class AzulTDRClient:
         links_row = one(self.big_query_adapter.run_sql(f'''
             SELECT {links_columns}
             FROM {self.target.name}.links
-            WHERE links_id = "{bundle_fqid.uuid}"
-                AND version = TIMESTAMP("{bundle_fqid.version}")
+            WHERE links_id = '{bundle_fqid.uuid}'
+                AND version = TIMESTAMP('{bundle_fqid.version}')
         '''))
         links_json = json.loads(links_row['content'])
         log.info('Retrieved links content, %s top-level links', len(links_json['links']))

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -633,7 +633,7 @@ class DSSIntegrationTest(AzulTestCase):
                                                                  replica=replica,
                                                                  uuid=bundle_uuid,
                                                                  version=bundle_version,
-                                                                 num_workers=config.num_dss_workers)
+                                                                 num_workers=config.num_repo_workers)
             log.info('Captured log calls: %r', captured_log.mock_calls)
             self.assertGreater(len(metadata), 0)
             self.assertGreater(set(f['name'] for f in manifest), set(metadata.keys()))

--- a/test/service/test_tdr.py
+++ b/test/service/test_tdr.py
@@ -28,6 +28,7 @@ from tinyquery import (
 )
 
 from azul import (
+    RequirementError,
     cached_property,
     config,
     dss,
@@ -297,13 +298,13 @@ class TestTDRClient(AzulTestCase):
 
         with self.subTest('invalid entity id'):
             new_link['entity']['entity_type'] = 'cell_suspension'
-            with self.assertRaises(ValueError):
+            with self.assertRaises(RequirementError):
                 self._test_bundle(dataset, test_bundle)
 
         with self.subTest('invalid entity type'):
             new_link['entity']['entity_type'] = 'project'
             new_link['entity']['entity_id'] = project + 'bad'
-            with self.assertRaises(ValueError):
+            with self.assertRaises(RequirementError):
                 self._test_bundle(dataset, test_bundle)
 
     def convert_metadata(self, metadata: MutableJSON) -> MutableJSON:


### PR DESCRIPTION
Currently seeing a 4-5x speedup on fetching one bundle on the initial commit