### PR TITLE
Fix misnamed `make requirements_update` in contribution guide

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ Author (before primary review)
 - [ ] Freebies are referenced in commit titles <sub>or there are no freebies in this PR</sub>
 - [ ] This PR is blocked by previous PR in chain <sub>or this PR is not chained to another PR</sub>
 - [ ] Added `chain` label to the blocking PR <sub>or this PR is not chained to another PR</sub>
-- [ ] Ran `make update_requirements` <sub>or this PR does not change requirements*.txt</sub>
+- [ ] Ran `make requirements_update` <sub>or this PR does not change requirements*.txt</sub>
 - [ ] Mentioned `make requirements` in UPGRADING.rst <sub>or this PR does not change requirements*.txt</sub>
 - [ ] Documented upgrade of personal deployments in UPGRADING.rst <sub>or this PR does not require upgrading</sub>
 


### PR DESCRIPTION
Author (before primary review)

- [x] PR title references issue
- [ ] Title of main commit references issue (N/A)
- [ ] PR is linked to Zenhub issue (N/A)
- [x] Added `HCA` label <sub>or this PR does not target an `hca/*` branch</sub>
- [x] Created issue to track porting these changes <sub>or this PR does not need porting</sub> 
- [x] Added `[r]` prefix at start of commit title <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label <sub>or this PR does not require reindexing</sub>
- [x] Freebies are blocked on this PR <sub>or there are no freebies in this PR</sub>
- [x] Freebies are referenced in commit titles <sub>or there are no freebies in this PR</sub>
- [x] Added `chain` label <sub>or this PR is not the base of another PR</sub>
- [x] Made this PR a blocker of next PR in chain <sub>or this PR is not the base of another PR</sub>
- [x] Ran `make update_requirements` <sub>or this PR does not change requirements*.txt</sub>
- [x] Mentioned `make requirements` in UPGRADING.rst <sub>or this PR does not change requirements*.txt</sub>
- [x] Documented upgrade of personal deployments in UPGRADING.rst <sub>or this PR does not require upgrading</sub>

Primary reviewer (before pushing merge commit)

- [ ] Checked `reindex` label and `[r]` prefix of commit title
- [ ] Rebased and squashed branch
- [ ] Sanity-checked history
- [ ] Build passes in `sandbox` <sub>or commented that sandbox will be skipped</sub>
- [ ] Reindexed `sandbox` <sub>or this PR does not require reindexing</sub>
- [ ] Added PR reference to merge commit

Primary reviewer (after pushing merge commit)

- [ ] Moved linked issue to Merged
- [ ] Pushed merge commit to Github
- [ ] Deleted PR branch from Github and Gitlab
- [ ] Moved freebies to Merged column <sub>or there are no freebies in this PR</sub> 
- [ ] Shortened chain <sub>or this PR is not the base of another PR</sub>
- [ ] Verified that `N reviews` labelling is accurate
- [ ] Commented on demo expectations <sub>or labeled as `no demo`</sub>
- [ ] Pushed merge commit to Gitlab
- [ ] Reindexed `dev` <sub>or this PR does not require reindexing</sub>
- [ ] Unassign reviewer from PR
