### PR TITLE
Fix: Noisy alarm from EC2 for CreateNetworkInterface during initial deploy (#5363)

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -20,6 +20,16 @@ reverted. This is all fairly informal and loosely defined. Hopefully we won't
 have too many entries in this file.
 
 
+#5363 Noisy alarm from EC2 for CreateNetworkInterface during initial deploy
+===========================================================================
+
+Operator
+~~~~~~~~
+
+Manually deploy the ``shared`` component of any main deployment just before
+pushing the merge commit to the GitLab instance in that deployment.
+
+
 #5408 Prepare for vacation
 ==========================
 

--- a/terraform/shared/shared.tf.json.template.py
+++ b/terraform/shared/shared.tf.json.template.py
@@ -75,6 +75,10 @@ cis_alarms = [
                             '$.eventSource != "elasticloadbalancing.amazonaws.com"',
                             '$.eventName != "DescribeTargetGroupAttributes"',
                             '$.userIdentity.invokedBy != "inspector2.amazonaws.com"',
+                        ])),
+                        paren(' || '.join([
+                            '$.eventSource != "ec2.amazonaws.com"',
+                            '$.eventName != "CreateNetworkInterface"',
                         ]))
                     ]) + '}'
                     ),


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=promotion.md`,
`&template=hotfix.md`, `&template=backport.md` or `&template=gitlab.md` to
switch the template.
-->

Connected issues: #5363


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR title references all connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] For each connected issue, there is at least one commit whose title references that issue
- [x] PR is connected to all connected issues via ZenHub
- [x] PR description links to connected issues
- [x] Added `partial` label to PR <sub>or this PR completely resolves all connected issues</sub>

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR <sub>or this PR does not require reindexing</sub>
- [x] PR and connected issue are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or this PR is not chained to another PR</sub>
- [x] Added `base` label to the blocking PR <sub>or this PR is not chained to another PR</sub>
- [x] Added `chained` label to this PR <sub>or this PR is not chained to another PR</sub>


### Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR <sub>or this PR does not require upgrading</sub>


### Author (operator tasks)

- [x] Added checklist items for additional operator tasks <sub>or this PR does not require additional tasks</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the `prod` branch has no temporary hotfixes for any connected issues</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not touch requirements*.txt, common.mk, Makefile and Dockerfile</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not touch requirements*.txt</sub>
- [x] Added `reqs` label to PR <sub>or this PR does not touch requirements*.txt</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>


### Peer reviewer (after requesting changes)

Uncheck the *Author (before every review)* checklists.


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] Requested review from primary reviewer
- [x] Assigned PR to primary reviewer


### Primary reviewer (after requesting changes)

Uncheck the *before every review* checklists. Update the `N reviews` label.


### Primary reviewer (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved ticket to *Approved* column
- [x] Assigned PR to current operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] PR has checklist items for upgrading instructions <sub>or PR is not labeled `upgrade`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Pushed PR branch to GitLab `dev` and added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Deleted unreferenced indices in `hammerbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Started reindex in `sandbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Started reindex in `hammerbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `hammerbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Title of merge commit starts with title from this PR
- [x] Added PR reference to merge commit title
- [x] Added commit title tags to merge commit title
- [x] Moved connected issues to Merged column in ZenHub
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Manually deployed `dev.shared`
- [x] Pushed merge commit to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Updated CloudWatch Logs query `api_unauthorized` in `platform-hca-dev` (See `Notes` section below)
- [x] Manually deployed `anvildev.shared`
- [x] Pushed merge commit to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Updated CloudWatch Logs query `api_unauthorized` in `platform-anvil-dev` (See `Notes` section below)
- [x] Manually deployed `anvilprod.shared`
- [x] Pushed merge commit to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [x] Updated CloudWatch Logs query `api_unauthorized` in `platform-anvil-prod` (See `Notes` section below)
- [x] Build passes on GitLab `dev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `dev`<sup>1</sup>
- [x] Build passes on GitLab `anvildev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvildev`<sup>1</sup>
- [x] Build passes on GitLab `anvilprod`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvilprod`<sup>1</sup>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Deleted PR branch from GitLab `anvilprod`

<sup>1</sup> When pushing the merge commit is skipped due to the PR being
labelled `no sandbox`, the next build triggered by a PR whose merge commit *is*
pushed determines this checklist item.


### Operator (reindex)

- [x] Deleted unreferenced indices in `dev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Deleted unreferenced indices in `anvildev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Deleted unreferenced indices in `anvilprod` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing</sub>
- [x] Started reindex in `anvilprod` <sub>or this PR does not require reindexing</sub>
- [x] Checked for and triaged indexing failures in `dev` <sub>or this PR does not require reindexing</sub>
- [x] Checked for and triaged indexing failures in `anvildev` <sub>or this PR does not require reindexing</sub>
- [x] Checked for and triaged indexing failures in `anvilprod` <sub>or this PR does not require reindexing</sub>
- [x] Emptied fail queues in `dev` deployment <sub>or this PR does not require reindexing</sub>
- [x] Emptied fail queues in `anvildev` deployment <sub>or this PR does not require reindexing</sub>
- [x] Emptied fail queues in `anvilprod` deployment <sub>or this PR does not require reindexing</sub>


### Operator

- [x] Added checklist item to `prod` promotion PR:
> - [ ] Manually deployed `prod.shared`
> - [ ] Updated CloudWatch Logs query `api_unauthorized` in `platform-hca-prod`
- [x] Unassigned PR


## Notes

This query fragment should be added to the CloudWatch Logs Insights saved query `api_unauthorized` in the associated AWS project after the merge commit is pushed to a deployment.

```
or
eventSource = 'ec2.amazonaws.com' and eventName = 'CreateNetworkInterface'
```

## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
