### PR TITLE
Fix: Tallies repeatedly failed with Runtime.ExitError after prod reindex (#3485)

### DIFF
--- a/lambdas/indexer/.chalice/config.json.template.py
+++ b/lambdas/indexer/.chalice/config.json.template.py
@@ -43,7 +43,7 @@ emit({
                 },
                 indexer.aggregate_retry.name: {
                     "reserved_concurrency": config.aggregation_concurrency(retry=True),
-                    "lambda_memory_size": 3008,
+                    "lambda_memory_size": 6500,
                     "lambda_timeout": config.aggregation_lambda_timeout(retry=True)
                 },
                 indexer.update_health_cache.name: {

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -712,7 +712,7 @@ class Config:
         return (15 if retry else 5) * 60
 
     def aggregation_lambda_timeout(self, *, retry: bool) -> int:
-        return (5 if retry else 1) * 60
+        return (10 if retry else 1) * 60
 
     # For the period from 05/31/2020 to 06/06/2020, the max was 18s and the
     # average + 3 standard deviations was 1.8s in the `dev` deployment.


### PR DESCRIPTION
https://github.com/DataBiosphere/azul/issues/3485

Author

- [x] PR title references issue
- [x] PR title matches issue title (preceded by `Fix: ` for bugs)   <sub>or there is a good reason why they're different</sub>
- [x] Title of main commit references issue
- [x] PR is connected to Zenhub issue and description links to issue

Author (reindex)

- [x] Added `r` tag to commit title                         <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR                           <sub>or this PR does not require reindexing</sub>

Author (freebies & chains)

- [x] Freebies are blocked on this PR                       <sub>or there are no freebies in this PR</sub>
- [x] Freebies are referenced in commit titles              <sub>or there are no freebies in this PR</sub>
- [x] This PR is blocked by previous PR in the chain        <sub>or this PR is not chained to another PR</sub>
- [x] Added `chain` label to the blocking PR                <sub>or this PR is not chained to another PR</sub>

Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst  <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title                         <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR                           <sub>or this PR does not require upgrading</sub>
- [x] Added announcement to PR description                  <sub>or this PR does not require announcement</sub>
- [x] Added checklist items for additional operator tasks   <sub>or this PR does not require additional tasks</sub>

Author (requirements, before every review)

- [x] Ran `make requirements_update`                        <sub>or this PR leaves requirements*.txt, common.mk and Makefile untouched</sub>
- [x] Added `R` tag to commit title                         <sub>or this PR leaves requirements*.txt untouched</sub>
- [x] Added `reqs` label to PR                              <sub>or this PR leaves requirements*.txt untouched</sub>

Author (before every review)

- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>
- [x] Rebased branch on `develop`, squashed old fixups

Primary reviewer (after approval)

- [x] Commented in issue about demo expectations            <sub>or labelled issue as `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] Moved ticket to Approved column
- [x] Assigned PR to an operator

Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear              <sub>or issue is labeled as `no demo`</sub>
- [x] Rebased and squashed branch
- [x] Sanity-checked history
- [x] Pushed PR branch to Github
- [x] Branch pushed to Gitlab and added `sandbox` label     <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passed in sandbox                               <sub>or PR is labeled `no sandbox`</sub>
- [x] Started reindex in `sandbox`                          <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `sandbox`                     <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title
- [x] Moved linked issue to Merged column
- [x] Pushed merge commit to Github

Operator (after pushing the merge commit)

- [x] Made announcement requested by author                 <sub>or PR description does not contain an announcement</sub>
- [x] Moved freebies to Merged column                       <sub>or there are no freebies in this PR</sub> 
- [x] Shortened the PR chain                                <sub>or this PR is not the base of another PR</sub>
- [x] Verified that `N reviews` labelling is accurate
- [x] Pushed merge commit to Gitlab                         <sub>or this changes can be pushed later, together with another PR</sub>
- [x] Deleted PR branch from Github and Gitlab

Operator (reindex) 

- [x] Started reindex in `dev`                              <sub>or this PR does not require reindexing or does not target `dev`</sub>
- [x] Checked for failures in `dev`                         <sub>or this PR does not require reindexing or does not target `dev`</sub>
- [x] Started reindex in `prod`                             <sub>or this PR does not require reindexing or does not target `prod`</sub>
- [x] Checked for failures in `prod`                        <sub>or this PR does not require reindexing or does not target `prod`</sub>

Operator

- [x] Unassigned PR
