### PR TITLE
Fix: A project in dcp7 catalog causes AssertionError (#3238)

### DIFF
--- a/src/azul/plugins/metadata/hca/contributor_matrices.py
+++ b/src/azul/plugins/metadata/hca/contributor_matrices.py
@@ -258,9 +258,34 @@ def make_stratification_tree(files: Sequence[Mapping[str, str]]) -> JSON:
     ...         }
     ...     ]
     ... )
-    Traceback (most recent call last):
-    ...
-    AssertionError: ['genusSpecies', 'organ']
+    {
+        "genusSpecies": {
+            "a": {
+                "organ": {
+                    "b": [
+                        {
+                            "uuid": "u",
+                            "version": "v",
+                            "name": "n",
+                            "size": 1,
+                            "source": "s",
+                            "url": null
+                        }
+                    ],
+                    "Unspecified": [
+                        {
+                            "uuid": "u",
+                            "version": "v",
+                            "name": "n",
+                            "size": 1,
+                            "source": "s",
+                            "url": null
+                        }
+                    ]
+                }
+            }
+        }
+    }
 
     >>> f(
     ...     [
@@ -317,12 +342,15 @@ def make_stratification_tree(files: Sequence[Mapping[str, str]]) -> JSON:
                 distinct_values[dimension].add(value)
     sorted_dimensions = sorted(distinct_values, key=dimension_placement)
 
-    # Verify that every stratum uses the same dimensions
-    # FIXME: Allow CGM stratification tree with varying dimensions
-    # https://github.com/DataBiosphere/azul/issues/2443
+    # Ensure every stratum of every file has the same dimensions
     for file in files:
         for stratum in file['strata']:
-            assert set(sorted_dimensions) == stratum.keys(), sorted_dimensions
+            # FIXME: https://github.com/DataBiosphere/azul/issues/2443
+            #        Instead of creating 'Unspecified' nodes the tree branches
+            #        should not include those nodes, making the branches shorter
+            #        and of different lengths.
+            for dimension in set(sorted_dimensions).difference(stratum.keys()):
+                stratum[dimension] = 'Unspecified'
 
     # Build the tree, as a nested dictionary. The keys in the dictionary
     # alternate between dimensions and values. The leaves of the tree are
@@ -333,9 +361,8 @@ def make_stratification_tree(files: Sequence[Mapping[str, str]]) -> JSON:
         for stratum in file['strata']:
             node = tree
             for dimension in sorted_dimensions:
-                value = stratum.get(dimension)
-                if value is not None:
-                    node = node[dimension][value]
+                value = stratum[dimension]
+                node = node[dimension][value]
             node.append({k: v for k, v in file.items() if k != 'strata'})
 
     return tree


### PR DESCRIPTION
Fix: A project in dcp7 catalog causes AssertionError (#3238)

Author

- [x] PR title references issue
- [x] Title of main commit references issue
- [x] PR is linked to Zenhub issue

Author (reindex)

- [x] Added `r` tag to commit title                         <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR                           <sub>or this PR does not require reindexing</sub>

Author (freebies & chains)

- [x] Freebies are blocked on this PR                       <sub>or there are no freebies in this PR</sub>
- [x] Freebies are referenced in commit titles              <sub>or there are no freebies in this PR</sub>
- [x] This PR is blocked by previous PR in the chain        <sub>or this PR is not chained to another PR</sub>
- [x] Added `chain` label to the blocking PR                <sub>or this PR is not chained to another PR</sub>

Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst  <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title                         <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR                           <sub>or this PR does not require upgrading</sub>

Author (requirements, before every review)

- [x] Ran `make requirements_update`                        <sub>or this PR leaves requirements*.txt, common.mk and Makefile untouched</sub>
- [x] Added `R` tag to commit title                         <sub>or this PR leaves requirements*.txt untouched</sub>
- [x] Added `reqs` label to PR                              <sub>or this PR leaves requirements*.txt untouched</sub>

Author (before every review)

- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>
- [ ] ~Rebased branch on `develop`, squashed old fixups~
- [x] Rebased branch on `prod`, squashed old fixups

Primary reviewer (after approval)

- [x] Commented in issue about demo expectations            <sub>or labelled issue as `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] Moved ticket to Approved column
- [x] Assigned PR to an operator

Operator (before pushing merge the commit)

- [ ] Checked `reindex` label and `r` commit title tag
- [ ] Checked that demo expectations are clear              <sub>or issue is labeled as `no demo`</sub>
- [ ] Rebased and squashed branch
- [ ] Sanity-checked history
- [ ] Pushed PR branch to Github
- [ ] Branch pushed to Gitlab                               <sub>or PR is labeled `no sandbox`</sub>
- [ ] Build passes in sandbox and added `sandbox` label     <sub>or PR is labeled `no sandbox`</sub>
- [ ] Started reindex in `sandbox`                          <sub>or this PR does not require reindexing `sandbox`</sub>
- [ ] Checked for failures in `sandbox`                     <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title
- [x] Moved linked issue to Merged column
- [ ] Pushed merge commit to Github

Operator (after pushing the merge commit)

- [ ] Moved freebies to Merged column                       <sub>or there are no freebies in this PR</sub> 
- [ ] Shortened the PR chain                                <sub>or this PR is not the base of another PR</sub>
- [ ] Verified that `N reviews` labelling is accurate
- [ ] Pushed merge commit to Gitlab                         <sub>or this changes can be pushed later, together with another PR</sub>
- [ ] Deleted PR branch from Github and Gitlab

Operator (reindex) 

- [ ] Started reindex in `dev`                              <sub>or this PR does not require reindexing or does not target `dev`</sub>
- [ ] Checked for failures in `dev`                         <sub>or this PR does not require reindexing or does not target `dev`</sub>
- [ ] Started reindex in `prod`                             <sub>or this PR does not require reindexing or does not target `prod`</sub>
- [ ] Checked for failures in `prod`                        <sub>or this PR does not require reindexing or does not target `prod`</sub>

Operator

- [ ] Unassigned PR
