### PR TITLE
Fix: Sporadic failures related to 'ConflictException' when running make deploy (#1951)

### DIFF
--- a/scripts/prepare_lambda_deployment.py
+++ b/scripts/prepare_lambda_deployment.py
@@ -35,10 +35,6 @@ def transform_tf(input_json):
         'es_instance_count': {}
     }
 
-    input_json['output']['rest_api_id'] = {
-        'value': '${aws_api_gateway_rest_api.rest_api.id}'
-    }
-
     for func in input_json['resource']['aws_lambda_function'].values():
         assert 'layers' not in func
         func['layers'] = ["${var.layer_arn}"]

--- a/scripts/prepare_lambda_deployment.py
+++ b/scripts/prepare_lambda_deployment.py
@@ -35,6 +35,10 @@ def transform_tf(input_json):
         'es_instance_count': {}
     }
 
+    input_json['output']['stage_name'] = {
+        'value': '${aws_api_gateway_deployment.rest_api.stage_name}'
+    }
+
     for func in input_json['resource']['aws_lambda_function'].values():
         assert 'layers' not in func
         func['layers'] = ["${var.layer_arn}"]

--- a/terraform/api_gateway.tf.json.template.py
+++ b/terraform/api_gateway.tf.json.template.py
@@ -91,16 +91,10 @@ emit_tf({
     # Note that ${} references exist to interpolate a value AND express a dependency.
     "resource": [
         {
-            "aws_api_gateway_deployment": {
-                lambda_.name: {
-                    "rest_api_id": "${module.chalice_%s.RestAPIId}" % lambda_.name,
-                    "stage_name": config.deployment_stage
-                }
-            },
             "aws_api_gateway_base_path_mapping": {
                 f"{lambda_.name}_{i}": {
                     "api_id": "${module.chalice_%s.RestAPIId}" % lambda_.name,
-                    "stage_name": "${aws_api_gateway_deployment.%s.stage_name}" % lambda_.name,
+                    "stage_name": "${module.chalice_%s.stage_name}" % lambda_.name,
                     "domain_name": "${aws_api_gateway_domain_name.%s_%i.domain_name}" % (lambda_.name, i)
                 }
                 for i, domain in enumerate(lambda_.domains)

--- a/terraform/api_gateway.tf.json.template.py
+++ b/terraform/api_gateway.tf.json.template.py
@@ -93,13 +93,13 @@ emit_tf({
         {
             "aws_api_gateway_deployment": {
                 lambda_.name: {
-                    "rest_api_id": "${module.chalice_%s.rest_api_id}" % lambda_.name,
+                    "rest_api_id": "${module.chalice_%s.RestAPIId}" % lambda_.name,
                     "stage_name": config.deployment_stage
                 }
             },
             "aws_api_gateway_base_path_mapping": {
                 f"{lambda_.name}_{i}": {
-                    "api_id": "${module.chalice_%s.rest_api_id}" % lambda_.name,
+                    "api_id": "${module.chalice_%s.RestAPIId}" % lambda_.name,
                     "stage_name": "${aws_api_gateway_deployment.%s.stage_name}" % lambda_.name,
                     "domain_name": "${aws_api_gateway_domain_name.%s_%i.domain_name}" % (lambda_.name, i)
                 }
@@ -174,7 +174,7 @@ emit_tf({
                                     "command": ' '.join(map(shlex.quote, [
                                         "python",
                                         config.project_root + "/scripts/log_api_gateway.py",
-                                        "${module.chalice_%s.rest_api_id}" % lambda_.name,
+                                        "${module.chalice_%s.RestAPIId}" % lambda_.name,
                                         config.deployment_stage,
                                         "${aws_cloudwatch_log_group.%s.arn}" % lambda_.name
                                     ]))


### PR DESCRIPTION
TODO: 
- [x] Decide about commit title
- [x] Reproduce Abraham's error
- [x] Try and reproduce error encountered beore

Author

- [x] PR title references issue
- [x] Title of main commit references issue
- [x] PR is linked to Zenhub issue

Author (reindex)

- [x] Added `r` tag to commit title                         <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR                           <sub>or this PR does not require reindexing</sub>

Author (freebies & chains)

- [x] Freebies are blocked on this PR                       <sub>or there are no freebies in this PR</sub>
- [x] Freebies are referenced in commit titles              <sub>or there are no freebies in this PR</sub>
- [x] This PR is blocked by previous PR in the chain        <sub>or this PR is not chained to another PR</sub>
- [x] Added `chain` label to the blocking PR                <sub>or this PR is not chained to another PR</sub>

Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst  <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title                         <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR                           <sub>or this PR does not require upgrading</sub>

Author (requirements, before every review)

- [x] Ran `make requirements_update`                        <sub>or this PR leaves requirements*.txt, common.mk and Makefile untouched</sub>
- [x] Added `R` tag to commit title                         <sub>or this PR leaves requirements*.txt untouched</sub>
- [x] Added `reqs` label to PR                              <sub>or this PR leaves requirements*.txt untouched</sub>

Author (before every review)

- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>
- [x] Rebased branch on `develop`, squashed old fixups

Primary reviewer (after approval)

- [x] Commented on demo expectations                        <sub>or labelled PR as `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] Moved ticket to Approved column
- [x] Assigned PR to an operator

Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that Demo expectations are clear              <sub>or PR is labeled as `no demo`</sub>
- [x] Rebased and squashed branch
- [x] Sanity-checked history
- [x] Pushed PR branch to Github
- [x] Branch pushed to Gitlab                               <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in sandbox and added `sandbox` label     <sub>or PR is labeled `no sandbox`</sub>
- [x] Started reindex in `sandbox`                          <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `sandbox`                     <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title
- [x] Moved linked issue to Merged column
- [x] Pushed merge commit to Github

Operator (after pushing the merge commit)

- [ ] Moved freebies to Merged column                       <sub>or there are no freebies in this PR</sub> 
- [ ] Shortened the PR chain                                <sub>or this PR is not the base of another PR</sub>
- [ ] Verified that `N reviews` labelling is accurate
- [ ] Pushed merge commit to Gitlab                         <sub>or this changes can be pushed later, together with another PR</sub>
- [ ] Deleted PR branch from Github and Gitlab

Operator (reindex) 

- [ ] Started reindex in `dev`                              <sub>or this PR does not require reindexing or does not target `dev`</sub>
- [ ] Checked for failures in `dev`                         <sub>or this PR does not require reindexing or does not target `dev`</sub>
- [ ] Started reindex in `prod`                             <sub>or this PR does not require reindexing or does not target `prod`</sub>
- [ ] Checked for failures in `prod`                        <sub>or this PR does not require reindexing or does not target `prod`</sub>

Operator

- [ ] Unassigned PR
