### PR TITLE
Fix: Summary endpoint's file count is inconsistent (#3318)

### DIFF
--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -882,6 +882,8 @@ class Config:
 
     terms_aggregation_size = 99999
 
+    precision_threshold = 40000
+
     minimum_compression_size = 0
 
     @property

--- a/src/azul/service/elasticsearch_service.py
+++ b/src/azul/service/elasticsearch_service.py
@@ -60,7 +60,6 @@ from azul.service.hca_response_v5 import (
     AutoCompleteResponse,
     FileSearchResponse,
     KeywordSearchResponse,
-    SummaryResponse,
 )
 from azul.service.utilities import (
     json_pp,
@@ -504,61 +503,67 @@ class ElasticsearchService(DocumentService, AbstractService):
                                          post_filter=False,
                                          entity_type=entity_type)
 
-        # Add a total file size aggregate
-        es_search.aggs.metric(
-            'totalFileSize',
-            'sum',
-            field='contents.files.size_')
+        if entity_type == 'files':
+            # Add a total file size aggregate
+            es_search.aggs.metric('totalFileSize',
+                                  'sum',
+                                  field='contents.files.size_')
+        elif entity_type == 'cell_suspensions':
+            # Add a cell count aggregate per organ
+            es_search.aggs.bucket(
+                'cellCountSummaries',
+                'terms',
+                field='contents.cell_suspensions.organ.keyword',
+                size=config.terms_aggregation_size
+            ).bucket(
+                'cellCount',
+                'sum',
+                field='contents.cell_suspensions.total_estimated_cells_'
+            )
+            # Add a total cell count aggregate
+            es_search.aggs.metric('totalCellCount',
+                                  'sum',
+                                  field='contents.cell_suspensions.total_estimated_cells_')
+        elif entity_type == 'samples':
+            # Add an organ aggregate to the Elasticsearch request
+            es_search.aggs.bucket('organTypes',
+                                  'terms',
+                                  field='contents.samples.effective_organ.keyword',
+                                  size=config.terms_aggregation_size)
+        else:
+            assert entity_type == 'projects', entity_type
 
-        # Add a cell count aggregate per organ
-        es_search.aggs.bucket(
-            'cellCountSummaries',
-            'terms',
-            field='contents.cell_suspensions.organ.keyword',
-            size=config.terms_aggregation_size
-        ).bucket(
-            'cellCount',
-            'sum',
-            field='contents.cell_suspensions.total_estimated_cells_'
-        )
+        cardinality_aggregations = {
+            'files': {
+                'fileCount': 'contents.files.uuid'
+            },
+            'samples': {
+                'specimenCount': 'contents.specimens.document_id',
+                'speciesCount': 'contents.donors.genus_species',
+                'donorCount': 'contents.donors.document_id',
+            },
+            'projects': {
+                'projectCount': 'contents.projects.uuid',
+                'labCount': 'contents.projects.laboratory',
+            }
+        }.get(entity_type, {})
 
-        # Add a total cell count aggregate
-        es_search.aggs.metric(
-            'totalCellCount',
-            'sum',
-            field='contents.cell_suspensions.total_estimated_cells_'
-        )
-
-        # Add an organ aggregate to the Elasticsearch request
-        es_search.aggs.bucket(
-            'organTypes',
-            'terms',
-            field='contents.samples.effective_organ.keyword',
-            size=config.terms_aggregation_size
-        )
-
-        for cardinality, agg_name in (
-            ('contents.specimens.document_id', 'specimenCount'),
-            ('contents.donors.genus_species', 'speciesCount'),
-            ('contents.files.uuid', 'fileCount'),
-            ('contents.donors.document_id', 'donorCount'),
-            ('contents.projects.laboratory', 'labCount'),
-            ('contents.projects.document_id', 'projectCount')
-        ):
-            es_search.aggs.metric(
-                agg_name, 'cardinality',
-                field=cardinality + '.keyword',
-                precision_threshold="40000")
+        for agg_name, cardinality in cardinality_aggregations.items():
+            es_search.aggs.metric(agg_name,
+                                  'cardinality',
+                                  field=cardinality + '.keyword',
+                                  precision_threshold='40000')
 
         self._annotate_aggs_for_translation(es_search)
         es_search = es_search.extra(size=0)
         es_response = es_search.execute(ignore_cache=True)
         assert len(es_response.hits) == 0
         self._translate_response_aggs(catalog, es_response)
-        final_response = SummaryResponse(es_response.to_dict())
+
         if config.debug == 2 and logger.isEnabledFor(logging.DEBUG):
             logger.debug('Elasticsearch request: %s', json.dumps(es_search.to_dict(), indent=4))
-        return final_response.return_response().to_json()
+
+        return es_response.aggregations.to_dict()
 
     def transform_request(self,
                           catalog: CatalogName,

--- a/src/azul/service/elasticsearch_service.py
+++ b/src/azul/service/elasticsearch_service.py
@@ -565,7 +565,12 @@ class ElasticsearchService(DocumentService, AbstractService):
         if config.debug == 2 and logger.isEnabledFor(logging.DEBUG):
             logger.debug('Elasticsearch request: %s', json.dumps(es_search.to_dict(), indent=4))
 
-        return es_response.aggregations.to_dict()
+        result = es_response.aggs.to_dict()
+        for agg_name in cardinality_aggregations:
+            agg_value = result[agg_name]['value']
+            assert agg_value <= threshold / 2, (agg_name, agg_value, threshold)
+
+        return result
 
     def transform_request(self,
                           catalog: CatalogName,

--- a/src/azul/service/elasticsearch_service.py
+++ b/src/azul/service/elasticsearch_service.py
@@ -506,25 +506,25 @@ class ElasticsearchService(DocumentService, AbstractService):
 
         # Add a total file size aggregate
         es_search.aggs.metric(
-            'total_size',
+            'totalFileSize',
             'sum',
             field='contents.files.size_')
 
         # Add a cell count aggregate per organ
         es_search.aggs.bucket(
-            'group_by_organ',
+            'cellCountSummaries',
             'terms',
             field='contents.cell_suspensions.organ.keyword',
             size=config.terms_aggregation_size
         ).bucket(
-            'cell_count',
+            'cellCount',
             'sum',
             field='contents.cell_suspensions.total_estimated_cells_'
         )
 
         # Add a total cell count aggregate
         es_search.aggs.metric(
-            'total_cell_count',
+            'totalCellCount',
             'sum',
             field='contents.cell_suspensions.total_estimated_cells_'
         )

--- a/src/azul/service/elasticsearch_service.py
+++ b/src/azul/service/elasticsearch_service.py
@@ -201,6 +201,8 @@ class ElasticsearchService(DocumentService, AbstractService):
         # Make an inner aggregate that will contain the terms in question
         _field = f'{facet_config[agg]}.keyword'
         service_config = self.service_config(catalog)
+        # FIXME: Approximation errors for terms aggregation are unchecked
+        #        https://github.com/DataBiosphere/azul/issues/3413
         if agg == 'project':
             _sub_field = service_config.translation['projectId'] + '.keyword'
             aggregate.bucket('myTerms', 'terms', field=_field, size=config.terms_aggregation_size).bucket(

--- a/src/azul/service/elasticsearch_service.py
+++ b/src/azul/service/elasticsearch_service.py
@@ -545,16 +545,16 @@ class ElasticsearchService(DocumentService, AbstractService):
                 'donorCount': 'contents.donors.document_id',
             },
             'projects': {
-                'projectCount': 'contents.projects.uuid',
                 'labCount': 'contents.projects.laboratory',
             }
         }.get(entity_type, {})
 
+        threshold = config.precision_threshold
         for agg_name, cardinality in cardinality_aggregations.items():
             es_search.aggs.metric(agg_name,
                                   'cardinality',
                                   field=cardinality + '.keyword',
-                                  precision_threshold='40000')
+                                  precision_threshold=str(threshold))
 
         self._annotate_aggs_for_translation(es_search)
         es_search = es_search.extra(size=0)

--- a/src/azul/service/elasticsearch_service.py
+++ b/src/azul/service/elasticsearch_service.py
@@ -317,6 +317,8 @@ class ElasticsearchService(DocumentService, AbstractService):
 
         if enable_aggregation:
             for agg, translation in facet_config.items():
+                # FIXME: Aggregation filters may be redundant when post_filter is false
+                #        https://github.com/DataBiosphere/azul/issues/3435
                 es_search.aggs.bucket(agg, self._create_aggregate(catalog, filters, facet_config, agg))
 
         return es_search

--- a/src/azul/service/hca_response_v5.py
+++ b/src/azul/service/hca_response_v5.py
@@ -249,10 +249,10 @@ class SummaryResponse(AbstractResponse):
             return list(map(function, values))
 
         return SummaryRepresentation(
-            projectCount=agg_value('projectCount', 'value'),
+            projectCount=agg_value('project', 'doc_count'),
             specimenCount=agg_value('specimenCount', 'value'),
             speciesCount=agg_value('speciesCount', 'value'),
-            fileCount=agg_value('fileCount', 'value'),
+            fileCount=agg_value('fileFormat', 'doc_count'),
             totalFileSize=agg_value('totalFileSize', 'value'),
             donorCount=agg_value('donorCount', 'value'),
             labCount=agg_value('labCount', 'value'),

--- a/src/azul/service/hca_response_v5.py
+++ b/src/azul/service/hca_response_v5.py
@@ -131,7 +131,7 @@ class OrganCellCountSummary(JsonObject):
         self = cls()
         self.organType = [bucket['key']]
         self.countOfDocsWithOrganType = bucket['doc_count']
-        self.totalCellCountByOrgan = bucket['cell_count']['value']
+        self.totalCellCountByOrgan = bucket['cellCount']['value']
         return self
 
 
@@ -253,16 +253,16 @@ class SummaryResponse(AbstractResponse):
             specimenCount=agg_value('specimenCount', 'value'),
             speciesCount=agg_value('speciesCount', 'value'),
             fileCount=agg_value('fileCount', 'value'),
-            totalFileSize=agg_value('total_size', 'value'),
+            totalFileSize=agg_value('totalFileSize', 'value'),
             donorCount=agg_value('donorCount', 'value'),
             labCount=agg_value('labCount', 'value'),
-            totalCellCount=agg_value('total_cell_count', 'value'),
+            totalCellCount=agg_value('totalCellCount', 'value'),
             organTypes=agg_values(OrganType.for_bucket,
                                   'organTypes', 'buckets'),
             fileTypeSummaries=agg_values(FileTypeSummary.for_bucket,
                                          'fileFormat', 'myTerms', 'buckets'),
             cellCountSummaries=agg_values(OrganCellCountSummary.for_bucket,
-                                          'group_by_organ', 'buckets')
+                                          'cellCountSummaries', 'buckets')
         )
 
 

--- a/src/azul/service/hca_response_v5.py
+++ b/src/azul/service/hca_response_v5.py
@@ -232,9 +232,9 @@ T = TypeVar('T')
 
 class SummaryResponse(AbstractResponse):
 
-    def __init__(self, raw_response):
+    def __init__(self, aggregations):
         super().__init__()
-        self.aggregations = raw_response['aggregations']
+        self.aggregations = aggregations
 
     def return_response(self):
         def agg_value(*path: str) -> JSON:

--- a/src/azul/service/index_query_service.py
+++ b/src/azul/service/index_query_service.py
@@ -25,6 +25,9 @@ from azul.service.elasticsearch_service import (
     ElasticsearchService,
     Pagination,
 )
+from azul.service.hca_response_v5 import (
+    SummaryResponse,
+)
 from azul.types import (
     AnyMutableJSON,
     JSON,
@@ -141,13 +144,11 @@ class IndexQueryService(ElasticsearchService):
 
     def get_summary(self, catalog: CatalogName, filters):
         filters = self.parse_filters(filters)
-        # Request a summary for each entity type and cherry-pick summary fields from the summaries for the entity
-        # that is authoritative for those fields.
-        summary_fields_by_authority = {
+        aggs_by_authority = {
             'files': [
                 'totalFileSize',
-                'fileTypeSummaries',
-                'fileCount',
+                'fileFormat',
+                'fileCount'
             ],
             'samples': [
                 'organTypes',
@@ -157,7 +158,7 @@ class IndexQueryService(ElasticsearchService):
             ],
             'projects': [
                 'projectCount',
-                'labCount',
+                'labCount'
             ],
             'cell_suspensions': [
                 'totalCellCount',
@@ -165,20 +166,21 @@ class IndexQueryService(ElasticsearchService):
             ]
         }
 
-        def make_summary(entity_type):
+        def transform_summary(entity_type):
             """Returns the key and value for a dict entry to transformation summary"""
             return entity_type, self.transform_summary(catalog=catalog,
                                                        filters=filters,
                                                        entity_type=entity_type)
 
-        with ThreadPoolExecutor(max_workers=len(summary_fields_by_authority)) as executor:
-            summaries = dict(executor.map(make_summary,
-                                          summary_fields_by_authority))
-        unified_summary = {field: summaries[entity_type][field]
-                           for entity_type, summary_fields in summary_fields_by_authority.items()
-                           for field in summary_fields}
-        assert all(len(unified_summary) == len(summary) for summary in summaries.values())
-        return unified_summary
+        with ThreadPoolExecutor(max_workers=len(aggs_by_authority)) as executor:
+            aggs = dict(executor.map(transform_summary, aggs_by_authority))
+
+        aggs = {
+            agg_name: aggs[entity_type][agg_name]
+            for entity_type, summary_fields in aggs_by_authority.items()
+            for agg_name in summary_fields
+        }
+        return SummaryResponse(aggs).return_response().to_json()
 
     def get_search(self,
                    catalog: CatalogName,

--- a/src/azul/service/index_query_service.py
+++ b/src/azul/service/index_query_service.py
@@ -161,7 +161,7 @@ class IndexQueryService(ElasticsearchService):
             ],
             'cell_suspensions': [
                 'totalCellCount',
-                'cellCountSummaries',
+                'cellCountSummaries'
             ]
         }
 


### PR DESCRIPTION
https://github.com/DataBiosphere/azul/issues/3318

Author

- [x] PR title references issue
- [x] Title of main commit references issue
- [x] PR is connected to Zenhub issue and description links to issue

Author (reindex)

- [x] Added `r` tag to commit title                         <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR                           <sub>or this PR does not require reindexing</sub>

Author (freebies & chains)

- [x] Freebies are blocked on this PR                       <sub>or there are no freebies in this PR</sub>
- [x] Freebies are referenced in commit titles              <sub>or there are no freebies in this PR</sub>
- [x] This PR is blocked by previous PR in the chain        <sub>or this PR is not chained to another PR</sub>
- [x] Added `chain` label to the blocking PR                <sub>or this PR is not chained to another PR</sub>

Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst  <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title                         <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR                           <sub>or this PR does not require upgrading</sub>
- [x] Added announcement to PR description                  <sub>or this PR does not require announcement</sub>

Author (requirements, before every review)

- [x] Ran `make requirements_update`                        <sub>or this PR leaves requirements*.txt, common.mk and Makefile untouched</sub>
- [x] Added `R` tag to commit title                         <sub>or this PR leaves requirements*.txt untouched</sub>
- [x] Added `reqs` label to PR                              <sub>or this PR leaves requirements*.txt untouched</sub>

Author (before every review)

- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>
- [x] Rebased branch on `develop`, squashed old fixups

Primary reviewer (after approval)

- [x] Commented in issue about demo expectations            <sub>or labelled issue as `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] Moved ticket to Approved column
- [x] Assigned PR to an operator

Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear              <sub>or issue is labeled as `no demo`</sub>
- [x] Rebased and squashed branch
- [x] Sanity-checked history
- [x] Pushed PR branch to Github
- [x] Branch pushed to Gitlab and added `sandbox` label     <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passed in sandbox                               <sub>or PR is labeled `no sandbox`</sub>
- [x] Started reindex in `sandbox`                          <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `sandbox`                     <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title
- [x] Moved linked issue to Merged column
- [ ] Pushed merge commit to Github

Operator (after pushing the merge commit)

- [ ] Made announcement requested by author                 <sub>or PR description does not contain an announcement</sub>
- [ ] Moved freebies to Merged column                       <sub>or there are no freebies in this PR</sub> 
- [ ] Shortened the PR chain                                <sub>or this PR is not the base of another PR</sub>
- [ ] Verified that `N reviews` labelling is accurate
- [ ] Pushed merge commit to Gitlab                         <sub>or this changes can be pushed later, together with another PR</sub>
- [ ] Deleted PR branch from Github and Gitlab

Operator (reindex) 

- [ ] Started reindex in `dev`                              <sub>or this PR does not require reindexing or does not target `dev`</sub>
- [ ] Checked for failures in `dev`                         <sub>or this PR does not require reindexing or does not target `dev`</sub>
- [ ] Started reindex in `prod`                             <sub>or this PR does not require reindexing or does not target `prod`</sub>
- [ ] Checked for failures in `prod`                        <sub>or this PR does not require reindexing or does not target `prod`</sub>

Operator

- [ ] Unassigned PR
