### PR TITLE
Replace snapshot and remove workaround (#5229)

### DIFF
--- a/deployments/anvilprod/environment.py
+++ b/deployments/anvilprod/environment.py
@@ -56,7 +56,7 @@ def mkdict(previous_catalog: dict[str, str],
 
 
 anvil_sources = mkdict({}, 3, mkdelta([
-    mksrc('datarepo-dev-43738c90', 'ANVIL_1000G_2019_Dev_20230302_ANV5_202303032342', 22814),
+    mksrc('datarepo-dev-e53e74aa', 'ANVIL_1000G_2019_Dev_20230609_ANV5_202306121732', 6804),
     mksrc('datarepo-dev-42c70e6a', 'ANVIL_CCDG_Sample_1_20230228_ANV5_202302281520', 28),
     mksrc('datarepo-dev-97ad270b', 'ANVIL_CMG_Sample_1_20230225_ANV5_202302281509', 25)
 ]))


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=promotion.md`,
`&template=hotfix.md`, `&template=backport.md` or `&template=gitlab.md` to
switch the template.
-->

Connected issues: #5229

Followup PR to remove [the initial workaround](https://github.com/DataBiosphere/azul/pull/5231)

## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR title references all connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] For each connected issue, there is at least one commit whose title references that issue
- [x] PR is connected to all connected issues via ZenHub
- [x] PR description links to connected issues
- [x] Added `partial` label to PR <sub>or this PR completely resolves all connected issues</sub>

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR <sub>or this PR does not require reindexing</sub>
- [x] Added `a` (compatible changes) or `A` (incompatible ones) tag to commit title <sub>or this PR does not modify the Azul service API</sub>
- [x] Added `API` label to connected issues <sub>or this PR does not modify the Azul service API</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or this PR is not chained to another PR</sub>
- [x] Added `base` label to the blocking PR <sub>or this PR is not chained to another PR</sub>
- [x] Added `chained` label to this PR <sub>or this PR is not chained to another PR</sub>


### Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR <sub>or this PR does not require upgrading</sub>


### Author (operator tasks)

- [x] Added checklist items for additional operator tasks <sub>or this PR does not require additional tasks</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the `prod` branch has no temporary hotfixes for any connected issues</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not touch requirements*.txt, common.mk, Makefile and Dockerfile</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not touch requirements*.txt</sub>
- [x] Added `reqs` label to PR <sub>or this PR does not touch requirements*.txt</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>


### Peer reviewer (after requesting changes)

Uncheck the *Author (before every review)* checklists.


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] Requested review from primary reviewer
- [x] Assigned PR to primary reviewer


### Primary reviewer (after requesting changes)

Uncheck the *before every review* checklists. Update the `N reviews` label.


### Primary reviewer (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved ticket to *Approved* column
- [x] Assigned PR to current operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] PR has checklist items for upgrading instructions <sub>or PR is not labeled `upgrade`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Pushed PR branch to GitLab `dev` and added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] ~Started reindex in `sandbox`~ this PR does not require reindexing `sandbox`
- [x] ~Started reindex in `anvilbox`~ this PR does not require reindexing `anvilbox`
- [x] ~Checked for failures in `sandbox`~ this PR does not require reindexing `sandbox`
- [x] ~Checked for failures in `anvilbox`~ this PR does not require reindexing `anvilbox`
- [x] Title of merge commit starts with title from this PR
- [x] Added PR reference to merge commit title
- [x] Added commit title tags to merge commit title
- [x] Moved connected issues to Merged column in ZenHub
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed merge commit to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed merge commit to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes on GitLab `dev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `dev`<sup>1</sup>
- [x] Build passes on GitLab `anvildev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvildev`<sup>1</sup>
- [x] Build passes on GitLab `anvilprod`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvilprod`<sup>1</sup>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Deleted PR branch from GitLab `anvilprod`

<sup>1</sup> When pushing the merge commit is skipped due to the PR being
labelled `no sandbox`, the next build triggered by a PR whose merge commit *is*
pushed determines this checklist item.


### Operator (reindex)

- [x] Deleted unreferenced indices in `dev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Deleted unreferenced indices in `anvildev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Deleted unreferenced indices in `anvilprod` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [ ] ~Started reindex in `dev`~ this PR does not require reindexing `dev`
- [ ] ~Started reindex in `anvildev`~ this PR does not require reindexing `anvildev`
- [x] Started reindex in `anvilprod`
- [ ] ~Checked for and triaged indexing failures in `dev`~ this PR does not require reindexing `dev`
- [ ] ~Checked for and triaged indexing failures in `anvildev`~ this PR does not require reindexing `anvildev`
- [x] Checked for and triaged indexing failures in `anvilprod`
- [ ] ~Emptied fail queues in `dev` deployment~ this PR does not require reindexing `dev`
- [ ] ~Emptied fail queues in `anvildev` deployment~ this PR does not require reindexing `anvildev`
- [x] Emptied fail queues in `anvilprod` deployment


### Operator

- [x] Unassigned PR


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
