### PR TITLE
Fix: Population of contents.sequencing_inputs disregards graph relationships (#2907)

### DIFF
--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -425,14 +425,14 @@ class TestManifestEndpoints(ManifestTestCase, DSSUnitTestCase):
             ('sample.biomaterial_core.biomaterial_id', '', '1209_T || 1210_T'),
 
             ('sequencing_input.provenance.document_id',
-             '0037c9eb-8038-432f-8d9d-13ee094e54ab || aaaaaaaa-8038-432f-8d9d-13ee094e54ab',
+             '',
              '0037c9eb-8038-432f-8d9d-13ee094e54ab || aaaaaaaa-8038-432f-8d9d-13ee094e54ab'),
 
             ('sequencing_input.biomaterial_core.biomaterial_id',
-             '22028_5#300 || 22030_5#300',
+             '',
              '22028_5#300 || 22030_5#300'),
 
-            ('sequencing_input_type', 'cell_suspension', 'cell_suspension')
+            ('sequencing_input_type', '', 'cell_suspension')
         ]
         self.maxDiff = None
         bundle_fqid = self.bundle_fqid(uuid='f79257a7-dfc6-46d6-ae00-ba4b25313c10',


### PR DESCRIPTION
<!-- 
This is the PR template for regular PRs against `develop`. Edit the URL in your 
browser's location bar, appending either `&template=promotion.md`, 
`&template=hotfix.md`, `&template=backport.md` or `&template=gitlab.md` to
switch the template.
-->

Connected issues: #2907


## Checklist


### Author

- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR title references all connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue        <sub>or comment in PR explains why they're different</sub>
- [x] For each connected issue, there is at least one commit whose title references that issue
- [x] PR is connected to all connected issues via Zenhub 
- [x] PR description links to connected issues
- [x] Added `partial` label to PR                                   <sub>or this PR completely resolves all connected issues</sub>

<sup>1</sup> when the issue title describes a problem, the corresponding PR title is `Fix: ` followed by the issue title   


### Author (reindex)

- [x] Added `r` tag to commit title                                 <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR                                   <sub>or this PR does not require reindexing</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain               <sub>or this PR is not chained to another PR</sub>
- [x] Added `base` label to the blocking PR                        <sub>or this PR is not chained to another PR</sub>
- [x] Added `chained` label to this PR                             <sub>or this PR is not chained to another PR</sub>


### Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst          <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title                                 <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR                                   <sub>or this PR does not require upgrading</sub>


### Author (operator tasks)

- [x] Added checklist items for additional operator tasks           <sub>or this PR does not require additional tasks</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title                            <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues      <sub>or the `prod` branch has no temporary hotfixes for any connected issues</sub>


### Author (requirements, before every review)

- [x] Ran `make requirements_update`                                <sub>or this PR does not touch requirements*.txt, common.mk, Makefile and Dockerfile</sub>
- [x] Added `R` tag to commit title                                 <sub>or this PR does not touch requirements*.txt</sub>
- [x] Added `reqs` label to PR                                      <sub>or this PR does not touch requirements*.txt</sub>


### Author (rebasing, integration test)

- [x] `make integration_test` passes in personal deployment         <sub>or this PR does not touch functionality that could break the IT</sub>
- [x] Rebased PR branch on `develop`, squashed old fixups


### Peer reviewer (after requesting changes)

Uncheck the *Author (requirements)* and *Author (rebasing, integration test)* 
checklists.


### Peer reviewer (after approval)

- [x] Ticket is in *Review requested* column
- [x] Requested review from primary reviewer
- [x] Assigned PR to primary reviewer


### Primary reviewer (after requesting changes)

Uncheck the *Author (requirements)* and *Author (rebasing, integration test)* 
checklists. Update the `N reviews` label. 


### Primary reviewer (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations         <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved ticket to *Approved* column
- [x] Assigned PR to current operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear                      <sub>or all connected issues are labeled `no demo`</sub>
- [x] Rebased and squashed PR branch
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Pushed PR branch to GitLab `dev` and added `sandbox` label    <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment                          <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build log for anomalies in `sandbox` deployment      <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox`                     <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices</sub> 
- [x] Started reindex in `sandbox`                                  <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `sandbox`                             <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev`                         <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment                         <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build log for anomalies in `anvilbox` deployment     <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `anvilbox`                    <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices</sub> 
- [x] Started reindex in `anvilbox`                                 <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `anvilbox`                            <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title
- [x] Moved connected issues to Merged column
- [x] Pushed merge commit to GitHub


### Operator (after pushing the merge commit)

- [x] Shortened the PR chain                                        <sub>or this PR is not labeled `base`</sub>
- [x] Pushed merge commit to GitLab `dev`                           <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed merge commit to GitLab `anvildev`                      <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes on GitLab `dev`<sup>1</sup>
- [x] Reviewed build log for anomalies on GitLab `dev`<sup>1</sup>
- [x] Build passes on GitLab `anvildev`<sup>1</sup>
- [x] Reviewed build log for anomalies on GitLab `anvildev`<sup>1</sup>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`

<sup>1</sup> When pushing the merge commit is skipped due to the PR being
labelled `no sandbox`, the next build triggered by a PR whose merge commit *is* 
pushed determines this checklist item.


### Operator (reindex) 

- [x] Deleted unreferenced indices in `dev`                         <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices</sub> 
- [x] Deleted unreferenced indices in `anvildev`                    <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices</sub> 
- [x] Started reindex in `dev`                                      <sub>or this PR does not require reindexing</sub>
- [x] Started reindex in `anvildev`                                 <sub>or this PR does not require reindexing</sub>
- [x] Checked for and triaged indexing failures in `dev`            <sub>or this PR does not require reindexing</sub>
- [x] Checked for and triaged indexing failures in `anvildev`       <sub>or this PR does not require reindexing</sub>
- [x] Emptied fail queues in `dev` deployment                       <sub>or this PR does not require reindexing</sub>
- [x] Emptied fail queues in `anvildev` deployment                  <sub>or this PR does not require reindexing</sub>


### Operator

- [x] Unassigned PR


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
