### PR TITLE
Clean up old versions of portal database in S3 (#2830)

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,14 @@ temporary credentials were issued in. To account for the region specificity of
 the bucket, you may want to include the region name at then end of the bucket
 name. That way you can have consistent bucket names across regions.
 
+Next, create a lifecycle policy for the bucket. This rule governs the deletion
+of ephemeral object versions that are generated in large numbers by integration
+tests on personal and sandbox deployments. Name the rule `expire-tag`; enter
+`expires` for the Object tags Key and `true` for the Object tags Value; select
+the *Permanently delete previous versions of objects* checkbox, and enter *30*
+for *Number of days after objects become previous versions*. Then click *Create
+rule.*
+
 ### 3.1.1 Route 53 hosted zones
 
 Create a Route 53 hosted zone for the Azul service and indexer. Multiple

--- a/src/azul/portal_service.py
+++ b/src/azul/portal_service.py
@@ -43,9 +43,13 @@ log = logging.getLogger(__name__)
 
 class PortalService:
 
-    def __init__(self):
-        self.client = aws.client('s3')
-        self.version_service = VersionService()
+    @cached_property
+    def client(self):
+        return aws.client('s3')
+
+    @cached_property
+    def version_service(self) -> VersionService:
+        return VersionService()
 
     @property
     def bucket(self):

--- a/src/azul/portal_service.py
+++ b/src/azul/portal_service.py
@@ -232,7 +232,8 @@ class PortalService:
         response = self.client.put_object(Bucket=self.bucket,
                                           Key=self.object_key,
                                           Body=json_bytes,
-                                          ContentType='application/json')
+                                          ContentType='application/json',
+                                          Tagging='='.join(self._expiration_tag))
         new_version = response['VersionId']
         try:
             self.version_service.put(self._db_url, version, new_version)
@@ -265,3 +266,7 @@ class PortalService:
     @property
     def _db_url(self) -> str:
         return f's3:/{self.bucket}/{self.object_key}'
+
+    @property
+    def _expiration_tag(self) -> Tuple[str, str]:
+        return 'expires', str(not config.is_main_deployment()).lower()

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -777,12 +777,27 @@ class AzulClientIntegrationTest(IntegrationTestCase):
                           notifications)
 
 
-@unittest.skipIf(config.is_main_deployment(), 'Test would pollute portal DB')
-class PortalRegistrationIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
+class PortalTestCase(IntegrationTestCase):
 
     @cached_property
     def portal_service(self) -> PortalService:
         return PortalService()
+
+
+class PortalExpirationIntegrationTest(PortalTestCase):
+
+    def test_expiration_tagging(self):
+        # This will upload the default DB if it is missing
+        self.portal_service.read()
+        s3_client = self.portal_service.client
+        response = s3_client.get_object_tagging(Bucket=self.portal_service.bucket,
+                                                Key=self.portal_service.object_key)
+        tags = [(tag['Key'], tag['Value']) for tag in response['TagSet']]
+        self.assertIn(self.portal_service._expiration_tag, tags)
+
+
+@unittest.skipIf(config.is_main_deployment(), 'Test would pollute portal DB')
+class PortalRegistrationIntegrationTest(PortalTestCase, AlwaysTearDownTestCase):
 
     @property
     def expected_db(self) -> JSONs:


### PR DESCRIPTION
https://github.com/DataBiosphere/azul/issues/2830

Author

- [x] PR title references issue
- [x] PR title matches issue title (preceded by `Fix: ` for bugs)   <sub>or there is a good reason why they're different</sub>
- [x] Title of main commit references issue
- [x] PR is connected to Zenhub issue and description links to issue

Author (reindex)

- [x] Added `r` tag to commit title                         <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR                           <sub>or this PR does not require reindexing</sub>

Author (freebies & chains)

- [x] Freebies are blocked on this PR                       <sub>or there are no freebies in this PR</sub>
- [x] Freebies are referenced in commit titles              <sub>or there are no freebies in this PR</sub>
- [x] This PR is blocked by previous PR in the chain        <sub>or this PR is not chained to another PR</sub>
- [x] Added `chain` label to the blocking PR                <sub>or this PR is not chained to another PR</sub>

Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst  <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title                         <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR                           <sub>or this PR does not require upgrading</sub>
- [x] Added announcement to PR description                  <sub>or this PR does not require announcement</sub>

Author (requirements, before every review)

- [x] Ran `make requirements_update`                        <sub>or this PR leaves requirements*.txt, common.mk and Makefile untouched</sub>
- [x] Added `R` tag to commit title                         <sub>or this PR leaves requirements*.txt untouched</sub>
- [x] Added `reqs` label to PR                              <sub>or this PR leaves requirements*.txt untouched</sub>

Author (before every review)

- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>
- [x] Rebased branch on `develop`, squashed old fixups

Primary reviewer (after approval)

- [x] Commented in issue about demo expectations            <sub>or labelled issue as `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] Moved ticket to Approved column
- [x] Assigned PR to an operator

Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear              <sub>or issue is labeled as `no demo`</sub>
- [x] Rebased and squashed branch
- [x] Sanity-checked history
- [x] Pushed PR branch to Github
- [x] Branch pushed to Gitlab and added `sandbox` label     <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passed in sandbox                               <sub>or PR is labeled `no sandbox`</sub>
- [x] Started reindex in `sandbox`                          <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `sandbox`                     <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title
- [x] Moved linked issue to Merged column
- [ ] Pushed merge commit to Github

Operator (after pushing the merge commit)

- [ ] Made announcement requested by author                 <sub>or PR description does not contain an announcement</sub>
- [ ] Moved freebies to Merged column                       <sub>or there are no freebies in this PR</sub> 
- [ ] Shortened the PR chain                                <sub>or this PR is not the base of another PR</sub>
- [ ] Verified that `N reviews` labelling is accurate
- [ ] Pushed merge commit to Gitlab                         <sub>or this changes can be pushed later, together with another PR</sub>
- [ ] Deleted PR branch from Github and Gitlab

Operator (reindex) 

- [ ] Started reindex in `dev`                              <sub>or this PR does not require reindexing or does not target `dev`</sub>
- [ ] Checked for failures in `dev`                         <sub>or this PR does not require reindexing or does not target `dev`</sub>
- [ ] Started reindex in `prod`                             <sub>or this PR does not require reindexing or does not target `prod`</sub>
- [ ] Checked for failures in `prod`                        <sub>or this PR does not require reindexing or does not target `prod`</sub>

Operator

- [ ] Unassigned PR
