### PR TITLE
Fix: Lambda servicecachehealth times out (partial #5467)

### DIFF
--- a/src/azul/plugins/__init__.py
+++ b/src/azul/plugins/__init__.py
@@ -324,7 +324,7 @@ class MetadataPlugin(Plugin[BUNDLE]):
 
     @property
     @abstractmethod
-    def exposed_indices(self) -> Mapping[EntityType, Sorting]:
+    def exposed_indices(self) -> dict[EntityType, Sorting]:
         """
         The indices for which the service provides an `/index/…` endpoint.
         The return value maps the outer entity type of each exposed index to the

--- a/src/azul/plugins/metadata/anvil/__init__.py
+++ b/src/azul/plugins/metadata/anvil/__init__.py
@@ -1,6 +1,5 @@
 from typing import (
     Iterable,
-    Mapping,
     Optional,
     Sequence,
     Type,
@@ -48,7 +47,7 @@ from azul.types import (
 class Plugin(MetadataPlugin[AnvilBundle]):
 
     @property
-    def exposed_indices(self) -> Mapping[EntityType, Sorting]:
+    def exposed_indices(self) -> dict[EntityType, Sorting]:
         return dict(
             activities=Sorting(field_name='activities.activity_id'),
             biosamples=Sorting(field_name='biosamples.biosample_id'),

--- a/src/azul/plugins/metadata/hca/__init__.py
+++ b/src/azul/plugins/metadata/hca/__init__.py
@@ -3,7 +3,6 @@ from collections.abc import (
     Sequence,
 )
 from typing import (
-    Mapping,
     Optional,
     Type,
 )
@@ -138,7 +137,7 @@ class Plugin(MetadataPlugin[HCABundle]):
         return mapping
 
     @property
-    def exposed_indices(self) -> Mapping[EntityType, Sorting]:
+    def exposed_indices(self) -> dict[EntityType, Sorting]:
         return dict(
             bundles=Sorting(field_name='bundleVersion', descending=True, max_page_size=100),
             files=Sorting(field_name='fileName'),

--- a/src/azul/terra.py
+++ b/src/azul/terra.py
@@ -347,7 +347,7 @@ class TerraClient(OAuth2Client):
             # from the pool are reused after a long period of idleness.
             retry = urllib3.Retry(total=None,
                                   connect=retries,
-                                  read=2,
+                                  read=0,
                                   redirect=0,
                                   status=0,
                                   other=retries)

--- a/test/health_check_test_case.py
+++ b/test/health_check_test_case.py
@@ -233,11 +233,12 @@ class HealthCheckTestCase(LocalAppTestCase,
         return {
             'other_lambdas': {
                 'up': up,
-                **({
+                **{
                     lambda_name: {
                         'up': up
-                    } for lambda_name in self._other_lambda_names()
-                })
+                    }
+                    for lambda_name in self._other_lambda_names()
+                }
             }
         }
 

--- a/test/indexer/test_health_check.py
+++ b/test/indexer/test_health_check.py
@@ -8,6 +8,9 @@ from moto import (
 from azul.logging import (
     configure_test_logging,
 )
+from azul.types import (
+    MutableJSON,
+)
 from azul_test_case import (
     DCP1TestCase,
 )
@@ -30,11 +33,11 @@ class TestIndexerHealthCheck(DCP1TestCase, HealthCheckTestCase):
     def _expected_health(self,
                          endpoints_up: bool = True,
                          es_up: bool = True
-                         ):
+                         ) -> MutableJSON:
         return {
             'up': False,
-            **self._expected_elasticsearch(es_up),
-            **self._expected_queues(not es_up),
+            **self._expected_elasticsearch(up=es_up),
+            **self._expected_queues(up=not es_up),
             **self._expected_progress()
         }
 

--- a/test/indexer/test_health_check.py
+++ b/test/indexer/test_health_check.py
@@ -1,5 +1,3 @@
-import unittest
-
 from moto import (
     mock_sqs,
     mock_sts,
@@ -50,6 +48,3 @@ class TestIndexerHealthCheck(DCP1TestCase, HealthCheckTestCase):
 
 
 del HealthCheckTestCase
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/indexer/test_health_check.py
+++ b/test/indexer/test_health_check.py
@@ -1,6 +1,3 @@
-from collections.abc import (
-    Mapping,
-)
 import unittest
 
 from moto import (
@@ -31,7 +28,7 @@ class TestIndexerHealthCheck(DCP1TestCase, HealthCheckTestCase):
         return 'indexer'
 
     def _expected_health(self,
-                         endpoint_states: Mapping[str, bool],
+                         endpoints_up: bool = True,
                          es_up: bool = True
                          ):
         return {
@@ -44,10 +41,9 @@ class TestIndexerHealthCheck(DCP1TestCase, HealthCheckTestCase):
     @mock_sts
     @mock_sqs
     def test_queues_down(self):
-        endpoint_states = self._endpoint_states()
-        response = self._test(endpoint_states, lambdas_up=True)
+        response = self._test()
         self.assertEqual(503, response.status_code)
-        self.assertEqual(self._expected_health(endpoint_states), response.json())
+        self.assertEqual(self._expected_health(), response.json())
 
 
 del HealthCheckTestCase

--- a/test/service/test_health_check.py
+++ b/test/service/test_health_check.py
@@ -8,6 +8,9 @@ from moto import (
 from azul.logging import (
     configure_test_logging,
 )
+from azul.types import (
+    MutableJSON,
+)
 from azul_test_case import (
     DCP1TestCase,
 )
@@ -30,11 +33,11 @@ class TestServiceHealthCheck(DCP1TestCase, HealthCheckTestCase):
     def _expected_health(self,
                          endpoints_up: bool = True,
                          es_up: bool = True
-                         ):
+                         ) -> MutableJSON:
         return {
-            'up': False,
-            **self._expected_elasticsearch(es_up),
-            **self._expected_api_endpoints(endpoints_up),
+            'up': es_up and endpoints_up,
+            **self._expected_elasticsearch(up=es_up),
+            **self._expected_api_endpoints(up=endpoints_up),
         }
 
     @mock_sts

--- a/test/service/test_health_check.py
+++ b/test/service/test_health_check.py
@@ -1,5 +1,3 @@
-import unittest
-
 from moto import (
     mock_sqs,
     mock_sts,
@@ -50,6 +48,3 @@ class TestServiceHealthCheck(DCP1TestCase, HealthCheckTestCase):
 
 
 del HealthCheckTestCase
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/service/test_health_check.py
+++ b/test/service/test_health_check.py
@@ -37,7 +37,7 @@ class TestServiceHealthCheck(DCP1TestCase, HealthCheckTestCase):
         return {
             'up': False,
             **self._expected_elasticsearch(es_up),
-            **self._expected_api_endpoints(endpoint_states),
+            **self._expected_api_endpoints(any(endpoint_states.values())),
         }
 
     @mock_sts
@@ -46,16 +46,6 @@ class TestServiceHealthCheck(DCP1TestCase, HealthCheckTestCase):
         self._create_mock_queues()
         endpoint_states = self._endpoint_states(up_endpoints=(),
                                                 down_endpoints=self.endpoints)
-        response = self._test(endpoint_states, lambdas_up=True)
-        self.assertEqual(503, response.status_code)
-        self.assertEqual(self._expected_health(endpoint_states), response.json())
-
-    @mock_sts
-    @mock_sqs
-    def test_one_api_endpoint_down(self):
-        self._create_mock_queues()
-        endpoint_states = self._endpoint_states(up_endpoints=self.endpoints[1:],
-                                                down_endpoints=self.endpoints[:1])
         response = self._test(endpoint_states, lambdas_up=True)
         self.assertEqual(503, response.status_code)
         self.assertEqual(self._expected_health(endpoint_states), response.json())

--- a/test/service/test_health_check.py
+++ b/test/service/test_health_check.py
@@ -1,6 +1,3 @@
-from collections.abc import (
-    Mapping,
-)
 import unittest
 
 from moto import (
@@ -31,24 +28,22 @@ class TestServiceHealthCheck(DCP1TestCase, HealthCheckTestCase):
         return 'service'
 
     def _expected_health(self,
-                         endpoint_states: Mapping[str, bool],
+                         endpoints_up: bool = True,
                          es_up: bool = True
                          ):
         return {
             'up': False,
             **self._expected_elasticsearch(es_up),
-            **self._expected_api_endpoints(any(endpoint_states.values())),
+            **self._expected_api_endpoints(endpoints_up),
         }
 
     @mock_sts
     @mock_sqs
     def test_all_api_endpoints_down(self):
         self._create_mock_queues()
-        endpoint_states = self._endpoint_states(up_endpoints=(),
-                                                down_endpoints=self.endpoints)
-        response = self._test(endpoint_states, lambdas_up=True)
+        response = self._test(endpoints_up=False)
         self.assertEqual(503, response.status_code)
-        self.assertEqual(self._expected_health(endpoint_states), response.json())
+        self.assertEqual(self._expected_health(endpoints_up=False), response.json())
 
 
 del HealthCheckTestCase


### PR DESCRIPTION
Connected issues: #5467 


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR title references all connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] For each connected issue, there is at least one commit whose title references that issue
- [x] PR is connected to all connected issues via ZenHub
- [x] PR description links to connected issues
- [x] Added `p` tag to titles of partial commits
- [x] Added `partial` label to PR <sub>or this PR completely resolves all connected issues</sub>
- [x] All connected issues are resolved partially <sub>or this PR does not have the `partial` label</sub>

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR <sub>or this PR does not require reindexing</sub>
- [x] PR and connected issue are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or this PR is not chained to another PR</sub>
- [x] Added `base` label to the blocking PR <sub>or this PR is not chained to another PR</sub>
- [x] Added `chained` label to this PR <sub>or this PR is not chained to another PR</sub>


### Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR <sub>or this PR does not require upgrading</sub>


### Author (operator tasks)

- [x] Added checklist items for additional operator tasks <sub>or this PR does not require additional tasks</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the `prod` branch has no temporary hotfixes for any connected issues</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not touch requirements*.txt, common.mk, Makefile and Dockerfile</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not touch requirements*.txt</sub>
- [x] Added `reqs` label to PR <sub>or this PR does not touch requirements*.txt</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>


### Peer reviewer (after requesting changes)

Uncheck the *Author (before every review)* checklists.


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] Requested review from primary reviewer
- [x] Assigned PR to primary reviewer


### Primary reviewer (after requesting changes)

Uncheck the *before every review* checklists. Update the `N reviews` label.


### Primary reviewer (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved ticket to *Approved* column
- [x] Assigned PR to current operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] PR has checklist items for upgrading instructions <sub>or PR is not labeled `upgrade`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Pushed PR branch to GitLab `dev` and added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Deleted unreferenced indices in `hammerbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Started reindex in `sandbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Started reindex in `hammerbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `hammerbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Title of merge commit starts with title from this PR
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only include `p` if the PR is labeled `partial`</sub>
- [x] Moved connected issues to Merged column in ZenHub
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed merge commit to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed merge commit to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes on GitLab `dev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `dev`<sup>1</sup>
- [x] Build passes on GitLab `anvildev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvildev`<sup>1</sup>
- [x] Build passes on GitLab `anvilprod`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvilprod`<sup>1</sup>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Deleted PR branch from GitLab `anvilprod`

<sup>1</sup> When pushing the merge commit is skipped due to the PR being
labelled `no sandbox`, the next build triggered by a PR whose merge commit *is*
pushed determines this checklist item.


### Operator (reindex)

- [x] Deleted unreferenced indices in `dev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Deleted unreferenced indices in `anvildev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Deleted unreferenced indices in `anvilprod` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing</sub>
- [x] Started reindex in `anvilprod` <sub>or this PR does not require reindexing</sub>
- [x] Checked for and triaged indexing failures in `dev` <sub>or this PR does not require reindexing</sub>
- [x] Checked for and triaged indexing failures in `anvildev` <sub>or this PR does not require reindexing</sub>
- [x] Checked for and triaged indexing failures in `anvilprod` <sub>or this PR does not require reindexing</sub>
- [x] Emptied fail queues in `dev` deployment <sub>or this PR does not require reindexing</sub>
- [x] Emptied fail queues in `anvildev` deployment <sub>or this PR does not require reindexing</sub>
- [x] Emptied fail queues in `anvilprod` deployment <sub>or this PR does not require reindexing</sub>


### Operator

- [x] Unassigned PR


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
