### PR TITLE
Fix: FileAggregator._group_keys has incorrect type hint (#3108)

### DIFF
--- a/src/azul/indexer/aggregate.py
+++ b/src/azul/indexer/aggregate.py
@@ -407,5 +407,5 @@ class GroupingAggregator(SimpleAggregator):
         ]
 
     @abstractmethod
-    def _group_keys(self, entity) -> Tuple[Any]:
+    def _group_keys(self, entity) -> Tuple[Any, ...]:
         raise NotImplementedError

--- a/src/azul/plugins/metadata/hca/aggregate.py
+++ b/src/azul/plugins/metadata/hca/aggregate.py
@@ -73,7 +73,7 @@ class FileAggregator(GroupingAggregator):
                     content_description=entity['content_description'],
                     matrix_cell_count=(fqid, entity.get('matrix_cell_count')))
 
-    def _group_keys(self, entity) -> Tuple[Any]:
+    def _group_keys(self, entity) -> Tuple[Any, ...]:
         return entity['file_format'], entity['is_intermediate']
 
     def _get_accumulator(self, field) -> Optional[Accumulator]:
@@ -107,7 +107,7 @@ class CellSuspensionAggregator(GroupingAggregator):
             'total_estimated_cells': (entity['document_id'], entity['total_estimated_cells']),
         }
 
-    def _group_keys(self, entity) -> Tuple[Any]:
+    def _group_keys(self, entity) -> Tuple[Any, ...]:
         return frozenset(entity['organ']),
 
     def _get_accumulator(self, field) -> Optional[Accumulator]:


### PR DESCRIPTION
Author

- [x] PR title references issue
- [x] Title of main commit references issue
- [x] PR is linked to Zenhub issue

Author (reindex)

- [x] Added `r` tag to commit title                         <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR                           <sub>or this PR does not require reindexing</sub>

Author (freebies & chains)

- [x] Freebies are blocked on this PR                       <sub>or there are no freebies in this PR</sub>
- [x] Freebies are referenced in commit titles              <sub>or there are no freebies in this PR</sub>
- [x] This PR is blocked by previous PR in the chain        <sub>or this PR is not chained to another PR</sub>
- [x] Added `chain` label to the blocking PR                <sub>or this PR is not chained to another PR</sub>

Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst  <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title                         <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR                           <sub>or this PR does not require upgrading</sub>

Author (requirements, before every review)

- [x] Ran `make requirements_update`                        <sub>or this PR leaves requirements*.txt, common.mk and Makefile untouched</sub>
- [x] Added `R` tag to commit title                         <sub>or this PR leaves requirements*.txt untouched</sub>
- [x] Added `reqs` label to PR                              <sub>or this PR leaves requirements*.txt untouched</sub>

Author (before every review)

- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>
- [x] Rebased branch on `develop`, squashed old fixups

Primary reviewer (after approval)

- [x] Commented in issue about demo expectations            <sub>or labelled issue as `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] Moved ticket to Approved column
- [x] Assigned PR to an operator

Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear              <sub>or issue is labeled as `no demo`</sub>
- [x] Rebased and squashed branch
- [x] Sanity-checked history
- [x] Pushed PR branch to Github
- [x] Branch pushed to Gitlab                               <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in sandbox and added `sandbox` label     <sub>or PR is labeled `no sandbox`</sub>
- [x] Started reindex in `sandbox`                          <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `sandbox`                     <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title
- [x] Moved linked issue to Merged column
- [x] Pushed merge commit to Github

Operator (after pushing the merge commit)

- [x] Moved freebies to Merged column                       <sub>or there are no freebies in this PR</sub> 
- [x] Shortened the PR chain                                <sub>or this PR is not the base of another PR</sub>
- [x] Verified that `N reviews` labelling is accurate
- [x] Pushed merge commit to Gitlab                         <sub>or this changes can be pushed later, together with another PR</sub>
- [ ] Deleted PR branch from Github and Gitlab

Operator (reindex) 

- [x] Started reindex in `dev`                              <sub>or this PR does not require reindexing or does not target `dev`</sub>
- [x] Checked for failures in `dev`                         <sub>or this PR does not require reindexing or does not target `dev`</sub>
- [x] Started reindex in `prod`                             <sub>or this PR does not require reindexing or does not target `prod`</sub>
- [x] Checked for failures in `prod`                        <sub>or this PR does not require reindexing or does not target `prod`</sub>

Operator

- [ ] Unassigned PR
