### PR TITLE
Fix: GitLab backup script should start instance after completing (#4819)

### DIFF
--- a/OPERATOR.rst
+++ b/OPERATOR.rst
@@ -277,11 +277,7 @@ Before any changes are applied, run::
 	git checkout -b gitlab/yyyy-mm-dd/<GitLab version> github/develop
 	_select dev.gitlab
 
-Use the following script to create a snapshot of the storage volume attached to
-the GitLab instance. The script will stop (NOT terminate) the instance, and
-create a properly tagged snapshot of the GitLab EBS volume. Run::
-
-	python scripts/create_gitlab_snapshot.py
+Create a backup of the GitLab volume, see `Backup GitLab volumes`_ for help.
 
 Edit the `GitLab Terraform`_ file, updating the version of the Docker images for
 ``gitlab-ce`` and ``gitlab-runner``. Then run::
@@ -302,6 +298,20 @@ update the ``prod`` deployment, but select the ``prod.gitlab`` component  and
 use ``CI_COMMIT_REF_NAME=prod`` in all ``make`` invocations. Once both instances
 have been successfully updated, file a PR with the changes against the
 ``develop`` branch and request review from the lead.
+
+Backup GitLab volumes
+^^^^^^^^^^^^^^^^^^^^^
+
+Use the ``create_gitlab_snapshot.py`` script to back up the EBS data volume
+attached to each of our GitLab instances. The script will stop the instance,
+create a snapshot of the GitLab EBS volume, tag the snapshot and finally restart
+the instance::
+
+	python scripts/create_gitlab_snapshot.py
+
+For GitLab or ClamAV updates, use the ``--no-restart`` flag in order to leave
+the instance stopped after the snapshot has been created. There is no point in
+starting the instance only to have the update terminate it again.
 
 Adding snapshots to ``dev``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/scripts/create_gitlab_snapshot.py
+++ b/scripts/create_gitlab_snapshot.py
@@ -110,11 +110,11 @@ def create_snapshot(volume: JSON):
                                            dict(ResourceType='snapshot',
                                                 Tags=[{'Key': k, 'Value': v} for k, v in tags.items()])
                                        ])
-    snapshot = response['SnapshotId']
+    snapshot_id = response['SnapshotId']
     log.info('Snapshot %r of volume %r is being created …',
-             snapshot, volume['VolumeId'])
+             snapshot_id, volume['VolumeId'])
     waiter = aws.ec2.get_waiter('snapshot_completed')
-    waiter.wait(SnapshotIds=[snapshot],
+    waiter.wait(SnapshotIds=[snapshot_id],
                 WaiterConfig=dict(MaxAttempts=9999, Delay=15))
     log.info('Snapshot %r of volume %r is complete',
              volume['VolumeId'], config.deployment_stage)

--- a/scripts/create_gitlab_snapshot.py
+++ b/scripts/create_gitlab_snapshot.py
@@ -57,17 +57,13 @@ def main(argv):
         start_instance(instance)
 
 
-# This filter is used to locate the EBS data volume to be backed up
-gitlab_filter = [
-    {
+def gitlab_volume_info() -> JSON:
+    filter = {
         'Name': 'tag:Name',
         'Values': ['azul-gitlab']
     }
-]
-
-
-def gitlab_volume_info() -> JSON:
-    return one(aws.ec2.describe_volumes(Filters=gitlab_filter)['Volumes'])
+    response = aws.ec2.describe_volumes(Filters=[filter])
+    return one(response['Volumes'])
 
 
 def shutdown_instance(instance: JSON):


### PR DESCRIPTION
Connected issues: #4819


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR title references all connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] For each connected issue, there is at least one commit whose title references that issue
- [x] PR is connected to all connected issues via ZenHub
- [x] PR description links to connected issues
- [x] Added `partial` label to PR <sub>or this PR completely resolves all connected issues</sub>

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR <sub>or this PR does not require reindexing</sub>
- [x] Added `a` (compatible changes) or `A` (incompatible ones) tag to commit title <sub>or this PR does not modify the Azul service API</sub>
- [x] Added `API` label to connected issues <sub>or this PR does not modify the Azul service API</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or this PR is not chained to another PR</sub>
- [x] Added `base` label to the blocking PR <sub>or this PR is not chained to another PR</sub>
- [x] Added `chained` label to this PR <sub>or this PR is not chained to another PR</sub>


### Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR <sub>or this PR does not require upgrading</sub>


### Author (operator tasks)

- [x] Added checklist items for additional operator tasks <sub>or this PR does not require additional tasks</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the `prod` branch has no temporary hotfixes for any connected issues</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not touch requirements*.txt, common.mk, Makefile and Dockerfile</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not touch requirements*.txt</sub>
- [x] Added `reqs` label to PR <sub>or this PR does not touch requirements*.txt</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>


### Peer reviewer (after requesting changes)

Uncheck the *Author (before every review)* checklists.


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] Requested review from primary reviewer
- [x] Assigned PR to primary reviewer


### Primary reviewer (after requesting changes)

Uncheck the *before every review* checklists. Update the `N reviews` label.


### Primary reviewer (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved ticket to *Approved* column
- [x] Assigned PR to current operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Pushed PR branch to GitLab `dev` and added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Started reindex in `sandbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title
- [x] Moved connected issues to Merged column in ZenHub
- [x] Pushed merge commit to GitHub


### Operator (after pushing the merge commit)

- [x] Shortened the PR chain <sub>or this PR is not labeled `base`</sub>
- [x] Pushed merge commit to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed merge commit to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes on GitLab `dev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `dev`<sup>1</sup>
- [x] Build passes on GitLab `anvildev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvildev`<sup>1</sup>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`

<sup>1</sup> When pushing the merge commit is skipped due to the PR being
labelled `no sandbox`, the next build triggered by a PR whose merge commit *is*
pushed determines this checklist item.


### Operator (reindex)

- [x] Deleted unreferenced indices in `dev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Deleted unreferenced indices in `anvildev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing</sub>
- [x] Checked for and triaged indexing failures in `dev` <sub>or this PR does not require reindexing</sub>
- [x] Checked for and triaged indexing failures in `anvildev` <sub>or this PR does not require reindexing</sub>
- [x] Emptied fail queues in `dev` deployment <sub>or this PR does not require reindexing</sub>
- [x] Emptied fail queues in `anvildev` deployment <sub>or this PR does not require reindexing</sub>


### Operator

- [x] Unassigned PR


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
