### PR TITLE
Remove `:` from versions in BDBag manifest (#2064)

### DIFF
--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -844,7 +844,8 @@ class BDBagManifestGenerator(FileBasedManifestGenerator):
             # For each bundle containing the current file …
             doc_bundle: JSON
             for doc_bundle in doc['bundles']:
-                bundle_fqid: FQID = (doc_bundle['uuid'], doc_bundle['version'])
+                # Versions indexed by TDR contain ':', but Terra won't allow ':' in the 'entity:participant_id' field
+                bundle_fqid: FQID = doc_bundle['uuid'], doc_bundle['version'].replace(':', '')
 
                 bundle_cells = {'entity:participant_id': '.'.join(bundle_fqid)}
                 self._extract_fields([doc_bundle], bundle_column_mapping, bundle_cells)

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -844,7 +844,8 @@ class BDBagManifestGenerator(FileBasedManifestGenerator):
             # For each bundle containing the current file …
             doc_bundle: JSON
             for doc_bundle in doc['bundles']:
-                # Versions indexed by TDR contain ':', but Terra won't allow ':' in the 'entity:participant_id' field
+                # Versions indexed by TDR contain ':', but Terra won't allow ':'
+                # in the 'entity:participant_id' field
                 bundle_fqid: FQID = doc_bundle['uuid'], doc_bundle['version'].replace(':', '')
 
                 bundle_cells = {'entity:participant_id': '.'.join(bundle_fqid)}

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -310,9 +310,13 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
             data_path = os.path.join(os.path.dirname(first(zip_fh.namelist())), 'data')
             file_path = os.path.join(data_path, 'participants.tsv')
             with zip_fh.open(file_path) as file:
-                self.__check_manifest(file, 'bundle_uuid', bdbag=True)
+                rows = self.__check_manifest(file, 'bundle_uuid')
+                for row in rows:
+                    # Terra doesn't allow colons in this column, but they may
+                    # exist in versions indexed by TDR
+                    self.assertNotIn(':', row['entity:participant_id'])
 
-    def __check_manifest(self, file: IO[bytes], uuid_field_name: str, bdbag: bool = False):
+    def __check_manifest(self, file: IO[bytes], uuid_field_name: str) -> List[Mapping[str, str]]:
         text = TextIOWrapper(file)
         reader = csv.DictReader(text, delimiter='\t')
         rows = list(reader)
@@ -321,11 +325,7 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
         self.assertIn(uuid_field_name, reader.fieldnames)
         bundle_uuid = rows[0][uuid_field_name]
         self.assertEqual(bundle_uuid, str(uuid.UUID(bundle_uuid)))
-        if bdbag:
-            for row in rows:
-                # Terra doesn't allow colons in this column, but they may exist
-                # in versions indexed by TDR
-                self.assertNotIn(':', row['entity:participant_id'])
+        return rows
 
     def _test_drs(self, file_uuid: str):
         base_url = config.service_endpoint() + http_object_path('')


### PR DESCRIPTION
~I wasn't sure how fine grained of an approach to take so I just stripped out all `:` in all regex matches that look like a bundle version.~

~I intended to recreate the problem on my deployment and add a test that recreates this, but I realized that this involved indexing data in TDR, so I've postponed. I believe this fix will work, but it's not a very precise solution.~