### PR TITLE
Remove front matter from PR template (#2129)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,26 +2,29 @@ Author (before primary review)
 
 - [ ] PR title references issue
 - [ ] Title of main commit references issue
-- [ ] PR linked to Zenhub issue
+- [ ] PR is linked to Zenhub issue
 - [ ] Added `HCA` label <sub>or this PR does not target an `hca/*` branch</sub>
 - [ ] Created issue to track porting these changes <sub>or this PR does not need porting</sub> 
-- [ ] Added `[r]` tag to commit title <sub>or this PR does not require reindexing</sub>
+- [ ] Added `[r]` prefix at start of commit title <sub>or this PR does not require reindexing</sub>
 - [ ] Added `reindex` label <sub>or this PR does not require reindexing</sub>
-- [ ] Freebies are blocked on PR <sub>or there are no freebies in this PR</sub>
+- [ ] Freebies are blocked on this PR <sub>or there are no freebies in this PR</sub>
 - [ ] Freebies are referenced in commit titles <sub>or there are no freebies in this PR</sub>
 - [ ] Added `chain` label <sub>or this PR is not the base of another PR</sub>
 - [ ] Made this PR a blocker of next PR in chain <sub>or this PR is not the base of another PR</sub>
 
-Primary reviewer (before merging)
+Primary reviewer (before pushing merge commit)
 
-- [ ] Checked reindex label and `[r]` tag in commit title
+- [ ] Checked `reindex` label and `[r]` prefix of commit title
 - [ ] Rebased and squashed branch
 - [ ] Sanity-checked history
-- [ ] Build passes in sandbox <sub>or commented that sandbox will be skipped</sub>
+- [ ] Build passes in `sandbox` <sub>or commented that sandbox will be skipped</sub>
 - [ ] Reindexed `sandbox` <sub>or this PR does not require reindexing</sub>
+- [ ] Added PR reference to merge commit
 
-Primary reviewer (after merging)
+Primary reviewer (after pushing merge commit)
 
-- [ ] Check `N reviews` labelling is accurate
-- [ ] Commented on demo expectations <sub>or label as `no demo`</sub>
+- [ ] Pushed merge commit to Github and Gitlab
+- [ ] Deleted PR branch from Github and Gitlab
+- [ ] Verified that `N reviews` labelling is accurate
+- [ ] Commented on demo expectations <sub>or labeled as `no demo`</sub>
 - [ ] Reindexed `dev` <sub>or this PR does not require reindexing</sub>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,3 @@
----
-name: default
-about: 'A PR with check lists for author and primary reviewer'
-title: 
-labels: orange 
-assignees: ''
----
-
 Author (before primary review)
 
 - [ ] PR title references issue

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,25 +3,25 @@ Author (before primary review)
 - [ ] PR title references issue
 - [ ] Title of main commit references issue
 - [ ] PR linked to Zenhub issue
-- [ ] Added `HCA` label <font color="#888">or this PR does not target an `hca/*` branch</font>
-- [ ] Created issue to track porting these changes <font color="#888">or this PR does not need porting</font> 
-- [ ] Added `[r]` tag to commit title <font color="#888">or this PR does not require reindexing</font>
-- [ ] Added `reindex` label <font color="#888">or this PR does not require reindexing</font>
-- [ ] Freebies are blocked on PR <font color="#888">or there are no freebies in this PR</font>
-- [ ] Freebies are referenced in commit titles <font color="#888">or there are no freebies in this PR</font>
-- [ ] Added `chain` label <font color="#888">or this PR is not the base of another PR</font>
-- [ ] Made this PR a blocker of next PR in chain <font color="#888">or this PR is not the base of another PR</font>
+- [ ] Added `HCA` label <sub>or this PR does not target an `hca/*` branch</sub>
+- [ ] Created issue to track porting these changes <sub>or this PR does not need porting</sub> 
+- [ ] Added `[r]` tag to commit title <sub>or this PR does not require reindexing</sub>
+- [ ] Added `reindex` label <sub>or this PR does not require reindexing</sub>
+- [ ] Freebies are blocked on PR <sub>or there are no freebies in this PR</sub>
+- [ ] Freebies are referenced in commit titles <sub>or there are no freebies in this PR</sub>
+- [ ] Added `chain` label <sub>or this PR is not the base of another PR</sub>
+- [ ] Made this PR a blocker of next PR in chain <sub>or this PR is not the base of another PR</sub>
 
 Primary reviewer (before merging)
 
 - [ ] Checked reindex label and `[r]` tag in commit title
 - [ ] Rebased and squashed branch
 - [ ] Sanity-checked history
-- [ ] Build passes in sandbox <font color="#888">or commented that sandbox will be skipped</font>
-- [ ] Reindexed `sandbox` <font color="#888">or this PR does not require reindexing</font>
+- [ ] Build passes in sandbox <sub>or commented that sandbox will be skipped</sub>
+- [ ] Reindexed `sandbox` <sub>or this PR does not require reindexing</sub>
 
 Primary reviewer (after merging)
 
 - [ ] Check `N reviews` labelling is accurate
-- [ ] Commented on demo expectations <font color="#888">or label as `no demo`</font>
-- [ ] Reindexed `dev` <font color="#888">or this PR does not require reindexing</font>
+- [ ] Commented on demo expectations <sub>or label as `no demo`</sub>
+- [ ] Reindexed `dev` <sub>or this PR does not require reindexing</sub>


### PR DESCRIPTION
Author (before primary review)

- [x] PR title references issue
- [x] Title of main commit references issue
- [x] PR linked to Zenhub issue
- [x] Added `HCA` label <font color="#888">or this PR does not target an `hca/*` branch</font>
- [x] Created issue to track porting these changes <font color="#888">or this PR does not need porting</font> 
- [x] Added `[r]` tag to commit title <font color="#888">or this PR does not require reindexing</font>
- [x] Added `reindex` label <font color="#888">or this PR does not require reindexing</font>
- [x] Freebies are blocked on PR <font color="#888">or there are no freebies in this PR</font>
- [x] Freebies are referenced in commit titles <font color="#888">or there are no freebies in this PR</font>
- [x] Added `chain` label <font color="#888">or this PR is not the base of another PR</font>
- [x] Made this PR a blocker of next PR in chain <font color="#888">or this PR is not the base of another PR</font>

Primary reviewer (before merging)

- [x] Checked reindex label and `[r]` tag in commit title
- [x] Rebased and squashed branch
- [x] Sanity-checked history
- [x] Build passes in sandbox <font color="#888">or commented that sandbox will be skipped</font>
- [x] Reindexed `sandbox` <font color="#888">or this PR does not require reindexing</font>

Primary reviewer (after merging)

- [ ] Check `N reviews` labelling is accurate
- [ ] Commented on demo expectations <font color="#888">or label as `no demo`</font>
- [ ] Reindexed `dev` <font color="#888">or this PR does not require reindexing</font>
