### PR TITLE
Fix: Extraneous `null` values in hits[].samples[].* (#2071)

### DIFF
--- a/src/azul/indexer/document.py
+++ b/src/azul/indexer/document.py
@@ -445,13 +445,7 @@ class Document(Generic[C]):
                 # FIXME: Assert that a non-list field_type implies a non-list
                 #        doc (only possible for contributions).
                 #        https://github.com/DataBiosphere/azul/issues/2689
-                # FIXME: Samples are an exception since they are polymorphic.
-                #        Unused fields are left as None, even if field_types
-                #        would normally dictate otherwise.
-                #        https://github.com/DataBiosphere/azul/issues/2071
-                assert (isinstance(doc, list)
-                        or (doc is not None if forward else doc != NullableString.null_string)
-                        or path[:2] == ('contents', 'samples'))
+                assert isinstance(doc, list)
 
                 field_types = one(field_types)
             if isinstance(field_types, FieldType):

--- a/src/azul/indexer/transform.py
+++ b/src/azul/indexer/transform.py
@@ -3,6 +3,7 @@ from abc import (
     abstractmethod,
 )
 from typing import (
+    FrozenSet,
     Iterable,
 )
 
@@ -28,6 +29,10 @@ class Transformer(ABC):
         contributions for.
         """
         raise NotImplementedError
+
+    @classmethod
+    def inner_entity_types(cls) -> FrozenSet[str]:
+        return frozenset((cls.entity_type(),))
 
     @classmethod
     @abstractmethod

--- a/src/azul/plugins/metadata/hca/__init__.py
+++ b/src/azul/plugins/metadata/hca/__init__.py
@@ -154,7 +154,7 @@ class Plugin(MetadataPlugin):
                 "biologicalSex": "contents.donors.biological_sex",
                 "sampleId": "contents.samples.biomaterial_id",
                 "sampleEntityType": "contents.samples.entity_type",
-                "sampleDisease": "contents.samples.disease",
+                "sampleDisease": "contents.sample_specimens.disease",
                 "specimenDisease": "contents.specimens.disease",
                 "genusSpecies": "contents.donors.genus_species",
                 "donorDisease": "contents.donors.diseases",

--- a/src/azul/plugins/metadata/hca/transform.py
+++ b/src/azul/plugins/metadata/hca/transform.py
@@ -898,7 +898,7 @@ class BaseTransformer(Transformer, metaclass=ABCMeta):
         @classmethod
         def to_dict(cls, cellline: api_class) -> MutableJSON:
             return {
-                **super().to_dict(),
+                **super().to_dict(cellline),
                 'organ': None,
                 'organ_part': [],
                 'model_organ': cellline.model_organ,
@@ -913,7 +913,7 @@ class BaseTransformer(Transformer, metaclass=ABCMeta):
         @classmethod
         def to_dict(cls, organoid: api_class) -> MutableJSON:
             return {
-                **super().to_dict(),
+                **super().to_dict(organoid),
                 'organ': None,
                 'organ_part': [],
                 'model_organ': organoid.model_organ,
@@ -922,13 +922,13 @@ class BaseTransformer(Transformer, metaclass=ABCMeta):
             }
 
     class SampleSpecimen(Sample):
-        entity_type = 'organoids'
+        entity_type = 'specimens'
         api_class = api.SpecimenFromOrganism
 
         @classmethod
         def to_dict(cls, specimen: api_class) -> MutableJSON:
             return {
-                **super().to_dict(),
+                **super().to_dict(specimen),
                 'organ': specimen.organ,
                 'organ_part': sorted(specimen.organ_parts),
                 'model_organ': None,
@@ -937,9 +937,9 @@ class BaseTransformer(Transformer, metaclass=ABCMeta):
             }
 
     sample_types: Mapping[Callable, Type[Sample]] = {
-        _cell_line, SampleCellLine,
-        _organoid, SampleOrganoid,
-        _specimen, SampleSpecimen
+        _cell_line: SampleCellLine,
+        _organoid: SampleOrganoid,
+        _specimen: SampleSpecimen
     }
 
     def _samples(self, samples: Iterable[api.Biomaterial]) -> MutableJSON:
@@ -955,7 +955,7 @@ class BaseTransformer(Transformer, metaclass=ABCMeta):
             for to_dict, sample_type in self.sample_types.items():
                 if isinstance(sample, sample_type.api_class):
                     entity_type = f'sample_{sample_type.entity_type}'
-                    result[entity_type].append(to_dict(sample))
+                    result[entity_type].append(to_dict(self, sample))
                     result['samples'].append(sample_type.to_dict(sample))
                     break
             else:

--- a/src/azul/service/hca_response_v5.py
+++ b/src/azul/service/hca_response_v5.py
@@ -1,7 +1,4 @@
 import abc
-from collections import (
-    ChainMap,
-)
 import logging
 from typing import (
     Callable,
@@ -394,28 +391,26 @@ class KeywordSearchResponse(AbstractResponse, EntryFetcher):
     def make_organoids(self, entry):
         return [self.make_organoid(organoid) for organoid in entry["contents"]["organoids"]]
 
-    def make_sample(self, sample):
-        lookup = {
-            'cell_lines': ('cellLines', self.make_cell_line),
-            'organoids': ('organoids', self.make_organoid),
-            'specimens': ('specimens', self.make_specimen),
-        }
-        entity_type = sample['entity_type']
-        if isinstance(entity_type, list):
-            entity_type, make_functions = map(list, zip(*map(lookup.get, entity_type)))
-            entity_dicts = (make_function(sample) for make_function in make_functions)
-            entity_dict = ChainMap(*entity_dicts)
-        else:
-            entity_type, make_function = lookup[entity_type]
-            entity_dict = make_function(sample)
+    def make_sample(self, sample, entity_dict, entity_type):
+        is_aggregate = isinstance(sample['document_id'], list)
+        organ_prop = 'organ' if entity_type == 'specimens' else 'model_organ'
         return {
-            'sampleEntityType': entity_type,
-            'effectiveOrgan': sample['effective_organ'],
+            'sampleEntityType': [entity_type] if is_aggregate else entity_type,
+            'effectiveOrgan': sample[organ_prop],
             **entity_dict
         }
 
     def make_samples(self, entry):
-        return [self.make_sample(sample) for sample in entry["contents"]["samples"]]
+        pieces = [
+            (self.make_cell_line, 'cellLines', 'sample_cell_lines'),
+            (self.make_organoid, 'organoids', 'sample_organoids'),
+            (self.make_specimen, 'specimens', 'sample_specimens'),
+        ]
+        return [
+            self.make_sample(sample, entity_fn(sample), entity_type)
+            for entity_fn, entity_type, sample_entity_type in pieces
+            for sample in entry['contents'][sample_entity_type]
+        ]
 
     def map_entries(self, entry):
         """

--- a/src/azul/service/hca_response_v5.py
+++ b/src/azul/service/hca_response_v5.py
@@ -409,7 +409,7 @@ class KeywordSearchResponse(AbstractResponse, EntryFetcher):
         return [
             self.make_sample(sample, entity_fn(sample), entity_type)
             for entity_fn, entity_type, sample_entity_type in pieces
-            for sample in entry['contents'][sample_entity_type]
+            for sample in entry['contents'].get(sample_entity_type, [])
         ]
 
     def map_entries(self, entry):

--- a/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T113344.698028Z.results.json
+++ b/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T113344.698028Z.results.json
@@ -21,8 +21,6 @@
                         "effective_organ": "pancreas"
                     }
                 ],
-                "sample_cell_lines": [],
-                "sample_organoids": [],
                 "sample_specimens": [
                     {
                         "has_input_biomaterial": "~null",
@@ -477,8 +475,6 @@
                         "effective_organ": "pancreas"
                     }
                 ],
-                "sample_cell_lines": [],
-                "sample_organoids": [],
                 "sample_specimens": [
                     {
                         "has_input_biomaterial": "~null",
@@ -708,8 +704,6 @@
                         "effective_organ": "pancreas"
                     }
                 ],
-                "sample_cell_lines": [],
-                "sample_organoids": [],
                 "sample_specimens": [
                     {
                         "has_input_biomaterial": "~null",
@@ -939,8 +933,6 @@
                         "effective_organ": "pancreas"
                     }
                 ],
-                "sample_cell_lines": [],
-                "sample_organoids": [],
                 "sample_specimens": [
                     {
                         "has_input_biomaterial": "~null",
@@ -1194,8 +1186,6 @@
                         "effective_organ": "pancreas"
                     }
                 ],
-                "sample_cell_lines": [],
-                "sample_organoids": [],
                 "sample_specimens": [
                     {
                         "has_input_biomaterial": "~null",
@@ -1462,8 +1452,6 @@
                         ]
                     }
                 ],
-                "sample_cell_lines": [],
-                "sample_organoids": [],
                 "sample_specimens": [
                     {
                         "has_input_biomaterial": [
@@ -1972,8 +1960,6 @@
                         ]
                     }
                 ],
-                "sample_cell_lines": [],
-                "sample_organoids": [],
                 "sample_specimens": [
                     {
                         "has_input_biomaterial": [
@@ -2260,8 +2246,6 @@
                         ]
                     }
                 ],
-                "sample_cell_lines": [],
-                "sample_organoids": [],
                 "sample_specimens": [
                     {
                         "has_input_biomaterial": [
@@ -2534,8 +2518,6 @@
                         "effective_organ": "pancreas"
                     }
                 ],
-                "sample_cell_lines": [],
-                "sample_organoids": [],
                 "sample_specimens": [
                     {
                         "has_input_biomaterial": "~null",
@@ -2794,8 +2776,6 @@
                         ]
                     }
                 ],
-                "sample_cell_lines": [],
-                "sample_organoids": [],
                 "sample_specimens": [
                     {
                         "has_input_biomaterial": [
@@ -3088,8 +3068,6 @@
                         "effective_organ": "pancreas"
                     }
                 ],
-                "sample_cell_lines": [],
-                "sample_organoids": [],
                 "sample_specimens": [
                     {
                         "has_input_biomaterial": "~null",
@@ -3357,8 +3335,6 @@
                         ]
                     }
                 ],
-                "sample_cell_lines": [],
-                "sample_organoids": [],
                 "sample_specimens": [
                     {
                         "has_input_biomaterial": [

--- a/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T113344.698028Z.results.json
+++ b/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T113344.698028Z.results.json
@@ -9,18 +9,29 @@
             "contents": {
                 "samples": [
                     {
+                        "document_id": "a21dc760-a500-4236-bcff-da34a0e873d2",
+                        "biomaterial_id": "DID_scRSq06_pancreas",
                         "entity_type": "specimens",
+                        "organ": "pancreas",
+                        "organ_part": [
+                            "islet of Langerhans"
+                        ],
+                        "model_organ": "~null",
+                        "model_organ_part": "~null",
+                        "effective_organ": "pancreas"
+                    }
+                ],
+                "sample_cell_lines": [],
+                "sample_organoids": [],
+                "sample_specimens": [
+                    {
                         "has_input_biomaterial": "~null",
                         "_source": "specimen_from_organism",
                         "document_id": "a21dc760-a500-4236-bcff-da34a0e873d2",
                         "biomaterial_id": "DID_scRSq06_pancreas",
-                        "cell_line_type": "~null",
                         "disease": [
                             "normal"
                         ],
-                        "effective_organ": "pancreas",
-                        "model_organ": "~null",
-                        "model_organ_part": "~null",
                         "organ": "pancreas",
                         "organ_part": [
                             "islet of Langerhans"
@@ -454,18 +465,29 @@
             "contents": {
                 "samples": [
                     {
+                        "document_id": "a21dc760-a500-4236-bcff-da34a0e873d2",
+                        "biomaterial_id": "DID_scRSq06_pancreas",
                         "entity_type": "specimens",
+                        "organ": "pancreas",
+                        "organ_part": [
+                            "islet of Langerhans"
+                        ],
+                        "model_organ": "~null",
+                        "model_organ_part": "~null",
+                        "effective_organ": "pancreas"
+                    }
+                ],
+                "sample_cell_lines": [],
+                "sample_organoids": [],
+                "sample_specimens": [
+                    {
                         "has_input_biomaterial": "~null",
                         "_source": "specimen_from_organism",
                         "document_id": "a21dc760-a500-4236-bcff-da34a0e873d2",
                         "biomaterial_id": "DID_scRSq06_pancreas",
-                        "cell_line_type": "~null",
                         "disease": [
                             "normal"
                         ],
-                        "effective_organ": "pancreas",
-                        "model_organ": "~null",
-                        "model_organ_part":  "~null",
                         "organ": "pancreas",
                         "organ_part": [
                             "islet of Langerhans"
@@ -674,18 +696,29 @@
             "contents": {
                 "samples": [
                     {
+                        "document_id": "a21dc760-a500-4236-bcff-da34a0e873d2",
+                        "biomaterial_id": "DID_scRSq06_pancreas",
                         "entity_type": "specimens",
+                        "organ": "pancreas",
+                        "organ_part": [
+                            "islet of Langerhans"
+                        ],
+                        "model_organ": "~null",
+                        "model_organ_part": "~null",
+                        "effective_organ": "pancreas"
+                    }
+                ],
+                "sample_cell_lines": [],
+                "sample_organoids": [],
+                "sample_specimens": [
+                    {
                         "has_input_biomaterial": "~null",
                         "_source": "specimen_from_organism",
                         "document_id": "a21dc760-a500-4236-bcff-da34a0e873d2",
                         "biomaterial_id": "DID_scRSq06_pancreas",
-                        "cell_line_type": "~null",
                         "disease": [
                             "normal"
                         ],
-                        "effective_organ": "pancreas",
-                        "model_organ": "~null",
-                        "model_organ_part": "~null",
                         "organ": "pancreas",
                         "organ_part": [
                             "islet of Langerhans"
@@ -894,18 +927,29 @@
             "contents": {
                 "samples": [
                     {
+                        "document_id": "a21dc760-a500-4236-bcff-da34a0e873d2",
+                        "biomaterial_id": "DID_scRSq06_pancreas",
                         "entity_type": "specimens",
+                        "organ": "pancreas",
+                        "organ_part": [
+                            "islet of Langerhans"
+                        ],
+                        "model_organ": "~null",
+                        "model_organ_part": "~null",
+                        "effective_organ": "pancreas"
+                    }
+                ],
+                "sample_cell_lines": [],
+                "sample_organoids": [],
+                "sample_specimens": [
+                    {
                         "has_input_biomaterial": "~null",
                         "_source": "specimen_from_organism",
                         "document_id": "a21dc760-a500-4236-bcff-da34a0e873d2",
                         "biomaterial_id": "DID_scRSq06_pancreas",
-                        "cell_line_type": "~null",
                         "disease": [
                             "normal"
                         ],
-                        "effective_organ": "pancreas",
-                        "model_organ": "~null",
-                        "model_organ_part": "~null",
                         "organ": "pancreas",
                         "organ_part": [
                             "islet of Langerhans"
@@ -1138,18 +1182,29 @@
             "contents": {
                 "samples": [
                     {
+                        "document_id": "a21dc760-a500-4236-bcff-da34a0e873d2",
+                        "biomaterial_id": "DID_scRSq06_pancreas",
                         "entity_type": "specimens",
+                        "organ": "pancreas",
+                        "organ_part": [
+                            "islet of Langerhans"
+                        ],
+                        "model_organ": "~null",
+                        "model_organ_part": "~null",
+                        "effective_organ": "pancreas"
+                    }
+                ],
+                "sample_cell_lines": [],
+                "sample_organoids": [],
+                "sample_specimens": [
+                    {
                         "has_input_biomaterial": "~null",
                         "_source": "specimen_from_organism",
                         "document_id": "a21dc760-a500-4236-bcff-da34a0e873d2",
                         "biomaterial_id": "DID_scRSq06_pancreas",
-                        "cell_line_type": "~null",
                         "disease": [
                             "normal"
                         ],
-                        "effective_organ": "pancreas",
-                        "model_organ": "~null",
-                        "model_organ_part": "~null",
                         "organ": "pancreas",
                         "organ_part": [
                             "islet of Langerhans"
@@ -1381,9 +1436,36 @@
             "contents": {
                 "samples": [
                     {
+                        "document_id": [
+                            "a21dc760-a500-4236-bcff-da34a0e873d2"
+                        ],
+                        "biomaterial_id": [
+                            "DID_scRSq06_pancreas"
+                        ],
                         "entity_type": [
                             "specimens"
                         ],
+                        "organ": [
+                            "pancreas"
+                        ],
+                        "organ_part": [
+                            "islet of Langerhans"
+                        ],
+                        "model_organ": [
+                            "~null"
+                        ],
+                        "model_organ_part": [
+                            "~null"
+                        ],
+                        "effective_organ": [
+                            "pancreas"
+                        ]
+                    }
+                ],
+                "sample_cell_lines": [],
+                "sample_organoids": [],
+                "sample_specimens": [
+                    {
                         "has_input_biomaterial": [
                             "~null"
                         ],
@@ -1396,20 +1478,8 @@
                         "biomaterial_id": [
                             "DID_scRSq06_pancreas"
                         ],
-                        "cell_line_type": [
-                            "~null"
-                        ],
                         "disease": [
                             "normal"
-                        ],
-                        "effective_organ": [
-                            "pancreas"
-                        ],
-                        "model_organ": [
-                            "~null"
-                        ],
-                        "model_organ_part": [
-                            "~null"
                         ],
                         "organ": [
                             "pancreas"
@@ -1876,9 +1946,36 @@
             "contents": {
                 "samples": [
                     {
+                        "document_id": [
+                            "a21dc760-a500-4236-bcff-da34a0e873d2"
+                        ],
+                        "biomaterial_id": [
+                            "DID_scRSq06_pancreas"
+                        ],
                         "entity_type": [
                             "specimens"
                         ],
+                        "organ": [
+                            "pancreas"
+                        ],
+                        "organ_part": [
+                            "islet of Langerhans"
+                        ],
+                        "model_organ": [
+                            "~null"
+                        ],
+                        "model_organ_part": [
+                            "~null"
+                        ],
+                        "effective_organ": [
+                            "pancreas"
+                        ]
+                    }
+                ],
+                "sample_cell_lines": [],
+                "sample_organoids": [],
+                "sample_specimens": [
+                    {
                         "has_input_biomaterial": [
                             "~null"
                         ],
@@ -1891,20 +1988,8 @@
                         "biomaterial_id": [
                             "DID_scRSq06_pancreas"
                         ],
-                        "cell_line_type": [
-                            "~null"
-                        ],
                         "disease": [
                             "normal"
-                        ],
-                        "effective_organ": [
-                            "pancreas"
-                        ],
-                        "model_organ": [
-                            "~null"
-                        ],
-                        "model_organ_part": [
-                            "~null"
                         ],
                         "organ": [
                             "pancreas"
@@ -2149,9 +2234,36 @@
             "contents": {
                 "samples": [
                     {
+                        "document_id": [
+                            "a21dc760-a500-4236-bcff-da34a0e873d2"
+                        ],
+                        "biomaterial_id": [
+                            "DID_scRSq06_pancreas"
+                        ],
                         "entity_type": [
                             "specimens"
                         ],
+                        "organ": [
+                            "pancreas"
+                        ],
+                        "organ_part": [
+                            "islet of Langerhans"
+                        ],
+                        "model_organ": [
+                            "~null"
+                        ],
+                        "model_organ_part": [
+                            "~null"
+                        ],
+                        "effective_organ": [
+                            "pancreas"
+                        ]
+                    }
+                ],
+                "sample_cell_lines": [],
+                "sample_organoids": [],
+                "sample_specimens": [
+                    {
                         "has_input_biomaterial": [
                             "~null"
                         ],
@@ -2164,20 +2276,8 @@
                         "biomaterial_id": [
                             "DID_scRSq06_pancreas"
                         ],
-                        "cell_line_type": [
-                            "~null"
-                        ],
                         "disease": [
                             "normal"
-                        ],
-                        "effective_organ": [
-                            "pancreas"
-                        ],
-                        "model_organ": [
-                            "~null"
-                        ],
-                        "model_organ_part": [
-                            "~null"
                         ],
                         "organ": [
                             "pancreas"
@@ -2422,18 +2522,29 @@
             "contents": {
                 "samples": [
                     {
+                        "document_id": "a21dc760-a500-4236-bcff-da34a0e873d2",
+                        "biomaterial_id": "DID_scRSq06_pancreas",
                         "entity_type": "specimens",
+                        "organ": "pancreas",
+                        "organ_part": [
+                            "islet of Langerhans"
+                        ],
+                        "model_organ": "~null",
+                        "model_organ_part": "~null",
+                        "effective_organ": "pancreas"
+                    }
+                ],
+                "sample_cell_lines": [],
+                "sample_organoids": [],
+                "sample_specimens": [
+                    {
                         "has_input_biomaterial": "~null",
                         "_source": "specimen_from_organism",
                         "document_id": "a21dc760-a500-4236-bcff-da34a0e873d2",
                         "biomaterial_id": "DID_scRSq06_pancreas",
-                        "cell_line_type": "~null",
                         "disease": [
                             "normal"
                         ],
-                        "effective_organ": "pancreas",
-                        "model_organ": "~null",
-                        "model_organ_part": "~null",
                         "organ": "pancreas",
                         "organ_part": [
                             "islet of Langerhans"
@@ -2657,9 +2768,36 @@
             "contents": {
                 "samples": [
                     {
+                        "document_id": [
+                            "a21dc760-a500-4236-bcff-da34a0e873d2"
+                        ],
+                        "biomaterial_id": [
+                            "DID_scRSq06_pancreas"
+                        ],
                         "entity_type": [
                             "specimens"
                         ],
+                        "organ": [
+                            "pancreas"
+                        ],
+                        "organ_part": [
+                            "islet of Langerhans"
+                        ],
+                        "model_organ": [
+                            "~null"
+                        ],
+                        "model_organ_part": [
+                            "~null"
+                        ],
+                        "effective_organ": [
+                            "pancreas"
+                        ]
+                    }
+                ],
+                "sample_cell_lines": [],
+                "sample_organoids": [],
+                "sample_specimens": [
+                    {
                         "has_input_biomaterial": [
                             "~null"
                         ],
@@ -2672,20 +2810,8 @@
                         "biomaterial_id": [
                             "DID_scRSq06_pancreas"
                         ],
-                        "cell_line_type": [
-                            "~null"
-                        ],
                         "disease": [
                             "normal"
-                        ],
-                        "effective_organ": [
-                            "pancreas"
-                        ],
-                        "model_organ": [
-                            "~null"
-                        ],
-                        "model_organ_part": [
-                            "~null"
                         ],
                         "organ": [
                             "pancreas"
@@ -2950,25 +3076,36 @@
             "contents": {
                 "samples": [
                     {
+                        "document_id": "a21dc760-a500-4236-bcff-da34a0e873d2",
+                        "biomaterial_id": "DID_scRSq06_pancreas",
                         "entity_type": "specimens",
+                        "organ": "pancreas",
+                        "organ_part": [
+                            "islet of Langerhans"
+                        ],
+                        "model_organ": "~null",
+                        "model_organ_part": "~null",
+                        "effective_organ": "pancreas"
+                    }
+                ],
+                "sample_cell_lines": [],
+                "sample_organoids": [],
+                "sample_specimens": [
+                    {
                         "has_input_biomaterial": "~null",
                         "_source": "specimen_from_organism",
                         "document_id": "a21dc760-a500-4236-bcff-da34a0e873d2",
                         "biomaterial_id": "DID_scRSq06_pancreas",
-                        "cell_line_type": "~null",
                         "disease": [
                             "normal"
                         ],
-                        "model_organ": "~null",
-                        "model_organ_part": "~null",
                         "organ": "pancreas",
                         "organ_part": [
                             "islet of Langerhans"
                         ],
                         "storage_method": "~null",
                         "preservation_method": "~null",
-                        "_type": "specimen",
-                        "effective_organ": "pancreas"
+                        "_type": "specimen"
                     }
                 ],
                 "sequencing_inputs": [
@@ -3194,9 +3331,36 @@
             "contents": {
                 "samples": [
                     {
+                        "document_id": [
+                            "a21dc760-a500-4236-bcff-da34a0e873d2"
+                        ],
+                        "biomaterial_id": [
+                            "DID_scRSq06_pancreas"
+                        ],
                         "entity_type": [
                             "specimens"
                         ],
+                        "organ": [
+                            "pancreas"
+                        ],
+                        "organ_part": [
+                            "islet of Langerhans"
+                        ],
+                        "model_organ": [
+                            "~null"
+                        ],
+                        "model_organ_part": [
+                            "~null"
+                        ],
+                        "effective_organ": [
+                            "pancreas"
+                        ]
+                    }
+                ],
+                "sample_cell_lines": [],
+                "sample_organoids": [],
+                "sample_specimens": [
+                    {
                         "has_input_biomaterial": [
                             "~null"
                         ],
@@ -3209,17 +3373,8 @@
                         "biomaterial_id": [
                             "DID_scRSq06_pancreas"
                         ],
-                        "cell_line_type": [
-                            "~null"
-                        ],
                         "disease": [
                             "normal"
-                        ],
-                        "model_organ": [
-                            "~null"
-                        ],
-                        "model_organ_part": [
-                            "~null"
                         ],
                         "organ": [
                             "pancreas"
@@ -3235,9 +3390,6 @@
                         ],
                         "_type": [
                             "specimen"
-                        ],
-                        "effective_organ": [
-                            "pancreas"
                         ]
                     }
                 ],


### PR DESCRIPTION
Author

- [x] PR title references issue
- [x] Title of main commit references issue
- [x] PR is linked to Zenhub issue

Author (reindex)

- [x] Added `r` tag to commit title                         <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR                           <sub>or this PR does not require reindexing</sub>

Author (freebies & chains)

- [x] Freebies are blocked on this PR                       <sub>or there are no freebies in this PR</sub>
- [x] Freebies are referenced in commit titles              <sub>or there are no freebies in this PR</sub>
- [x] This PR is blocked by previous PR in the chain        <sub>or this PR is not chained to another PR</sub>
- [x] Added `chain` label to the blocking PR                <sub>or this PR is not chained to another PR</sub>

Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst  <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title                         <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR                           <sub>or this PR does not require upgrading</sub>

Author (requirements, before every review)

- [x] Ran `make requirements_update`                        <sub>or this PR leaves requirements*.txt, common.mk and Makefile untouched</sub>
- [x] Added `R` tag to commit title                         <sub>or this PR leaves requirements*.txt untouched</sub>
- [x] Added `reqs` label to PR                              <sub>or this PR leaves requirements*.txt untouched</sub>

Author (before every review)

- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>
- [x] Rebased branch on `develop`, squashed old fixups

Primary reviewer (after approval)

- [x] Commented on demo expectations                        <sub>or labelled PR as `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] Moved ticket to Approved column
- [x] Assigned PR to an operator

Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that Demo expectations are clear              <sub>or PR is labeled as `no demo`</sub>
- [x] Rebased and squashed branch
- [x] Sanity-checked history
- [x] Pushed PR branch to Github
- [x] Branch pushed to Gitlab and build passes in `sandbox` <sub>or added `no sandbox` label</sub>
- [x] Started reindex in `sandbox`                          <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `sandbox`                     <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title
- [x] Moved linked issue to Merged column
- [ ] Pushed merge commit to Github

Operator (after pushing the merge commit)

- [ ] Moved freebies to Merged column                       <sub>or there are no freebies in this PR</sub> 
- [ ] Shortened the PR chain                                <sub>or this PR is not the base of another PR</sub>
- [ ] Verified that `N reviews` labelling is accurate
- [ ] Pushed merge commit to Gitlab                         <sub>or this changes can be pushed later, together with another PR</sub>
- [ ] Deleted PR branch from Github and Gitlab

Operator (reindex) 

- [ ] Purchased BQ slot committment in `dev`                <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Started reindex in `dev`                              <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Deleted BQ slot committment in `dev`                  <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Checked for failures in `dev`                         <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Purchased BQ slot committment in `prod`               <sub>or this PR does not require reindexing `prod`</sub>
- [ ] Started reindex in `prod`                             <sub>or this PR does not require reindexing `prod`</sub>
- [ ] Deleted BQ slot committment in `prod`                 <sub>or this PR does not require reindexing `prod`</sub>
- [ ] Checked for failures in `prod`                        <sub>or this PR does not require reindexing `prod`</sub>

Operator

- [ ] Unassigned PR
