### PR TITLE
Fix order of index notifications for reindex script (#2085)

### DIFF
--- a/scripts/reindex.py
+++ b/scripts/reindex.py
@@ -52,7 +52,10 @@ parser.add_argument('--partition-prefix-length',
 parser.add_argument('--catalogs',
                     nargs='+',
                     metavar='NAME',
-                    default=config.catalogs.keys() - config.integration_test_catalogs.keys(),
+                    default=[
+                        c for c in config.catalogs
+                        if c not in config.integration_test_catalogs
+                    ],
                     choices=config.catalogs,
                     help='The names of the catalogs to reindex.')
 parser.add_argument('--delete',


### PR DESCRIPTION
Author

- [x] PR title references issue
- [x] Title of main commit references issue
- [x] PR is linked to Zenhub issue

Author (reindex)

- [x] Added `r` tag to commit title                         <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR                           <sub>or this PR does not require reindexing</sub>

Author (freebies & chains)

- [x] Freebies are blocked on this PR                       <sub>or there are no freebies in this PR</sub>
- [x] Freebies are referenced in commit titles              <sub>or there are no freebies in this PR</sub>
- [x] This PR is blocked by previous PR in the chain        <sub>or this PR is not chained to another PR</sub>
- [x] Added `chain` label to the blocking PR                <sub>or this PR is not chained to another PR</sub>

Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst  <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title                         <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR                           <sub>or this PR does not require upgrading</sub>

Author (requirements, before every review)

- [x] Ran `make requirements_update`                        <sub>or this PR leaves requirements*.txt, common.mk and Makefile untouched</sub>
- [x] Added `R` tag to commit title                         <sub>or this PR leaves requirements*.txt untouched</sub>
- [x] Added `reqs` label to PR                              <sub>or this PR leaves requirements*.txt untouched</sub>

Author (before every review)

- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>
- [x] Rebased branch on `develop`, squashed old fixups

Primary reviewer (after approval)

- [x] Commented on demo expectations                        <sub>or labelled PR as `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] Moved ticket to Approved column
- [x] Assigned PR to an operator

Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that Demo expectations are clear              <sub>or PR is labeled as `no demo`</sub>
- [x] Rebased and squashed branch
- [x] Sanity-checked history
- [x] Pushed PR branch to Github
- [x] Branch pushed to Gitlab and build passes in `sandbox` <sub>or added `no sandbox` label</sub>
- [x] Started reindex in `sandbox`                          <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `sandbox`                     <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title
- [x] Moved linked issue to Merged column
- [ ] Pushed merge commit to Github

Operator (after pushing the merge commit)

- [ ] Moved freebies to Merged column                       <sub>or there are no freebies in this PR</sub> 
- [ ] Shortened the PR chain                                <sub>or this PR is not the base of another PR</sub>
- [ ] Verified that `N reviews` labelling is accurate
- [ ] Pushed merge commit to Gitlab                         <sub>or this changes can be pushed later, together with another PR</sub>
- [ ] Deleted PR branch from Github and Gitlab

Operator (reindex) 

- [ ] Purchased BQ slot committment in `dev`                <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Started reindex in `dev`                              <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Deleted BQ slot committment in `dev`                  <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Checked for failures in `dev`                         <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Purchased BQ slot committment in `prod`               <sub>or this PR does not require reindexing `prod`</sub>
- [ ] Started reindex in `prod`                             <sub>or this PR does not require reindexing `prod`</sub>
- [ ] Deleted BQ slot committment in `prod`                 <sub>or this PR does not require reindexing `prod`</sub>
- [ ] Checked for failures in `prod`                        <sub>or this PR does not require reindexing `prod`</sub>

Operator

- [ ] Unassigned PR
