### PR TITLE
Fix: Manifest cache hits log error about object expiration (#2655)

### DIFF
--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -1644,13 +1644,11 @@ class TestManifestExpiration(AzulUnitTestCase):
 
     def test_get_seconds_until_expire(self):
         """
-        Verify a header with valid Expiration and LastModified values returns the correct expiration value
+        Verify a header with valid Expiration and LastModified values returns
+        the correct expiration value.
         """
-        margin = ManifestService._date_diff_margin
-        for object_age, expect_error in [(0, False),
-                                         (margin - 1, False),
-                                         (margin, False),
-                                         (margin + 1, True)]:
+        test_data = [(1, False), (0, False), (-1, True)]
+        for object_age, expect_error in test_data:
             with self.subTest(object_age=object_age, expect_error=expect_error):
                 with mock.patch.object(manifest_service, 'datetime') as mock_datetime:
                     now = datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
Author

- [x] PR title references issue
- [x] Title of main commit references issue
- [x] PR is linked to Zenhub issue

Author (reindex)

- [x] Added `r` tag to commit title                         <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR                           <sub>or this PR does not require reindexing</sub>

Author (freebies & chains)

- [x] Freebies are blocked on this PR                       <sub>or there are no freebies in this PR</sub>
- [x] Freebies are referenced in commit titles              <sub>or there are no freebies in this PR</sub>
- [x] This PR is blocked by previous PR in the chain        <sub>or this PR is not chained to another PR</sub>
- [x] Added `chain` label to the blocking PR                <sub>or this PR is not chained to another PR</sub>

Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst  <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title                         <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR                           <sub>or this PR does not require upgrading</sub>

Author (requirements, before every review)

- [x] Ran `make requirements_update`                        <sub>or this PR leaves requirements*.txt, common.mk and Makefile untouched</sub>
- [x] Added `R` tag to commit title                         <sub>or this PR leaves requirements*.txt untouched</sub>
- [x] Added `reqs` label to PR                              <sub>or this PR leaves requirements*.txt untouched</sub>

Author (before every review)

- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>
- [x] Rebased branch on `develop`, squashed old fixups

Primary reviewer (after approval)

- [x] Commented on demo expectations                        <sub>or labelled PR as `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] Moved ticket to Approved column
- [x] Assigned PR to an operator

Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that Demo expectations are clear              <sub>or PR is labeled as `no demo`</sub>
- [x] Rebased and squashed branch
- [x] Sanity-checked history
- [x] Pushed PR branch to Github
- [x] Branch pushed to Gitlab and build passes in `sandbox` <sub>or added `no sandbox` label</sub>
- [x] Started reindex in `sandbox`                          <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `sandbox`                     <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title
- [x] Moved linked issue to Merged column
- [ ] Pushed merge commit to Github

Operator (after pushing the merge commit)

- [ ] Moved freebies to Merged column                       <sub>or there are no freebies in this PR</sub> 
- [ ] Shortened the PR chain                                <sub>or this PR is not the base of another PR</sub>
- [ ] Verified that `N reviews` labelling is accurate
- [ ] Pushed merge commit to Gitlab                         <sub>or this changes can be pushed later, together with another PR</sub>
- [ ] Deleted PR branch from Github and Gitlab

Operator (reindex) 

- [ ] Purchased BQ slot committment in `dev`                <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Started reindex in `dev`                              <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Deleted BQ slot committment in `dev`                  <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Checked for failures in `dev`                         <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Purchased BQ slot committment in `prod`               <sub>or this PR does not require reindexing `prod`</sub>
- [ ] Started reindex in `prod`                             <sub>or this PR does not require reindexing `prod`</sub>
- [ ] Deleted BQ slot committment in `prod`                 <sub>or this PR does not require reindexing `prod`</sub>
- [ ] Checked for failures in `prod`                        <sub>or this PR does not require reindexing `prod`</sub>

Operator

- [ ] Unassigned PR
