### PR TITLE
Fix: Lambda `servicecachehealth` times out (#5467, #5622)

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -20,6 +20,16 @@ reverted. This is all fairly informal and loosely defined. Hopefully we won't
 have too many entries in this file.
 
 
+#5467 Lambda servicecachehealth times out
+=========================================
+
+Operator
+~~~~~~~~
+
+Manually deploy the ``gitlab`` component of any main deployment just before
+pushing the merge commit to the GitLab instance in that deployment.
+
+
 #5876 Upgrade dependencies 2024-01-22
 =====================================
 

--- a/terraform/gitlab/gitlab.tf.json.template.py
+++ b/terraform/gitlab/gitlab.tf.json.template.py
@@ -1020,6 +1020,17 @@ emit_tf({} if config.terraform_component != 'gitlab' else {
             }
             for zone in range(num_zones)
         },
+        'aws_vpc_endpoint': {
+            f'gitlab_{service}': {
+                'service_name': f'com.amazonaws.{config.region}.{service}',
+                'vpc_endpoint_type': 'Gateway',
+                'vpc_id': '${aws_vpc.gitlab.id}',
+                'route_table_ids': [
+                    '${aws_route_table.gitlab_%d.id}' % i for i in range(num_zones)
+                ],
+            }
+            for service in ['dynamodb', 's3']
+        },
         'aws_default_security_group': {
             'gitlab': {
                 'vpc_id': '${aws_vpc.gitlab.id}',


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=promotion.md`,
`&template=hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to
switch the template.
-->

Connected issues: #5467, #5622


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] Added `partial` label to PR <sub>or this PR completely resolves all connected issues</sub>
- [x] All connected issues are resolved partially <sub>or this PR does not have the `partial` label</sub>

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR <sub>or this PR does not require reindexing</sub>
- [x] PR and connected issue are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or this PR is not chained to another PR</sub>
- [x] Added `base` label to the blocking PR <sub>or this PR is not chained to another PR</sub>
- [x] Added `chained` label to this PR <sub>or this PR is not chained to another PR</sub>


### Author (upgrading deployments)

- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `upgrade` label to PR <sub>or this PR does not require upgrading deployments</sub>


### Author (operator tasks)

- [x] Added checklist items for additional operator tasks <sub>or this PR does not require additional tasks</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the `prod` branch has no temporary hotfixes for any connected issues</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not touch requirements*.txt, common.mk, Makefile and Dockerfile</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not touch requirements*.txt</sub>
- [x] Added `reqs` label to PR <sub>or this PR does not touch requirements*.txt</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>


### Peer reviewer (after requesting changes)

Uncheck the *Author (before every review)* checklists.


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] Requested review from system administrator
- [x] PR is assigned to system administrator


### System administrator (after requesting changes)

Uncheck the *before every review* checklists. Update the `N reviews` label.


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved ticket to *Approved* column
- [x] PR is assigned to current operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] PR has checklist items for upgrading instructions <sub>or PR is not labeled `upgrade`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Deleted unreferenced indices in `hammerbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilprod`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Started reindex in `hammerbox` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for failures in `hammerbox` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Title of merge commit starts with title from this PR
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only include `p` if the PR is labeled `partial`</sub>
- [x] Moved connected issues to Merged column in ZenHub
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Deployed `dev.gitlab`
- [x] Pushed merge commit to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Deployed `anvildev.gitlab`
- [x] Pushed merge commit to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Deployed `anvilprod.gitlab`
- [x] Pushed merge commit to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes on GitLab `dev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `dev`<sup>1</sup>
- [x] Build passes on GitLab `anvildev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvildev`<sup>1</sup>
- [x] Build passes on GitLab `anvilprod`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvilprod`<sup>1</sup>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Deleted PR branch from GitLab `anvilprod`

<sup>1</sup> When pushing the merge commit is skipped due to the PR being
labelled `no sandbox`, the next build triggered by a PR whose merge commit *is*
pushed determines this checklist item.


### Operator (reindex)

- [x] Deleted unreferenced indices in `dev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvildev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Deleted unreferenced indices in `anvilprod` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilprod`</sub>
- [x] Considered deindexing individual sources in `dev` <sub>or this PR does not merely remove sources from existing catalogs in `dev`</sub>
- [x] Considered deindexing individual sources in `anvildev` <sub>or this PR does not merely remove sources from existing catalogs in `anvildev`</sub>
- [x] Considered deindexing individual sources in `anvilprod` <sub>or this PR does not merely remove sources from existing catalogs in `anvilprod`</sub>
- [x] Considered indexing individual sources in `dev` <sub>or this PR does not merely add sources to existing catalogs in `dev`</sub>
- [x] Considered indexing individual sources in `anvildev` <sub>or this PR does not merely add sources to existing catalogs in `anvildev`</sub>
- [x] Considered indexing individual sources in `anvilprod` <sub>or this PR does not merely add sources to existing catalogs in `anvilprod`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Started reindex in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Checked for and triaged indexing failures in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for and triaged indexing failures in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for and triaged indexing failures in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Emptied fail queues in `dev` deployment <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` deployment <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `anvilprod` deployment <sub>or this PR does not require reindexing `anvilprod`</sub>


### Operator

- [x] Added CL items to upcoming promotion PR
> - [ ] Deployed `prod.gitlab`
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
