### PR TITLE
Fix: GitHub API rate limit exceeded in test_canned_staging_area (#4757, #4438)

### DIFF
--- a/src/azul/plugins/repository/canned/__init__.py
+++ b/src/azul/plugins/repository/canned/__init__.py
@@ -194,7 +194,6 @@ class Plugin(RepositoryPlugin[CannedBundle, SimpleSourceSpec, CannedSourceRef, C
                          file_uuid: str,
                          *,
                          file_version: Optional[str] = None,
-                         replica: Optional[str] = None,
                          ) -> Optional[str]:
         # Check all sources for the file. If a file_version was specified return
         # when we find a match, otherwise continue checking all sources and
@@ -243,8 +242,7 @@ class CannedFileDownload(RepositoryFileDownload):
                ) -> None:
         assert isinstance(plugin, Plugin)
         url = plugin._direct_file_url(file_uuid=self.file_uuid,
-                                      file_version=self.file_version,
-                                      replica=None)
+                                      file_version=self.file_version)
         self._location = url
 
     @property

--- a/src/azul/plugins/repository/canned/__init__.py
+++ b/src/azul/plugins/repository/canned/__init__.py
@@ -174,7 +174,7 @@ class Plugin(RepositoryPlugin[CannedBundle, SimpleSourceSpec, CannedSourceRef, C
         >>> source_url = 'https://github.com/USER/REPO/tree/REF/tests'
 
         >>> plugin._construct_file_url(source_url, 'foo.zip')
-        'https://github.com/USER/REPO/raw/REF/tests/foo.zip'
+        'https://github.com/USER/REPO/raw/REF/tests/data/foo.zip'
 
         >>> plugin._construct_file_url(source_url, '')
         Traceback (most recent call last):
@@ -184,6 +184,7 @@ class Plugin(RepositoryPlugin[CannedBundle, SimpleSourceSpec, CannedSourceRef, C
         url = furl(source_url)
         require(url.path.segments[2] == 'tree', source_url)
         url.path.segments[2] = 'raw'
+        url.path.segments.append('data')
         require(len(file_name) > 0, 'file_name cannot be empty')
         require(not file_name.endswith('/'), file_name)
         for segment in file_name.split('/'):

--- a/src/azul/plugins/repository/canned/__init__.py
+++ b/src/azul/plugins/repository/canned/__init__.py
@@ -2,13 +2,10 @@
 This repository plugin allows reading from a canned staging area like the one in
 the GitHub repo https://github.com/HumanCellAtlas/schema-test-data .
 
-NOTE: Use of this plugin requires a GitHub personal access token specified in an
-environment variable `GITHUB_TOKEN`. See:
-https://github.com/DataBiosphere/hca-metadata-api#github-credentials
-
-Due to this requirement, this plugin cannot be used to index data directly from
-the canned staging area, however it can be used with the `can_bundle.py` script
-to create a local canned bundle from files in the canned staging area.
+NOTE: This plugin's purpose is for testing and verification of a canned staging
+area, and should not be used to create catalogs on a deployment. It can however
+be used with the `can_bundle.py` script to create a local canned bundle from the
+files in the canned staging area.
 """
 from collections.abc import (
     Sequence,
@@ -18,6 +15,12 @@ from dataclasses import (
     dataclass,
 )
 import logging
+from pathlib import (
+    Path,
+)
+from tempfile import (
+    TemporaryDirectory,
+)
 import time
 from typing import (
     Optional,
@@ -68,7 +71,7 @@ from azul.uuids import (
     validate_uuid_prefix,
 )
 from humancellatlas.data.metadata.helpers.staging_area import (
-    GitHubStagingAreaFactory,
+    CannedStagingAreaFactory,
     StagingArea,
 )
 
@@ -120,12 +123,51 @@ class Plugin(RepositoryPlugin[CannedBundle, SimpleSourceSpec, CannedSourceRef, C
         ]
 
     def _lookup_source_id(self, spec: SimpleSourceSpec) -> str:
-        return spec.name
+        return str(spec)
+
+    def parse_github_url(self, url: furl) -> tuple[furl, Path, str]:
+        """
+        Parse a GitHub URL.
+
+        :param url: A GitHub URL of the format
+                    https://github.com/<OWNER>/<NAME>/tree/<REF>[/<PATH>]. Note
+                    that REF can be the name of a branch, the name of a tag, or
+                    a commit SHA. If REF contains special characters like `/`,
+                    '?` or `#` they must be URL-encoded. This is especially
+                    noteworthy for `/` in branch names.
+
+        :return: A tuple containing the URL of a GitHub repository, a relative
+                 path inside that repository, and a Git ref.
+
+        >>> plugin = Plugin(_sources=set())
+
+        >>> plugin.parse_github_url(furl('https://github.com/OWNER/NAME/tree/REF/tests'))
+        (furl('https://github.com/OWNER/NAME.git'), PosixPath('tests'), 'REF')
+        """
+        require(url.scheme == 'https', url)
+        require(url.host == 'github.com', url)
+        owner, name, slug, ref, *path = url.path.segments
+        require(slug == 'tree', url)
+        remote_url = furl(url.origin)
+        remote_url.path.add((owner, f'{name}.git'))
+        return remote_url, Path(*path), ref
 
     @lru_cache
-    def staging_area(self, source_spec: SimpleSourceSpec) -> StagingArea:
-        factory = GitHubStagingAreaFactory.from_url(source_spec.name)
-        return factory.load_staging_area()
+    def staging_area(self, url: str) -> StagingArea:
+        """
+        Process the contents of a staging area.
+
+        :param url: The URL of a staging area located in a GitHub repository.
+
+        :return: A StagingArea object containing the contents of the staging
+                 area's JSON files.
+        """
+        with TemporaryDirectory() as tmpdir:
+            remote_url, path, ref = self.parse_github_url(furl(url))
+            factory = CannedStagingAreaFactory.clone_remote(remote_url,
+                                                            Path(tmpdir),
+                                                            ref)
+            return factory.load_staging_area(path)
 
     def _assert_source(self, source: CannedSourceRef):
         assert source.spec in self.sources, (source, self.sources)
@@ -139,7 +181,8 @@ class Plugin(RepositoryPlugin[CannedBundle, SimpleSourceSpec, CannedSourceRef, C
         validate_uuid_prefix(prefix)
         log.info('Listing bundles with prefix %r in source %r.', prefix, source)
         bundle_fqids = []
-        for link in self.staging_area(source.spec).links.values():
+        staging_area = self.staging_area(source.spec.name)
+        for link in staging_area.links.values():
             if link.uuid.startswith(prefix):
                 bundle_fqids.append(CannedBundleFQID(source=source,
                                                      uuid=link.uuid,
@@ -151,8 +194,8 @@ class Plugin(RepositoryPlugin[CannedBundle, SimpleSourceSpec, CannedSourceRef, C
     def fetch_bundle(self, bundle_fqid: CannedBundleFQID) -> CannedBundle:
         self._assert_source(bundle_fqid.source)
         now = time.time()
-        staging_area = self.staging_area(bundle_fqid.source.spec)
-        version, manifest, metadata = staging_area.get_bundle(bundle_fqid.uuid)
+        staging_area = self.staging_area(bundle_fqid.source.spec.name)
+        version, manifest, metadata = staging_area.get_bundle_parts(bundle_fqid.uuid)
         if bundle_fqid.version is None:
             bundle_fqid = CannedBundleFQID(source=bundle_fqid.source,
                                            uuid=bundle_fqid.uuid,
@@ -168,55 +211,56 @@ class Plugin(RepositoryPlugin[CannedBundle, SimpleSourceSpec, CannedSourceRef, C
     def portal_db(self) -> Sequence[JSON]:
         return []
 
-    def _construct_file_url(self, source_url: str, file_name: str) -> str:
+    def _construct_file_url(self, url: furl, file_name: str) -> furl:
         """
         >>> plugin = Plugin(_sources=set())
-        >>> source_url = 'https://github.com/USER/REPO/tree/REF/tests'
+        >>> url = furl('https://github.com/OWNER/REPO/tree/REF/tests')
 
-        >>> plugin._construct_file_url(source_url, 'foo.zip')
-        'https://github.com/USER/REPO/raw/REF/tests/data/foo.zip'
+        >>> plugin._construct_file_url(url, 'foo.zip')
+        furl('https://github.com/OWNER/REPO/raw/REF/tests/data/foo.zip')
 
-        >>> plugin._construct_file_url(source_url, '')
+        >>> plugin._construct_file_url(url, '')
         Traceback (most recent call last):
         ...
         azul.RequirementError: file_name cannot be empty
         """
-        url = furl(source_url)
-        require(url.path.segments[2] == 'tree', source_url)
-        url.path.segments[2] = 'raw'
-        url.path.segments.append('data')
+        require(url.path.segments[2] == 'tree', str(url))
+        file_url = furl(url)
+        file_url.path.segments[2] = 'raw'
+        file_url.path.segments.append('data')
         require(len(file_name) > 0, 'file_name cannot be empty')
         require(not file_name.endswith('/'), file_name)
         for segment in file_name.split('/'):
-            url.path.segments.append(segment)
-        return str(url)
+            file_url.path.segments.append(segment)
+        return file_url
 
     def _direct_file_url(self,
                          file_uuid: str,
                          *,
                          file_version: Optional[str] = None,
-                         ) -> Optional[str]:
+                         ) -> Optional[furl]:
         # Check all sources for the file. If a file_version was specified return
         # when we find a match, otherwise continue checking all sources and
         # return the URL for the match with the latest (largest) version.
         found_version = None
         found_url = None
         for source_spec in self.sources:
-            staging_area = self.staging_area(source_spec)
+            staging_area = self.staging_area(source_spec.name)
             try:
                 descriptor = staging_area.descriptors[file_uuid]
             except KeyError:
                 continue
             else:
+                staging_area_url = furl(source_spec.name)
                 actual_file_version = descriptor.content['file_version']
                 if file_version:
                     if file_version == actual_file_version:
                         file_name = descriptor.content['file_name']
-                        return self._construct_file_url(source_spec.name, file_name)
+                        return self._construct_file_url(staging_area_url, file_name)
                 else:
                     if found_version is None or actual_file_version > found_version:
                         file_name = descriptor.content['file_name']
-                        found_url = self._construct_file_url(source_spec.name, file_name)
+                        found_url = self._construct_file_url(staging_area_url, file_name)
                         found_version = actual_file_version
         return found_url
 
@@ -234,7 +278,7 @@ class Plugin(RepositoryPlugin[CannedBundle, SimpleSourceSpec, CannedSourceRef, C
 
 
 class CannedFileDownload(RepositoryFileDownload):
-    _location: Optional[str] = None
+    _location: Optional[furl] = None
     _retry_after: Optional[int] = None
 
     def update(self,
@@ -248,7 +292,7 @@ class CannedFileDownload(RepositoryFileDownload):
 
     @property
     def location(self) -> Optional[str]:
-        return self._location
+        return None if self._location is None else str(self._location)
 
     @property
     def retry_after(self) -> Optional[int]:

--- a/test/test_doctests.py
+++ b/test/test_doctests.py
@@ -34,6 +34,7 @@ import azul.openapi.responses
 import azul.openapi.schema
 import azul.plugins.metadata.hca.indexer.transform
 import azul.plugins.metadata.hca.service.contributor_matrices
+import azul.plugins.repository.canned
 import azul.plugins.repository.tdr_hca
 import azul.service.drs_controller
 import azul.service.manifest_service
@@ -83,6 +84,7 @@ def load_tests(_loader, tests, _ignore):
         azul.openapi.responses,
         azul.openapi.schema,
         azul.plugins.metadata.hca.service.contributor_matrices,
+        azul.plugins.repository.canned,
         azul.plugins.repository.tdr_hca,
         azul.plugins.metadata.hca.indexer.transform,
         azul.service.drs_controller,


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=promotion.md`,
`&template=hotfix.md`, `&template=backport.md` or `&template=gitlab.md` to
switch the template.
-->

Connected issues: #4757, #4438


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR title references all connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] For each connected issue, there is at least one commit whose title references that issue
- [x] PR is connected to all connected issues via ZenHub
- [x] PR description links to connected issues
- [x] Added `p` tag to titles of partial commits
- [x] Added `partial` label to PR <sub>or this PR completely resolves all connected issues</sub>
- [x] All connected issues are resolved partially <sub>or this PR does not have the `partial` label</sub>

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR <sub>or this PR does not require reindexing</sub>
- [x] PR and connected issue are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or this PR is not chained to another PR</sub>
- [x] Added `base` label to the blocking PR <sub>or this PR is not chained to another PR</sub>
- [x] Added `chained` label to this PR <sub>or this PR is not chained to another PR</sub>


### Author (upgrading)

- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading</sub>
- [x] Added `upgrade` label to PR <sub>or this PR does not require upgrading</sub>


### Author (operator tasks)

- [x] Added checklist items for additional operator tasks <sub>or this PR does not require additional tasks</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the `prod` branch has no temporary hotfixes for any connected issues</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not touch requirements*.txt, common.mk, Makefile and Dockerfile</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not touch requirements*.txt</sub>
- [x] Added `reqs` label to PR <sub>or this PR does not touch requirements*.txt</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>


### Peer reviewer (after requesting changes)

Uncheck the *Author (before every review)* checklists.


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] Requested review from primary reviewer
- [x] Assigned PR to primary reviewer


### Primary reviewer (after requesting changes)

Uncheck the *before every review* checklists. Update the `N reviews` label.


### Primary reviewer (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved ticket to *Approved* column
- [x] Assigned PR to current operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] PR has checklist items for upgrading instructions <sub>or PR is not labeled `upgrade`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Pushed PR branch to GitLab `dev` and added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Deleted unreferenced indices in `hammerbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Started reindex in `sandbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Started reindex in `hammerbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Checked for failures in `hammerbox` <sub>or this PR does not require reindexing `sandbox`</sub>
- [x] Title of merge commit starts with title from this PR
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only include `p` if the PR is labeled `partial`</sub>
- [x] Moved connected issues to Merged column in ZenHub
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed merge commit to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed merge commit to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes on GitLab `dev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `dev`<sup>1</sup>
- [x] Build passes on GitLab `anvildev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvildev`<sup>1</sup>
- [x] Build passes on GitLab `anvilprod`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvilprod`<sup>1</sup>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Deleted PR branch from GitLab `anvilprod`

<sup>1</sup> When pushing the merge commit is skipped due to the PR being
labelled `no sandbox`, the next build triggered by a PR whose merge commit *is*
pushed determines this checklist item.


### Operator (reindex)

- [x] Deleted unreferenced indices in `dev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Deleted unreferenced indices in `anvildev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Deleted unreferenced indices in `anvilprod` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices </sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing</sub>
- [x] Started reindex in `anvilprod` <sub>or this PR does not require reindexing</sub>
- [x] Checked for and triaged indexing failures in `dev` <sub>or this PR does not require reindexing</sub>
- [x] Checked for and triaged indexing failures in `anvildev` <sub>or this PR does not require reindexing</sub>
- [x] Checked for and triaged indexing failures in `anvilprod` <sub>or this PR does not require reindexing</sub>
- [x] Emptied fail queues in `dev` deployment <sub>or this PR does not require reindexing</sub>
- [x] Emptied fail queues in `anvildev` deployment <sub>or this PR does not require reindexing</sub>
- [x] Emptied fail queues in `anvilprod` deployment <sub>or this PR does not require reindexing</sub>


### Operator

- [x] Unassigned PR


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
