### PR TITLE
Move anvilprod to anvilproject.org domain (#5284)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2076,7 +2076,7 @@ Runtime platform                                    arch=amd64 os=linux pid=7 re
 Running in system-mode.
 
 Enter the GitLab instance URL (for example, https://gitlab.com/):
-https://gitlab.prod.anvil.gi.ucsc.edu/
+https://gitlab.anvil.gi.ucsc.edu/
 Enter the registration token:
 REDACTED
 Enter a description for the runner:

--- a/deployments/anvilprod/environment.py
+++ b/deployments/anvilprod/environment.py
@@ -317,7 +317,7 @@ def env() -> Mapping[str, Optional[str]]:
 
         'AZUL_DEPLOYMENT_STAGE': 'anvilprod',
 
-        'AZUL_DOMAIN_NAME': 'prod.anvil.gi.ucsc.edu',
+        'AZUL_DOMAIN_NAME': 'explore.anvilproject.org',
         'AZUL_PRIVATE_API': '0',
 
         'AZUL_S3_BUCKET': 'edu-ucsc-gi-platform-anvil-prod-storage-{AZUL_DEPLOYMENT_STAGE}.{AWS_DEFAULT_REGION}',

--- a/deployments/hammerbox/environment.py
+++ b/deployments/hammerbox/environment.py
@@ -343,7 +343,7 @@ def env() -> Mapping[str, Optional[str]]:
         # This deployment uses a subdomain of the `anvilprod` deployment's
         # domain.
         #
-        'AZUL_DOMAIN_NAME': 'prod.anvil.gi.ucsc.edu',
+        'AZUL_DOMAIN_NAME': 'explore.anvilproject.org',
         'AZUL_SUBDOMAIN_TEMPLATE': '*.{AZUL_DEPLOYMENT_STAGE}',
         'AZUL_PRIVATE_API': '0',
 

--- a/docs/compliance/change_management.rst
+++ b/docs/compliance/change_management.rst
@@ -210,7 +210,7 @@ issues are marked as merged, and the promotion PR checklist is completed with
 the operator unassigning themself from the promotion PR.
 
 .. _GitLab prod: https://gitlab.azul.data.humancellatlas.org/ucsc/azul
-.. _GitLab anvilprod: https://gitlab.prod.anvil.gi.ucsc.edu
+.. _GitLab anvilprod: https://gitlab.explore.anvilproject.org
 
 As a final step in the process, a meeting is held once a week for developers to
 demonstrate to the team the changes they’ve implemented. Following the demo

--- a/docs/compliance/change_management.rst
+++ b/docs/compliance/change_management.rst
@@ -210,7 +210,7 @@ issues are marked as merged, and the promotion PR checklist is completed with
 the operator unassigning themself from the promotion PR.
 
 .. _GitLab prod: https://gitlab.azul.data.humancellatlas.org/ucsc/azul
-.. _GitLab anvilprod: https://prod.anvil.gi.ucsc.edu
+.. _GitLab anvilprod: https://gitlab.prod.anvil.gi.ucsc.edu
 
 As a final step in the process, a meeting is held once a week for developers to
 demonstrate to the team the changes they’ve implemented. Following the demo

--- a/scripts/rename_resources.py
+++ b/scripts/rename_resources.py
@@ -19,15 +19,6 @@ from azul.terraform import (
 log = logging.getLogger(__name__)
 
 renamed: dict[str, Optional[str]] = {
-    'data.aws_route53_zone.portal': 'data.aws_route53_zone.browser',
-    'aws_cloudfront_distribution.portal': 'aws_cloudfront_distribution.browser',
-    'aws_acm_certificate.portal': 'aws_acm_certificate.browser',
-    'aws_acm_certificate_validation.portal': 'aws_acm_certificate_validation.browser',
-    'aws_route53_record.portal': 'aws_route53_record.browser',
-    # @formatter:off
-    'aws_route53_record.portal_validation["anvil.gi.ucsc.edu"]': 'aws_route53_record.browser_validation["anvil.gi.ucsc.edu"]',  # noqa E501
-    'aws_route53_record.portal_validation["prod.anvil.gi.ucsc.edu"]': 'aws_route53_record.browser_validation["prod.anvil.gi.ucsc.edu"]'  # noqa E501
-    # @formatter:on
 }
 
 

--- a/test/health_check_test_case.py
+++ b/test/health_check_test_case.py
@@ -145,8 +145,8 @@ class HealthCheckTestCase(LocalAppTestCase,
         # A successful response is obtained when all the systems are functional
         self._create_mock_queues()
         app = load_app_module(self.lambda_name(), unit_test=True)
-        app.update_health_cache(MagicMock(), MagicMock())
         with self._mock():
+            app.update_health_cache(MagicMock(), MagicMock())
             response = self._test('/health/cached')
         self.assertEqual(200, response.status_code)
 

--- a/test/indexer/test_health_check.py
+++ b/test/indexer/test_health_check.py
@@ -42,7 +42,8 @@ class TestIndexerHealthCheck(DCP1TestCase, HealthCheckTestCase):
     @mock_sts
     @mock_sqs
     def test_queues_down(self):
-        response = self._test()
+        with self._mock():
+            response = self._test('/health/fast')
         self.assertEqual(503, response.status_code)
         self.assertEqual(self._expected_health(), response.json())
 

--- a/test/service/test_health_check.py
+++ b/test/service/test_health_check.py
@@ -42,7 +42,8 @@ class TestServiceHealthCheck(DCP1TestCase, HealthCheckTestCase):
     @mock_sqs
     def test_all_api_endpoints_down(self):
         self._create_mock_queues()
-        response = self._test(endpoints_up=False)
+        with self._mock(endpoints_up=False):
+            response = self._test('/health/fast')
         self.assertEqual(503, response.status_code)
         self.assertEqual(self._expected_health(endpoints_up=False), response.json())
 


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=promotion.md`,
`&template=hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to
switch the template.
-->

Connected issues: #5284


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] Added `partial` label to PR <sub>or this PR completely resolves all connected issues</sub>
- [x] All connected issues are resolved partially <sub>or this PR does not have the `partial` label</sub>

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR <sub>or this PR does not require reindexing</sub>
- [x] PR and connected issue are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or this PR is not chained to another PR</sub>
- [x] Added `base` label to the blocking PR <sub>or this PR is not chained to another PR</sub>
- [x] Added `chained` label to this PR <sub>or this PR is not chained to another PR</sub>


### Author (upgrading deployments)

- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `upgrade` label to PR <sub>or this PR does not require upgrading deployments</sub>


### Author (operator tasks)

- [x] Added checklist items for additional operator tasks <sub>or this PR does not require additional tasks</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the `prod` branch has no temporary hotfixes for any connected issues</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not touch requirements*.txt, common.mk, Makefile and Dockerfile</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not touch requirements*.txt</sub>
- [x] Added `reqs` label to PR <sub>or this PR does not touch requirements*.txt</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>


### Peer reviewer (after requesting changes)

Uncheck the *Author (before every review)* checklists.


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] Requested review from system administrator
- [x] PR is assigned to system administrator


### System administrator (after requesting changes)

Uncheck the *before every review* checklists. Update the `N reviews` label.


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved ticket to *Approved* column
- [x] PR is assigned to current operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] PR has checklist items for upgrading instructions <sub>or PR is not labeled `upgrade`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Deleted unreferenced indices in `hammerbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilprod`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Started reindex in `hammerbox` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for failures in `hammerbox` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Title of merge commit starts with title from this PR
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only include `p` if the PR is labeled `partial`</sub>
- [x] Moved connected issues to Merged column in ZenHub
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed merge commit to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed merge commit to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes on GitLab `dev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `dev`<sup>1</sup>
- [x] Build passes on GitLab `anvildev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvildev`<sup>1</sup>
- [x] PR is assigned to system administrator


### System Administrator

- [x] Upload GitLab configuration changes to `anvilprod`
- [x] Deploy `anvilprod.gitlab`
- [x] Notify everyone to update their Git remotes and bookmarked URLs to GitLab `anvilprod`
- [x] PR is assigned to operator


### Operator

- [x] Build passes on GitLab `anvilprod`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvilprod`<sup>1</sup>
- [x] Push https://github.com/DataBiosphere/data-browser/commit/8b99880f21a5e695ea6a9ee235722d9d8d21764a to GitLab `anvilprod`
- [x] Retrigger `deploy_browser` job on `anvilprod`
- [x] Check that https://explore.anvilproject.org is functional
- [x] Deploy `anvildev.gitlab` (should be no-op)
- [x] Deploy `dev.gitlab` (should be no-op)
- [x] Push https://github.com/DataBiosphere/data-browser/commit/8b99880f21a5e695ea6a9ee235722d9d8d21764a to GitLab `anvildev`
- [x] Retrigger `deploy_browser` job on `anvildev`
- [x] Check that https://anvil.gi.ucsc.edu/ is functional
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Deleted PR branch from GitLab `anvilprod`

<sup>1</sup> When pushing the merge commit is skipped due to the PR being
labelled `no sandbox`, the next build triggered by a PR whose merge commit *is*
pushed determines this checklist item.


### Operator (reindex)

- [x] Deleted unreferenced indices in `dev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvildev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Deleted unreferenced indices in `anvilprod` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilprod`</sub>
- [x] Considered deindexing individual sources in `dev` <sub>or this PR does not merely remove sources from existing catalogs in `dev`</sub>
- [x] Considered deindexing individual sources in `anvildev` <sub>or this PR does not merely remove sources from existing catalogs in `anvildev`</sub>
- [x] Considered deindexing individual sources in `anvilprod` <sub>or this PR does not merely remove sources from existing catalogs in `anvilprod`</sub>
- [x] Considered indexing individual sources in `dev` <sub>or this PR does not merely add sources to existing catalogs in `dev`</sub>
- [x] Considered indexing individual sources in `anvildev` <sub>or this PR does not merely add sources to existing catalogs in `anvildev`</sub>
- [x] Considered indexing individual sources in `anvilprod` <sub>or this PR does not merely add sources to existing catalogs in `anvilprod`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Started reindex in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Checked for and triaged indexing failures in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for and triaged indexing failures in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for and triaged indexing failures in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Emptied fail queues in `dev` deployment <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` deployment <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `anvilprod` deployment <sub>or this PR does not require reindexing `anvilprod`</sub>


### Operator

- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
