### PR TITLE
Fix: PR checklist should mention unchaining steps (#5190)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/backport.md
+++ b/.github/PULL_REQUEST_TEMPLATE/backport.md
@@ -47,8 +47,9 @@ Uncheck the *before every review* checklists. Update the `N reviews` label.
 - [ ] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
 - [ ] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
 - [ ] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
+- [ ] Title of merge commit starts with title from this PR
 - [ ] Added PR reference (this PR) to merge commit title
-- [ ] Collected commit title tags in merge commit title
+- [ ] Added commit title tags to merge commit title
 - [ ] Pushed merge commit to GitHub
 
 

--- a/.github/PULL_REQUEST_TEMPLATE/gitlab.md
+++ b/.github/PULL_REQUEST_TEMPLATE/gitlab.md
@@ -42,8 +42,9 @@ Connected issue: #4014
 - [ ] Squashed PR branch and rebased onto `develop`
 - [ ] Sanity-checked history
 - [ ] Pushed PR branch to GitHub
+- [ ] Title of merge commit starts with title from this PR
 - [ ] Added PR reference to merge commit title
-- [ ] Collected commit title tags in merge commit title
+- [ ] Added commit title tags to merge commit title
 - [ ] Moved connected issue to Merged column in ZenHub
 - [ ] Pushed merge commit to GitHub
 

--- a/.github/PULL_REQUEST_TEMPLATE/gitlab.md
+++ b/.github/PULL_REQUEST_TEMPLATE/gitlab.md
@@ -49,9 +49,16 @@ Connected issue: #4014
 - [ ] Pushed merge commit to GitHub
 
 
+### Operator (chain shortening)
+
+- [ ] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
+- [ ] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
+- [ ] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
+- [ ] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>
+
+
 ### Operator (after pushing the merge commit)
 
-- [ ] Shortened the PR chain <sub>or this PR is not labeled `base`</sub>
 - [ ] Deleted PR branch from GitHub
 
 

--- a/.github/PULL_REQUEST_TEMPLATE/hotfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/hotfix.md
@@ -48,8 +48,9 @@ Connected issue: #0000
 - [ ] Squashed PR branch and rebased onto `prod`
 - [ ] Sanity-checked history
 - [ ] Pushed PR branch to GitHub
+- [ ] Title of merge commit starts with title from this PR
 - [ ] Added PR reference to merge commit title
-- [ ] Collected commit title tags in merge commit title
+- [ ] Added commit title tags to merge commit title
 - [ ] Moved connected issue to *Merged prod* column in ZenHub
 - [ ] Pushed merge commit to GitHub
 

--- a/.github/PULL_REQUEST_TEMPLATE/promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/promotion.md
@@ -41,8 +41,9 @@ Connected issue: #0000
 ### Operator (before pushing merge the commit)
 
 - [ ] Pushed PR branch to GitHub
+- [ ] Title of merge commit starts with title from this PR
 - [ ] Added PR reference to merge commit title
-- [ ] Collected commit title tags in merge commit title
+- [ ] Added commit title tags to merge commit title
 - [ ] Pushed merge commit to GitHub
 
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -119,8 +119,9 @@ Uncheck the *before every review* checklists. Update the `N reviews` label.
 - [ ] Started reindex in `anvilbox` <sub>or this PR does not require reindexing `sandbox`</sub>
 - [ ] Checked for failures in `sandbox` <sub>or this PR does not require reindexing `sandbox`</sub>
 - [ ] Checked for failures in `anvilbox` <sub>or this PR does not require reindexing `sandbox`</sub>
+- [ ] Title of merge commit starts with title from this PR
 - [ ] Added PR reference to merge commit title
-- [ ] Collected commit title tags in merge commit title
+- [ ] Added commit title tags to merge commit title
 - [ ] Moved connected issues to Merged column in ZenHub
 - [ ] Pushed merge commit to GitHub
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -126,9 +126,16 @@ Uncheck the *before every review* checklists. Update the `N reviews` label.
 - [ ] Pushed merge commit to GitHub
 
 
+### Operator (chain shortening)
+
+- [ ] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
+- [ ] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
+- [ ] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
+- [ ] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>
+
+
 ### Operator (after pushing the merge commit)
 
-- [ ] Shortened the PR chain <sub>or this PR is not labeled `base`</sub>
 - [ ] Pushed merge commit to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
 - [ ] Pushed merge commit to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
 - [ ] Build passes on GitLab `dev`<sup>1</sup>

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -284,11 +284,13 @@ def main():
                 },
                 {
                     'type': 'cli',
-                    'content': 'Added `base` label to the blocking PR', 'alt': 'or this PR is not chained to another PR'
+                    'content': 'Added `base` label to the blocking PR',
+                    'alt': 'or this PR is not chained to another PR'
                 },
                 {
                     'type': 'cli',
-                    'content': 'Added `chained` label to this PR', 'alt': 'or this PR is not chained to another PR'
+                    'content': 'Added `chained` label to this PR',
+                    'alt': 'or this PR is not chained to another PR'
                 }
             ]),
             *iif(t in (T.default, T.promotion), [
@@ -303,11 +305,13 @@ def main():
                 }),
                 iif(t is T.default, {
                     'type': 'cli',
-                    'content': 'Added `u` tag to commit title', 'alt': 'or this PR does not require upgrading'
+                    'content': 'Added `u` tag to commit title',
+                    'alt': 'or this PR does not require upgrading'
                 }),
                 {
                     'type': 'cli',
-                    'content': 'Added `upgrade` label to PR', 'alt': 'or this PR does not require upgrading'
+                    'content': 'Added `upgrade` label to PR',
+                    'alt': 'or this PR does not require upgrading'
                 }
             ]),
             *iif(t is T.default, [
@@ -378,11 +382,13 @@ def main():
                 },
                 {
                     'type': 'cli',
-                    'content': 'Added `R` tag to commit title', 'alt': 'or this PR does not touch requirements*.txt'
+                    'content': 'Added `R` tag to commit title',
+                    'alt': 'or this PR does not touch requirements*.txt'
                 },
                 {
                     'type': 'cli',
-                    'content': 'Added `reqs` label to PR', 'alt': 'or this PR does not touch requirements*.txt'
+                    'content': 'Added `reqs` label to PR',
+                    'alt': 'or this PR does not touch requirements*.txt'
                 },
                 iif(t is T.default, {
                     'type': 'cli',

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -570,11 +570,15 @@ def main():
             ))),
             {
                 'type': 'cli',
+                'content': 'Title of merge commit starts with title from this PR'
+            },
+            {
+                'type': 'cli',
                 'content': f"Added PR reference {iif(t is T.backport, '(this PR) ')}to merge commit title"
             },
             {
                 'type': 'cli',
-                'content': 'Collected commit title tags in merge commit title'
+                'content': 'Added commit title tags to merge commit title'
             },
             iif(t in (T.default, T.gitlab, T.hotfix), {
                 'type': 'cli',

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -598,14 +598,29 @@ def main():
                 'type': 'cli',
                 'content': 'Pushed merge commit to GitHub'
             },
+            *iif(t in (T.default, T.gitlab), [
+                {
+                    'type': 'h2',
+                    'content': 'Operator (chain shortening)'
+                },
+                *[
+                    {
+                        'type': 'cli',
+                        'content': content,
+                        'alt': 'or this PR is not labeled `base`'
+                    }
+                    for content in [
+                        'Changed the target branch of the blocked PR to `develop`',
+                        'Removed the `chained` label from the blocked PR',
+                        'Removed the blocking relationship from the blocked PR',
+                        'Removed the `base` label from this PR'
+                    ]
+                ]
+            ]),
             {
                 'type': 'h2',
                 'content': 'Operator (after pushing the merge commit)'
             },
-            iif(t in (T.default, T.gitlab), {
-                'type': 'cli',
-                'content': 'Shortened the PR chain', 'alt': 'or this PR is not labeled `base`'
-            }),
             *[
                 {
                     'type': 'cli',

--- a/OPERATOR.rst
+++ b/OPERATOR.rst
@@ -232,13 +232,6 @@ For an example of how to document failures within a PR `click here`_.
 
 .. _click here: https://github.com/DataBiosphere/azul/pull/3050#issuecomment-840033931
 
-Chain shortening
-^^^^^^^^^^^^^^^^
-
-Change the target branch of the blocked PR to ``develop`` and remove the ``chained``
-label from that PR. Remove the ``base`` label from the blocking PR. Lastly, remove the blocking
-relationship.
-
 Updating the AMI for GitLab instances
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=promotion.md`,
`&template=hotfix.md`, `&template=backport.md` or `&template=gitlab.md` to
switch the template.
-->

Connected issues: #5190


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR title references all connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] For each connected issue, there is at least one commit whose title references that issue
- [x] PR is connected to all connected issues via ZenHub
- [x] PR description links to connected issues
- [x] Added `partial` label to PR <sub>or this PR completely resolves all connected issues</sub>

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR <sub>or this PR does not require reindexing</sub>
- [x] Added `a` (compatible changes) or `A` (incompatible ones) tag to commit title <sub>or this PR does not modify the Azul service API</sub>
- [x] Added `API` label to connected issues <sub>or this PR does not modify the Azul service API</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or this PR is not chained to another PR</sub>
- [x] Added `base` label to the blocking PR <sub>or this PR is not chained to another PR</sub>
- [x] Added `chained` label to this PR <sub>or this PR is not chained to another PR</sub>


### Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR <sub>or this PR does not require upgrading</sub>


### Author (operator tasks)

- [x] Added checklist items for additional operator tasks <sub>or this PR does not require additional tasks</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the `prod` branch has no temporary hotfixes for any connected issues</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not touch requirements*.txt, common.mk, Makefile and Dockerfile</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not touch requirements*.txt</sub>
- [x] Added `reqs` label to PR <sub>or this PR does not touch requirements*.txt</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>


### Peer reviewer (after requesting changes)

Uncheck the *Author (before every review)* checklists.


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] Requested review from primary reviewer
- [x] Assigned PR to primary reviewer


### Primary reviewer (after requesting changes)

Uncheck the *before every review* checklists. Update the `N reviews` label.


### Primary reviewer (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved ticket to *Approved* column
- [x] Assigned PR to current operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] PR has checklist items for upgrading instructions <sub>or PR is not labeled `upgrade`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Pushed PR branch to GitLab `dev` and added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Started reindex in `sandbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title
- [x] Moved connected issues to Merged column in ZenHub
- [x] Pushed merge commit to GitHub


### Operator (after pushing the merge commit)

- [x] Shortened the PR chain <sub>or this PR is not labeled `base`</sub>
- [x] Pushed merge commit to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed merge commit to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes on GitLab `dev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `dev`<sup>1</sup>
- [x] Build passes on GitLab `anvildev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvildev`<sup>1</sup>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`

<sup>1</sup> When pushing the merge commit is skipped due to the PR being
labelled `no sandbox`, the next build triggered by a PR whose merge commit *is*
pushed determines this checklist item.


### Operator (reindex)

- [x] Deleted unreferenced indices in `dev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Deleted unreferenced indices in `anvildev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing</sub>
- [x] Checked for and triaged indexing failures in `dev` <sub>or this PR does not require reindexing</sub>
- [x] Checked for and triaged indexing failures in `anvildev` <sub>or this PR does not require reindexing</sub>
- [x] Emptied fail queues in `dev` deployment <sub>or this PR does not require reindexing</sub>
- [x] Emptied fail queues in `anvildev` deployment <sub>or this PR does not require reindexing</sub>


### Operator

- [x] Unassigned PR


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
