### PR TITLE
 Document triage of failed merge commits in operator manual

### DIFF
--- a/OPERATOR.rst
+++ b/OPERATOR.rst
@@ -79,6 +79,7 @@ Triaging ``sandbox`` failures
 * If the PR fails because of out-of-date requirements on a PR with the ``[R]``
   tag the operator should rerun ``make requirements_update``,
   `committing the changes separately`_ with a title like ``[R] Update requirements``.
+  It is not necessary to re-request a review after doing so.
 
 * For integration test failures, check if the PR has the ``reindex`` tag. If so,
   running an early reindex may resolve the failure.

--- a/OPERATOR.rst
+++ b/OPERATOR.rst
@@ -93,6 +93,19 @@ Triaging ``sandbox`` failures
   discretion on whether or not to open a new ticket, it is important to record
   unusual failures to determine their eventual frequency.
 
+Triaging GitLab build failures on ``dev`` and ``prod``
+""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+If a GitLab build fails on a main deployment, the operator must evaluate the
+impact of that failure. This evaluation should include visiting the Data Browser
+to verify it isn't broken.
+
+To restore the deployment to a known working state, the operator should rerun
+the deploy job of previous passing pipeline for that deployment. This can be
+done without pushing anything and only takes a couple of minutes. The branch
+for that deployment must then be reverted to the previously passing commit.
+
+
 .. _committing the changes separately: https://github.com/DataBiosphere/azul/issues/2899#issuecomment-804508017
 
 Reindexing

--- a/OPERATOR.rst
+++ b/OPERATOR.rst
@@ -114,7 +114,27 @@ Reindexing
 
 The operator must check the status of the queues after every reindex for
 failures. Use ``python scripts/manage_queues.py`` to identify any failed
-messages. If failed messages are found
+messages. If failed messages are found, use ``python scripts/manage_queues.py``
+to
+
+- dump the failed notifications to JSON file(s), using ``--delete`` to
+  simultaneously clear the ``notifications_fail`` queue
+
+- force-feed the failed notifications back into the ``notifications_retry``
+  queue. We feed directly into the retry queue, not the primary queue, to save
+  time if/when the messages fail again.
+
+This may cause the previously failed messages to succeed. Repeat this procedure
+until the set of failed notifications stabilizes, i.e., the
+``notifications_fail`` queue is empty or no previously failed notifications
+succeeded.
+
+Next, repeat the dump/delete/force-feed steps with the failed tallies, feeding
+them into ``tallies_retry`` queue (again, **NOT** the primary queue) until the
+set of failed tallies stabilizes.
+
+If at this point the fail queues are not empty, all remaining failures must be
+tracked in tickets:
 
 - document the failures within the PR that added the changes
 - triage against expected failures from existing issues


### PR DESCRIPTION
No issue.

Author

- [ ] ~~PR title references issue~~
- [ ] ~~PR title matches issue title (preceded by `Fix: ` for bugs)   <sub>or there is a good reason why they're different</sub>~~
- [ ] ~~Title of main commit references issue~~
- [ ] ~~PR is connected to Zenhub issue and description links to issue~~

Author (reindex)

- [x] Added `r` tag to commit title                         <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR                           <sub>or this PR does not require reindexing</sub>

Author (freebies & chains)

- [x] Freebies are blocked on this PR                       <sub>or there are no freebies in this PR</sub>
- [x] Freebies are referenced in commit titles              <sub>or there are no freebies in this PR</sub>
- [x] This PR is blocked by previous PR in the chain        <sub>or this PR is not chained to another PR</sub>
- [x] Added `chain` label to the blocking PR                <sub>or this PR is not chained to another PR</sub>

Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst  <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title                         <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR                           <sub>or this PR does not require upgrading</sub>
- [x] Added announcement to PR description                  <sub>or this PR does not require announcement</sub>

Author (requirements, before every review)

- [x] Ran `make requirements_update`                        <sub>or this PR leaves requirements*.txt, common.mk and Makefile untouched</sub>
- [x] Added `R` tag to commit title                         <sub>or this PR leaves requirements*.txt untouched</sub>
- [x] Added `reqs` label to PR                              <sub>or this PR leaves requirements*.txt untouched</sub>

Author (before every review)

- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>
- [x] Rebased branch on `develop`, squashed old fixups

Primary reviewer (after approval)

- [x] Commented in issue about demo expectations            <sub>or labelled issue as `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] Moved ticket to Approved column
- [x] Assigned PR to an operator

Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear              <sub>or issue is labeled as `no demo`</sub>
- [x] Rebased and squashed branch
- [x] Sanity-checked history
- [x] Pushed PR branch to Github
- [x] Branch pushed to Gitlab and added `sandbox` label     <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passed in sandbox                               <sub>or PR is labeled `no sandbox`</sub>
- [x] Started reindex in `sandbox`                          <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `sandbox`                     <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title
- [x] Moved ~linked issue~ PR to Merged column
- [ ] Pushed merge commit to Github

Operator (after pushing the merge commit)

- [ ] Made announcement requested by author                 <sub>or PR description does not contain an announcement</sub>
- [ ] Moved freebies to Merged column                       <sub>or there are no freebies in this PR</sub> 
- [ ] Shortened the PR chain                                <sub>or this PR is not the base of another PR</sub>
- [ ] Verified that `N reviews` labelling is accurate
- [ ] Pushed merge commit to Gitlab                         <sub>or this changes can be pushed later, together with another PR</sub>
- [ ] Deleted PR branch from Github and Gitlab

Operator (reindex) 

- [ ] Started reindex in `dev`                              <sub>or this PR does not require reindexing or does not target `dev`</sub>
- [ ] Checked for failures in `dev`                         <sub>or this PR does not require reindexing or does not target `dev`</sub>
- [ ] Started reindex in `prod`                             <sub>or this PR does not require reindexing or does not target `prod`</sub>
- [ ] Checked for failures in `prod`                        <sub>or this PR does not require reindexing or does not target `prod`</sub>

Operator

- [ ] Unassigned PR
