### PR TITLE
Refactor pagination dict to be a class (#2778)

### DIFF
--- a/lambdas/service/app.py
+++ b/lambdas/service/app.py
@@ -359,23 +359,21 @@ class ServiceApp(AzulChaliceApp):
     def get_pagination(self, entity_type: str) -> Pagination:
         query_params = self.current_request.query_params or {}
         default_sort, default_order = sort_defaults[entity_type]
-        pagination = {
-            "order": query_params.get('order', default_order),
-            "size": int(query_params.get('size', '10')),
-            "sort": query_params.get('sort', default_sort),
-        }
+        pagination = Pagination(order=query_params.get('order', default_order),
+                                size=int(query_params.get('size', '10')),
+                                sort=query_params.get('sort', default_sort),
+                                self_url=app.self_url())  # For `_generate_paging_dict()`
         sa = query_params.get('search_after')
         sb = query_params.get('search_before')
         sa_uid = query_params.get('search_after_uid')
         sb_uid = query_params.get('search_before_uid')
 
         if not sb and sa:
-            pagination['search_after'] = [json.loads(sa), sa_uid]
+            pagination.search_after = [json.loads(sa), sa_uid]
         elif not sa and sb:
-            pagination['search_before'] = [json.loads(sb), sb_uid]
+            pagination.search_before = [json.loads(sb), sb_uid]
         elif sa and sb:
             raise BadArgumentException("Bad arguments, only one of search_after or search_before can be set")
-        pagination['_self_url'] = app.self_url()  # For `_generate_paging_dict()`
         return pagination
 
     def file_url(self,

--- a/src/azul/service/index_query_service.py
+++ b/src/azul/service/index_query_service.py
@@ -154,7 +154,13 @@ class IndexQueryService(ElasticsearchService):
         assert all(len(unified_summary) == len(summary) for summary in summaries.values())
         return unified_summary
 
-    def get_search(self, catalog: CatalogName, entity_type, pagination, filters: str, _query, field):
+    def get_search(self,
+                   catalog: CatalogName,
+                   entity_type: str,
+                   pagination: Pagination,
+                   filters: str,
+                   _query: str,
+                   field: str):
         filters = self.parse_filters(filters)
         # HACK: Adding this small check to make sure the search bar works with
         if entity_type in ('donor', 'file-donor'):


### PR DESCRIPTION
Author

- [x] PR title references issue
- [x] Title of main commit references issue
- [x] PR is linked to Zenhub issue

Author (reindex)

- [x] Added `r` tag to commit title                         <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR                           <sub>or this PR does not require reindexing</sub>

Author (freebies & chains)

- [x] Freebies are blocked on this PR                       <sub>or there are no freebies in this PR</sub>
- [x] Freebies are referenced in commit titles              <sub>or there are no freebies in this PR</sub>
- [x] This PR is blocked by previous PR in the chain        <sub>or this PR is not chained to another PR</sub>
- [x] Added `chain` label to the blocking PR                <sub>or this PR is not chained to another PR</sub>

Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst  <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title                         <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR                           <sub>or this PR does not require upgrading</sub>

Author (requirements, before every review)

- [x] Ran `make requirements_update`                        <sub>or this PR leaves requirements*.txt, common.mk and Makefile untouched</sub>
- [x] Added `R` tag to commit title                         <sub>or this PR leaves requirements*.txt untouched</sub>
- [x] Added `reqs` label to PR                              <sub>or this PR leaves requirements*.txt untouched</sub>

Author (before every review)

- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>
- [x] Rebased branch on `develop`, squashed old fixups

Primary reviewer (after approval)

- [x] Commented in issue about demo expectations            <sub>or labelled issue as `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] Moved ticket to Approved column
- [x] Assigned PR to an operator

Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear              <sub>or issue is labeled as `no demo`</sub>
- [x] Rebased and squashed branch
- [x] Sanity-checked history
- [x] Pushed PR branch to Github
- [x] Branch pushed to Gitlab                               <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in sandbox and added `sandbox` label     <sub>or PR is labeled `no sandbox`</sub>
- [x] Started reindex in `sandbox`                          <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `sandbox`                     <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title
- [x] Moved linked issue to Merged column
- [x] Pushed merge commit to Github

Operator (after pushing the merge commit)

- [x] Moved freebies to Merged column                       <sub>or there are no freebies in this PR</sub> 
- [x] Shortened the PR chain                                <sub>or this PR is not the base of another PR</sub>
- [ ] ~~Verified that `N reviews` labelling is accurate~~ Not applicable 
- [x] Pushed merge commit to Gitlab                         <sub>or this changes can be pushed later, together with another PR</sub>
- [x] Deleted PR branch from Github and Gitlab

Operator (reindex) 

- [x] Started reindex in `dev`                              <sub>or this PR does not require reindexing or does not target `dev`</sub>
- [x] Checked for failures in `dev`                         <sub>or this PR does not require reindexing or does not target `dev`</sub>
- [x] Started reindex in `prod`                             <sub>or this PR does not require reindexing or does not target `prod`</sub>
- [x] Checked for failures in `prod`                        <sub>or this PR does not require reindexing or does not target `prod`</sub>

Operator

- [x] Unassigned PR
