### PR TITLE
Fix: Missed SourceSpec renamings in azul.plugins.repository.canned (#2843)

### DIFF
--- a/src/azul/plugins/repository/canned/__init__.py
+++ b/src/azul/plugins/repository/canned/__init__.py
@@ -95,24 +95,24 @@ class Plugin(RepositoryPlugin[SimpleSourceSpec, CannedSourceRef]):
             for spec in self._sources
         ]
 
-    def lookup_source_id(self, name: SimpleSourceSpec) -> str:
-        return name
+    def lookup_source_id(self, spec: SimpleSourceSpec) -> str:
+        return spec
 
     @lru_cache
-    def staging_area(self, source_name: SimpleSourceSpec) -> StagingArea:
-        factory = GitHubStagingAreaFactory.from_url(source_name)
+    def staging_area(self, source_spec: SimpleSourceSpec) -> StagingArea:
+        factory = GitHubStagingAreaFactory.from_url(source_spec.name)
         return factory.load_staging_area()
 
     def _assert_source(self, source: CannedSourceRef):
-        assert source.name in self.sources, (source, self.sources)
+        assert source.spec in self.sources, (source, self.sources)
 
     def list_bundles(self, source: CannedSourceRef, prefix: str) -> List[CannedBundleFQID]:
         self._assert_source(source)
-        prefix = source.name.prefix + prefix
+        prefix = source.spec.prefix + prefix
         validate_uuid_prefix(prefix)
         log.info('Listing bundles with prefix %r in source %r.', prefix, source)
         bundle_fqids = []
-        for link in self.staging_area(source.name).links.values():
+        for link in self.staging_area(source.spec).links.values():
             if link.uuid.startswith(prefix):
                 bundle_fqids.append(SourcedBundleFQID(source=source,
                                                       uuid=link.uuid,
@@ -124,7 +124,7 @@ class Plugin(RepositoryPlugin[SimpleSourceSpec, CannedSourceRef]):
     def fetch_bundle(self, bundle_fqid: CannedBundleFQID) -> Bundle:
         self._assert_source(bundle_fqid.source)
         now = time.time()
-        staging_area = self.staging_area(bundle_fqid.source.name)
+        staging_area = self.staging_area(bundle_fqid.source.spec)
         version, manifest, metadata = staging_area.get_bundle_metadata(bundle_fqid.uuid)
         if bundle_fqid.version is None:
             bundle_fqid = SourcedBundleFQID(source=bundle_fqid.source,
@@ -182,8 +182,8 @@ class Plugin(RepositoryPlugin[SimpleSourceSpec, CannedSourceRef]):
         # return the URL for the match with the latest (largest) version.
         found_version = None
         found_url = None
-        for source_name in self.sources:
-            staging_area = self.staging_area(source_name)
+        for source_spec in self.sources:
+            staging_area = self.staging_area(source_spec)
             try:
                 descriptor = staging_area.descriptors[file_uuid]
             except KeyError:
@@ -193,11 +193,11 @@ class Plugin(RepositoryPlugin[SimpleSourceSpec, CannedSourceRef]):
                 if file_version:
                     if file_version == actual_file_version:
                         file_name = descriptor.content['file_name']
-                        return self._construct_file_url(source_name, file_name)
+                        return self._construct_file_url(source_spec.name, file_name)
                 else:
                     if found_version is None or actual_file_version > found_version:
                         file_name = descriptor.content['file_name']
-                        found_url = self._construct_file_url(source_name, file_name)
+                        found_url = self._construct_file_url(source_spec.name, file_name)
                         found_version = actual_file_version
         return found_url
 

--- a/src/azul/plugins/repository/canned/__init__.py
+++ b/src/azul/plugins/repository/canned/__init__.py
@@ -125,7 +125,7 @@ class Plugin(RepositoryPlugin[SimpleSourceSpec, CannedSourceRef]):
         self._assert_source(bundle_fqid.source)
         now = time.time()
         staging_area = self.staging_area(bundle_fqid.source.spec)
-        version, manifest, metadata = staging_area.get_bundle_metadata(bundle_fqid.uuid)
+        version, manifest, metadata = staging_area.get_bundle(bundle_fqid.uuid)
         if bundle_fqid.version is None:
             bundle_fqid = SourcedBundleFQID(source=bundle_fqid.source,
                                             uuid=bundle_fqid.uuid,


### PR DESCRIPTION
Author

- [x] PR title references issue
- [x] Title of main commit references issue
- [x] PR is linked to Zenhub issue

Author (reindex)

- [x] Added `r` tag to commit title                         <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR                           <sub>or this PR does not require reindexing</sub>

Author (freebies & chains)

- [x] Freebies are blocked on this PR                       <sub>or there are no freebies in this PR</sub>
- [x] Freebies are referenced in commit titles              <sub>or there are no freebies in this PR</sub>
- [x] This PR is blocked by previous PR in the chain        <sub>or this PR is not chained to another PR</sub>
- [x] Added `chain` label to the blocking PR                <sub>or this PR is not chained to another PR</sub>

Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst  <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title                         <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR                           <sub>or this PR does not require upgrading</sub>

Author (requirements, before every review)

- [x] Ran `make requirements_update`                        <sub>or this PR leaves requirements*.txt, common.mk and Makefile untouched</sub>
- [x] Added `R` tag to commit title                         <sub>or this PR leaves requirements*.txt untouched</sub>
- [x] Added `reqs` label to PR                              <sub>or this PR leaves requirements*.txt untouched</sub>

Author (before every review)

- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>
- [x] Rebased branch on `develop`, squashed old fixups

Primary reviewer (after approval)

- [x] Commented in issue about demo expectations            <sub>or labelled issue as `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] Moved ticket to Approved column
- [x] Assigned PR to an operator

Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear              <sub>or issue is labeled as `no demo`</sub>
- [x] Rebased and squashed branch
- [x] Sanity-checked history
- [x] Pushed PR branch to Github
- [x] Branch pushed to Gitlab                               <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in sandbox and added `sandbox` label     <sub>or PR is labeled `no sandbox`</sub>
- [x] Started reindex in `sandbox`                          <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `sandbox`                     <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title
- [x] Moved linked issue to Merged column
- [ ] Pushed merge commit to Github

Operator (after pushing the merge commit)

- [ ] Moved freebies to Merged column                       <sub>or there are no freebies in this PR</sub> 
- [ ] Shortened the PR chain                                <sub>or this PR is not the base of another PR</sub>
- [ ] Verified that `N reviews` labelling is accurate
- [ ] Pushed merge commit to Gitlab                         <sub>or this changes can be pushed later, together with another PR</sub>
- [ ] Deleted PR branch from Github and Gitlab

Operator (reindex) 

- [ ] Started reindex in `dev`                              <sub>or this PR does not require reindexing or does not target `dev`</sub>
- [ ] Checked for failures in `dev`                         <sub>or this PR does not require reindexing or does not target `dev`</sub>
- [ ] Started reindex in `prod`                             <sub>or this PR does not require reindexing or does not target `prod`</sub>
- [ ] Checked for failures in `prod`                        <sub>or this PR does not require reindexing or does not target `prod`</sub>

Operator

- [ ] Unassigned PR
