### PR TITLE
Hotfix: Make dcp28 the default catalog on prod (#5290)

### DIFF
--- a/deployments/prod/environment.py
+++ b/deployments/prod/environment.py
@@ -890,7 +890,6 @@ def env() -> Mapping[str, Optional[str]]:
                                                     repository=dict(name='tdr_hca')),
                                        sources=mklist(sources))
             for atlas, catalog, sources in [
-                ('hca', 'dcp27', dcp27_sources),
                 ('hca', 'dcp28', dcp28_sources),
                 ('hca', 'dcp1', dcp1_sources),
                 ('lungmap', 'lm2', lm2_sources),


### PR DESCRIPTION
<!--
This is the PR template for hotfix PRs against `prod`.
-->

Connected issue: #5290


## Checklist


### Author

- [x] Target branch is `prod`
- [ ] ~Name of PR branch matches `hotfixes/<GitHub handle of author>/<issue#>-<slug>`~
- [x] PR title references the connected issue
- [x] PR title is `Hotfix: ` followed by title of connected issue
- [x] PR is connected to issue via ZenHub
- [x] PR description links to connected issue


### Author (hotfixes)

- [x] Added `h` tag to commit title <sub>or this PR does not include a temporary hotfix</sub>
- [x] Added `H` tag to commit title <sub>or this PR does not include a permanent hotfix</sub>
- [x] Added `hotfix` label to PR
- [x] Added `partial` label to PR <sub>or this PR is a permanent hotfix</sub>


### Author (before every review)

- [x] Rebased PR branch on `prod`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not touch requirements*.txt, common.mk, Makefile and Dockerfile</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not touch requirements*.txt</sub>
- [x] Added `reqs` label to PR <sub>or this PR does not touch requirements*.txt</sub>


### Primary reviewer (after approval)

- [x] Actually approved the PR
- [x] Labeled PR as `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] Moved ticket to *Approved* column
- [x] Assigned PR to current operator


### Operator (before pushing merge the commit)

- [x] Squashed PR branch and rebased onto `prod`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Title of merge commit starts with title from this PR
- [x] Added PR reference to merge commit title
- [x] Added commit title tags to merge commit title
- [x] Moved connected issue to *Merged prod* column in ZenHub
- [x] Pushed merge commit to GitHub


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `prod`
- [x] Build passes on GitLab `prod`
- [x] Reviewed build logs for anomalies on GitLab `prod`
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `prod`


### Operator (reindex)

- [x] Deleted unreferenced indices in `prod` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Started reindex in `prod` <sub>or neither this PR nor a prior failed promotion requires it</sub>
- [x] Checked for and triaged indexing failures in `prod` <sub>or neither this PR nor a prior failed promotion requires it</sub>
- [x] Emptied fail queues in `prod` deployment <sub>or neither this PR nor a prior failed promotion requires it</sub>
- [x] Created backport PR and linked to it in a comment on this PR


### Operator

- [x] Unassigned PR


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem