### PR TITLE
Fix: can_bundle.py chooses an arbitrary default source (#2818)

### DIFF
--- a/scripts/can_bundle.py
+++ b/scripts/can_bundle.py
@@ -12,7 +12,7 @@ import os
 import sys
 
 from more_itertools import (
-    first,
+    one,
 )
 
 from args import (
@@ -44,9 +44,12 @@ def main(argv):
     default_catalog = config.default_catalog
     plugin_cls = RepositoryPlugin.load(default_catalog)
     plugin = plugin_cls.create(default_catalog)
-    default_source = str(first(plugin.sources))
+    if len(plugin.sources) == 1:
+        source_arg = {'default': str(one(plugin.sources))}
+    else:
+        source_arg = {'required': True}
     parser.add_argument('--source', '-s',
-                        default=default_source,
+                        **source_arg,
                         help='The repository source containing the bundle')
     parser.add_argument('--uuid', '-b',
                         required=True,


### PR DESCRIPTION
Author

- [x] PR title references issue
- [x] Title of main commit references issue
- [x] PR is linked to Zenhub issue

Author (reindex)

- [x] Added `r` tag to commit title                         <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR                           <sub>or this PR does not require reindexing</sub>

Author (freebies & chains)

- [x] Freebies are blocked on this PR                       <sub>or there are no freebies in this PR</sub>
- [x] Freebies are referenced in commit titles              <sub>or there are no freebies in this PR</sub>
- [x] This PR is blocked by previous PR in the chain        <sub>or this PR is not chained to another PR</sub>
- [x] Added `chain` label to the blocking PR                <sub>or this PR is not chained to another PR</sub>

Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst  <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title                         <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR                           <sub>or this PR does not require upgrading</sub>

Author (requirements, before every review)

- [x] Ran `make requirements_update`                        <sub>or this PR leaves requirements*.txt, common.mk and Makefile untouched</sub>
- [x] Added `R` tag to commit title                         <sub>or this PR leaves requirements*.txt untouched</sub>
- [x] Added `reqs` label to PR                              <sub>or this PR leaves requirements*.txt untouched</sub>

Author (before every review)

- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>
- [x] Rebased branch on `develop`, squashed old fixups

Primary reviewer (after approval)

- [x] Commented on demo expectations                        <sub>or labelled PR as `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] Moved ticket to Approved column
- [x] Assigned PR to an operator

Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that Demo expectations are clear              <sub>or PR is labeled as `no demo`</sub>
- [x] Rebased and squashed branch
- [x] Sanity-checked history
- [x] Pushed PR branch to Github
- [x] Branch pushed to Gitlab and build passes in `sandbox` <sub>or added `no sandbox` label</sub>
- [x] Started reindex in `sandbox`                          <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `sandbox`                     <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title
- [x] Moved linked issue to Merged column
- [ ] Pushed merge commit to Github

Operator (after pushing the merge commit)

- [ ] Moved freebies to Merged column                       <sub>or there are no freebies in this PR</sub> 
- [ ] Shortened the PR chain                                <sub>or this PR is not the base of another PR</sub>
- [ ] Verified that `N reviews` labelling is accurate
- [x] Pushed merge commit to Gitlab                         <sub>or this changes can be pushed later, together with another PR</sub>
- [ ] Deleted PR branch from Github and Gitlab

Operator (reindex) 

- [x] Purchased BQ slot committment in `dev`                <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `dev`                              <sub>or this PR does not require reindexing `dev`</sub>
- [x] Deleted BQ slot committment in `dev`                  <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for failures in `dev`                         <sub>or this PR does not require reindexing `dev`</sub>
- [x] Purchased BQ slot committment in `prod`               <sub>or this PR does not require reindexing `prod`</sub>
- [x] Started reindex in `prod`                             <sub>or this PR does not require reindexing `prod`</sub>
- [x] Deleted BQ slot committment in `prod`                 <sub>or this PR does not require reindexing `prod`</sub>
- [x] Checked for failures in `prod`                        <sub>or this PR does not require reindexing `prod`</sub>

Operator

- [ ] Unassigned PR
