### PR TITLE
Fix: Layer sharing hides deployment issues (#3330)

### DIFF
--- a/scripts/stage_layer.py
+++ b/scripts/stage_layer.py
@@ -21,14 +21,9 @@ log = logging.getLogger(__name__)
 
 def main(argv):
     parser = ArgumentParser(description=__doc__)
-    parser.add_argument('-f', '--force', action='store_true',
-                        help='Force building and uploading of the layer package '
-                             'even if the dependencies have not changed. Taint '
-                             'the corresponding Terraform resource to ensure '
-                             'that Terraform re-provisions the Lambda layer.')
-    options = parser.parse_args(argv)
+    parser.parse_args(argv)
     layer = DependenciesLayer()
-    layer.update_layer(force=options.force)
+    layer.update_layer()
 
 
 if __name__ == '__main__':

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -864,11 +864,11 @@ class Config:
 
     @property
     def lambda_layer_bucket(self) -> str:
-        return self.versioned_bucket
+        return self.s3_bucket
 
     @property
     def lambda_layer_key(self) -> str:
-        return 'azul/lambda_layer'
+        return 'lambda_layers'
 
     @property
     def dynamo_object_version_table_name(self) -> str:


### PR DESCRIPTION
https://github.com/DataBiosphere/azul/issues/3330

Author

- [x] PR title references issue
- [x] PR title matches issue title (preceded by `Fix: ` for bugs)   <sub>or there is a good reason why they're different</sub>
- [x] Title of main commit references issue
- [x] PR is connected to Zenhub issue and description links to issue

Author (reindex)

- [x] Added `r` tag to commit title                         <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR                           <sub>or this PR does not require reindexing</sub>

Author (freebies & chains)

- [x] Freebies are blocked on this PR                       <sub>or there are no freebies in this PR</sub>
- [x] Freebies are referenced in commit titles              <sub>or there are no freebies in this PR</sub>
- [x] This PR is blocked by previous PR in the chain        <sub>or this PR is not chained to another PR</sub>
- [x] Added `chain` label to the blocking PR                <sub>or this PR is not chained to another PR</sub>

Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst  <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title                         <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR                           <sub>or this PR does not require upgrading</sub>
- [x] Added announcement to PR description                  <sub>or this PR does not require announcement</sub>

Author (requirements, before every review)

- [x] Ran `make requirements_update`                        <sub>or this PR leaves requirements*.txt, common.mk and Makefile untouched</sub>
- [x] Added `R` tag to commit title                         <sub>or this PR leaves requirements*.txt untouched</sub>
- [x] Added `reqs` label to PR                              <sub>or this PR leaves requirements*.txt untouched</sub>

Author (before every review)

- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>
- [x] Rebased branch on `develop`, squashed old fixups

Primary reviewer (after approval)

- [x] Commented in issue about demo expectations            <sub>or labelled issue as `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] Moved ticket to Approved column
- [x] Assigned PR to an operator

Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear              <sub>or issue is labeled as `no demo`</sub>
- [x] Rebased and squashed branch
- [x] Sanity-checked history
- [x] Pushed PR branch to Github
- [x] Branch pushed to Gitlab and added `sandbox` label     <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passed in sandbox                               <sub>or PR is labeled `no sandbox`</sub>
- [x] Started reindex in `sandbox`                          <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `sandbox`                     <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title
- [x] Moved linked issue to Merged column
- [ ] Pushed merge commit to Github

Operator (after pushing the merge commit)

- [ ] Made announcement requested by author                 <sub>or PR description does not contain an announcement</sub>
- [ ] Moved freebies to Merged column                       <sub>or there are no freebies in this PR</sub> 
- [ ] Shortened the PR chain                                <sub>or this PR is not the base of another PR</sub>
- [ ] Verified that `N reviews` labelling is accurate
- [ ] Pushed merge commit to Gitlab                         <sub>or this changes can be pushed later, together with another PR</sub>
- [ ] Deleted PR branch from Github and Gitlab

Operator (reindex) 

- [ ] Started reindex in `dev`                              <sub>or this PR does not require reindexing or does not target `dev`</sub>
- [ ] Checked for failures in `dev`                         <sub>or this PR does not require reindexing or does not target `dev`</sub>
- [ ] Delete layers from old location. Announce on Slack that everyone must immediately update their deployments.
- [ ] Started reindex in `prod`                             <sub>or this PR does not require reindexing or does not target `prod`</sub>
- [ ] Checked for failures in `prod`                        <sub>or this PR does not require reindexing or does not target `prod`</sub>

Operator

- [ ] Remind the operator to delete layers from old location in `prod` once this is promoted
- [ ] Unassigned PR
