### PR TITLE
Fix: Contribute lambda times out fetching upstream subgraphs (#3613)

### DIFF
--- a/src/azul/plugins/repository/tdr/__init__.py
+++ b/src/azul/plugins/repository/tdr/__init__.py
@@ -7,6 +7,7 @@ from concurrent.futures.thread import (
 import datetime
 from itertools import (
     groupby,
+    islice,
 )
 import json
 import logging
@@ -19,12 +20,14 @@ from typing import (
     Any,
     ClassVar,
     Dict,
+    Iterable,
     List,
     Optional,
     Sequence,
     Set,
     Tuple,
     Type,
+    Union,
     cast,
 )
 
@@ -59,6 +62,7 @@ from azul.drs import (
 )
 from azul.indexer import (
     Bundle,
+    BundleFQID,
     SourceRef,
     SourcedBundleFQID,
 )
@@ -354,30 +358,36 @@ class Plugin(RepositoryPlugin[TDRSourceSpec, TDRSourceRef]):
         unprocessed: Set[SourcedBundleFQID] = {root_bundle.fqid}
         processed: Set[SourcedBundleFQID] = set()
         stitched_links: List[JSON] = []
+        # Retrieving links in batches eliminates the risk of exceeding
+        # BigQuery's maximum query size. Using a batches size 1000 appears to be
+        # equally performant as retrieving the links without batching.
+        batch_size = 1000
         while unprocessed:
-            bundle = unprocessed.pop()
-            processed.add(bundle)
-            links = self._retrieve_links(bundle)
-            stitched_links.append(links)
-            project = EntityReference(entity_type='project',
-                                      entity_id=links['project_id'])
-            links = Links.from_json(project, links['content'])
-            linked_entities = links.all_entities()
-            dangling_inputs = links.dangling_inputs()
-            if bundle == root_bundle.fqid:
-                assert root_entities is None
-                root_entities = linked_entities - dangling_inputs
-            for entity in linked_entities:
-                entities[entity.entity_type].add(entity.entity_id)
-            if dangling_inputs:
-                if log.isEnabledFor(logging.DEBUG):
-                    log.debug('Bundle %r has dangling inputs: %r', bundle, dangling_inputs)
+            batch = set(islice(unprocessed, batch_size))
+            links = self._retrieve_links(batch)
+            processed.update(batch)
+            unprocessed -= batch
+            stitched_links.extend(links.values())
+            for links_id, links_json in links.items():
+                project = EntityReference(entity_type='project',
+                                          entity_id=links_json['project_id'])
+                links = Links.from_json(project, links_json['content'])
+                linked_entities = links.all_entities()
+                dangling_inputs = links.dangling_inputs()
+                if links_id == root_bundle.fqid:
+                    assert root_entities is None
+                    root_entities = linked_entities - dangling_inputs
+                for entity in linked_entities:
+                    entities[entity.entity_type].add(entity.entity_id)
+                if dangling_inputs:
+                    if log.isEnabledFor(logging.DEBUG):
+                        log.debug('Bundle %r has dangling inputs: %r', links_id, dangling_inputs)
+                    else:
+                        log.info('Bundle %r has %i dangling inputs', links_id, len(dangling_inputs))
+                    upstream = self._find_upstream_bundles(source, dangling_inputs)
+                    unprocessed |= upstream - processed
                 else:
-                    log.info('Bundle %r has %i dangling inputs', bundle, len(dangling_inputs))
-                upstream = self._find_upstream_bundles(source, dangling_inputs)
-                unprocessed |= upstream - processed
-            else:
-                log.debug('Bundle %r is self-contained', bundle)
+                    log.debug('Bundle %r is self-contained', links_id)
         assert root_entities is not None
         processed.remove(root_bundle.fqid)
         if processed:
@@ -385,51 +395,96 @@ class Plugin(RepositoryPlugin[TDRSourceSpec, TDRSourceRef]):
             log.info('Stitched %i bundle(s)%s', len(processed), arg)
         return entities, root_entities, stitched_links
 
-    def _retrieve_links(self, links_id: SourcedBundleFQID) -> JSON:
+    def _retrieve_links(self,
+                        links_ids: Set[SourcedBundleFQID]
+                        ) -> Dict[SourcedBundleFQID, JSON]:
         """
-        Retrieve a links entity from BigQuery and parse the `content` column.
-
-        :param links_id: Which links entity to retrieve.
+        Retrieve links entities from BigQuery and parse the `content` column.
+        :param links_ids: Which links entities to retrieve.
         """
-        links_columns = ', '.join(
-            TDRBundle.metadata_columns | {'project_id', 'links_id'}
-        )
-        source = links_id.source.spec
-        links = one(self._run_sql(f'''
-            SELECT {links_columns}
-            FROM {backtick(self._full_table_name(source, 'links'))}
-            WHERE links_id = '{links_id.uuid}'
-                AND version = TIMESTAMP('{links_id.version}')
-        '''))
-        links = dict(links)  # Enable item assignment to pre-parse content JSON
-        links['content'] = json.loads(links['content'])
+        source = one({fqid.source.spec for fqid in links_ids})
+        links = self._retrieve_entities(source, 'links', links_ids)
+        links = {
+            # Copy the values for we can reassign `content` below
+            fqid: dict(one(links_json
+                           for links_json in links
+                           if links_json['links_id'] == fqid.uuid))
+            for fqid in links_ids
+        }
+        for links_json in links.values():
+            links_json['content'] = json.loads(links_json['content'])
         return links
 
     def _retrieve_entities(self,
                            source: TDRSourceSpec,
                            entity_type: EntityType,
-                           entity_ids: Set[EntityID]
-                           ) -> BigQueryRows:
+                           entity_ids: Union[Set[EntityID], Set[BundleFQID]],
+                           ) -> List[BigQueryRow]:
+        """
+        Efficiently retrieve multiple entities from BigQuery in a single query.
+
+        :param source: Snapshot containing the entity table
+
+        :param entity_type: The type of entity, corresponding to the table name
+
+        :param entity_ids: For links, the fully qualified UUID and version of
+                           each `links` entity. For other entities, just the UUIDs.
+        """
         pk_column = entity_type + '_id'
-        non_pk_columns = (TDRBundle.data_columns
-                          if entity_type.endswith('_file')
-                          else TDRBundle.metadata_columns)
-        columns = ', '.join({pk_column, *non_pk_columns})
-        uuid_in_list = ' OR '.join(
-            f'{pk_column} = "{entity_id}"' for entity_id in entity_ids
+        version_column = 'version'
+        non_pk_columns = (
+            TDRBundle.links_columns if entity_type == 'links'
+            else TDRBundle.data_columns if entity_type.endswith('_file')
+            else TDRBundle.metadata_columns
         )
-        table_name = self._full_table_name(source, entity_type)
+        assert version_column in non_pk_columns
+        table_name = backtick(self._full_table_name(source, entity_type))
+        entity_id_type = one(set(map(type, entity_ids)))
+
+        def quote(s):
+            return f"'{s}'"
+
+        if entity_type == 'links':
+            assert issubclass(entity_id_type, BundleFQID), entity_id_type
+            entity_ids = cast(Set[BundleFQID], entity_ids)
+            where_columns = (pk_column, version_column)
+            where_values = (
+                (quote(fqid.uuid), f'TIMESTAMP({quote(fqid.version)})')
+                for fqid in entity_ids
+            )
+            expected = {fqid.uuid for fqid in entity_ids}
+        else:
+            assert issubclass(entity_id_type, str), (entity_type, entity_id_type)
+            where_columns = (pk_column,)
+            where_values = ((quote(entity_id),) for entity_id in entity_ids)
+            expected = entity_ids
+        query = f'''
+            SELECT {', '.join({pk_column, *non_pk_columns})}
+            FROM {table_name}
+            WHERE {self._in(where_columns, where_values)}
+        '''
         log.debug('Retrieving %i entities of type %r ...', len(entity_ids), entity_type)
-        rows = self._query_latest_version(source, f'''
-                       SELECT {columns}
-                       FROM {backtick(table_name)}
-                       WHERE {uuid_in_list}
-                   ''', group_by=pk_column)
+        rows = self._query_latest_version(source, query, group_by=pk_column)
         log.debug('Retrieved %i entities of type %r', len(rows), entity_type)
-        missing = entity_ids - {row[pk_column] for row in rows}
+        missing = expected - {row[pk_column] for row in rows}
         require(not missing,
                 f'Required entities not found in {table_name}: {missing}')
         return rows
+
+    def _in(self,
+            columns: Tuple[str, ...],
+            values: Iterable[Tuple[str, ...]]
+            ) -> str:
+        """
+        >>> plugin = Plugin(sources=set())
+        >>> plugin._in(('foo', 'bar'), [('"abc"', '123'), ('"def"', '456')])
+        '(foo, bar) IN (("abc", 123), ("def", 456))'
+        """
+
+        def join(i):
+            return '(' + ', '.join(i) + ')'
+
+        return join(columns) + ' IN ' + join(map(join, values))
 
     def _find_upstream_bundles(self,
                                source: TDRSourceRef,
@@ -616,6 +671,12 @@ class TDRBundle(Bundle[TDRSourceRef]):
         'descriptor',
         'JSON_EXTRACT_SCALAR(content, "$.file_core.file_name") AS file_name',
         'file_id'
+    }
+
+    # `links_id` is omitted for consistency since the other sets do not include
+    # the primary key
+    links_columns: ClassVar[Set[str]] = metadata_columns | {
+        'project_id'
     }
 
     def drs_path(self, manifest_entry: JSON) -> Optional[str]:

--- a/src/azul/plugins/repository/tdr/__init__.py
+++ b/src/azul/plugins/repository/tdr/__init__.py
@@ -405,7 +405,7 @@ class Plugin(RepositoryPlugin[TDRSourceSpec, TDRSourceRef]):
         source = one({fqid.source.spec for fqid in links_ids})
         links = self._retrieve_entities(source, 'links', links_ids)
         links = {
-            # Copy the values for we can reassign `content` below
+            # Copy the values so we can reassign `content` below
             fqid: dict(one(links_json
                            for links_json in links
                            if links_json['links_id'] == fqid.uuid))

--- a/src/azul/terra.py
+++ b/src/azul/terra.py
@@ -517,6 +517,7 @@ class TDRClient(SAMClient):
             ignore = ('referencedTables', 'statementType', 'queryPlan')
             stats = {k: v for k, v in stats.items() if k not in ignore}
         return {
+            'job_id': job.job_id,
             'stats': stats,
             'query': self._trunc_query(job.query)
         }

--- a/src/azul/terra.py
+++ b/src/azul/terra.py
@@ -479,7 +479,8 @@ class TDRClient(SAMClient):
     def run_sql(self, query: str) -> BigQueryRows:
         bigquery = self._bigquery(self.credentials.project_id)
         if log.isEnabledFor(logging.DEBUG):
-            log.debug('Query: %r', self._trunc_query(query))
+            log.debug('Query (%r characters total): %r',
+                      len(query), self._trunc_query(query))
         if config.bigquery_batch_mode:
             job_config = QueryJobConfig(priority=QueryPriority.BATCH)
             job: QueryJob = bigquery.query(query, job_config=job_config)

--- a/test/indexer/test_tdr.py
+++ b/test/indexer/test_tdr.py
@@ -7,7 +7,9 @@ from operator import (
 )
 from typing import (
     Callable,
+    Iterable,
     Mapping,
+    Tuple,
 )
 import unittest
 from unittest import (
@@ -278,6 +280,23 @@ class TestPlugin(tdr.Plugin):
 
     def _full_table_name(self, source: TDRSourceSpec, table_name: str) -> str:
         return source.bq_name + '.' + table_name
+
+    def _in(self,
+            columns: Tuple[str, ...],
+            values: Iterable[Tuple[str, ...]]
+            ) -> str:
+        """
+        >>> plugin = TestPlugin(sources=set(), tinyquery=None)
+        >>> plugin._in(('foo', 'bar'), [('"abc"', '123'), ('"def"', '456')])
+        '(foo = "abc" AND bar = 123) OR (foo = "def" AND bar = 456)'
+        """
+        return ' OR '.join(
+            '(' + ' AND '.join(
+                f'{column} = {inner_value}'
+                for column, inner_value in zip(columns, value)
+            ) + ')'
+            for value in values
+        )
 
 
 class TestTDRSourceList(AzulTestCase):

--- a/test/test_doctests.py
+++ b/test/test_doctests.py
@@ -90,7 +90,8 @@ def load_tests(_loader, tests, _ignore):
         load_script('envhook'),
         load_script('export_environment'),
         load_module(root + '/.flake8/azul_flake8.py', 'azul_flake8'),
-        load_module(root + '/test/test_tagging.py', 'test_tagging')
+        load_module(root + '/test/test_tagging.py', 'test_tagging'),
+        load_module(root + '/test/indexer/test_tdr.py', 'test_tdr')
     ]:
         suite = doctest.DocTestSuite(module)
         assert suite.countTestCases() > 0, module


### PR DESCRIPTION
https://github.com/DataBiosphere/azul/issues/3613

### Author

- [x] PR title references issue
- [ ] ~~PR title matches issue title (preceded by `Fix: ` for bugs)~~   <sub>the `Fix: ` prefix is appropriate here even though the issue is not labeled 'bug'</sub>
- [x] Title of main commit references issue
- [x] PR is connected to Zenhub issue and description links to issue

### Author (reindex)

- [x] Added `r` tag to commit title                         <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR                           <sub>or this PR does not require reindexing</sub>

### Author (freebies & chains)

- [x] Freebies are blocked on this PR                       <sub>or there are no freebies in this PR</sub>
- [x] Freebies are referenced in commit titles              <sub>or there are no freebies in this PR</sub>
- [x] This PR is blocked by previous PR in the chain        <sub>or this PR is not chained to another PR</sub>
- [x] Added `chain` label to the blocking PR                <sub>or this PR is not chained to another PR</sub>

### Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst  <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title                         <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR                           <sub>or this PR does not require upgrading</sub>
- [x] Added announcement to PR description                  <sub>or this PR does not require announcement</sub>
- [x] Added checklist items for additional operator tasks   <sub>or this PR does not require additional tasks</sub>

### Author (requirements, before every review)

- [x] Ran `make requirements_update`                        <sub>or this PR does not touch requirements*.txt, common.mk, Makefile and Dockerfile</sub>
- [x] Added `R` tag to commit title                         <sub>or this PR does not touch requirements*.txt</sub>
- [x] Added `reqs` label to PR                              <sub>or this PR does not touch requirements*.txt</sub>

### Author (before every review)

- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>
- [x] Gathered performance data on the dcp11 snapshot as described [here](https://github.com/DataBiosphere/azul/issues/3613#issuecomment-961301758)
- [x] Rebased branch on `develop`, squashed old fixups

### Primary reviewer (after approval)

- [x] Commented in issue about demo expectations            <sub>or labelled issue as `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] Moved ticket to Approved column
- [x] Assigned PR to an operator

### Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear              <sub>or issue is labeled as `no demo`</sub>
- [x] Rebased and squashed branch
- [x] Sanity-checked history
- [x] Pushed PR branch to Github
- [x] Branch pushed to Gitlab and added `sandbox` label     <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passed in sandbox                               <sub>or PR is labeled `no sandbox`</sub>
- [ ] Started reindex in `sandbox`                          <sub>or this PR does not require reindexing `sandbox`</sub>
- [ ] Checked for failures in `sandbox`                     <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title
- [ ] Moved linked issue to Merged column
- [ ] Pushed merge commit to Github

### Operator (after pushing the merge commit)

- [ ] Made announcement requested by author                 <sub>or PR description does not contain an announcement</sub>
- [ ] Moved freebies to Merged column                       <sub>or there are no freebies in this PR</sub> 
- [ ] Shortened the PR chain                                <sub>or this PR is not the base of another PR</sub>
- [ ] Verified that `N reviews` labelling is accurate       <sub>or or this PR is authored by lead</sub>
- [ ] Pushed merge commit to Gitlab                         <sub>or or merge commit can be pushed later, with another PR</sub>
- [ ] Deleted PR branch from Github and Gitlab
- [ ] Build passes on Gitlab

### Operator (reindex) 

- [ ] Started reindex in target deployment                  <sub>or this PR does not require reindexing</sub>
- [ ] Checked for and triaged indexing failures             <sub>or this PR does not require reindexing</sub>
- [ ] Emptied fail queues in target deployment              <sub>or this PR does not require reindexing</sub>

### Operator

- [ ] Unassigned PR
