### PR TITLE
Fix: TDR timeouts don't raise the correct exception (#4229)

### DIFF
--- a/src/azul/terra.py
+++ b/src/azul/terra.py
@@ -42,6 +42,7 @@ from more_itertools import (
 )
 import urllib3
 from urllib3.exceptions import (
+    MaxRetryError,
     TimeoutError,
 )
 from urllib3.response import (
@@ -345,7 +346,7 @@ class TerraClient(OAuth2Client):
                                                  timeout=timeout,
                                                  retries=retry,
                                                  body=body)
-        except TimeoutError:
+        except (TimeoutError, MaxRetryError):
             raise TerraTimeoutException(url, timeout)
 
         assert isinstance(response, urllib3.HTTPResponse)

--- a/src/azul/terra.py
+++ b/src/azul/terra.py
@@ -330,7 +330,7 @@ class TerraClient(OAuth2Client):
         try:
             # Limited retries on I/O errors such as refused or dropped
             # connections. The latter are actually very likely if connections
-            # from the pool are reused after a long periods idleness.
+            # from the pool are reused after a long period of idleness.
             retry = urllib3.Retry(total=None,
                                   connect=2,
                                   read=2,


### PR DESCRIPTION
Connected issue: #4229 


## Checklist


### Author

- [x] Target branch is `develop`
- [x] Name of source branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR title references the connected issue
- [x] PR title matches<sup>1</sup> title of connected issue         <sub>or comment in PR explains why they're different</sub>
- [x] Title of at least one commit references connected issue
- [x] PR is connected to issue via Zenhub 
- [x] PR description links to connected issue
- [x] Added `partial` label to PR                                    <sub>or this PR completely resolves the connected issue</sub>

<sup>1</sup> when the issue title describes a problem, the PR title is `Fix: ` followed by the issue title   


### Author (reindex)

- [x] Added `r` tag to commit title                                 <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR                                   <sub>or this PR does not require reindexing</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain               <sub>or this PR is not chained to another PR</sub>
- [x] Added `base` label to the blocking PR                        <sub>or this PR is not chained to another PR</sub>
- [x] Added `chained` label to this PR                             <sub>or this PR is not chained to another PR</sub>


### Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst          <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title                                 <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR                                   <sub>or this PR does not require upgrading</sub>


### Author (operator tasks)

- [x] Added checklist items for additional operator tasks           <sub>or this PR does not require additional tasks</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title                            <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfix connected to the issue          <sub>or there is no temporary hotfix for the connected issue on the `prod` branch</sub>


### Author (requirements)

- [x] Ran `make requirements_update`                                <sub>or this PR does not touch requirements*.txt, common.mk, Makefile and Dockerfile</sub>
- [x] Added `R` tag to commit title                                 <sub>or this PR does not touch requirements*.txt</sub>
- [x] Added `reqs` label to PR                                      <sub>or this PR does not touch requirements*.txt</sub>


### Author (rebasing, integration test)

- [x] `make integration_test` passes in personal deployment         <sub>or this PR does not touch functionality that could break the IT</sub>
- [x] Rebased branch on `develop`, squashed old fixups


### Peer reviewer (after requesting changes)

Uncheck the *Author (requirements)* and *Author (rebasing, integration test)* 
checklists.


### Peer reviewer (after approval)

- [x] Ticket is in *Review requested* column
- [x] Requested review from primary reviewer
- [x] Assigned PR to primary reviewer


### Primary reviewer (after requesting changes)

Uncheck the *Author (requirements)* and *Author (rebasing, integration test)* 
checklists. Update the `N reviews` label. 


### Primary reviewer (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issue as `demo` or `no demo`
- [x] Commented on connected issue about demo expectations          <sub>or labelled connected issue as `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved ticket to *Approved* column
- [x] Assigned PR to current operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear                      <sub>or connected issue is labeled as `no demo`</sub>
- [x] Rebased and squashed branch
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Branch pushed to GitLab and added `sandbox` label             <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passed in sandbox                                       <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox`                     <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices</sub> 
- [x] Started reindex in `sandbox`                                  <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `sandbox`                             <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title
- [x] Moved connected issue to Merged column
- [x] Pushed merge commit to GitHub


### Operator (after pushing the merge commit)

- [ ] Shortened the PR chain                                        <sub>or this PR is not labeled `base`</sub>
- [ ] Pushed merge commit to GitLab                                 <sub>or merge commit can be pushed later, with another PR</sub>
- [ ] Deleted PR branch from GitHub and GitLab
- [ ] Build passes on GitLab


### Operator (reindex) 

- [ ] Deleted unreferenced indices in `dev`                         <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices</sub> 
- [ ] Started reindex in `dev`                                      <sub>or this PR does not require reindexing</sub>
- [ ] Checked for and triaged indexing failures                     <sub>or this PR does not require reindexing</sub>
- [ ] Emptied fail queues in target deployment                      <sub>or this PR does not require reindexing</sub>


### Operator

- [ ] Unassigned PR


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
