### PR TITLE
Fix: GitLab security group has unused entries (#3803)

### DIFF
--- a/terraform/gitlab/gitlab.tf.json.template.py
+++ b/terraform/gitlab/gitlab.tf.json.template.py
@@ -743,14 +743,7 @@ emit_tf({} if config.terraform_component != 'gitlab' else {
                         "protocol": "tcp",
                         "from_port": 443,
                         "to_port": 443
-                    },
-                    *({
-                        **ingress_egress_block,
-                        "cidr_blocks": ["0.0.0.0/0"],
-                        "protocol": "tcp",
-                        "from_port": ext_port,
-                        "to_port": ext_port
-                    } for ext_port, int_port, name in nlb_ports)
+                    }
                 ]
             },
             "gitlab": {


### PR DESCRIPTION
https://github.com/DataBiosphere/azul/issues/3803

### Author

- [ ] ~PR title references issue~
- [ ] ~PR title matches issue title (preceded by `Fix: ` for bugs)   <sub>or there is a good reason why they're different</sub>~
- [ ] ~Title of main commit references issue~
- [ ] ~PR is connected to Zenhub issue and description links to issue~

### Author (reindex)

- [x] Added `r` tag to commit title                         <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR                           <sub>or this PR does not require reindexing</sub>

### Author (freebies & chains)

- [x] Freebies are blocked on this PR                       <sub>or there are no freebies in this PR</sub>
- [x] Freebies are referenced in commit titles              <sub>or there are no freebies in this PR</sub>
- [x] This PR is blocked by previous PR in the chain        <sub>or this PR is not chained to another PR</sub>
- [x] Added `chain` label to the blocking PR                <sub>or this PR is not chained to another PR</sub>

### Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst  <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title                         <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR                           <sub>or this PR does not require upgrading</sub>
- [x] Added announcement to PR description                  <sub>or this PR does not require announcement</sub>
- [x] Added checklist items for additional operator tasks   <sub>or this PR does not require additional tasks</sub>

### Author (requirements, before every review)

- [x] Ran `make requirements_update`                        <sub>or this PR does not touch requirements*.txt, common.mk, Makefile and Dockerfile</sub>
- [x] Added `R` tag to commit title                         <sub>or this PR does not touch requirements*.txt</sub>
- [x] Added `reqs` label to PR                              <sub>or this PR does not touch requirements*.txt</sub>

### Author (before every review)

- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>
- [x] Rebased branch on `develop`, squashed old fixups

### Primary reviewer (after approval)

- [x] Commented in issue about demo expectations            <sub>or labelled issue as `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] Moved ticket to Approved column
- [x] Assigned PR to an operator

### Operator (before pushing merge the commit)

- [ ] Checked `reindex` label and `r` commit title tag
- [ ] Checked that demo expectations are clear              <sub>or issue is labeled as `no demo`</sub>
- [ ] Rebased and squashed branch
- [ ] Sanity-checked history
- [ ] Pushed PR branch to Github
- [ ] Branch pushed to Gitlab and added `sandbox` label     <sub>or PR is labeled `no sandbox`</sub>
- [ ] Build passed in sandbox                               <sub>or PR is labeled `no sandbox`</sub>
- [ ] Started reindex in `sandbox`                          <sub>or this PR does not require reindexing `sandbox`</sub>
- [ ] Checked for failures in `sandbox`                     <sub>or this PR does not require reindexing `sandbox`</sub>
- [ ] Added PR reference to merge commit title
- [ ] Collected commit title tags in merge commit title
- [ ] Moved linked issue to Merged column
- [ ] Pushed merge commit to Github

### Operator (after pushing the merge commit)

- [ ] Made announcement requested by author                 <sub>or PR description does not contain an announcement</sub>
- [ ] Moved freebies to Merged column                       <sub>or there are no freebies in this PR</sub> 
- [ ] Shortened the PR chain                                <sub>or this PR is not the base of another PR</sub>
- [ ] Verified that `N reviews` labelling is accurate       <sub>or this PR is authored by lead</sub>
- [ ] Pushed merge commit to Gitlab                         <sub>or merge commit can be pushed later, with another PR</sub>
- [ ] Deleted PR branch from Github and Gitlab
- [ ] Build passes on Gitlab
- [ ] Moved issues to `prod` or `Merged prod`               <sub>or this PR does not represent a promotion</sub>

### Operator (reindex) 

- [ ] Started reindex in target deployment                  <sub>or this PR does not require reindexing</sub>
- [ ] Checked for and triaged indexing failures             <sub>or this PR does not require reindexing</sub>
- [ ] Emptied fail queues in target deployment              <sub>or this PR does not require reindexing</sub>
- [ ] Filed backport PR                                     <sub>or this PR does not represent a hotfix</sub>

### Operator

- [ ] Unassigned PR
