### PR TITLE
Standardize process for back-porting `prod` to `develop` in operator manual (#3378)

### DIFF
--- a/OPERATOR.rst
+++ b/OPERATOR.rst
@@ -185,7 +185,7 @@ old catalog.
 
 
 Promoting to ``prod``
----------------------
+^^^^^^^^^^^^^^^^^^^^^
 
 Promotions to ``prod`` should happen weekly on Wednesdays, at 3pm. We promote
 earlier in the week in order to triage any potential issues during reindexing.
@@ -229,7 +229,7 @@ To do a promotion:
 #. On the Zenhub board, move the issues that were merged from the "dev" column to "prod".
 
 Backporting from ``prod`` to ``develop``
-----------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 #. Open a PR from the GitHub UI
 

--- a/OPERATOR.rst
+++ b/OPERATOR.rst
@@ -298,6 +298,6 @@ Handing over operator duties
 #. Old operator must re-assign expected indexing failure tickets to the new operator, along with
    ticket that tracks operator duties.
 
-#. New operator must ask to join the ``Azul Operators`` Github permissions group on DataBiosphere, and be given ``Maintainer`` access on GitLab. It's easiest to ask the tech lead via Slack.
+#. New operator must request the necessary permissions, as specified in `Getting started as operator`_.
 
 .. _all tickets in the approved column: https://github.com/DataBiosphere/azul/pulls?q=is%3Apr+is%3Aopen+reviewed-by%3Ahannes-ucsc+review%3Aapproved

--- a/OPERATOR.rst
+++ b/OPERATOR.rst
@@ -231,15 +231,27 @@ To do a promotion:
 Backporting from ``prod`` to ``develop``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-#. Open a PR from the GitHub UI
+#. Open a PR from the GitHub UI titled::
+
+       Backport: <Commit hash(es) of changes being backported> (#<Issue number(s)>, PR #<PR number>)
+
+   e.g. ``"Backport 32c55d7 and d574f91 (#3383, #3353, PR #3365)"``. Note that
+   the order of the commit hashes and issue numbers must be consistent to
+   preserve their association. The PR branch should be `prod` and the target
+   branch should be `develop`.
 
 #. Trim PR checklist to the section ``Primary reviewer``
 
-#. Get approval from a peer
+#. Get approval from a peer. The PR should only be assigned to one person at a
+   time, either the reviewer or the operator.
 
-#. Push a merge commit titled ``Merge branch 'prod' to develop`` to the ``develop`` branch.
+#. Perform the merge. The commit title should match the PR title ::
 
-**Note that the HEAD from the merge commit needs to be the same as the HEAD commit on the PR branch.**
+       git merge prod --no-ff
+
+
+#. Push the merge commit to ``develop``. It is normal for the branch history to
+  look very ugly following the merge.
 
 .. _#team-boardwalk Slack channel: https://ucsc-gi.slack.com/archives/C705Y6G9Z
 


### PR DESCRIPTION
https://github.com/DataBiosphere/azul/issues/3378

Author

- [x] PR title references issue
- [x] PR title matches issue title (preceded by `Fix: ` for bugs)   <sub>or there is a good reason why they're different</sub>
- [x] Title of main commit references issue
- [x] PR is connected to Zenhub issue and description links to issue

Author (reindex)

- [x] Added `r` tag to commit title                         <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR                           <sub>or this PR does not require reindexing</sub>

Author (freebies & chains)

- [x] Freebies are blocked on this PR                       <sub>or there are no freebies in this PR</sub>
- [x] Freebies are referenced in commit titles              <sub>or there are no freebies in this PR</sub>
- [x] This PR is blocked by previous PR in the chain        <sub>or this PR is not chained to another PR</sub>
- [x] Added `chain` label to the blocking PR                <sub>or this PR is not chained to another PR</sub>

Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst  <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title                         <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR                           <sub>or this PR does not require upgrading</sub>
- [x] Added announcement to PR description                  <sub>or this PR does not require announcement</sub>

Author (requirements, before every review)

- [x] Ran `make requirements_update`                        <sub>or this PR leaves requirements*.txt, common.mk and Makefile untouched</sub>
- [x] Added `R` tag to commit title                         <sub>or this PR leaves requirements*.txt untouched</sub>
- [x] Added `reqs` label to PR                              <sub>or this PR leaves requirements*.txt untouched</sub>

Author (before every review)

- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>
- [x] Rebased branch on `develop`, squashed old fixups

**Primary reviewer unnecessary for changes to operator manual**
~Primary reviewer (after approval)~

- [ ] ~Commented in issue about demo expectations            <sub>or labelled issue as `no demo`</sub>~
- [ ] ~Decided if PR can be labeled `no sandbox`~
- [ ] ~PR title is appropriate as title of merge commit~
- [ ] ~Moved ticket to Approved column~
- [ ] ~Assigned PR to an operator~

Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear              <sub>or issue is labeled as `no demo`</sub>
- [x] Rebased and squashed branch
- [x] Sanity-checked history
- [x] Pushed PR branch to Github
- [x] Branch pushed to Gitlab and added `sandbox` label     <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passed in sandbox                               <sub>or PR is labeled `no sandbox`</sub>
- [x] Started reindex in `sandbox`                          <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `sandbox`                     <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title
- [x] Moved linked issue to Merged column
- [ ] Pushed merge commit to Github

Operator (after pushing the merge commit)

- [ ] Made announcement requested by author                 <sub>or PR description does not contain an announcement</sub>
- [ ] Moved freebies to Merged column                       <sub>or there are no freebies in this PR</sub> 
- [ ] Shortened the PR chain                                <sub>or this PR is not the base of another PR</sub>
- [ ] Verified that `N reviews` labelling is accurate
- [ ] Pushed merge commit to Gitlab                         <sub>or this changes can be pushed later, together with another PR</sub>
- [ ] Deleted PR branch from Github and Gitlab

Operator (reindex) 

- [ ] Started reindex in `dev`                              <sub>or this PR does not require reindexing or does not target `dev`</sub>
- [ ] Checked for failures in `dev`                         <sub>or this PR does not require reindexing or does not target `dev`</sub>
- [ ] Started reindex in `prod`                             <sub>or this PR does not require reindexing or does not target `prod`</sub>
- [ ] Checked for failures in `prod`                        <sub>or this PR does not require reindexing or does not target `prod`</sub>

Operator

- [ ] Unassigned PR
