### PR TITLE
Reject empty sources during deployment (partial #5498)

### DIFF
--- a/scripts/post_deploy_tdr.py
+++ b/scripts/post_deploy_tdr.py
@@ -2,19 +2,21 @@ from concurrent.futures import (
     ThreadPoolExecutor,
     as_completed,
 )
-from itertools import (
-    chain,
-)
 import logging
 
 from azul import (
+    CatalogName,
     config,
     require,
+)
+from azul.azulclient import (
+    AzulClient,
 )
 from azul.logging import (
     configure_script_logging,
 )
 from azul.terra import (
+    SourceRef as TDRSourceRef,
     TDRClient,
     TDRSourceSpec,
 )
@@ -23,6 +25,8 @@ log = logging.getLogger(__name__)
 
 tdr = TDRClient.for_indexer()
 public_tdr = TDRClient.for_anonymous_user()
+
+client = AzulClient()
 
 
 def register_with_sam():
@@ -40,11 +44,14 @@ def verify_sources():
     }
     assert tdr_catalogs, tdr_catalogs
     futures = []
+    all_sources = set()
     with ThreadPoolExecutor(max_workers=16) as tpe:
-        for source in set(chain.from_iterable(map(config.sources, tdr_catalogs))):
-            source = TDRSourceSpec.parse(source)
-            for check in (tdr.check_api_access, tdr.check_bigquery_access, verify_source):
-                futures.append(tpe.submit(check, source))
+        for catalog in tdr_catalogs:
+            catalog_sources = config.sources(catalog)
+            for source in catalog_sources - all_sources:
+                source = TDRSourceSpec.parse(source)
+                futures.append(tpe.submit(verify_source, catalog, source))
+            all_sources |= catalog_sources
         for completed_future in as_completed(futures):
             futures.remove(completed_future)
             e = completed_future.exception()
@@ -54,8 +61,9 @@ def verify_sources():
                 raise e
 
 
-def verify_source(source_spec: TDRSourceSpec):
+def verify_source(catalog: CatalogName, source_spec: TDRSourceSpec):
     source = tdr.lookup_source(source_spec)
+    log.info('TDR client is authorized for API access to %s.', source_spec)
     require(source.project == source_spec.project,
             'Actual Google project of TDR source differs from configured one',
             source.project, source_spec.project)
@@ -64,6 +72,11 @@ def verify_source(source_spec: TDRSourceSpec):
     require(source.location.lower() == config.tdr_source_location.lower(),
             'Actual storage location of TDR source differs from configured one',
             source.location, config.tdr_source_location)
+    ref = TDRSourceRef(id=source.id, spec=source_spec)
+    plugin = client.repository_plugin(catalog)
+    subgraph_count = sum(plugin.list_partitions(ref).values())
+    require(subgraph_count > 0,
+            'Source spec is empty (bad prefix?)', source_spec)
 
 
 def verify_source_access():

--- a/scripts/post_deploy_tdr.py
+++ b/scripts/post_deploy_tdr.py
@@ -72,6 +72,8 @@ def verify_source(catalog: CatalogName, source_spec: TDRSourceSpec):
     require(source.location.lower() == config.tdr_source_location.lower(),
             'Actual storage location of TDR source differs from configured one',
             source.location, config.tdr_source_location)
+    # FIXME: Eliminate azul.terra.TDRClient.TDRSource
+    #        https://github.com/DataBiosphere/azul/issues/5524
     ref = TDRSourceRef(id=source.id, spec=source_spec)
     plugin = client.repository_plugin(catalog)
     subgraph_count = sum(plugin.list_partitions(ref).values())

--- a/src/azul/terra.py
+++ b/src/azul/terra.py
@@ -431,6 +431,8 @@ class TDRClient(SAMClient):
     A client for the Broad Institute's Terra Data Repository aka "Jade".
     """
 
+    # FIXME: Eliminate azul.terra.TDRClient.TDRSource
+    #        https://github.com/DataBiosphere/azul/issues/5524
     @attr.s(frozen=True, kw_only=True, auto_attribs=True)
     class TDRSource:
         project: str

--- a/src/azul/terra.py
+++ b/src/azul/terra.py
@@ -458,13 +458,6 @@ class TDRClient(SAMClient):
                 'Source name changed unexpectedly', source, response)
         return response
 
-    def check_api_access(self, source: TDRSourceSpec) -> None:
-        """
-        Verify that the client is authorized to read from the TDR service API.
-        """
-        self._lookup_source(source)
-        log.info('TDR client is authorized for API access to %s.', source)
-
     def _lookup_source(self, source: TDRSourceSpec) -> MutableJSON:
         endpoint = self._repository_endpoint(source.type_name + 's')
         endpoint.set(args=dict(filter=source.bq_name, limit='2'))


### PR DESCRIPTION
Title does not match issue because this is a partial PR

Connected issues: #5498


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR title references all connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] For each connected issue, there is at least one commit whose title references that issue
- [x] PR is connected to all connected issues via ZenHub
- [x] PR description links to connected issues
- [x] Added `partial` label to PR <sub>or this PR completely resolves all connected issues</sub>

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR <sub>or this PR does not require reindexing</sub>
- [x] PR and connected issue are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or this PR is not chained to another PR</sub>
- [x] Added `base` label to the blocking PR <sub>or this PR is not chained to another PR</sub>
- [x] Added `chained` label to this PR <sub>or this PR is not chained to another PR</sub>


### Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR <sub>or this PR does not require upgrading</sub>


### Author (operator tasks)

- [x] Added checklist items for additional operator tasks <sub>or this PR does not require additional tasks</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the `prod` branch has no temporary hotfixes for any connected issues</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not touch requirements*.txt, common.mk, Makefile and Dockerfile</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not touch requirements*.txt</sub>
- [x] Added `reqs` label to PR <sub>or this PR does not touch requirements*.txt</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>


### Peer reviewer (after requesting changes)

Uncheck the *Author (before every review)* checklists.


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] Requested review from primary reviewer
- [x] Assigned PR to primary reviewer


### Primary reviewer (after requesting changes)

Uncheck the *before every review* checklists. Update the `N reviews` label.


### Primary reviewer (after approval)

- [x] Actually approved the PR
- [ ] ~Labeled connected issues as `demo` or `no demo`~
- [ ] ~Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>~
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved ticket to *Approved* column
- [x] Assigned PR to current operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] PR has checklist items for upgrading instructions <sub>or PR is not labeled `upgrade`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Pushed PR branch to GitLab `dev` and added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Deleted unreferenced indices in `hammerbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Started reindex in `sandbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Started reindex in `hammerbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `hammerbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Title of merge commit starts with title from this PR
- [x] Added PR reference to merge commit title
- [x] Added commit title tags to merge commit title
- [x] Moved connected issues to Merged column in ZenHub
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed merge commit to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed merge commit to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes on GitLab `dev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `dev`<sup>1</sup>
- [x] Build passes on GitLab `anvildev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvildev`<sup>1</sup>
- [x] Build passes on GitLab `anvilprod`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvilprod`<sup>1</sup>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Deleted PR branch from GitLab `anvilprod`

<sup>1</sup> When pushing the merge commit is skipped due to the PR being
labelled `no sandbox`, the next build triggered by a PR whose merge commit *is*
pushed determines this checklist item.


### Operator (reindex)

- [x] Deleted unreferenced indices in `dev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Deleted unreferenced indices in `anvildev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Deleted unreferenced indices in `anvilprod` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing</sub>
- [x] Started reindex in `anvilprod` <sub>or this PR does not require reindexing</sub>
- [x] Checked for and triaged indexing failures in `dev` <sub>or this PR does not require reindexing</sub>
- [x] Checked for and triaged indexing failures in `anvildev` <sub>or this PR does not require reindexing</sub>
- [x] Checked for and triaged indexing failures in `anvilprod` <sub>or this PR does not require reindexing</sub>
- [x] Emptied fail queues in `dev` deployment <sub>or this PR does not require reindexing</sub>
- [x] Emptied fail queues in `anvildev` deployment <sub>or this PR does not require reindexing</sub>
- [x] Emptied fail queues in `anvilprod` deployment <sub>or this PR does not require reindexing</sub>


### Operator

- [x] Unassigned PR


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
