### PR TITLE
Allow Gitlab to deploy DataBrowser/DataPortal to `prod` (HumanCellAtlas/data-browser#1393)

### DIFF
--- a/terraform/gitlab/gitlab.tf.json.template.py
+++ b/terraform/gitlab/gitlab.tf.json.template.py
@@ -531,10 +531,10 @@ emit_tf({} if config.terraform_component != 'gitlab' else {
                                     "s3:PutObjectAcl"
                                 ],
                                 "resources": [
-                                    "arn:aws:s3:::dev.singlecell.gi.ucsc.edu/*",
-                                    "arn:aws:s3:::dev.explore.singlecell.gi.ucsc.edu/*",
-                                    "arn:aws:s3:::dev.explore.singlecell.gi.ucsc.edu",
-                                    "arn:aws:s3:::dev.singlecell.gi.ucsc.edu"
+                                    "arn:aws:s3:::org-humancellatlas-data-portal-dcp2-prod/*",
+                                    "arn:aws:s3:::org-humancellatlas-data-browser-dcp2-prod/*",
+                                    "arn:aws:s3:::org-humancellatlas-data-browser-dcp2-prod",
+                                    "arn:aws:s3:::org-humancellatlas-data-portal-dcp2-prod"
                                 ]
                             },
                             {
@@ -542,10 +542,10 @@ emit_tf({} if config.terraform_component != 'gitlab' else {
                                     "cloudfront:CreateInvalidation"
                                 ],
                                 "resources": [
-                                    "arn:aws:cloudfront::122796619775:distribution/E3562WJBOLN8W8"
+                                    "arn:aws:cloudfront::122796619775:distribution/E1LYQC3LZXO7M3"
                                 ]
                             }
-                        ] if config.domain_name == 'dev.singlecell.gi.ucsc.edu' else [
+                        ] if config.domain_name == 'dcp2.data.humancellatlas.org' or config.domain_name == 'data.humancellatlas.org' else [
                         ]
                     )
                 ]


### PR DESCRIPTION
@hannes-ucsc I have updated the AWS resources for the UCSC prod gitlab. I have updated the bucket names and the CloudFront distribution id for the two new S3 buckets and one new CloudFront instance in prod. 

I also updated the test on config.domainName to check for data.humancellatlas.org or dcp2.data.humancellatlas.org. Not sure if this is the correct way to test for the multiple possible domain names for this environment so that may need to be adjusted. Once we are switched over we can delete the dcp2. 

This is for https://github.com/HumanCellAtlas/data-browser/issues/1393

Please let me know if you see any issues with this or have enough information to apply the updates to the resources.

Cheers,
Dave






Author (check before every review)

- [x] PR title references issue
- [ ] Title of main commit references issue
- [x] PR is linked to Zenhub issue
- [x] Added `DCP/1` label                                   <sub>or this PR does not target an `hca/*` branch</sub>
- [x] Created issue to track porting these changes          <sub>or this PR does not need porting</sub> 
- [x] Added `r` tag to commit title                         <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR                           <sub>or this PR does not require reindexing</sub>
- [x] Freebies are blocked on this PR                       <sub>or there are no freebies in this PR</sub>
- [x] Freebies are referenced in commit titles              <sub>or there are no freebies in this PR</sub>
- [x] This PR is blocked by previous PR in chain            <sub>or this PR is not chained to another PR</sub>
- [x] Added `chain` label to the blocking PR                <sub>or this PR is not chained to another PR</sub>
- [x] Ran `make requirements_update`                        <sub>or this PR leaves requirements*.txt, common.mk and Makefile untouched</sub>
- [x] Added `R` tag to commit title                         <sub>or this PR leaves requirements*.txt untouched</sub>
- [x] Added `reqs` label to PR                              <sub>or this PR leaves requirements*.txt untouched</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst  <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title                         <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR                           <sub>or this PR does not require upgrading</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>
- [x] Rebased branch on `develop`

Primary reviewer (before pushing merge commit)

- [ ] Checked `reindex` label and `r` commit title tag
- [ ] Rebased and squashed branch
- [ ] Sanity-checked history
- [ ] Build passes in `sandbox`                             <sub>or added `no sandbox` label</sub>
- [ ] Reindexed `sandbox`                                   <sub>or this PR does not require reindexing</sub>
- [ ] Added PR reference to merge commit
- [ ] Moved linked issue to Merged
- [ ] Pushed merge commit to Github

Primary reviewer (after pushing merge commit)

- [ ] Moved freebies to Merged column                       <sub>or there are no freebies in this PR</sub> 
- [ ] Shortened chain                                       <sub>or this PR is not the base of another PR</sub>
- [ ] Verified that `N reviews` labelling is accurate
- [ ] Commented on demo expectations                        <sub>or labeled as `no demo`</sub>
- [ ] Pushed merge commit to Gitlab                         <sub>or this changes can be pushed later, together with another PR</sub>
- [ ] Reindexed `dev`                                       <sub>or this PR does not require reindexing</sub>
- [ ] Deleted PR branch from Github and Gitlab
- [ ] Unassign reviewer from PR
