### PR TITLE
Prevent failure due to `write` AWS lambda memory exhaustion (#2013)

### DIFF
--- a/lambdas/indexer/.chalice/config.json.template.py
+++ b/lambdas/indexer/.chalice/config.json.template.py
@@ -23,7 +23,7 @@ emit({
                     "lambda_timeout": config.indexer_lambda_timeout,
                 },
                 "write": {
-                    "lambda_memory_size": 2048,
+                    "lambda_memory_size": 3008,
                     "lambda_timeout": config.indexer_lambda_timeout,
                 },
                 "nudge": {


### PR DESCRIPTION
The fix was copied from PR #1716 which resolved #1693.

[Edit] Supersedes https://github.com/DataBiosphere/azul/pull/2032