### PR TITLE
Separate ES domain for sandbox and personal deployments (#2171)

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -11,6 +11,29 @@ reverted. This is all fairly informal and loosely defined. Hopefully we won't
 have too many entries in this file.
 
 
+#2071 Separate ES domain for sandbox and personal deployments
+=============================================================
+
+1. Before upgrading to this commit, and for every one of your personal
+   deployments, run ``make delete`` to delete any indices that deployment may
+   have used on the ``dev`` ES domain.
+
+2. Upgrade to this commit or a later one.
+
+3. For each personal deployment:
+
+   a. Configure it to share an ES domain with the sandbox deployment. See
+      example deployment for details.
+
+   b. Run ``make package``
+
+   c. Run ``make deploy``
+
+   d. Run ``make create``
+
+   e. Run ``make reindex``
+
+
 #2015 Change DRS URLs to Broad resolver
 =======================================
 

--- a/deployments/.example.local/environment.py
+++ b/deployments/.example.local/environment.py
@@ -47,10 +47,10 @@ def env() -> Mapping[str, Optional[str]]:
         'AZUL_URL_REDIRECT_BASE_DOMAIN_NAME': 'dev.url.singlecell.gi.ucsc.edu',
         'AZUL_URL_REDIRECT_FULL_DOMAIN_NAME': '{AZUL_DEPLOYMENT_STAGE}.{AZUL_URL_REDIRECT_BASE_DOMAIN_NAME}',
 
-        # A personal deployment shares an ES domain with `dev`
+        # A personal deployment shares an ES domain with `sandbox`
         #
         'AZUL_SHARE_ES_DOMAIN': '1',
-        'AZUL_ES_DOMAIN': 'azul-index-dev',
+        'AZUL_ES_DOMAIN': 'azul-index-sandbox',
 
         'azul_dss_query_prefix': '42',
 

--- a/deployments/sandbox/environment.py
+++ b/deployments/sandbox/environment.py
@@ -48,10 +48,9 @@ def env() -> Mapping[str, Optional[str]]:
         'AZUL_URL_REDIRECT_BASE_DOMAIN_NAME': 'dev.url.singlecell.gi.ucsc.edu',
         'AZUL_URL_REDIRECT_FULL_DOMAIN_NAME': '{AZUL_DEPLOYMENT_STAGE}.{AZUL_URL_REDIRECT_BASE_DOMAIN_NAME}',
         
-        # The sandbox deployment shares an ES domain with `dev`
-        #
-        'AZUL_SHARE_ES_DOMAIN': '1',
-        'AZUL_ES_DOMAIN': 'azul-index-dev',
+        # $0.186/h × 2 × 24h/d × 30d/mo = $267.84/mo
+        'AZUL_ES_INSTANCE_TYPE': 'r5.large.elasticsearch',
+        'AZUL_ES_INSTANCE_COUNT': '2',
 
         'azul_dss_query_prefix': '42',
         


### PR DESCRIPTION
Author (before primary review)

- [x] PR title references issue
- [x] Title of main commit references issue
- [x] PR is linked to Zenhub issue
- [x] Added `HCA` label <sub>or this PR does not target an `hca/*` branch</sub>
- [x] Created issue to track porting these changes <sub>or this PR does not need porting</sub> 
- [x] Added `[r]` prefix at start of commit title <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label <sub>or this PR does not require reindexing</sub>
- [x] Freebies are blocked on this PR <sub>or there are no freebies in this PR</sub>
- [x] Freebies are referenced in commit titles <sub>or there are no freebies in this PR</sub>
- [x] Added `chain` label <sub>or this PR is not the base of another PR</sub>
- [x] Made this PR a blocker of next PR in chain <sub>or this PR is not the base of another PR</sub>
- [x] Ran `make update_requirements` <sub>or this PR does not change requirements*.txt</sub>
- [x] Mentioned `make requirements` in UPGRADING.rst <sub>or this PR does not change requirements*.txt</sub>
- [x] Documented upgrade of personal deployments in UPGRADING.rst <sub>or this PR does not require upgrading</sub>

Primary reviewer (before pushing merge commit)

- [x] Checked `reindex` label and `[r]` prefix of commit title
- [x] Rebased and squashed branch
- [x] Sanity-checked history
- [x] Build passes in `sandbox` <sub>or commented that sandbox will be skipped</sub>
- [x] Reindexed `sandbox` <sub>or this PR does not require reindexing</sub>
- [x] Added PR reference to merge commit

Primary reviewer (after pushing merge commit)

- [ ] Pushed merge commit to Github and Gitlab
- [ ] Shortened chain <sub>or this PR is not the base of another PR</sub>
- [ ] Deleted PR branch from Github and Gitlab
- [ ] Verified that `N reviews` labelling is accurate
- [ ] Commented on demo expectations <sub>or labeled as `no demo`</sub>
- [ ] Reindexed `dev` <sub>or this PR does not require reindexing</sub>
