### PR TITLE
Clean up Terraform resource names (#2033)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,7 +95,7 @@ early_reindex:
   when: manual
   script:
     - make reindex
-  timeout: 6h 10m  # also see max_timeout in reindex.py
+  timeout: 13h 10m  # also see max_timeout in reindex.py
 
 reindex:
   extends: .base
@@ -103,4 +103,4 @@ reindex:
   when: manual
   script:
     - make reindex
-  timeout: 6h 10m  # also see max_timeout in reindex.py
+  timeout: 13h 10m  # also see max_timeout in reindex.py

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,7 +95,7 @@ early_reindex:
   when: manual
   script:
     - make reindex
-  timeout: 6h 10m  # to allow the waiting on message queues by reindex.py time to complete
+  timeout: 6h 10m  # also see max_timeout in reindex.py
 
 reindex:
   extends: .base
@@ -103,4 +103,4 @@ reindex:
   when: manual
   script:
     - make reindex
-  timeout: 6h 10m  # to allow the waiting on message queues by reindex.py time to complete
+  timeout: 6h 10m  # also see max_timeout in reindex.py

--- a/scripts/reindex.py
+++ b/scripts/reindex.py
@@ -120,7 +120,7 @@ def main(argv: List[str]):
         if args.wait:
             # Match max_timeout to reindex job timeout in `.gitlab-ci.yml`
             azul_client.wait_for_indexer(min_timeout=10 * 60 if config.dss_query_prefix else None,
-                                         max_timeout=6 * 60 * 60)
+                                         max_timeout=13 * 60 * 60)
 
 
 if __name__ == "__main__":

--- a/scripts/reindex.py
+++ b/scripts/reindex.py
@@ -118,9 +118,9 @@ def main(argv: List[str]):
             else:
                 azul_client.reindex(catalog)
         if args.wait:
-            # Total wait time for queues must be less than timeout in `.gitlab-ci.yml`
-            min_timeout = 10 * 60 if config.dss_query_prefix else None
-            azul_client.wait_for_indexer(min_timeout=min_timeout)
+            # Match max_timeout to reindex job timeout in `.gitlab-ci.yml`
+            azul_client.wait_for_indexer(min_timeout=10 * 60 if config.dss_query_prefix else None,
+                                         max_timeout=6 * 60 * 60)
 
 
 if __name__ == "__main__":

--- a/scripts/rename_resources.py
+++ b/scripts/rename_resources.py
@@ -7,6 +7,7 @@ from azul.logging import (
 )
 
 log = logging.getLogger(__name__)
+
 renamed = {
     'aws_cloudwatch_log_group.azul_error_log': 'aws_cloudwatch_log_group.error_log',
     'aws_cloudwatch_log_group.azul_index_log': 'aws_cloudwatch_log_group.index_log',
@@ -37,16 +38,16 @@ def terraform_state(*args):
 
 
 def main():
-    for resource in terraform_state('list').stdout.decode().splitlines():
+    current_names = terraform_state('list').stdout.decode().splitlines()
+    for current_name in current_names:
         try:
-            log.info('Found %r, renaming to %r', resource, renamed[resource])
+            new_name = renamed[current_name]
         except KeyError:
-            if resource in renamed.values():
-                log.info('Found %r, already renamed', resource)
-            else:
-                pass
+            if current_name in renamed.values():
+                log.info('Found %r, already renamed', current_name)
         else:
-            terraform_state('mv', resource, renamed[resource])
+            log.info('Found %r, renaming to %r', current_name, new_name)
+            terraform_state('mv', current_name, new_name)
 
 
 if __name__ == '__main__':

--- a/scripts/rename_resources.py
+++ b/scripts/rename_resources.py
@@ -1,0 +1,54 @@
+import logging
+import os
+import subprocess
+
+from azul.logging import (
+    configure_script_logging,
+)
+
+log = logging.getLogger(__name__)
+renamed = {
+    'aws_cloudwatch_log_group.azul_error_log': 'aws_cloudwatch_log_group.error_log',
+    'aws_cloudwatch_log_group.azul_index_log': 'aws_cloudwatch_log_group.index_log',
+    'aws_cloudwatch_log_group.azul_search_log': 'aws_cloudwatch_log_group.search_log',
+    'aws_cloudwatch_log_resource_policy.azul_es_cloudwatch_policy': 'aws_cloudwatch_log_resource_policy.index',
+    'aws_dynamodb_table.cart_items_table': 'aws_dynamodb_table.cart_items',
+    'aws_dynamodb_table.carts_table': 'aws_dynamodb_table.carts',
+    'aws_dynamodb_table.users_table': 'aws_dynamodb_table.users',
+    'aws_dynamodb_table.versions_table': 'aws_dynamodb_table.object_versions',
+    'aws_elasticsearch_domain.elasticsearch[0]': 'aws_elasticsearch_domain.index',
+    'aws_iam_role.state_machine_iam_role': 'aws_iam_role.states',
+    'aws_iam_role_policy.state_machine_iam_policy': 'aws_iam_role_policy.states',
+    'aws_s3_bucket.bucket': 'aws_s3_bucket.storage',
+    'aws_s3_bucket.url_bucket': 'aws_s3_bucket.urls',
+    'aws_sfn_state_machine.cart_export_state_machine': 'aws_sfn_state_machine.cart_export',
+    'aws_sfn_state_machine.cart_item_state_machine': 'aws_sfn_state_machine.cart_item',
+    'aws_sfn_state_machine.manifest_state_machine': 'aws_sfn_state_machine.manifest',
+    'null_resource.hmac-secret': 'null_resource.hmac_secret'
+}
+
+
+def terraform_state(*args):
+    return subprocess.run(['terraform', 'state', *args],
+                          cwd=os.path.join(os.environ['project_root'], 'terraform'),
+                          check=True,
+                          capture_output=True,
+                          shell=False)
+
+
+def main():
+    for resource in terraform_state('list').stdout.decode().splitlines():
+        try:
+            log.info('Found %r, renaming to %r', resource, renamed[resource])
+        except KeyError:
+            if resource in renamed.values():
+                log.info('Found %r, already renamed', resource)
+            else:
+                pass
+        else:
+            terraform_state('mv', resource, renamed[resource])
+
+
+if __name__ == '__main__':
+    configure_script_logging(log)
+    main()

--- a/src/azul/queues.py
+++ b/src/azul/queues.py
@@ -238,8 +238,10 @@ class Queues:
         start_time = time.time()
         num_bundles = 0
 
-        logger.info('Waiting for %s queues to %s ...',
-                    len(queues), 'drain' if empty else 'fill')
+        logger.info('Waiting for %s queues to %s notifications about %s bundles ...',
+                    len(queues),
+                    'be drained of' if empty else 'fill with',
+                    'an unknown number of' if num_expected_bundles is None else num_expected_bundles)
 
         while True:
             # Determine queue lengths

--- a/src/azul/queues.py
+++ b/src/azul/queues.py
@@ -267,7 +267,10 @@ class Queues:
                 else:
                     num_bundles = num_expected_bundles
                 # It takes approx. 6 seconds per worker to process a bundle
-                timeout = limit_timeout(6 * num_bundles / config.indexer_concurrency)
+                # FIXME: Temporarily doubling the time, but needs fine-tuning
+                #        https://github.com/DataBiosphere/azul/issues/2147
+                #        https://github.com/DataBiosphere/azul/issues/2189
+                timeout = limit_timeout(12 * num_bundles / config.indexer_concurrency)
 
             # Do we have time left?
             remaining_time = start_time + timeout - time.time()

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -10,6 +10,10 @@ config: $(patsubst %.template.py,%,$(wildcard *.tf.json.template.py))
 init: check_terraform check_branch check_aws config
 	terraform init
 
+.PHONY: rename_resources
+rename_resources: init
+	python $(project_root)/scripts/rename_resources.py
+
 .PHONY: validate
 validate: init
 	terraform validate
@@ -19,7 +23,7 @@ plan: validate
 	terraform plan
 
 .PHONY: apply
-apply: validate
+apply: validate rename_resources
 	$(MAKE) unlink_health_checks
 	terraform apply
 	$(MAKE) link_health_checks
@@ -27,7 +31,7 @@ apply: validate
 	$(MAKE) sam
 
 .PHONY: auto_apply
-auto_apply: validate
+auto_apply: validate rename_resources
 	$(MAKE) unlink_health_checks
 	terraform apply -auto-approve
 	$(MAKE) link_health_checks

--- a/terraform/authentication.tf.json.template.py
+++ b/terraform/authentication.tf.json.template.py
@@ -42,7 +42,7 @@ emit_tf({
                 }
             },
             "null_resource": {
-                "hmac-secret": {
+                "hmac_secret": {
                     "provisioner": [
                         {
                             "local-exec": {

--- a/terraform/dynamo.tf.json.template.py
+++ b/terraform/dynamo.tf.json.template.py
@@ -13,7 +13,7 @@ emit_tf(
         "resource": [
             {
                 "aws_dynamodb_table": {
-                    "users_table": {
+                    "users": {
                         "name": config.dynamo_user_table_name,
                         "billing_mode": "PAY_PER_REQUEST",
                         "hash_key": "UserId",
@@ -24,7 +24,7 @@ emit_tf(
                             }
                         ]
                     },
-                    "carts_table": {
+                    "carts": {
                         "name": config.dynamo_cart_table_name,
                         "billing_mode": "PAY_PER_REQUEST",
                         "hash_key": "UserId",
@@ -57,7 +57,7 @@ emit_tf(
                             }
                         ]
                     },
-                    "cart_items_table": {
+                    "cart_items": {
                         "name": config.dynamo_cart_item_table_name,
                         "billing_mode": "PAY_PER_REQUEST",
                         "hash_key": "CartId",
@@ -73,7 +73,7 @@ emit_tf(
                             }
                         ]
                     },
-                    "versions_table": {
+                    "object_versions": {
                         "name": config.dynamo_object_version_table_name,
                         "billing_mode": "PAY_PER_REQUEST",
                         "hash_key": VersionService.key_name,

--- a/terraform/modules.tf.json.template.py
+++ b/terraform/modules.tf.json.template.py
@@ -18,11 +18,11 @@ emit_tf({
             "es_endpoint":
                 aws.es_endpoint
                 if config.share_es_domain else
-                ("${aws_elasticsearch_domain.elasticsearch[0].endpoint}", 443),
+                ("${aws_elasticsearch_domain.index.endpoint}", 443),
             "es_instance_count":
                 aws.es_instance_count
                 if config.share_es_domain else
-                "${aws_elasticsearch_domain.elasticsearch[0].cluster_config[0].instance_count}",
+                "${aws_elasticsearch_domain.index.cluster_config[0].instance_count}",
         } for lambda_name in config.lambda_names()
     }
 })

--- a/terraform/s3.tf.json.template.py
+++ b/terraform/s3.tf.json.template.py
@@ -9,7 +9,7 @@ emit_tf({
     "resource": [
         {
             "aws_s3_bucket": {
-                "bucket": {
+                "storage": {
                     "bucket": config.s3_bucket,
                     "acl": "private",
                     "force_destroy": True,
@@ -22,7 +22,7 @@ emit_tf({
                         }
                     }
                 },
-                "url_bucket": {
+                "urls": {
                     "bucket": config.url_redirect_full_domain_name,
                     "force_destroy": not config.is_main_deployment(),
                     "acl": "public-read",
@@ -40,7 +40,7 @@ emit_tf({
                     "name": config.url_redirect_full_domain_name,
                     "type": "CNAME",
                     "ttl": "300",
-                    "records": ["${aws_s3_bucket.url_bucket.website_endpoint}"]
+                    "records": ["${aws_s3_bucket.urls.website_endpoint}"]
                 }
             }
         }] if config.url_redirect_base_domain_name else [])

--- a/terraform/step_function.tf.json.template.py
+++ b/terraform/step_function.tf.json.template.py
@@ -37,7 +37,7 @@ def cart_item_states():
 emit_tf({
     "resource": {
         "aws_iam_role": {
-            "state_machine_iam_role": {
+            "states": {
                 "name": config.qualified_resource_name("statemachine"),
                 "assume_role_policy": json.dumps({
                     "Version": "2012-10-17",
@@ -56,9 +56,9 @@ emit_tf({
             }
         },
         "aws_iam_role_policy": {
-            "state_machine_iam_policy": {
+            "states": {
                 "name": config.qualified_resource_name("statemachine"),
-                "role": "${aws_iam_role.state_machine_iam_role.id}",
+                "role": "${aws_iam_role.states.id}",
                 "policy": json.dumps({
                     "Version": "2012-10-17",
                     "Statement": [
@@ -78,9 +78,9 @@ emit_tf({
             }
         },
         "aws_sfn_state_machine": {
-            "manifest_state_machine": {
+            "manifest": {
                 "name": config.manifest_state_machine_name,
-                "role_arn": "${aws_iam_role.state_machine_iam_role.arn}",
+                "role_arn": "${aws_iam_role.states.arn}",
                 "definition": json.dumps({
                     "StartAt": "WriteManifest",
                     "States": {
@@ -92,17 +92,17 @@ emit_tf({
                     }
                 }, indent=2)
             },
-            "cart_item_state_machine": {
+            "cart_item": {
                 "name": config.cart_item_state_machine_name,
-                "role_arn": "${aws_iam_role.state_machine_iam_role.arn}",
+                "role_arn": "${aws_iam_role.states.arn}",
                 "definition": json.dumps({
                     "StartAt": "WriteBatch",
                     "States": cart_item_states()
                 }, indent=2)
             },
-            "cart_export_state_machine": {
+            "cart_export": {
                 "name": config.cart_export_state_machine_name,
-                "role_arn": "${aws_iam_role.state_machine_iam_role.arn}",
+                "role_arn": "${aws_iam_role.states.arn}",
                 "definition": json.dumps({
                     "StartAt": "SendToCollectionAPI",
                     "States": {

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -129,7 +129,7 @@ class IntegrationTestCase(AzulTestCase, metaclass=ABCMeta):
 class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
     prefix_length = 2
     max_bundles = 64
-    min_timeout = 10 * 60
+    min_timeout = 20 * 60
 
     @classmethod
     def setUpClass(cls) -> None:


### PR DESCRIPTION
Rename Terraform resources for consistency, and add a script that
renames existing resources when `make deploy` is called.