### PR TITLE
Fix: Every rate blocked request is logged, incurring charges (#5939)

### DIFF
--- a/scripts/manage_vpc_acl.py
+++ b/scripts/manage_vpc_acl.py
@@ -1,0 +1,135 @@
+import argparse
+import logging
+import re
+import sys
+from more_itertools import one
+
+from azul.deployment import (
+    aws
+)
+log = logging.getLogger('azul.gitlab.vpc_acl')
+
+ec2 = aws.ec2
+
+
+def determine_available_rule_num(entries: list[dict]) -> int:
+    # When adding a CIDR to a blocked rule, we care only about determining
+    # the next available inbound rule number less than 100.
+    ingres_rules = {e['RuleNumber'] for e in entries if e['Egress'] is False}
+    for i in range(len(ingres_rules)):
+        i += 1
+        if i not in ingres_rules:
+            return i
+
+
+def add_cidr_to_vpc_acl(acl_name: str, cidr: str):
+    acl_id, entries = acl_info(acl_name)
+    response = ec2.create_network_acl_entry(
+        CidrBlock=cidr,
+        Egress=False,  # Ingress rule
+        NetworkAclId=acl_id,
+        Protocol='-1',  # All protocols
+        RuleAction='deny',
+        RuleNumber=determine_available_rule_num(entries)
+    )
+
+
+def acl_info(acl_name: str):
+    network_acl = _lookup_acl_by_vpc_name(acl_name)
+    acl_id = network_acl['NetworkAclId']
+    entries = network_acl['Entries']
+    return acl_id, entries
+
+
+def remove_cidr_from_vpc_acl(acl_name: str, cidr: str):
+    # Get the Network ACL ID based on the ACL name
+    acl_id, entries = acl_info(acl_name)
+    matched = [e for e in entries if e['CidrBlock'] == cidr]
+    if matched:
+        matched = one(matched)
+        # Remove the IP CIDR from the Network ACL
+        response = ec2.delete_network_acl_entry(
+            Egress=False,  # Ingress rule
+            NetworkAclId=acl_id,
+            RuleNumber=matched['RuleNumber'],  # Choose the same rule number used when adding the CIDR
+        )
+    else:
+        log.warning('CIDR %s, does not match any actively managed CIDRs in this ACL', cidr)
+
+
+def validate_ip_cidr(s: str) -> str:
+    if re.match(''.join([
+        '^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}',
+        '(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(/\\d{1,2})$']),
+            s):
+        return s
+    else:
+        log.error('Invalid CIDR format in %s, use CIDR notation (e.g. 10.0.0.0/16)', s)
+        raise ValueError('Invalid CIDR format in %s', s)
+
+
+def _lookup_acl_by_vpc_name(vpc_name: str) -> dict:
+    vpc = ec2.describe_vpcs(Filters=[{'Name': 'tag:Name', 'Values': [vpc_name]}])
+    vpc = one(vpc['Vpcs'])
+    response = ec2.describe_network_acls(
+        Filters=[
+            {
+                'Name': 'vpc-id',
+                'Values': [vpc['VpcId']]
+            }
+        ]
+    )
+    return one(response['NetworkAcls'])
+
+
+def list_ips_in_vpc_acl(acl_name: str, *d) -> None:
+    network_acl = _lookup_acl_by_vpc_name(acl_name)
+    acl_entries = sorted(network_acl['Entries'], key=lambda e: e['Egress'])
+    keys = acl_entries[0].keys()
+    list_output(acl_entries, keys)
+
+
+def list_output(acl_entries, keys) -> None:
+    header = '\t'.join(keys)
+    print(header)
+    print('-' * (len(header) + len(keys) * 4))
+    for entry in acl_entries:
+        protocol = entry['Protocol']
+        entry['Protocol'] = 'Any' if protocol == '-1' else protocol
+        rule_number = entry['RuleNumber']
+        entry['RuleNumber'] = '\t' + ('*' if rule_number >= 32767 else str(rule_number))
+        entry['RuleAction'] = '\t' + entry['RuleAction']
+        print('\t'.join([str(entry[k]) for k in keys]))
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO,
+                        format='%(asctime)s %(levelname)+7s %(name)s: %(message)s')
+
+    p = argparse.ArgumentParser(description='Manage the GitLab VPC ACL to add or remove targeted CIDRs')
+    sps = p.add_subparsers(help='sub-command help', dest='command')
+
+    actions = {
+        'add': add_cidr_to_vpc_acl,
+        'remove': remove_cidr_from_vpc_acl,
+        'list': list_ips_in_vpc_acl
+    }
+    for s in actions:
+        sp = sps.add_parser(s,
+                            help=f'Manage the GitLab VPC ACL to {s} the specified CIDR'
+                            if s != 'list' else
+                            f'List the managed CIDRs in the GitLab VPC ACL')
+        sp.add_argument('--cidr',
+                        metavar='CIDR',
+                        type=validate_ip_cidr,
+                        required=True if s in ('add', 'remove') else False,
+                        default=None,
+                        help='The IP CIDR to block')
+        sp.add_argument('--vpc-name',
+                        nargs='?',
+                        default='azul-gitlab',
+                        help='If specified, this ACL will be used instead of the GitLab VPC one')
+        sp.set_defaults(func=actions[s])
+
+    args = p.parse_args(sys.argv[1:])
+    args.func(args.vpc_name, args.cidr)

--- a/terraform/cloudwatch.tf.json.template.py
+++ b/terraform/cloudwatch.tf.json.template.py
@@ -352,10 +352,10 @@ emit_tf({
                         'waf_rate_blocked': {
                             'alarm_name': config.qualified_resource_name('waf_rate_blocked'),
                             'comparison_operator': 'GreaterThanThreshold',
-                            'threshold': 0,
+                            'threshold': 6000,
                             'datapoints_to_alarm': 1,
                             'evaluation_periods': 1,
-                            'period': 5 * 60,
+                            'period': 10 * 60,
                             'metric_name': 'BlockedRequests',
                             'namespace': 'AWS/WAFV2',
                             'statistic': 'Sum',


### PR DESCRIPTION
Connected issues: #5939 
## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] Added `partial` label to PR <sub>or this PR completely resolves all connected issues</sub>
- [x] All connected issues are resolved partially <sub>or this PR does not have the `partial` label</sub>

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR <sub>or this PR does not require reindexing</sub>
- [x] PR and connected issue are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or this PR is not chained to another PR</sub>
- [x] Added `base` label to the blocking PR <sub>or this PR is not chained to another PR</sub>
- [x] Added `chained` label to this PR <sub>or this PR is not chained to another PR</sub>


### Author (upgrading deployments)

- [ ] Ran `make image_manifests.json` and committed any resulting changes <sub>or this PR does not modify `azul_docker_images` or any other variables referenced in the definition of that variable</sub>
- [ ] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [ ] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [ ] Added `upgrade` label to PR <sub>or this PR does not require upgrading deployments</sub>


### Author (operator tasks)

- [ ] Added checklist items for additional operator tasks <sub>or this PR does not require additional tasks</sub>


### Author (hotfixes)

- [ ] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [ ] Reverted the temporary hotfixes for any connected issues <sub>or the `prod` branch has no temporary hotfixes for any connected issues</sub>


### Author (before every review)

- [ ] Rebased PR branch on `develop`, squashed old fixups
- [ ] Ran `make requirements_update` <sub>or this PR does not touch requirements*.txt, common.mk, Makefile and Dockerfile</sub>
- [ ] Added `R` tag to commit title <sub>or this PR does not touch requirements*.txt</sub>
- [ ] Added `reqs` label to PR <sub>or this PR does not touch requirements*.txt</sub>
- [ ] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>


### Peer reviewer (after requesting changes)

Uncheck the *Author (before every review)* checklists.


### Peer reviewer (after approval)

- [ ] PR is not a draft
- [ ] Ticket is in *Review requested* column
- [ ] Requested review from system administrator
- [ ] PR is assigned to system administrator


### System administrator (after requesting changes)

Uncheck the *before every review* checklists. Update the `N reviews` label.


### System administrator (after approval)

- [ ] Actually approved the PR
- [ ] Labeled connected issues as `demo` or `no demo`
- [ ] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [ ] Decided if PR can be labeled `no sandbox`
- [ ] PR title is appropriate as title of merge commit
- [ ] `N reviews` label is accurate
- [ ] Moved ticket to *Approved* column
- [ ] PR is assigned to current operator


### Operator (before pushing merge the commit)

- [ ] Checked `reindex` label and `r` commit title tag
- [ ] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [ ] PR has checklist items for upgrading instructions <sub>or PR is not labeled `upgrade`</sub>
- [ ] Squashed PR branch and rebased onto `develop`
- [ ] Sanity-checked history
- [ ] Pushed PR branch to GitHub
- [ ] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [ ] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Pushed PR branch to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Build passes in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Reviewed build logs for anomalies in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [ ] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [ ] Deleted unreferenced indices in `hammerbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilprod`</sub>
- [ ] Started reindex in `sandbox` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Started reindex in `anvilbox` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Started reindex in `hammerbox` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [ ] Checked for failures in `sandbox` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Checked for failures in `anvilbox` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Checked for failures in `hammerbox` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [ ] Title of merge commit starts with title from this PR
- [ ] Added PR reference to merge commit title
- [ ] Collected commit title tags in merge commit title <sub>but only include `p` if the PR is labeled `partial`</sub>
- [ ] Moved connected issues to Merged column in ZenHub
- [ ] Pushed merge commit to GitHub


### Operator (chain shortening)

- [ ] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [ ] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [ ] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [ ] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [ ] Pushed merge commit to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Pushed merge commit to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Pushed merge commit to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Build passes on GitLab `dev`<sup>1</sup>
- [ ] Reviewed build logs for anomalies on GitLab `dev`<sup>1</sup>
- [ ] Build passes on GitLab `anvildev`<sup>1</sup>
- [ ] Reviewed build logs for anomalies on GitLab `anvildev`<sup>1</sup>
- [ ] Build passes on GitLab `anvilprod`<sup>1</sup>
- [ ] Reviewed build logs for anomalies on GitLab `anvilprod`<sup>1</sup>
- [ ] Deleted PR branch from GitHub
- [ ] Deleted PR branch from GitLab `dev`
- [ ] Deleted PR branch from GitLab `anvildev`
- [ ] Deleted PR branch from GitLab `anvilprod`

<sup>1</sup> When pushing the merge commit is skipped due to the PR being
labelled `no sandbox`, the next build triggered by a PR whose merge commit *is*
pushed determines this checklist item.


### Operator (reindex)

- [ ] Deleted unreferenced indices in `dev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [ ] Deleted unreferenced indices in `anvildev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [ ] Deleted unreferenced indices in `anvilprod` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilprod`</sub>
- [ ] Considered deindexing individual sources in `dev` <sub>or this PR does not merely remove sources from existing catalogs in `dev`</sub>
- [ ] Considered deindexing individual sources in `anvildev` <sub>or this PR does not merely remove sources from existing catalogs in `anvildev`</sub>
- [ ] Considered deindexing individual sources in `anvilprod` <sub>or this PR does not merely remove sources from existing catalogs in `anvilprod`</sub>
- [ ] Considered indexing individual sources in `dev` <sub>or this PR does not merely add sources to existing catalogs in `dev`</sub>
- [ ] Considered indexing individual sources in `anvildev` <sub>or this PR does not merely add sources to existing catalogs in `anvildev`</sub>
- [ ] Considered indexing individual sources in `anvilprod` <sub>or this PR does not merely add sources to existing catalogs in `anvilprod`</sub>
- [ ] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Started reindex in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [ ] Checked for and triaged indexing failures in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Checked for and triaged indexing failures in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Checked for and triaged indexing failures in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [ ] Emptied fail queues in `dev` deployment <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Emptied fail queues in `anvildev` deployment <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Emptied fail queues in `anvilprod` deployment <sub>or this PR does not require reindexing `anvilprod`</sub>


### Operator

- [ ] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
