### PR TITLE
Fix: ManifestPartition.from_json does not convert search_after to tuple (#3291)

### DIFF
--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -256,9 +256,10 @@ class ManifestPartition:
 
     @classmethod
     def from_json(cls, partition: JSON) -> 'ManifestPartition':
-        # FIXME: Should convert search_after from list back to tuple
-        #        https://github.com/databiosphere/azul/issues/3291
-        return cls(**partition)
+        return cls(**{
+            k: tuple(v) if isinstance(v, list) else v
+            for k, v in partition.items()
+        })
 
     def to_json(self) -> MutableJSON:
         return attr.asdict(self)

--- a/test/service/test_manifest_async.py
+++ b/test/service/test_manifest_async.py
@@ -218,9 +218,7 @@ class TestManifestController(LocalAppTestCase):
                                           part_etags=('some_etag',),
                                           page_index=512,
                                           is_last_page=False,
-                                          # FIXME: Should really be a tuple
-                                          #        https://github.com/databiosphere/azul/issues/3291
-                                          search_after=['foo', 'doc#bar'])  # type: ignore
+                                          search_after=('foo', 'doc#bar'))
                     )
 
                     with mock.patch.object(ManifestService, 'get_manifest') as mock_get_manifest:


### PR DESCRIPTION
https://github.com/DataBiosphere/azul/issues/3291

Author

- [x] PR title references issue
- [x] PR title matches issue title (preceded by `Fix: ` for bugs)   <sub>or there is a good reason why they're different</sub>
- [x] Title of main commit references issue
- [x] PR is connected to Zenhub issue and description links to issue

Author (reindex)

- [x] Added `r` tag to commit title                         <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR                           <sub>or this PR does not require reindexing</sub>

Author (freebies & chains)

- [x] Freebies are blocked on this PR                       <sub>or there are no freebies in this PR</sub>
- [x] Freebies are referenced in commit titles              <sub>or there are no freebies in this PR</sub>
- [x] This PR is blocked by previous PR in the chain        <sub>or this PR is not chained to another PR</sub>
- [x] Added `chain` label to the blocking PR                <sub>or this PR is not chained to another PR</sub>

Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst  <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title                         <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR                           <sub>or this PR does not require upgrading</sub>
- [x] Added announcement to PR description                  <sub>or this PR does not require announcement</sub>

Author (requirements, before every review)

- [x] Ran `make requirements_update`                        <sub>or this PR leaves requirements*.txt, common.mk and Makefile untouched</sub>
- [x] Added `R` tag to commit title                         <sub>or this PR leaves requirements*.txt untouched</sub>
- [x] Added `reqs` label to PR                              <sub>or this PR leaves requirements*.txt untouched</sub>

Author (before every review)

- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>
- [x] Rebased branch on `develop`, squashed old fixups

Primary reviewer (after approval)

- [x] Commented in issue about demo expectations            <sub>or labelled issue as `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] Moved ticket to Approved column
- [x] Assigned PR to an operator

Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear              <sub>or issue is labeled as `no demo`</sub>
- [x] Rebased and squashed branch
- [x] Sanity-checked history
- [x] Pushed PR branch to Github
- [x] Branch pushed to Gitlab and added `sandbox` label     <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passed in sandbox                               <sub>or PR is labeled `no sandbox`</sub>
- [x] Started reindex in `sandbox`                          <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `sandbox`                     <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title
- [x] Moved linked issue to Merged column
- [ ] Pushed merge commit to Github

Operator (after pushing the merge commit)

- [ ] Made announcement requested by author                 <sub>or PR description does not contain an announcement</sub>
- [ ] Moved freebies to Merged column                       <sub>or there are no freebies in this PR</sub> 
- [ ] Shortened the PR chain                                <sub>or this PR is not the base of another PR</sub>
- [ ] Verified that `N reviews` labelling is accurate
- [ ] Pushed merge commit to Gitlab                         <sub>or this changes can be pushed later, together with another PR</sub>
- [ ] Deleted PR branch from Github and Gitlab

Operator (reindex) 

- [ ] Started reindex in `dev`                              <sub>or this PR does not require reindexing or does not target `dev`</sub>
- [ ] Checked for failures in `dev`                         <sub>or this PR does not require reindexing or does not target `dev`</sub>
- [ ] Started reindex in `prod`                             <sub>or this PR does not require reindexing or does not target `prod`</sub>
- [ ] Checked for failures in `prod`                        <sub>or this PR does not require reindexing or does not target `prod`</sub>

Operator

- [ ] Unassigned PR
