### PR TITLE
Fix: AzulChaliceLocalIntegrationTest fails when IT catalog name changes (#3520)

### DIFF
--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -156,6 +156,8 @@ log = logging.getLogger(__name__)
 # noinspection PyPep8Naming
 def setUpModule():
     configure_test_logging(log)
+    for catalog in config.integration_test_catalogs:
+        IndexService().create_indices(catalog)
 
 
 class SupportsRead(Protocol):


### PR DESCRIPTION
https://github.com/DataBiosphere/azul/issues/3520

### Author

- [x] PR title references issue
- [x] PR title matches issue title (preceded by `Fix: ` for bugs)   <sub>or there is a good reason why they're different</sub>
- [x] Title of main commit references issue
- [x] PR is connected to Zenhub issue and description links to issue

### Author (reindex)

- [x] Added `r` tag to commit title                         <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR                           <sub>or this PR does not require reindexing</sub>

### Author (freebies & chains)

- [x] Freebies are blocked on this PR                       <sub>or there are no freebies in this PR</sub>
- [x] Freebies are referenced in commit titles              <sub>or there are no freebies in this PR</sub>
- [x] This PR is blocked by previous PR in the chain        <sub>or this PR is not chained to another PR</sub>
- [x] Added `chain` label to the blocking PR                <sub>or this PR is not chained to another PR</sub>

### Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst  <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title                         <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR                           <sub>or this PR does not require upgrading</sub>
- [x] Added announcement to PR description                  <sub>or this PR does not require announcement</sub>
- [x] Added checklist items for additional operator tasks   <sub>or this PR does not require additional tasks</sub>

### Author (requirements, before every review)

- [x] Ran `make requirements_update`                        <sub>or this PR leaves requirements*.txt, common.mk and Makefile untouched</sub>
- [x] Added `R` tag to commit title                         <sub>or this PR leaves requirements*.txt untouched</sub>
- [x] Added `reqs` label to PR                              <sub>or this PR leaves requirements*.txt untouched</sub>

### Author (before every review)

- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>
- [x] Rebased branch on `develop`, squashed old fixups

### Primary reviewer (after approval)

- [x] Commented in issue about demo expectations            <sub>or labelled issue as `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] Moved ticket to Approved column
- [x] Assigned PR to an operator

### Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear              <sub>or issue is labeled as `no demo`</sub>
- [x] Rebased and squashed branch
- [x] Sanity-checked history
- [x] Pushed PR branch to Github
- [x] Branch pushed to Gitlab and added `sandbox` label     <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passed in sandbox                               <sub>or PR is labeled `no sandbox`</sub>
- [x] Started reindex in `sandbox`                          <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `sandbox`                     <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title
- [x] Moved linked issue to Merged column
- [x] Pushed merge commit to Github

### Operator (after pushing the merge commit)

- [x] Made announcement requested by author                 <sub>or PR description does not contain an announcement</sub>
- [x] Moved freebies to Merged column                       <sub>or there are no freebies in this PR</sub> 
- [x] Shortened the PR chain                                <sub>or this PR is not the base of another PR</sub>
- [x] Verified that `N reviews` labelling is accurate       <sub>or or this PR is authored by lead</sub>
- [x] Pushed merge commit to Gitlab                         <sub>or or merge commit can be pushed later, with another PR</sub>
- [x] Deleted PR branch from Github and Gitlab
- [x] Build passes on Gitlab

### Operator (reindex) 

- [x] Started reindex in target deployment                  <sub>or this PR does not require reindexing</sub>
- [x] Checked for and triaged indexing failures             <sub>or this PR does not require reindexing</sub>
- [x] Emptied fail queues in target deployment              <sub>or this PR does not require reindexing</sub>

### Operator

- [x] Unassigned PR
