### PR TITLE
Use upsert for writing replicas (partial #5975)

### DIFF
--- a/environment.py
+++ b/environment.py
@@ -183,6 +183,10 @@ def env() -> Mapping[str, Optional[str]]:
         # Whether to create and populate an index for replica documents.
         'AZUL_ENABLE_REPLICAS': '1',
 
+        # Maximum number of conflicts to allow before giving when writing
+        # replica documents.
+        'AZUL_REPLICA_CONFLICT_LIMIT': '10',
+
         # The name of the current deployment. This variable controls the name of
         # all cloud resources and is the main vehicle for isolating cloud
         # resources between deployments.

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -769,6 +769,10 @@ class Config:
     def enable_replicas(self) -> bool:
         return self._boolean(self.environ['AZUL_ENABLE_REPLICAS'])
 
+    @property
+    def replica_conflict_limit(self) -> int:
+        return int(self.environ['AZUL_REPLICA_CONFLICT_LIMIT'])
+
     # Because this property is relatively expensive to produce and frequently
     # used we are applying aggressive caching here, knowing very well that
     # this eliminates the option to reconfigure the running process by

--- a/src/azul/indexer/document.py
+++ b/src/azul/indexer/document.py
@@ -1102,6 +1102,10 @@ class OpType(Enum):
     #: Remove the document from the index or fail if it does not exist
     delete = auto()
 
+    #: Modify a document in the index via a scripted update or fail if it does
+    #: not exist
+    update = auto()
+
 
 C = TypeVar('C', bound=DocumentCoordinates)
 
@@ -1308,11 +1312,7 @@ class Document(Generic[C]):
                 if op_type is OpType.delete else
                 {
                     '_source' if bulk else 'body':
-                        self.translate_fields(doc=self.to_json(),
-                                              field_types=field_types[coordinates.entity.catalog],
-                                              forward=True)
-                        if self.needs_translation else
-                        self.to_json()
+                        self._body(field_types[coordinates.entity.catalog])
                 }
             ),
             '_id' if bulk else 'id': self.coordinates.document_id
@@ -1342,6 +1342,15 @@ class Document(Generic[C]):
     @property
     def op_type(self) -> OpType:
         raise NotImplementedError
+
+    def _body(self, field_types: FieldTypes) -> JSON:
+        assert self.op_type is not OpType.update
+        body = self.to_json()
+        if self.needs_translation:
+            body = self.translate_fields(doc=body,
+                                         field_types=field_types,
+                                         forward=True)
+        return body
 
 
 class DocumentSource(SourceRef[SimpleSourceSpec, SourceRef]):
@@ -1541,11 +1550,33 @@ class Replica(Document[ReplicaCoordinates[E]]):
     def to_json(self) -> JSON:
         return dict(super().to_json(),
                     replica_type=self.replica_type,
-                    hub_ids=self.hub_ids)
+                    # Ensure that index contents is deterministic for unit tests
+                    hub_ids=sorted(set(self.hub_ids)))
 
     @property
     def op_type(self) -> OpType:
-        return OpType.create
+        if self.version_type is VersionType.create_only:
+            return OpType.create
+        elif self.version_type is VersionType.none:
+            return OpType.update
+        else:
+            assert False, self.version_type
+
+    def _body(self, field_types: FieldTypes) -> JSON:
+        if self.op_type is OpType.update:
+            return {
+                'script': {
+                    'source': '''
+                        Stream stream = Stream.concat(ctx._source.hub_ids.stream(), params.hub_ids.stream());
+                        ctx._source.hub_ids = stream.sorted().distinct().collect(Collectors.toList());
+                    ''',
+                    'params': {
+                        'hub_ids': self.hub_ids
+                    }
+                }
+            }
+        else:
+            return super()._body(field_types)
 
 
 CataloguedContribution = Contribution[CataloguedEntityReference]

--- a/src/azul/indexer/document.py
+++ b/src/azul/indexer/document.py
@@ -1102,8 +1102,8 @@ class OpType(Enum):
     #: Remove the document from the index or fail if it does not exist
     delete = auto()
 
-    #: Modify a document in the index via a scripted update or fail if it does
-    #: not exist
+    #: Modify a document in the index via a scripted update or create it if it
+    #: does not exist
     update = auto()
 
 
@@ -1344,7 +1344,6 @@ class Document(Generic[C]):
         raise NotImplementedError
 
     def _body(self, field_types: FieldTypes) -> JSON:
-        assert self.op_type is not OpType.update
         body = self.to_json()
         if self.needs_translation:
             body = self.translate_fields(doc=body,
@@ -1528,10 +1527,6 @@ class Replica(Document[ReplicaCoordinates[E]]):
 
     hub_ids: list[EntityID]
 
-    #: The version_type attribute will change to VersionType.none if writing
-    #: to Elasticsearch fails with 409
-    version_type: VersionType = VersionType.create_only
-
     needs_translation: ClassVar[bool] = False
 
     def __attrs_post_init__(self):
@@ -1555,28 +1550,22 @@ class Replica(Document[ReplicaCoordinates[E]]):
 
     @property
     def op_type(self) -> OpType:
-        if self.version_type is VersionType.create_only:
-            return OpType.create
-        elif self.version_type is VersionType.none:
-            return OpType.update
-        else:
-            assert False, self.version_type
+        assert self.version_type is VersionType.none, self.version_type
+        return OpType.update
 
     def _body(self, field_types: FieldTypes) -> JSON:
-        if self.op_type is OpType.update:
-            return {
-                'script': {
-                    'source': '''
+        return {
+            'script': {
+                'source': '''
                         Stream stream = Stream.concat(ctx._source.hub_ids.stream(), params.hub_ids.stream());
                         ctx._source.hub_ids = stream.sorted().distinct().collect(Collectors.toList());
                     ''',
-                    'params': {
-                        'hub_ids': self.hub_ids
-                    }
+                'params': {
+                    'hub_ids': self.hub_ids
                 }
-            }
-        else:
-            return super()._body(field_types)
+            },
+            'upsert': super()._body(field_types)
+        }
 
 
 CataloguedContribution = Contribution[CataloguedEntityReference]

--- a/src/azul/indexer/index_controller.py
+++ b/src/azul/indexer/index_controller.py
@@ -185,10 +185,15 @@ class IndexController(AppController):
                                for entity, num_contributions in tallies.items()]
 
                     if replicas:
-                        log.info('Writing %i replicas to index.', len(replicas))
-                        num_written, num_present = self.index_service.replicate(catalog, replicas)
-                        log.info('Successfully wrote %i replicas; %i were already present',
-                                 num_written, num_present)
+                        if delete:
+                            # FIXME: Replica index does not support deletions
+                            #        https://github.com/DataBiosphere/azul/issues/5846
+                            log.warning('Deletion of replicas is not supported')
+                        else:
+                            log.info('Writing %i replicas to index.', len(replicas))
+                            num_written, num_present = self.index_service.replicate(catalog, replicas)
+                            log.info('Successfully wrote %i replicas; %i were already present',
+                                     num_written, num_present)
                     else:
                         log.info('No replicas to write.')
 

--- a/src/azul/indexer/index_service.py
+++ b/src/azul/indexer/index_service.py
@@ -226,7 +226,8 @@ class IndexService(DocumentService):
             #        number of contributions per bundle.
             # https://github.com/DataBiosphere/azul/issues/610
             tallies.update(self.contribute(catalog, contributions))
-            self.replicate(catalog, replicas)
+        # FIXME: Replica index does not support deletions
+        #        https://github.com/DataBiosphere/azul/issues/5846
         self.aggregate(tallies)
 
     def deep_transform(self,

--- a/src/azul/indexer/index_service.py
+++ b/src/azul/indexer/index_service.py
@@ -416,7 +416,7 @@ class IndexService(DocumentService):
         with a count of 0 may exist. This is ok. See description of aggregate().
         """
         tallies = Counter()
-        writer = self._create_writer(catalog)
+        writer = self._create_writer(DocumentType.contribution, catalog)
         while contributions:
             writer.write(contributions)
             retry_contributions = []
@@ -450,7 +450,7 @@ class IndexService(DocumentService):
         catalogs.
         """
         # Use catalog specified in each tally
-        writer = self._create_writer(catalog=None)
+        writer = self._create_writer(DocumentType.aggregate, catalog=None)
         while True:
             # Read the aggregates
             old_aggregates = self._read_aggregates(tallies)
@@ -504,7 +504,7 @@ class IndexService(DocumentService):
                   catalog: CatalogName,
                   replicas: list[Replica]
                   ) -> tuple[int, int]:
-        writer = self._create_writer(catalog)
+        writer = self._create_writer(DocumentType.replica, catalog)
         num_replicas = len(replicas)
         num_written, num_present = 0, 0
         while replicas:
@@ -785,16 +785,25 @@ class IndexService(DocumentService):
                 for entity_type, entities in result.items()
             }
 
-    def _create_writer(self, catalog: Optional[CatalogName]) -> 'IndexWriter':
+    def _create_writer(self,
+                       doc_type: DocumentType,
+                       catalog: Optional[CatalogName]
+                       ) -> 'IndexWriter':
         # We allow one conflict retry in the case of duplicate notifications and
         # switch from 'add' to 'update'. After that, there should be no
-        # conflicts because we use an SQS FIFO message group per entity. For
-        # other errors we use SQS message redelivery to take care of the
-        # retries.
+        # conflicts because we use an SQS FIFO message group per entity.
+        # Conflicts are common when writing replicas due to entities being
+        # shared between bundles. For other errors we use SQS message redelivery
+        # to take care of the retries.
+        limits = {
+            DocumentType.contribution: 1,
+            DocumentType.aggregate: 1,
+            DocumentType.replica: config.replica_conflict_limit
+        }
         return IndexWriter(catalog,
                            self.catalogued_field_types(),
                            refresh=False,
-                           conflict_retry_limit=1,
+                           conflict_retry_limit=limits[doc_type],
                            error_retry_limit=0)
 
 

--- a/src/azul/indexer/index_service.py
+++ b/src/azul/indexer/index_service.py
@@ -512,19 +512,26 @@ class IndexService(DocumentService):
             writer.write(replicas)
             retry_replicas = []
             for r in replicas:
-                if r.coordinates in writer.retries:
-                    conflicts = writer.conflicts[r.coordinates]
-                    if conflicts == 0:
+                if r.version_type is VersionType.create_only:
+                    if r.coordinates in writer.retries:
                         retry_replicas.append(r)
-                    elif conflicts == 1:
-                        # FIXME: Track replica hub IDs
-                        #        https://github.com/DataBiosphere/azul/issues/5360
-                        writer.conflicts.pop(r.coordinates)
-                        num_present += 1
                     else:
-                        assert False, (conflicts, r.coordinates)
+                        num_written += 1
+                elif r.version_type is VersionType.none:
+                    if r.coordinates in writer.retries:
+                        retry_replicas.append(r)
+                        conflicts = writer.conflicts[r.coordinates]
+                        if conflicts in (0, 1):
+                            num_present += conflicts
+                        else:
+                            assert False, (conflicts, r.coordinates)
+                    else:
+                        # Replica was already counted in `num_present`, so
+                        # incrementing `num_written` would result in an incorrect
+                        # final count
+                        pass
                 else:
-                    num_written += 1
+                    assert False, r.version_type
             replicas = retry_replicas
 
         writer.raise_on_errors()
@@ -860,8 +867,6 @@ class IndexWriter:
     def _write_individually(self, documents: Iterable[Document]):
         log.info('Writing documents individually')
         for doc in documents:
-            if isinstance(doc, Replica):
-                assert doc.version_type is VersionType.create_only, doc
             try:
                 method = getattr(self.es_client, doc.op_type.name)
                 method(refresh=self.refresh, **doc.to_index(self.catalog, self.field_types))
@@ -921,6 +926,8 @@ class IndexWriter:
         if isinstance(doc, Aggregate):
             log.debug('Successfully wrote %s with %i contribution(s).',
                       coordinates, doc.num_contributions)
+        elif isinstance(doc, Replica) and doc.version_type is VersionType.none:
+            log.debug('Successfully updated %s.', coordinates)
         else:
             log.debug('Successfully wrote %s.', coordinates)
 

--- a/src/azul/indexer/transform.py
+++ b/src/azul/indexer/transform.py
@@ -124,7 +124,11 @@ class Transformer(metaclass=ABCMeta):
                             source=self.bundle.fqid.source,
                             contents=contents)
 
-    def _replica(self, contents: MutableJSON, entity: EntityReference) -> Replica:
+    def _replica(self,
+                 contents: MutableJSON,
+                 entity: EntityReference,
+                 hub_ids: list[EntityID]
+                 ) -> Replica:
         coordinates = ReplicaCoordinates(content_hash=json_hash(contents).hexdigest(),
                                          entity=attr.evolve(entity,
                                                             entity_type='replica'))
@@ -132,7 +136,7 @@ class Transformer(metaclass=ABCMeta):
                        version=None,
                        replica_type=self.replica_type(entity),
                        contents=contents,
-                       hub_ids=[])
+                       hub_ids=hub_ids)
 
     @classmethod
     @abstractmethod

--- a/src/azul/plugins/metadata/anvil/indexer/transform.py
+++ b/src/azul/plugins/metadata/anvil/indexer/transform.py
@@ -186,11 +186,12 @@ class BaseTransformer(Transformer, metaclass=ABCMeta):
     def _add_replica(self,
                      contribution: Optional[MutableJSON],
                      entity: EntityReference,
+                     hub_ids: list[EntityID]
                      ) -> Transform:
         no_replica = not config.enable_replicas or self.entity_type() == 'bundles'
         return (
             None if contribution is None else self._contribution(contribution, entity),
-            None if no_replica else self._replica(self.bundle.entities[entity], entity)
+            None if no_replica else self._replica(self.bundle.entities[entity], entity, hub_ids)
         )
 
     def _pluralize(self, entity_type: str) -> str:
@@ -475,6 +476,7 @@ class BaseTransformer(Transformer, metaclass=ABCMeta):
 class SingletonTransformer(BaseTransformer, metaclass=ABCMeta):
 
     def _transform(self, entity: EntityReference) -> Transform:
+        files = self._entities_by_type['file']
         contents = dict(
             activities=self._entities(self._activity, chain.from_iterable(
                 self._entities_by_type[activity_type]
@@ -484,9 +486,10 @@ class SingletonTransformer(BaseTransformer, metaclass=ABCMeta):
             datasets=[self._dataset(self._only_dataset())],
             diagnoses=self._entities(self._diagnosis, self._entities_by_type['diagnosis']),
             donors=self._entities(self._donor, self._entities_by_type['donor']),
-            files=self._entities(self._file, self._entities_by_type['file'])
+            files=self._entities(self._file, files)
         )
-        return self._add_replica(contents, entity)
+        hub_ids = [f.entity_id for f in files]
+        return self._add_replica(contents, entity, hub_ids)
 
     @classmethod
     def field_types(cls) -> FieldTypes:
@@ -527,15 +530,17 @@ class ActivityTransformer(BaseTransformer):
 
     def _transform(self, entity: EntityReference) -> Transform:
         linked = self._linked_entities(entity)
+        files = linked['file']
         contents = dict(
             activities=[self._activity(entity)],
             biosamples=self._entities(self._biosample, linked['biosample']),
             datasets=[self._dataset(self._only_dataset())],
             diagnoses=self._entities(self._diagnosis, linked['diagnosis']),
             donors=self._entities(self._donor, linked['donor']),
-            files=self._entities(self._file, linked['file']),
+            files=self._entities(self._file, files),
         )
-        return self._add_replica(contents, entity)
+        hub_ids = [f.entity_id for f in files]
+        return self._add_replica(contents, entity, hub_ids)
 
 
 class BiosampleTransformer(BaseTransformer):
@@ -546,6 +551,7 @@ class BiosampleTransformer(BaseTransformer):
 
     def _transform(self, entity: EntityReference) -> Transform:
         linked = self._linked_entities(entity)
+        files = linked['file']
         contents = dict(
             activities=self._entities(self._activity, chain.from_iterable(
                 linked[activity_type]
@@ -555,15 +561,18 @@ class BiosampleTransformer(BaseTransformer):
             datasets=[self._dataset(self._only_dataset())],
             diagnoses=self._entities(self._diagnosis, linked['diagnosis']),
             donors=self._entities(self._donor, linked['donor']),
-            files=self._entities(self._file, linked['file']),
+            files=self._entities(self._file, files),
         )
-        return self._add_replica(contents, entity)
+        hub_ids = [f.entity_id for f in files]
+        return self._add_replica(contents, entity, hub_ids)
 
 
 class DiagnosisTransformer(BaseTransformer):
 
     def _transform(self, entity: EntityReference) -> Transform:
-        return self._add_replica(None, entity)
+        files = self._linked_entities(entity)['file']
+        hub_ids = [f.entity_id for f in files]
+        return self._add_replica(None, entity, hub_ids)
 
     @classmethod
     def entity_type(cls) -> EntityType:
@@ -599,6 +608,7 @@ class DonorTransformer(BaseTransformer):
 
     def _transform(self, entity: EntityReference) -> Transform:
         linked = self._linked_entities(entity)
+        files = linked['file']
         contents = dict(
             activities=self._entities(self._activity, chain.from_iterable(
                 linked[activity_type]
@@ -608,9 +618,10 @@ class DonorTransformer(BaseTransformer):
             datasets=[self._dataset(self._only_dataset())],
             diagnoses=self._entities(self._diagnosis, linked['diagnosis']),
             donors=[self._donor(entity)],
-            files=self._entities(self._file, linked['file']),
+            files=self._entities(self._file, files),
         )
-        return self._add_replica(contents, entity)
+        hub_ids = [f.entity_id for f in files]
+        return self._add_replica(contents, entity, hub_ids)
 
 
 class FileTransformer(BaseTransformer):
@@ -632,4 +643,8 @@ class FileTransformer(BaseTransformer):
             donors=self._entities(self._donor, linked['donor']),
             files=[self._file(entity)],
         )
-        return self._add_replica(contents, entity)
+        # The result of the link traversal does not include the starting entity,
+        # so without this step the file itself wouldn't be included in its hubs
+        files = (entity, *linked['file'])
+        hub_ids = [f.entity_id for f in files]
+        return self._add_replica(contents, entity, hub_ids)

--- a/src/azul/plugins/metadata/hca/indexer/transform.py
+++ b/src/azul/plugins/metadata/hca/indexer/transform.py
@@ -503,7 +503,8 @@ class BaseTransformer(Transformer, metaclass=ABCMeta):
 
     def _add_replica(self,
                      contribution: MutableJSON,
-                     entity: Union[api.Entity, DatedEntity]
+                     entity: Union[api.Entity, DatedEntity],
+                     hub_ids: list[EntityID]
                      ) -> Transform:
         entity_ref = EntityReference(entity_id=str(entity.document_id),
                                      entity_type=self.entity_type())
@@ -511,7 +512,7 @@ class BaseTransformer(Transformer, metaclass=ABCMeta):
             replica = None
         else:
             assert isinstance(entity, api.Entity), entity
-            replica = self._replica(entity.json, entity_ref)
+            replica = self._replica(entity.json, entity_ref, hub_ids)
         return (
             self._contribution(contribution, entity_ref),
             replica
@@ -1468,7 +1469,8 @@ class FileTransformer(PartitionedTransformer[api.File]):
                         additional_contents = self.matrix_stratification_values(file)
                         for entity_type, values in additional_contents.items():
                             contents[entity_type].extend(values)
-                yield self._add_replica(contents, file)
+                hub_ids = list(map(str, visitor.files))
+                yield self._add_replica(contents, file, hub_ids)
 
     def matrix_stratification_values(self, file: api.File) -> JSON:
         """
@@ -1563,7 +1565,8 @@ class CellSuspensionTransformer(PartitionedTransformer):
                             ),
                             dates=[self._date(cell_suspension)],
                             projects=[self._project(self._api_project)])
-            yield self._add_replica(contents, cell_suspension)
+            hub_ids = list(map(str, visitor.files))
+            yield self._add_replica(contents, cell_suspension, hub_ids)
 
 
 class SampleTransformer(PartitionedTransformer):
@@ -1608,7 +1611,8 @@ class SampleTransformer(PartitionedTransformer):
                             ),
                             dates=[self._date(sample)],
                             projects=[self._project(self._api_project)])
-            yield self._add_replica(contents, sample)
+            hub_ids = list(map(str, visitor.files))
+            yield self._add_replica(contents, sample, hub_ids)
 
 
 class BundleAsEntity(DatedEntity):
@@ -1708,7 +1712,8 @@ class SingletonTransformer(BaseTransformer, metaclass=ABCMeta):
                         contributed_analyses=contributed_analyses,
                         dates=[self._date(self._singleton_entity())],
                         projects=[self._project(self._api_project)])
-        return self._add_replica(contents, self._singleton_entity())
+        hub_ids = list(map(str, visitor.files))
+        return self._add_replica(contents, self._singleton_entity(), hub_ids)
 
 
 class ProjectTransformer(SingletonTransformer):

--- a/test/indexer/__init__.py
+++ b/test/indexer/__init__.py
@@ -70,8 +70,11 @@ from es_test_case import (
 
 class ForcedRefreshIndexService(IndexService):
 
-    def _create_writer(self, catalog: Optional[CatalogName]) -> IndexWriter:
-        writer = super()._create_writer(catalog)
+    def _create_writer(self,
+                       doc_type: DocumentType,
+                       catalog: Optional[CatalogName]
+                       ) -> IndexWriter:
+        writer = super()._create_writer(doc_type, catalog)
         # With a single client thread, refresh=True is faster than
         # refresh="wait_for". The latter would limit the request rate to
         # 1/refresh_interval. That's only one request per second with

--- a/test/indexer/data/826dea02-e274-affe-aabc-eb3db63ad068.results.json
+++ b/test/indexer/data/826dea02-e274-affe-aabc-eb3db63ad068.results.json
@@ -438,7 +438,9 @@
         "_source": {
             "entity_id": "1509ef40-d1ba-440d-b298-16b7c173dcd4",
             "replica_type": "anvil_sequencingactivity",
-            "hub_ids": [],
+            "hub_ids": [
+                "15b76f9c-6b46-433f-851d-34e89f1b9ba6"
+            ],
             "contents": {
                 "activity_type": "Sequencing",
                 "assay_type": [],
@@ -868,7 +870,9 @@
         "_source": {
             "entity_id": "15b76f9c-6b46-433f-851d-34e89f1b9ba6",
             "replica_type": "anvil_file",
-            "hub_ids": [],
+            "hub_ids": [
+                "15b76f9c-6b46-433f-851d-34e89f1b9ba6"
+            ],
             "contents": {
                 "data_modality": [],
                 "datarepo_row_id": "15b76f9c-6b46-433f-851d-34e89f1b9ba6",
@@ -898,7 +902,10 @@
         "_source": {
             "entity_id": "15d85d30-ad4a-4f50-87a8-a27f59dd1b5f",
             "replica_type": "anvil_diagnosis",
-            "hub_ids": [],
+            "hub_ids": [
+                "15b76f9c-6b46-433f-851d-34e89f1b9ba6",
+                "3b17377b-16b1-431c-9967-e5d01fc5923f"
+            ],
             "contents": {
                 "datarepo_row_id": "15d85d30-ad4a-4f50-87a8-a27f59dd1b5f",
                 "diagnosis_age_lower_bound": null,
@@ -1474,7 +1481,10 @@
         "_source": {
             "entity_id": "2370f948-2783-4eb6-afea-e022897f4dcf",
             "replica_type": "anvil_dataset",
-            "hub_ids": [],
+            "hub_ids": [
+                "15b76f9c-6b46-433f-851d-34e89f1b9ba6",
+                "3b17377b-16b1-431c-9967-e5d01fc5923f"
+            ],
             "contents": {
                 "consent_group": [
                     "DS-BDIS"
@@ -1747,7 +1757,9 @@
                 "crc32": ""
             },
             "replica_type": "anvil_file",
-            "hub_ids": []
+            "hub_ids": [
+                "3b17377b-16b1-431c-9967-e5d01fc5923f"
+            ]
         }
     },
     {
@@ -2189,7 +2201,9 @@
         "_source": {
             "entity_id": "816e364e-1193-4e5b-a91a-14e4b009157c",
             "replica_type": "anvil_sequencingactivity",
-            "hub_ids": [],
+            "hub_ids": [
+                "3b17377b-16b1-431c-9967-e5d01fc5923f"
+            ],
             "contents": {
                 "activity_type": "Sequencing",
                 "assay_type": [],
@@ -2935,7 +2949,10 @@
         "_source": {
             "entity_id": "826dea02-e274-4ffe-aabc-eb3db63ad068",
             "replica_type": "anvil_biosample",
-            "hub_ids": [],
+            "hub_ids": [
+                "15b76f9c-6b46-433f-851d-34e89f1b9ba6",
+                "3b17377b-16b1-431c-9967-e5d01fc5923f"
+            ],
             "contents": {
                 "anatomical_site": null,
                 "apriori_cell_type": [],
@@ -3511,7 +3528,10 @@
         "_source": {
             "entity_id": "939a4bd3-86ed-4a8a-81f4-fbe0ee673461",
             "replica_type": "anvil_diagnosis",
-            "hub_ids": [],
+            "hub_ids": [
+                "15b76f9c-6b46-433f-851d-34e89f1b9ba6",
+                "3b17377b-16b1-431c-9967-e5d01fc5923f"
+            ],
             "contents": {
                 "datarepo_row_id": "939a4bd3-86ed-4a8a-81f4-fbe0ee673461",
                 "diagnosis_age_lower_bound": null,
@@ -4099,7 +4119,10 @@
                 "version": "2022-06-01T00:00:00.000000Z"
             },
             "replica_type": "anvil_donor",
-            "hub_ids": []
+            "hub_ids": [
+                "15b76f9c-6b46-433f-851d-34e89f1b9ba6",
+                "3b17377b-16b1-431c-9967-e5d01fc5923f"
+            ]
         }
     }
 ]

--- a/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T11:33:44.698028Z.results.json
+++ b/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T11:33:44.698028Z.results.json
@@ -3386,7 +3386,9 @@
             },
             "entity_id": "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
             "replica_type": "file",
-            "hub_ids": []
+            "hub_ids": [
+                "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb"
+            ]
         },
         "_type": "_doc"
     },
@@ -3422,7 +3424,10 @@
             },
             "entity_id": "412898c5-5b9b-4907-b07c-e9b89666e204",
             "replica_type": "cell_suspension",
-            "hub_ids": []
+            "hub_ids": [
+                "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
+                "70d1af4a-82c8-478a-8960-e9028b3616ca"
+            ]
         },
         "_type": "_doc"
     },
@@ -3451,7 +3456,9 @@
             },
             "entity_id": "70d1af4a-82c8-478a-8960-e9028b3616ca",
             "replica_type": "file",
-            "hub_ids": []
+            "hub_ids": [
+                "70d1af4a-82c8-478a-8960-e9028b3616ca"
+            ]
         },
         "_type": "_doc"
     },
@@ -3501,7 +3508,10 @@
             },
             "entity_id": "a21dc760-a500-4236-bcff-da34a0e873d2",
             "replica_type": "sample",
-            "hub_ids": []
+            "hub_ids": [
+                "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
+                "70d1af4a-82c8-478a-8960-e9028b3616ca"
+            ]
         },
         "_type": "_doc"
     },
@@ -3580,7 +3590,10 @@
             },
             "entity_id": "e8642221-4c2c-4fd7-b926-a68bce363c88",
             "replica_type": "project",
-            "hub_ids": []
+            "hub_ids": [
+                "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
+                "70d1af4a-82c8-478a-8960-e9028b3616ca"
+            ]
         },
         "_type": "_doc"
     }

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -63,7 +63,6 @@ from azul.indexer.document import (
     IndexName,
     Replica,
     ReplicaCoordinates,
-    VersionType,
     null_bool,
     null_int,
     null_str,
@@ -407,11 +406,8 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         expected_tallies_2[entity] = 1
         self.assertEqual(expected_tallies_2, tallies_2)
 
-        # All writes were logged as overwrites, except one. There are 1 fewer
-        # replicas than contributions.
-        num_replicas = num_contributions - 2 if config.enable_replicas else 0
-        self.assertEqual(num_contributions - 1 + num_replicas,
-                         len(logs.output))
+        # All writes were logged as overwrites, except one.
+        self.assertEqual(num_contributions - 1, len(logs.output))
         message_re = re.compile(r'^WARNING:azul\.indexer\.index_service:'
                                 r'Document .* exists. '
                                 r'Retrying with overwrite\.$')
@@ -2138,7 +2134,6 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         ]:
             with self.subTest(case):
                 replica.hub_ids[:] = hub_ids
-                replica.version_type = VersionType.create_only
                 self.index_service.replicate(self.catalog, [replica])
                 hit = one(self._get_all_hits())
                 self.assertEqual(hit['_id'], coordinates.document_id)

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -136,7 +136,7 @@ class DCP1IndexerTestCase(DCP1CannedBundleTestCase, IndexerTestCase):
 
     def _num_expected_replicas(self,
                                num_contribs: int,
-                               num_bundles: int = 1
+                               num_bundles: Optional[int] = None
                                ) -> int:
         """
         :param num_contribs: Number of contributions with distinct contents
@@ -145,8 +145,10 @@ class DCP1IndexerTestCase(DCP1CannedBundleTestCase, IndexerTestCase):
                             entities
         :return: How many replicas the indices are expected to contain
         """
-        # Bundle entities are not replicated
-        return max(0, num_contribs - num_bundles) if config.enable_replicas else 0
+        if num_bundles is None:
+            num_bundles = 0 if num_contribs == 0 else 1
+        # Bundle entities are not replicated.
+        return num_contribs - num_bundles if config.enable_replicas else 0
 
     def _assert_hit_counts(self,
                            hits: list[JSON],
@@ -478,11 +480,13 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         self.assertEqual(len(actual_addition_contributions), num_expected_addition_contributions)
         self.assertEqual(len(actual_deletion_contributions), num_expected_deletion_contributions)
         self._assert_hit_counts(hits,
+                                # Deletion notifications add deletion markers to the contributions index instead of
+                                # removing the existing contributions.
                                 num_contribs=num_expected_addition_contributions + num_expected_deletion_contributions,
                                 num_aggs=num_expected_aggregates,
-                                # Indexing the same contribution twice (regardless of whether either is a deletion)
-                                # does not create a new replica, so we expect fewer replicas than contributions
-                                num_replicas=self._num_expected_replicas(num_expected_deletion_contributions))
+                                # These deletion markers do not affect the number of replicas because we don't support
+                                # deletion of replicas.
+                                num_replicas=self._num_expected_replicas(num_expected_addition_contributions))
 
     def test_bundle_delete_downgrade(self):
         """


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=promotion.md`,
`&template=hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to
switch the template.
-->

Connected issues: #5975

Title does not match because PR is partial.

## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] Added `partial` label to PR <sub>or this PR completely resolves all connected issues</sub>
- [x] All connected issues are resolved partially <sub>or this PR does not have the `partial` label</sub>

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR <sub>or this PR does not require reindexing</sub>
- [x] PR and connected issue are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or this PR is not chained to another PR</sub>
- [x] Added `base` label to the blocking PR <sub>or this PR is not chained to another PR</sub>
- [x] Added `chained` label to this PR <sub>or this PR is not chained to another PR</sub>


### Author (upgrading deployments)

- [x] Ran `make image_manifests.json` and committed any resulting changes <sub>or this PR does not modify `azul_docker_images` or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `upgrade` label to PR <sub>or this PR does not require upgrading deployments</sub>


### Author (operator tasks)

- [x] Added checklist items for additional operator tasks <sub>or this PR does not require additional tasks</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the `prod` branch has no temporary hotfixes for any connected issues</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not touch requirements*.txt, common.mk, Makefile and Dockerfile</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not touch requirements*.txt</sub>
- [x] Added `reqs` label to PR <sub>or this PR does not touch requirements*.txt</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>


### Peer reviewer (after requesting changes)

Uncheck the *Author (before every review)* checklists.


### Peer reviewer (after approval)

- [ ] PR is not a draft
- [ ] Ticket is in *Review requested* column
- [ ] Requested review from system administrator
- [ ] PR is assigned to system administrator


### System administrator (after requesting changes)

Uncheck the *before every review* checklists. Update the `N reviews` label.


### System administrator (after approval)

- [ ] Actually approved the PR
- [ ] Labeled connected issues as `demo` or `no demo`
- [ ] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [ ] Decided if PR can be labeled `no sandbox`
- [ ] PR title is appropriate as title of merge commit
- [ ] `N reviews` label is accurate
- [ ] Moved ticket to *Approved* column
- [ ] PR is assigned to current operator


### Operator (before pushing merge the commit)

- [ ] Checked `reindex` label and `r` commit title tag
- [ ] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [ ] PR has checklist items for upgrading instructions <sub>or PR is not labeled `upgrade`</sub>
- [ ] Squashed PR branch and rebased onto `develop`
- [ ] Sanity-checked history
- [ ] Pushed PR branch to GitHub
- [ ] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [ ] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Pushed PR branch to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Build passes in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Reviewed build logs for anomalies in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [ ] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [ ] Deleted unreferenced indices in `hammerbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilprod`</sub>
- [ ] Started reindex in `sandbox` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Started reindex in `anvilbox` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Started reindex in `hammerbox` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [ ] Checked for failures in `sandbox` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Checked for failures in `anvilbox` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Checked for failures in `hammerbox` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [ ] Title of merge commit starts with title from this PR
- [ ] Added PR reference to merge commit title
- [ ] Collected commit title tags in merge commit title <sub>but only include `p` if the PR is labeled `partial`</sub>
- [ ] Moved connected issues to Merged column in ZenHub
- [ ] Pushed merge commit to GitHub


### Operator (chain shortening)

- [ ] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [ ] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [ ] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [ ] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [ ] Pushed merge commit to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Pushed merge commit to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Pushed merge commit to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Build passes on GitLab `dev`<sup>1</sup>
- [ ] Reviewed build logs for anomalies on GitLab `dev`<sup>1</sup>
- [ ] Build passes on GitLab `anvildev`<sup>1</sup>
- [ ] Reviewed build logs for anomalies on GitLab `anvildev`<sup>1</sup>
- [ ] Build passes on GitLab `anvilprod`<sup>1</sup>
- [ ] Reviewed build logs for anomalies on GitLab `anvilprod`<sup>1</sup>
- [ ] Deleted PR branch from GitHub
- [ ] Deleted PR branch from GitLab `dev`
- [ ] Deleted PR branch from GitLab `anvildev`
- [ ] Deleted PR branch from GitLab `anvilprod`

<sup>1</sup> When pushing the merge commit is skipped due to the PR being
labelled `no sandbox`, the next build triggered by a PR whose merge commit *is*
pushed determines this checklist item.


### Operator (reindex)

- [ ] Deleted unreferenced indices in `dev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [ ] Deleted unreferenced indices in `anvildev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [ ] Deleted unreferenced indices in `anvilprod` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilprod`</sub>
- [ ] Considered deindexing individual sources in `dev` <sub>or this PR does not merely remove sources from existing catalogs in `dev`</sub>
- [ ] Considered deindexing individual sources in `anvildev` <sub>or this PR does not merely remove sources from existing catalogs in `anvildev`</sub>
- [ ] Considered deindexing individual sources in `anvilprod` <sub>or this PR does not merely remove sources from existing catalogs in `anvilprod`</sub>
- [ ] Considered indexing individual sources in `dev` <sub>or this PR does not merely add sources to existing catalogs in `dev`</sub>
- [ ] Considered indexing individual sources in `anvildev` <sub>or this PR does not merely add sources to existing catalogs in `anvildev`</sub>
- [ ] Considered indexing individual sources in `anvilprod` <sub>or this PR does not merely add sources to existing catalogs in `anvilprod`</sub>
- [ ] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Started reindex in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [ ] Checked for and triaged indexing failures in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Checked for and triaged indexing failures in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Checked for and triaged indexing failures in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [ ] Emptied fail queues in `dev` deployment <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Emptied fail queues in `anvildev` deployment <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Emptied fail queues in `anvilprod` deployment <sub>or this PR does not require reindexing `anvilprod`</sub>


### Operator

- [ ] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
