### PR TITLE
Add 'sequencing_input' in 'terra.bdbag' manifests (#2113)

### DIFF
--- a/src/azul/project/hca/__init__.py
+++ b/src/azul/project/hca/__init__.py
@@ -198,6 +198,11 @@ class Plugin(azul.plugin.Plugin):
                     "_entity_type": "entity_type",
                     "sample.provenance.document_id": "document_id",
                     "sample.biomaterial_core.biomaterial_id": "biomaterial_id"
+                },
+                "contents.sequencing_inputs": {
+                    "sequencing_input.provenance.document_id": "document_id",
+                    "sequencing_input.biomaterial_core.biomaterial_id": "biomaterial_id",
+                    "sequencing_input_type": "sequencing_input_type"
                 }
             },
             cart_item={

--- a/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T113344.698028Z.results.json
+++ b/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T113344.698028Z.results.json
@@ -33,6 +33,13 @@
                         "_type": "specimen"
                     }
                 ],
+                "sequencing_inputs": [
+                    {
+                        "biomaterial_id": "GSM2172585 1",
+                        "document_id": "412898c5-5b9b-4907-b07c-e9b89666e204",
+                        "sequencing_input_type": "cell_suspension"
+                    }
+                ],
                 "sequencing_processes": [
                     {
                         "document_id": "771ddaf6-3a4f-4314-97fe-6294ff8e25a4"
@@ -453,6 +460,13 @@
                         "_type": "specimen"
                     }
                 ],
+                "sequencing_inputs": [
+                    {
+                        "biomaterial_id": "GSM2172585 1",
+                        "document_id": "412898c5-5b9b-4907-b07c-e9b89666e204",
+                        "sequencing_input_type": "cell_suspension"
+                    }
+                ],
                 "sequencing_processes": [
                     {
                         "document_id": "771ddaf6-3a4f-4314-97fe-6294ff8e25a4"
@@ -662,6 +676,13 @@
                         "_type": "specimen"
                     }
                 ],
+                "sequencing_inputs": [
+                    {
+                        "biomaterial_id": "GSM2172585 1",
+                        "document_id": "412898c5-5b9b-4907-b07c-e9b89666e204",
+                        "sequencing_input_type": "cell_suspension"
+                    }
+                ],
                 "sequencing_processes": [
                     {
                         "document_id": "771ddaf6-3a4f-4314-97fe-6294ff8e25a4"
@@ -869,6 +890,13 @@
                         "storage_method": "~null",
                         "preservation_method": "~null",
                         "_type": "specimen"
+                    }
+                ],
+                "sequencing_inputs": [
+                    {
+                        "biomaterial_id": "GSM2172585 1",
+                        "document_id": "412898c5-5b9b-4907-b07c-e9b89666e204",
+                        "sequencing_input_type": "cell_suspension"
                     }
                 ],
                 "sequencing_processes": [
@@ -1098,6 +1126,13 @@
                         "storage_method": "~null",
                         "preservation_method": "~null",
                         "_type": "specimen"
+                    }
+                ],
+                "sequencing_inputs": [
+                    {
+                        "biomaterial_id": "GSM2172585 1",
+                        "document_id": "412898c5-5b9b-4907-b07c-e9b89666e204",
+                        "sequencing_input_type": "cell_suspension"
                     }
                 ],
                 "sequencing_processes": [
@@ -1346,6 +1381,19 @@
                         ],
                         "_type": [
                             "specimen"
+                        ]
+                    }
+                ],
+                "sequencing_inputs": [
+                    {
+                        "biomaterial_id": [
+                            "GSM2172585 1"
+                        ],
+                        "document_id": [
+                            "412898c5-5b9b-4907-b07c-e9b89666e204"
+                        ],
+                        "sequencing_input_type": [
+                            "cell_suspension"
                         ]
                     }
                 ],
@@ -1805,6 +1853,19 @@
                         ]
                     }
                 ],
+                "sequencing_inputs": [
+                    {
+                        "biomaterial_id": [
+                            "GSM2172585 1"
+                        ],
+                        "document_id": [
+                            "412898c5-5b9b-4907-b07c-e9b89666e204"
+                        ],
+                        "sequencing_input_type": [
+                            "cell_suspension"
+                        ]
+                    }
+                ],
                 "sequencing_processes": [
                     {
                         "document_id": [
@@ -2050,6 +2111,19 @@
                         ]
                     }
                 ],
+                "sequencing_inputs": [
+                    {
+                        "biomaterial_id": [
+                            "GSM2172585 1"
+                        ],
+                        "document_id": [
+                            "412898c5-5b9b-4907-b07c-e9b89666e204"
+                        ],
+                        "sequencing_input_type": [
+                            "cell_suspension"
+                        ]
+                    }
+                ],
                 "sequencing_processes": [
                     {
                         "document_id": [
@@ -2267,6 +2341,19 @@
                         "storage_method": "~null",
                         "preservation_method": "~null",
                         "_type": "specimen"
+                    }
+                ],
+                "sequencing_inputs": [
+                    {
+                        "biomaterial_id": [
+                            "GSM2172585 1"
+                        ],
+                        "document_id": [
+                            "412898c5-5b9b-4907-b07c-e9b89666e204"
+                        ],
+                        "sequencing_input_type": [
+                            "cell_suspension"
+                        ]
                     }
                 ],
                 "sequencing_processes": [
@@ -2500,6 +2587,19 @@
                         ],
                         "_type": [
                             "specimen"
+                        ]
+                    }
+                ],
+                "sequencing_inputs": [
+                    {
+                        "biomaterial_id": [
+                            "GSM2172585 1"
+                        ],
+                        "document_id": [
+                            "412898c5-5b9b-4907-b07c-e9b89666e204"
+                        ],
+                        "sequencing_input_type": [
+                            "cell_suspension"
                         ]
                     }
                 ],
@@ -2739,6 +2839,13 @@
                         "preservation_method": "~null",
                         "_type": "specimen",
                         "effective_organ": "pancreas"
+                    }
+                ],
+                "sequencing_inputs": [
+                    {
+                        "biomaterial_id": "GSM2172585 1",
+                        "document_id": "412898c5-5b9b-4907-b07c-e9b89666e204",
+                        "sequencing_input_type": "cell_suspension"
                     }
                 ],
                 "sequencing_processes": [
@@ -2993,6 +3100,19 @@
                         ],
                         "effective_organ": [
                             "pancreas"
+                        ]
+                    }
+                ],
+                "sequencing_inputs": [
+                    {
+                        "biomaterial_id": [
+                            "GSM2172585 1"
+                        ],
+                        "document_id": [
+                            "412898c5-5b9b-4907-b07c-e9b89666e204"
+                        ],
+                        "sequencing_input_type": [
+                            "cell_suspension"
                         ]
                     }
                 ],

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -174,6 +174,16 @@ class TestManifestEndpoints(WebServiceTestCase):
              'aaaaaaaa-7bab-44ba-a81d-3d8cb3873244 || b4e55fe1-7bab-44ba-a81d-3d8cb3873244'),
 
             ('sample.biomaterial_core.biomaterial_id', '', '1209_T || 1210_T'),
+
+            ('sequencing_input.provenance.document_id',
+             '0037c9eb-8038-432f-8d9d-13ee094e54ab || aaaaaaaa-8038-432f-8d9d-13ee094e54ab',
+             '0037c9eb-8038-432f-8d9d-13ee094e54ab || aaaaaaaa-8038-432f-8d9d-13ee094e54ab'),
+
+            ('sequencing_input.biomaterial_core.biomaterial_id',
+             '22028_5#300 || 22030_5#300',
+             '22028_5#300 || 22030_5#300'),
+
+            ('sequencing_input_type', 'cell_suspension', 'cell_suspension')
         ]
         self.maxDiff = None
         self._index_canned_bundle(("f79257a7-dfc6-46d6-ae00-ba4b25313c10", "2018-09-14T133314.453337Z"))
@@ -291,6 +301,9 @@ class TestManifestEndpoints(WebServiceTestCase):
                 '_entity_type': 'specimens',
                 'sample__provenance__document_id': 'b5894cf5-ecdc-4ea6-a0b9-5335ab678c7a',
                 'sample__biomaterial_core__biomaterial_id': 'Q4_DEMO-sample_SAMN02797092',
+                'sequencing_input__provenance__document_id': '377f2f5a-4a45-4c62-8fb0-db9ef33f5cf0',
+                'sequencing_input__biomaterial_core__biomaterial_id': 'Q4_DEMO-cellsus_SAMN02797092',
+                'sequencing_input_type': 'cell_suspension',
                 '__bam_0__file_name': '377f2f5a-4a45-4c62-8fb0-db9ef33f5cf0_qc.bam',
                 '__bam_0__file_format': 'bam',
                 '__bam_0__read_index': '',
@@ -370,6 +383,9 @@ class TestManifestEndpoints(WebServiceTestCase):
                 '_entity_type': 'specimens',
                 'sample__provenance__document_id': 'a21dc760-a500-4236-bcff-da34a0e873d2',
                 'sample__biomaterial_core__biomaterial_id': 'DID_scRSq06_pancreas',
+                'sequencing_input__provenance__document_id': '412898c5-5b9b-4907-b07c-e9b89666e204',
+                'sequencing_input__biomaterial_core__biomaterial_id': 'GSM2172585 1',
+                'sequencing_input_type': 'cell_suspension',
                 '__bam_0__file_name': '',
                 '__bam_0__file_format': '',
                 '__bam_0__read_index': '',
@@ -472,6 +488,9 @@ class TestManifestEndpoints(WebServiceTestCase):
                     '_entity_type',
                     'sample__provenance__document_id',
                     'sample__biomaterial_core__biomaterial_id',
+                    'sequencing_input__provenance__document_id',
+                    'sequencing_input__biomaterial_core__biomaterial_id',
+                    'sequencing_input_type',
                     '__bam_0__file_name',
                     '__bam_0__file_format',
                     '__bam_0__read_index',


### PR DESCRIPTION
PR for `hca/develop`.
Adds `sequencing_input` fields `document_id` and `biomaterial_id` to `compact` and `terra.bdbag` manifests.