### PR TITLE
Fix: codecov picks up coverage data from `develop` builds (#2283)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ jobs:
       script:
         - pip install codecov
         - ln $COVERAGE_FILE .coverage
-        - codecov
+        - codecov --disable search
     - stage: coverage
       name: coveralls (don't rerun after success)
       # Currently not idempotent (https://github.com/lemurheavy/coveralls-public/issues/1435)


### PR DESCRIPTION
https://github.com/DataBiosphere/azul/issues/2283#issuecomment-701003364

Author (before primary review)

- [x] PR title references issue
- [x] Title of main commit references issue
- [x] PR is linked to Zenhub issue
- [x] Added `HCA` label <sub>or this PR does not target an `hca/*` branch</sub>
- [x] Created issue to track porting these changes <sub>or this PR does not need porting</sub> 
- [x] Added `[r]` prefix at start of commit title <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label <sub>or this PR does not require reindexing</sub>
- [x] Freebies are blocked on this PR <sub>or there are no freebies in this PR</sub>
- [x] Freebies are referenced in commit titles <sub>or there are no freebies in this PR</sub>
- [x] This PR is blocked by previous PR in chain <sub>or this PR is not chained to another PR</sub>
- [x] Added `chain` label to the blocking PR <sub>or this PR is not chained to another PR</sub>
- [x] Ran `make requirements_update` <sub>or this PR does not change requirements*.txt</sub>
- [x] Mentioned `make requirements` in UPGRADING.rst <sub>or this PR does not change requirements*.txt</sub>
- [x] Documented upgrade of personal deployments in UPGRADING.rst <sub>or this PR does not require upgrading</sub>

Primary reviewer (before pushing merge commit)

- [x] Checked `reindex` label and `[r]` prefix of commit title
- [x] Rebased and squashed branch
- [x] Sanity-checked history
- [x] Build passes in `sandbox` <sub>or commented that sandbox will be skipped</sub>
- [x] Reindexed `sandbox` <sub>or this PR does not require reindexing</sub>
- [x] Added PR reference to merge commit
- [x] Moved linked issue to Merged
- [ ] Pushed merge commit to Github

Primary reviewer (after pushing merge commit)

- [ ] Moved freebies to Merged column <sub>or there are no freebies in this PR</sub> 
- [ ] Shortened chain <sub>or this PR is not the base of another PR</sub>
- [ ] Verified that `N reviews` labelling is accurate
- [ ] Commented on demo expectations <sub>or labeled as `no demo`</sub>
- [ ] Pushed merge commit to Gitlab
- [ ] Reindexed `dev` <sub>or this PR does not require reindexing</sub>
- [ ] Deleted PR branch from Github and Gitlab
- [ ] Unassign reviewer from PR
