### PR TITLE
Fix: AnVIL deployments conflate indexer and public SAs (#4398, #5381)

### DIFF
--- a/src/azul/terra.py
+++ b/src/azul/terra.py
@@ -643,13 +643,7 @@ class TDRClient(SAMClient):
     def for_anonymous_user(cls) -> 'TDRClient':
         return cls(
             credentials_provider=ServiceAccountCredentialsProvider(
-                service_account=(
-                    # FIXME: AnVIL deployments conflate indexer and public SAs
-                    #        https://github.com/DataBiosphere/azul/issues/4398
-                    config.ServiceAccount.indexer
-                    if config.aws_account_name == 'platform-anvil-prod' else
-                    config.ServiceAccount.public
-                )
+                service_account=config.ServiceAccount.public
             )
         )
 

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -468,7 +468,8 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
             if index:
                 bundle_fqids = catalog.bundles
             else:
-                bundle_fqids = self._get_indexed_bundles(catalog.name)
+                with self._service_account_credentials:
+                    bundle_fqids = self._get_indexed_bundles(catalog.name)
             self._test_managed_access(catalog=catalog.name, bundle_fqids=bundle_fqids)
 
         if index and delete:
@@ -959,21 +960,21 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
 
     def _get_indexed_bundles(self,
                              catalog: CatalogName,
+                             filters: Optional[JSON] = None
                              ) -> set[SourcedBundleFQID]:
         indexed_fqids = set()
-        with self._service_account_credentials:
-            # FIXME: Use `bundles` index for `catalog_complete` subtest
-            #        https://github.com/DataBiosphere/azul/issues/5214
-            hits = self._get_entities(catalog, 'files')
-            if config.is_anvil_enabled(catalog):
-                # Primary bundles may not contain any files, and supplementary
-                # bundles contain only a file and a dataset. We can't use
-                # datasets to find all the indexed bundles because the number of
-                # bundles per dataset often exceeds the inner entity aggregation
-                # limit. Hence, we need to collect bundles separately for files
-                # and biosamples to cover supplementary and primary bundles,
-                # respectively.
-                hits.extend(self._get_entities(catalog, 'biosamples'))
+        # FIXME: Use `bundles` index for `catalog_complete` subtest
+        #        https://github.com/DataBiosphere/azul/issues/5214
+        hits = self._get_entities(catalog, 'files', filters)
+        if config.is_anvil_enabled(catalog):
+            # Primary bundles may not contain any files, and supplementary
+            # bundles contain only a file and a dataset. We can't use
+            # datasets to find all the indexed bundles because the number of
+            # bundles per dataset often exceeds the inner entity aggregation
+            # limit. Hence, we need to collect bundles separately for files
+            # and biosamples to cover supplementary and primary bundles,
+            # respectively.
+            hits.extend(self._get_entities(catalog, 'biosamples', filters))
         for hit in hits:
             source = one(hit['sources'])
             for bundle in hit.get('bundles', ()):
@@ -1013,7 +1014,8 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
             retries = 0
             deadline = time.time() + timeout
             while True:
-                indexed_fqids = self._get_indexed_bundles(catalog)
+                with self._service_account_credentials:
+                    indexed_fqids = self._get_indexed_bundles(catalog)
                 log.info('Detected %i of %i bundles on try #%i.',
                          len(indexed_fqids), num_bundles, retries)
                 if len(indexed_fqids) == num_bundles:
@@ -1172,8 +1174,8 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
                              one(hit[project_type])['accessible'])
         self.assertIsSubset(managed_access_source_ids, sources_found)
 
-        hits = self._get_entities(catalog, bundle_type)
-        hit_source_ids = set(map(source_id_from_hit, hits))
+        bundle_fqids = self._get_indexed_bundles(catalog)
+        hit_source_ids = {fqid.source.id for fqid in bundle_fqids}
         self.assertEqual(set(), hit_source_ids & managed_access_source_ids)
 
         source_filter = {'sourceId': {'is': list(managed_access_source_ids)}}
@@ -1183,8 +1185,8 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
         self.assertEqual(403 if managed_access_source_ids else 200, response.status)
 
         with self._service_account_credentials:
-            hits = self._get_entities(catalog, bundle_type, filters=source_filter)
-        hit_source_ids = set(map(source_id_from_hit, hits))
+            bundle_fqids = self._get_indexed_bundles(catalog, filters=source_filter)
+        hit_source_ids = {fqid.source.id for fqid in bundle_fqids}
         self.assertEqual(managed_access_source_ids, hit_source_ids)
         return hits
 

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -161,6 +161,7 @@ from azul.terra import (
 from azul.types import (
     JSON,
     JSONs,
+    MutableJSONs,
 )
 from azul_test_case import (
     AlwaysTearDownTestCase,
@@ -1052,7 +1053,11 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
                 hits = self._get_entities(catalog, entity_type)
                 self.assertEqual([], [hit['entryId'] for hit in hits])
 
-    def _get_entities(self, catalog: CatalogName, entity_type, filters: Optional[JSON] = None):
+    def _get_entities(self,
+                      catalog: CatalogName,
+                      entity_type: EntityType,
+                      filters: Optional[JSON] = None
+                      ) -> MutableJSONs:
         entities = []
         size = 100
         params = dict(catalog=catalog,


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=promotion.md`,
`&template=hotfix.md`, `&template=backport.md` or `&template=gitlab.md` to
switch the template.
-->

Supersedes: https://github.com/DataBiosphere/azul/pull/5378

Connected issues: #4398 #5381


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR title references all connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] For each connected issue, there is at least one commit whose title references that issue
- [x] PR is connected to all connected issues via ZenHub
- [x] PR description links to connected issues
- [x] Added `partial` label to PR <sub>or this PR completely resolves all connected issues</sub>

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR <sub>or this PR does not require reindexing</sub>
- [x] PR and connected issue are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or this PR is not chained to another PR</sub>
- [x] Added `base` label to the blocking PR <sub>or this PR is not chained to another PR</sub>
- [x] Added `chained` label to this PR <sub>or this PR is not chained to another PR</sub>


### Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR <sub>or this PR does not require upgrading</sub>


### Author (operator tasks)

- [x] Added checklist items for additional operator tasks <sub>or this PR does not require additional tasks</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the `prod` branch has no temporary hotfixes for any connected issues</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not touch requirements*.txt, common.mk, Makefile and Dockerfile</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not touch requirements*.txt</sub>
- [x] Added `reqs` label to PR <sub>or this PR does not touch requirements*.txt</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>


### Peer reviewer (after requesting changes)

Uncheck the *Author (before every review)* checklists.


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] Requested review from primary reviewer
- [x] Assigned PR to primary reviewer


### Primary reviewer (after requesting changes)

Uncheck the *before every review* checklists. Update the `N reviews` label.


### Primary reviewer (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved ticket to *Approved* column
- [x] Assigned PR to current operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] PR has checklist items for upgrading instructions <sub>or PR is not labeled `upgrade`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Pushed PR branch to GitLab `dev` and added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Started reindex in `sandbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Title of merge commit starts with title from this PR
- [x] Added PR reference to merge commit title
- [x] Added commit title tags to merge commit title
- [x] Moved connected issues to Merged column in ZenHub
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed merge commit to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed merge commit to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes on GitLab `dev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `dev`<sup>1</sup>
- [x] Build passes on GitLab `anvildev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvildev`<sup>1</sup>
- [x] Build passes on GitLab `anvilprod`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvilprod`<sup>1</sup>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Deleted PR branch from GitLab `anvilprod`

<sup>1</sup> When pushing the merge commit is skipped due to the PR being
labelled `no sandbox`, the next build triggered by a PR whose merge commit *is*
pushed determines this checklist item.


### Operator (reindex)

- [x] Deleted unreferenced indices in `dev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Deleted unreferenced indices in `anvildev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Deleted unreferenced indices in `anvilprod` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing</sub>
- [x] Started reindex in `anvilprod` <sub>or this PR does not require reindexing</sub>
- [x] Checked for and triaged indexing failures in `dev` <sub>or this PR does not require reindexing</sub>
- [x] Checked for and triaged indexing failures in `anvildev` <sub>or this PR does not require reindexing</sub>
- [x] Checked for and triaged indexing failures in `anvilprod` <sub>or this PR does not require reindexing</sub>
- [x] Emptied fail queues in `dev` deployment <sub>or this PR does not require reindexing</sub>
- [x] Emptied fail queues in `anvildev` deployment <sub>or this PR does not require reindexing</sub>
- [x] Emptied fail queues in `anvilprod` deployment <sub>or this PR does not require reindexing</sub>


### Operator

- [x] Unassigned PR


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
