### PR TITLE
Migrate reminders to GitHub schedule (#5733)

### DIFF
--- a/.github/ISSUE_TEMPLATE/audited_events_rule_set_review.md
+++ b/.github/ISSUE_TEMPLATE/audited_events_rule_set_review.md
@@ -1,0 +1,8 @@
+---
+name: Annual review of the rule set for audited events
+about: 'Issue template for annual review of the rule set for audited events'
+title: Review rule set for audited events
+labels: -,compliance,doc,no demo,orange,task
+assignees: nolunwa-ucsc,bvizzier-ucsc
+---
+- [ ] PM (@bvizzier-ucsc) and @nolunwa-ucsc, scheduled a meeting for the annual review of the rule set for audited events

--- a/.github/ISSUE_TEMPLATE/audited_events_rule_set_review.md
+++ b/.github/ISSUE_TEMPLATE/audited_events_rule_set_review.md
@@ -4,5 +4,7 @@ about: 'Issue template for annual review of the rule set for audited events'
 title: Review rule set for audited events
 labels: -,compliance,doc,no demo,orange,task
 assignees: nolunwa-ucsc,bvizzier-ucsc
+_start: 2024-04-04T10:00
+_period: 1 year
 ---
 - [ ] PM (@bvizzier-ucsc) and @nolunwa-ucsc, scheduled a meeting for the annual review of the rule set for audited events

--- a/.github/ISSUE_TEMPLATE/fedramp_inventory_review.md
+++ b/.github/ISSUE_TEMPLATE/fedramp_inventory_review.md
@@ -1,0 +1,20 @@
+---
+name: Review FedRAMP inventory
+about: 'Issue template for the current operator to perform a Port and Protocol review with system administrator'
+title: Monthly inventory review
+labels: +,compliance,infra,no demo,operator,orange,task,
+assignees: hannes-ucsc
+repository: azul-private
+---
+It is time for the system administrator to review the FedRAMP inventory and perform a Port and Protocol review in all deployments
+
+
+- [ ] Collect most recent `dev` inventories and attach them to this issue
+- [ ] Collect most recent `anvildev` inventories and attach them to this issue
+- [ ] Collect most recent `anvilprod` inventories and attach them to this issue
+- [ ] Collect most recent `prod` inventories and attach them to this issue
+
+- [ ] Reviewed `dev` inventory
+- [ ] Reviewed `anvildev` inventory
+- [ ] Reviewed `anvilprod` inventory
+- [ ] Reviewed `prod` inventory

--- a/.github/ISSUE_TEMPLATE/fedramp_inventory_review.md
+++ b/.github/ISSUE_TEMPLATE/fedramp_inventory_review.md
@@ -4,7 +4,9 @@ about: 'Issue template for the current operator to perform a Port and Protocol r
 title: Monthly inventory review
 labels: +,compliance,infra,no demo,operator,orange,task,
 assignees: hannes-ucsc
-repository: azul-private
+_repository: DataBiosphere/azul-private
+_start: 2024-03-01T09:00
+_period: 1 month
 ---
 It is time for the system administrator to review the FedRAMP inventory and perform a Port and Protocol review in all deployments
 

--- a/.github/ISSUE_TEMPLATE/gitlab_backups.md
+++ b/.github/ISSUE_TEMPLATE/gitlab_backups.md
@@ -4,6 +4,8 @@ about: 'Issue template for operator tasks to backup GitLab data volumes'
 title: Apply GitLab data volume backups
 labels: -,infra,no demo,operator,orange,task
 assignees: ''
+_start: 2024-02-26T09:00
+_period: 14 days
 ---
 
 - [ ] Ran GitLab data-volume backup script for `dev.gitlab`

--- a/.github/ISSUE_TEMPLATE/gitlab_backups.md
+++ b/.github/ISSUE_TEMPLATE/gitlab_backups.md
@@ -1,0 +1,16 @@
+---
+name: GitLab data volume backups
+about: 'Issue template for operator tasks to backup GitLab data volumes'
+title: Apply GitLab data volume backups
+labels: -,infra,no demo,operator,orange,task
+assignees: ''
+---
+
+- [ ] Ran GitLab data-volume backup script for `dev.gitlab`
+- [ ] Updated software packages and rebooted `dev.gitlab` <sub>or this is an unecessary step</sub> 
+- [ ] Ran GitLab data-volume backup script for `anvildev.gitlab`
+- [ ] Updated software packages and rebooted `anvildev.gitlab` <sub>or this is an unecessary step</sub>
+- [ ] Ran GitLab data-volume backup script for `anvilprod.gitlab`
+- [ ] Updated software packages and rebooted `anvilprod.gitlab` <sub>or this is an unecessary step</sub>
+- [ ] Ran GitLab data-volume backup script for `prod.gitlab`
+- [ ] Updated software packages and rebooted `prod.gitlab` <sub>or this is an unecessary step</sub>

--- a/.github/ISSUE_TEMPLATE/opensearch_updates.md
+++ b/.github/ISSUE_TEMPLATE/opensearch_updates.md
@@ -1,0 +1,25 @@
+---
+name: OpenSearch service software update
+about: 'Issue template for operator tasks to update OpenSearch instances software'
+title: Apply Amazon OpenSearch (ES) Software Update
+labels: -,infra,no demo,operator,orange,task
+assignees: ''
+---
+- [ ] Applied Amazon OpenSearch Software Update <sub>or OpenSearch is running on the lattest version</sub>
+    - [ ] Update `azul-index-dev`
+    - [ ] Cleared `azul-index-dev` outstanding notifications regarding this update
+    - [ ] Update `azul-index-anvildev`
+    - [ ] Cleared `azul-index-anvildev` outstanding notifications regarding this update
+    - [ ] Update `azul-index-anvilprod`
+    - [ ] Cleared `azul-index-anvilprod` outstanding notifications regarding this update
+    - [ ] Confirm with Azul devs that their personal deployments in `dev` are idle
+    - [ ] Update `azul-index-sandbox`
+    - [ ] Cleared `azul-index-sandbox` outstanding notifications regarding this update
+    - [ ] Confirm with Azul devs that their personal deployments in `anvil` are idle
+    - [ ] Update `azul-index-anvilbox`
+    - [ ] Cleared `azul-index-anvilbox` outstanding notifications regarding this update
+    - [ ] Confirm with Azul devs that their personal deployments in `anvilprod` are idle
+    - [ ] Update `azul-index-hammerbox`
+    - [ ] Cleared `azul-index-hammerbox` outstanding notifications regarding this update
+    - [ ] Update `azul-index-prod`
+    - [ ] Cleared `azul-index-prod` outstanding notifications regarding this update

--- a/.github/ISSUE_TEMPLATE/opensearch_updates.md
+++ b/.github/ISSUE_TEMPLATE/opensearch_updates.md
@@ -4,6 +4,8 @@ about: 'Issue template for operator tasks to update OpenSearch instances softwar
 title: Apply Amazon OpenSearch (ES) Software Update
 labels: -,infra,no demo,operator,orange,task
 assignees: ''
+_start: 2024-02-26T09:00
+_period: 14 days
 ---
 - [ ] Applied Amazon OpenSearch Software Update <sub>or OpenSearch is running on the lattest version</sub>
     - [ ] Update `azul-index-dev`

--- a/.github/ISSUE_TEMPLATE/promotion.md
+++ b/.github/ISSUE_TEMPLATE/promotion.md
@@ -1,0 +1,13 @@
+---
+name: Promotion pull request
+about: 'Issue template for the current operator to perform a scheduled promotion'
+title: Promotion
+labels: -,infra,no demo,operator,orange,task
+assignees: ''
+---
+- [ ] Confirmed with tech lead the commit that will be promoted
+- [ ] Confirmed this issues maches the appropriate title convention `Promotion yyyy-mm-dd`
+- [ ] Confirmed local `prod` branch is upto date with remote
+- [ ] Promotion feature branch follows appropriate name convention `promotions/yyyy-mm-dd`
+- [ ] Created promotion PR and completed the Author sections of the promotion checklist
+- [ ] Confirmed all pending checklist items from other PRs as upgrading instructions are accounted for

--- a/.github/ISSUE_TEMPLATE/promotion.md
+++ b/.github/ISSUE_TEMPLATE/promotion.md
@@ -4,6 +4,8 @@ about: 'Issue template for the current operator to perform a scheduled promotion
 title: Promotion
 labels: -,infra,no demo,operator,orange,task
 assignees: ''
+_start: 2024-02-27T09:00
+_period: 7 days
 ---
 - [ ] Confirmed with tech lead the commit that will be promoted
 - [ ] Confirmed this issues maches the appropriate title convention `Promotion yyyy-mm-dd`

--- a/.github/ISSUE_TEMPLATE/upgrade.md
+++ b/.github/ISSUE_TEMPLATE/upgrade.md
@@ -4,6 +4,8 @@ about: 'Issue template for bi-weekly dependency upgrades'
 title: Upgrade dependencies
 labels: orange,operator,infra,enh,debt 
 assignees: ''
+_start: 2023-11-27T09:00
+_period: 14 days
 ---
 - [ ] Update [PyCharm image](https://github.com/DataBiosphere/azul-docker-pycharm)
   - [ ] Bump [base image](https://hub.docker.com/_/debian/tags?name=bullseye) tag (only same Debian release), if possible

--- a/.github/workflows/schedule.py
+++ b/.github/workflows/schedule.py
@@ -1,5 +1,7 @@
+import argparse
 from datetime import (
     datetime,
+    timedelta,
 )
 import json
 import logging
@@ -7,43 +9,55 @@ from operator import (
     itemgetter,
 )
 import subprocess
+import sys
 import zoneinfo
 
 tz = zoneinfo.ZoneInfo('America/Los_Angeles')
 
-now = datetime.now(tz)
-
 log = logging.getLogger('azul.github.schedule')
 
+one_week = 7  # in days
 
-def create_upgrade_issue():
-    # Pick any date for `start` and an issue will be created on that date, as
-    # well as every two weeks before and after, but only in the future. Note
-    # that this doesn't mean that the start date has to lie in the future.
-    start = datetime(2023, 11, 27, tzinfo=tz)  # Monday, …
-    if 0 == (now - start).days % 14 and now.hour == 9:  # … every other week, at 9am
-        template = '.github/ISSUE_TEMPLATE/upgrade.md'
-        front_matter, body = _load_issue_template(template)
-        labels, title = front_matter['labels'], front_matter['title']
-        process = subprocess.run([
-            'gh', 'issue', 'list',
-            f'--search=in:title "{title} {now.date()}"',
-            '--json=number',
-            '--limit=10',
-        ], check=True, stdout=subprocess.PIPE)
-        results = json.loads(process.stdout)
-        issues = set(map(itemgetter('number'), results))
-        if issues:
-            log.info('At least one matching issue already exists: %r', issues)
-        else:
-            subprocess.run([
-                'gh', 'issue', 'create',
-                f'--title={title} {now.date()}',
-                f'--label={labels}',
-                f'--body={body}'
-            ], check=True)
+
+def create_issue(gh_create_issue: list[str], gh_issue_lookup: list[str]) -> None:
+    process = subprocess.run(gh_issue_lookup, check=True, stdout=subprocess.PIPE)
+    results = json.loads(process.stdout)
+    issues = set(map(itemgetter('number'), results))
+    if issues:
+        log.info('At least one matching issue already exists: %r', issues)
     else:
-        log.info('Current time is outside of the configured schedule window')
+        subprocess.run(gh_create_issue, check=True)
+
+
+def gh_commands(template: str,
+                issue_date: datetime) -> tuple[list[str], list[str]]:
+    template = f'.github/ISSUE_TEMPLATE/{template}'
+    front_matter, body = _load_issue_template(template)
+    labels, title, assignees = [front_matter[x]
+                                for x in ('labels', 'title', 'assignees')]
+
+    issue_date = issue_date.date()
+    in_repository = []
+    if template.endswith('fedramp_inventory_review.md'):
+        in_repository = ['--repo DataBiosphere/' + front_matter['repository']]
+    elif template.endswith('promotion.md'):
+        # We want the Wendsday date promotion issue to be created on Tuesdays
+        issue_date = issue_date + timedelta(days=1)
+    if assignees:
+        assignees = [f'--assignee {assignees}']
+    return [
+        'gh', 'issue', 'list',
+        f'--search=in:title "{title} {issue_date}"',
+        '--json=number',
+        '--limit=10',
+    ], [
+        'gh', 'issue', 'create',
+        *in_repository,
+        *assignees,
+        f'--title={title} {issue_date}',
+        f'--label={labels}',
+        f'--body={body}'
+    ]
 
 
 def _load_issue_template(path: str) -> tuple[dict[str, str], str]:
@@ -75,7 +89,105 @@ def _load_issue_template(path: str) -> tuple[dict[str, str], str]:
         return front_matter, f.read()
 
 
+def main(templates: list[tuple[str, datetime]], dry_run: bool) -> None:
+    for template, create_date in templates:
+        cmd_lookup, cmd_create = gh_commands(template, create_date)
+        if dry_run:
+            log.info('Would be running a mock command that creates an issue')
+            print(' '.join(cmd_create))
+        else:
+            create_issue(cmd_create, cmd_lookup)
+
+
+def _create(template: str,
+            start: datetime,
+            period_days: int,
+            at_hour: int,
+            ) -> tuple[str, datetime] | None:
+    """
+    Return a tuple of the template and the datetime.now() instance that matches the
+    configured shcedule for the provided template. This logs the schedule check for
+    each, and it only returns what falls within the schedule window.
+    """
+    log.info('Checking configured schedule time window for %r', template)
+    if 0 == (now - start).days % period_days and now.hour == at_hour:
+        log.info('Scheduling %r, it falls within schedule window', template)
+        return template, now
+    else:
+        log.info('Current time is outside of the configured schedule window')
+
+
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO,
                         format='%(asctime)s %(levelname)+7s %(name)s: %(message)s')
-    create_upgrade_issue()
+
+    args = sys.argv[1:]
+    parser = argparse.ArgumentParser(
+        description='Dryrun to display the command used by GH Actions to create an issue'
+    )
+    parser.add_argument('--dry-run',
+                        metavar='MOCKED_DATE',
+                        type=lambda s: datetime.strptime(s, '%Y-%m-%dT%H:%M'),
+                        help='Dry run based on mock date to verify the template issue configuration')
+    args = parser.parse_args(args)
+
+    now = datetime.now(tz)
+    if args.dry_run:
+        dt = args.dry_run
+        now = now.replace(year=dt.year,
+                          month=dt.month,
+                          day=dt.day,
+                          hour=dt.hour,
+                          minute=dt.minute)
+
+    templates = [
+        # Pick any date for `start` and an issue will be created on that date,
+        # and thereafter based on the given period, but only in the future.
+        # Note that this doesn't mean that the start date has to lie in the
+        # future. As an example, …
+        _create(template, start, period, hour) for template, start, period, hour in [
+            (
+                'upgrade.md',  # … the schedule for upgrade.md is set …
+                datetime(2023, 11, 27, tzinfo=tz),  # … for Monday …
+                one_week * 2,  # … every other week (14 days) …
+                9  # … at 9am.
+            ),
+            (
+                'promotion.md',
+                datetime(2024, 2, 27, tzinfo=tz),
+                one_week,
+                9
+            ),
+            (
+                'gitlab_backups.md',
+                datetime(2024, 2, 26, tzinfo=tz),
+                one_week * 2,
+                9
+            ),
+            (
+                'opensearch_updates.md',
+                datetime(2024, 2, 26, tzinfo=tz),
+                one_week * 2,
+                9
+            ),
+            (
+                'fedramp_inventory_review.md',
+                datetime(2024, 3, 1, tzinfo=tz),
+                one_week * 4,
+                9
+            ),
+            (
+                'audited_events_rule_set_review.md',
+                datetime(2024, 4, 3, tzinfo=tz),
+                364,  # Every year, (364 days)
+                10
+            ),
+        ]
+    ]
+    templates = list(filter(None, templates))  # Purge what isn't scheduled
+
+    if templates:
+        assert None not in templates, templates
+        main(templates, bool(args.dry_run))
+    else:
+        log.info('All templates are outside of the configured schedule window')

--- a/test/test_doctests.py
+++ b/test/test_doctests.py
@@ -105,6 +105,7 @@ def load_tests(_loader, tests, _ignore):
         load_script('envhook'),
         load_script('export_environment'),
         load_module(root + '/.flake8/azul_flake8.py', 'azul_flake8'),
+        load_module(root + '/.github/workflows/schedule.py', 'schedule'),
         test_tagging,
         service
     ]:


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=promotion.md`,
`&template=hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to
switch the template.
-->

Connected issues: #5733


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] Added `partial` label to PR <sub>or this PR completely resolves all connected issues</sub>
- [x] All connected issues are resolved partially <sub>or this PR does not have the `partial` label</sub>

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR <sub>or this PR does not require reindexing</sub>
- [x] PR and connected issue are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or this PR is not chained to another PR</sub>
- [x] Added `base` label to the blocking PR <sub>or this PR is not chained to another PR</sub>
- [x] Added `chained` label to this PR <sub>or this PR is not chained to another PR</sub>


### Author (upgrading deployments)

- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `upgrade` label to PR <sub>or this PR does not require upgrading deployments</sub>


### Author (operator tasks)

- [x] Added checklist items for additional operator tasks <sub>or this PR does not require additional tasks</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the `prod` branch has no temporary hotfixes for any connected issues</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not touch requirements*.txt, common.mk, Makefile and Dockerfile</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not touch requirements*.txt</sub>
- [x] Added `reqs` label to PR <sub>or this PR does not touch requirements*.txt</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>


### Peer reviewer (after requesting changes)

Uncheck the *Author (before every review)* checklists.


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] Requested review from system administrator
- [x] PR is assigned to system administrator


### System administrator (after requesting changes)

Uncheck the *before every review* checklists. Update the `N reviews` label.


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved ticket to *Approved* column
- [x] PR is assigned to current operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] PR has checklist items for upgrading instructions <sub>or PR is not labeled `upgrade`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Deleted unreferenced indices in `hammerbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilprod`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Started reindex in `hammerbox` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for failures in `hammerbox` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Title of merge commit starts with title from this PR
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only include `p` if the PR is labeled `partial`</sub>
- [x] Moved connected issues to Merged column in ZenHub
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Request for @achave11-ucsc to retire the Slack notifications mentioned in https://github.com/DataBiosphere/azul/issues/5733#issuecomment-1832902616
- [x] @achave11-ucsc confirms the agreed notifications have been retired
- [x] Pushed merge commit to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed merge commit to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed merge commit to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes on GitLab `dev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `dev`<sup>1</sup>
- [x] Build passes on GitLab `anvildev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvildev`<sup>1</sup>
- [x] Build passes on GitLab `anvilprod`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvilprod`<sup>1</sup>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Deleted PR branch from GitLab `anvilprod`

<sup>1</sup> When pushing the merge commit is skipped due to the PR being
labelled `no sandbox`, the next build triggered by a PR whose merge commit *is*
pushed determines this checklist item.


### Operator (reindex)

- [x] Deleted unreferenced indices in `dev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvildev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Deleted unreferenced indices in `anvilprod` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilprod`</sub>
- [x] Considered deindexing individual sources in `dev` <sub>or this PR does not merely remove sources from existing catalogs in `dev`</sub>
- [x] Considered deindexing individual sources in `anvildev` <sub>or this PR does not merely remove sources from existing catalogs in `anvildev`</sub>
- [x] Considered deindexing individual sources in `anvilprod` <sub>or this PR does not merely remove sources from existing catalogs in `anvilprod`</sub>
- [x] Considered indexing individual sources in `dev` <sub>or this PR does not merely add sources to existing catalogs in `dev`</sub>
- [x] Considered indexing individual sources in `anvildev` <sub>or this PR does not merely add sources to existing catalogs in `anvildev`</sub>
- [x] Considered indexing individual sources in `anvilprod` <sub>or this PR does not merely add sources to existing catalogs in `anvilprod`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Started reindex in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Checked for and triaged indexing failures in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for and triaged indexing failures in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for and triaged indexing failures in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Emptied fail queues in `dev` deployment <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` deployment <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `anvilprod` deployment <sub>or this PR does not require reindexing `anvilprod`</sub>


### Operator

- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
