### PR TITLE
Fix: Lambda layer zip file exceeded deployment package size limit (#3329)

### DIFF
--- a/lambdas/lambdas.mk
+++ b/lambdas/lambdas.mk
@@ -13,7 +13,7 @@
 # .pyc and uses this to determine when to re-compile, but since Gitlab clones
 # the repository each time it deploys, fresh timestamps prevented the deployment
 # package from being deterministic. With the `--invalidation-mode checked-hash`
-# option, Python embeds the hash of the source file embeded in the .pyc instead
+# option, Python embeds the hash of the source file embedded in the .pyc instead
 # of the timestamp, which is consistent regardless of when the files were
 # downloaded.
 #

--- a/lambdas/layer/.gitignore
+++ b/lambdas/layer/.gitignore
@@ -1,3 +1,4 @@
 /.chalice/*
 !/.chalice/config.json.template.py
 /vendor/*
+requirements.txt

--- a/lambdas/layer/requirements.trans.txt
+++ b/lambdas/layer/requirements.trans.txt
@@ -1,1 +1,0 @@
-../../requirements.trans.txt

--- a/lambdas/layer/requirements.txt
+++ b/lambdas/layer/requirements.txt
@@ -1,1 +1,0 @@
-../../requirements.txt

--- a/src/azul/lambda_layer.py
+++ b/src/azul/lambda_layer.py
@@ -1,18 +1,27 @@
-from collections import defaultdict
+from collections import (
+    defaultdict,
+)
 import logging
 from pathlib import (
     Path,
 )
+import re
 import shutil
 import subprocess
+from typing import (
+    Iterable,
+)
 from zipfile import (
     ZipFile,
     ZipInfo,
 )
 
+import attr
+
 from azul import (
     cached_property,
     config,
+    require,
 )
 from azul.deployment import (
     aws,
@@ -24,8 +33,48 @@ from azul.files import (
 log = logging.getLogger(__name__)
 
 
+@attr.s(auto_attribs=True, frozen=True, kw_only=True)
+class Requirement:
+    name: str
+    version: str
+    git: bool
+
+    wheel_re = re.compile(r'(?P<distribution>[^-]+)-'
+                          r'(?P<version>[^-]+)-'
+                          r'(?:(?P<build_tag>\d[^-]*)-)?'
+                          r'(?P<python_tag>[^-]+)-'
+                          r'(?P<abi_tag>[^-]+)-'
+                          r'(?P<platform_tag>[^-]+).whl')
+
+    @classmethod
+    def from_pin(cls, line: str):
+        if line.startswith('git+'):
+            line = line[len('git+'):]
+            version, name = line.split('#egg=')
+            return cls(name=name, version=version, git=True)
+        else:
+            name, version = line.split('==')
+            return cls(name=name, version=version, git=False)
+
+    @classmethod
+    def from_wheel(cls, wheel: str):
+        wheel = cls.wheel_re.fullmatch(wheel)
+        return cls(name=wheel['distribution'], version=wheel['version'], git=False)
+
+    def to_pin(self) -> str:
+        if self.git:
+            return f'git+{self.version}#egg={self.name}'
+        else:
+            return f'{self.name}=={self.version}'
+
+
 class DependenciesLayer:
-    layer_dir = Path(config.project_root) / 'lambdas' / 'layer'
+    root = Path(config.project_root)
+    lambda_dir = root / 'lambdas'
+    reqs_file = root / 'requirements.txt'
+    reqs_trans_file = root / 'requirements.trans.txt'
+    wheel_dir = lambda_dir / '.wheels'
+    layer_dir = lambda_dir / 'layer'
     out_dir = layer_dir / '.chalice' / 'terraform'
 
     @property
@@ -47,7 +96,8 @@ class DependenciesLayer:
             return False
 
     def update_layer(self, force: bool = False):
-        log.info('Using dependencies layer package at s3://%s/%s.', config.lambda_layer_bucket, self.object_key)
+        log.info('Using dependencies layer package at s3://%s/%s.',
+                 config.lambda_layer_bucket, self.object_key)
         if force or self._update_required():
             log.info('Staging layer package ...')
             input_zip = self.out_dir / 'deployment.zip'
@@ -55,7 +105,8 @@ class DependenciesLayer:
             if force:
                 log.info('Tainting current lambda layer resource to force update')
                 command = ['make', 'taint_dependencies_layer']
-                subprocess.run(command, cwd=Path(config.project_root) / 'terraform').check_returncode()
+                subprocess.run(command, cwd=self.root / 'terraform').check_returncode()
+            self._generate_requirements()
             self._build_package(input_zip, layer_zip)
             self._validate_layer(layer_zip)
             log.info('Uploading layer package to S3 ...')
@@ -63,6 +114,22 @@ class DependenciesLayer:
             log.info('Successfully staged updated layer package.')
         else:
             log.info('Layer package already up-to-date.')
+
+    def _generate_requirements(self):
+        reqs = self._all_reqs()
+        vendored_reqs = [Requirement.from_wheel(w.name)
+                         for w in self.wheel_dir.iterdir()]
+        require(set(vendored_reqs).issubset(reqs), vendored_reqs, reqs)
+        # Keep reqs a list to preserve ordering
+        non_vendored_reqs = [r for r in reqs if r not in vendored_reqs]
+        reqs_by_name = defaultdict(list)
+        for req in non_vendored_reqs:
+            reqs_by_name[req.name].append(req)
+        duplicates = {k: v for k, v in reqs_by_name.items() if len(v) > 1}
+        assert not duplicates, duplicates
+        with open(self.layer_dir / 'requirements.txt', 'w') as f:
+            for req in non_vendored_reqs:
+                f.write(req.to_pin() + '\n')
 
     def _build_package(self, input_zip: Path, output_zip: Path):
         command = ['chalice', 'package', self.out_dir]
@@ -92,10 +159,25 @@ class DependenciesLayer:
         duplicates = {k: v for k, v in files.items() if len(v) > 1}
         assert not duplicates, duplicates
 
+    def _all_reqs(self) -> Iterable[Requirement]:
+        reqs = []
+        for file in (self.reqs_file, self.reqs_trans_file):
+            reqs += self._parse_reqs(file)
+        return reqs
+
+    def _parse_reqs(self, reqs: Path) -> Iterable[Requirement]:
+        with reqs.open('r') as f:
+            for line in f:
+                if line.startswith('#') or line.startswith('-r'):
+                    continue
+                else:
+                    if ' #' in line:
+                        line, *_ = line.split(' #')
+                    line = line.strip()
+                    yield Requirement.from_pin(line)
+
     @cached_property
     def object_key(self):
-        sha = '.'.join(
-            file_sha1(Path(config.project_root) / f)
-            for f in ['requirements.txt', 'requirements.trans.txt']
-        )
+        sha = '.'.join(file_sha1(f)
+                       for f in (self.reqs_file, self.reqs_trans_file))
         return f'{config.lambda_layer_key}/{sha}.zip'


### PR DESCRIPTION
https://github.com/DataBiosphere/azul/issues/3329

Author

- [x] PR title references issue
- [x] Title of main commit references issue
- [x] PR is connected to Zenhub issue and description links to issue

Author (reindex)

- [x] Added `r` tag to commit title                         <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR                           <sub>or this PR does not require reindexing</sub>

Author (freebies & chains)

- [x] Freebies are blocked on this PR                       <sub>or there are no freebies in this PR</sub>
- [x] Freebies are referenced in commit titles              <sub>or there are no freebies in this PR</sub>
- [x] This PR is blocked by previous PR in the chain        <sub>or this PR is not chained to another PR</sub>
- [x] Added `chain` label to the blocking PR                <sub>or this PR is not chained to another PR</sub>

Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst  <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title                         <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR                           <sub>or this PR does not require upgrading</sub>
- [x] Added announcement to PR description                  <sub>or this PR does not require announcement</sub>

Author (requirements, before every review)

- [x] Ran `make requirements_update`                        <sub>or this PR leaves requirements*.txt, common.mk and Makefile untouched</sub>
- [x] Added `R` tag to commit title                         <sub>or this PR leaves requirements*.txt untouched</sub>
- [x] Added `reqs` label to PR                              <sub>or this PR leaves requirements*.txt untouched</sub>

Author (before every review)

- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>
- [x] Rebased branch on `develop`, squashed old fixups

Primary reviewer (after approval)

- [x] Commented in issue about demo expectations            <sub>or labelled issue as `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] Moved ticket to Approved column
- [x] Assigned PR to an operator

Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear              <sub>or issue is labeled as `no demo`</sub>
- [x] Rebased and squashed branch
- [x] Sanity-checked history
- [x] Pushed PR branch to Github
- [x] Branch pushed to Gitlab and added `sandbox` label     <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passed in sandbox                               <sub>or PR is labeled `no sandbox`</sub>
- [x] Started reindex in `sandbox`                          <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `sandbox`                     <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title
- [x] Moved linked issue to Merged column
- [ ] Pushed merge commit to Github

Operator (after pushing the merge commit)

- [ ] Made announcement requested by author                 <sub>or PR description does not contain an announcement</sub>
- [ ] Moved freebies to Merged column                       <sub>or there are no freebies in this PR</sub> 
- [ ] Shortened the PR chain                                <sub>or this PR is not the base of another PR</sub>
- [ ] Verified that `N reviews` labelling is accurate
- [ ] Pushed merge commit to Gitlab                         <sub>or this changes can be pushed later, together with another PR</sub>
- [ ] Deleted PR branch from Github and Gitlab

Operator (reindex) 

- [ ] Started reindex in `dev`                              <sub>or this PR does not require reindexing or does not target `dev`</sub>
- [ ] Checked for failures in `dev`                         <sub>or this PR does not require reindexing or does not target `dev`</sub>
- [ ] Started reindex in `prod`                             <sub>or this PR does not require reindexing or does not target `prod`</sub>
- [ ] Checked for failures in `prod`                        <sub>or this PR does not require reindexing or does not target `prod`</sub>

Operator

- [ ] Unassigned PR
