### PR TITLE
Mention `drop!` hunk comments in contribution guide

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1009,6 +1009,11 @@ Drop commits
 * At times it may be necessary to temporarily add a commit to a PR branch e.g.,
   to facilitate testing. These commits should be removed prior to landing the
   PR and their title is prefixed with ``drop!``.
+ 
+* The hunks in a ``drop!`` commit should carry an inline comment marking the
+  hunk as something that will be removed. That way a reviewer can easily tell
+  apart temporary hunks from permanent ones without having to consult the
+  commit history.
   
 * When squashing old fixups, ``drop!`` commits should be be retained.
 
@@ -1018,7 +1023,7 @@ Drop commits
   Alternatively, the primary reviewer may ask the PR author to do so in a final
   rejection of the PR. The final consolidation eliminates both ``fixup!`` and
   ``drop!`` commits.
-
+ 
 Status checks
 -------------
 


### PR DESCRIPTION
No issue.

### Author

- [ ] ~PR title references issue~
- [x] PR title matches issue title (preceded by `Fix: ` for bugs)   <sub>or there is a good reason why they're different</sub>
- [ ] ~Title of main commit references issue~
- [ ] ~PR is connected to Zenhub issue and description links to issue~

### Author (reindex)

- [x] Added `r` tag to commit title                         <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR                           <sub>or this PR does not require reindexing</sub>

### Author (freebies & chains)

- [x] Freebies are blocked on this PR                       <sub>or there are no freebies in this PR</sub>
- [x] Freebies are referenced in commit titles              <sub>or there are no freebies in this PR</sub>
- [x] This PR is blocked by previous PR in the chain        <sub>or this PR is not chained to another PR</sub>
- [x] Added `chain` label to the blocking PR                <sub>or this PR is not chained to another PR</sub>

### Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst  <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title                         <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR                           <sub>or this PR does not require upgrading</sub>
- [x] Added announcement to PR description                  <sub>or this PR does not require announcement</sub>
- [x] Added checklist items for additional operator tasks   <sub>or this PR does not require additional tasks</sub>

### Author (requirements, before every review)

- [x] Ran `make requirements_update`                        <sub>or this PR does not touch requirements*.txt, common.mk, Makefile and Dockerfile</sub>
- [x] Added `R` tag to commit title                         <sub>or this PR does not touch requirements*.txt</sub>
- [x] Added `reqs` label to PR                              <sub>or this PR does not touch requirements*.txt</sub>

### Author (before every review)

- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>
- [x] Rebased branch on `develop`, squashed old fixups

### Primary reviewer (after approval)

- [x] Commented in issue about demo expectations            <sub>or labelled issue as `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] Moved ticket to Approved column
- [x] Assigned PR to an operator

### Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [ ] ~~Checked that demo expectations are clear              <sub>or issue is labeled as `no demo`</sub>~~
- [x] Rebased and squashed branch
- [x] Sanity-checked history
- [x] Pushed PR branch to Github
- [x] Branch pushed to Gitlab and added `sandbox` label     <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passed in sandbox                               <sub>or PR is labeled `no sandbox`</sub>
- [x] Started reindex in `sandbox`                          <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `sandbox`                     <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title
- [x] Moved linked issue to Merged column
- [ ] Pushed merge commit to Github

### Operator (after pushing the merge commit)

- [ ] Made announcement requested by author                 <sub>or PR description does not contain an announcement</sub>
- [ ] Moved freebies to Merged column                       <sub>or there are no freebies in this PR</sub> 
- [ ] Shortened the PR chain                                <sub>or this PR is not the base of another PR</sub>
- [ ] Verified that `N reviews` labelling is accurate       <sub>or this PR is authored by lead</sub>
- [ ] Pushed merge commit to Gitlab                         <sub>or merge commit can be pushed later, with another PR</sub>
- [ ] Deleted PR branch from Github and Gitlab
- [ ] Build passes on Gitlab
- [ ] Moved issues to `prod` or `Merged prod`               <sub>or this PR does not represent a promotion</sub>

### Operator (reindex) 

- [ ] Started reindex in target deployment                  <sub>or this PR does not require reindexing</sub>
- [ ] Checked for and triaged indexing failures             <sub>or this PR does not require reindexing</sub>
- [ ] Emptied fail queues in target deployment              <sub>or this PR does not require reindexing</sub>
- [ ] Filed backport PR                                     <sub>or this PR does not represent a hotfix</sub>

### Operator

- [ ] Unassigned PR
