### PR TITLE
Simplify and streamline operator items in PR checklist (#5978)

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank.md
+++ b/.github/ISSUE_TEMPLATE/blank.md
@@ -1,7 +1,7 @@
 ---
 name: A New Issue
 about: 'Template for new issues'
-title: 
+title: ''
 labels: orange 
 assignees: ''
 ---
@@ -9,44 +9,6 @@ assignees: ''
 <!--
 Add your description here. For suspected bugs, the steps required to reproduce
 the problem, as well as the expected and actual outcome should be included in
-the description. Solutions should be proposed in a  separate comment, not the
-issue description. Please do not modify or delete the checklist below. The
-checklist should remain at the end of the issue description.
+the description. Solutions should be proposed in a separate comment, not the
+issue description.
 -->
-
-- [ ] Security design review completed; the Resolution of this issue does **not** …
-  - [ ] … affect authentication; for example:
-    - OAuth 2.0 with the application (API or Swagger UI)
-    - Authentication of developers with Google Cloud APIs
-    - Authentication of developers with AWS APIs
-    - Authentication with a GitLab instance in the system
-    - Password and 2FA authentication with GitHub
-    - API access token authentication with GitHub
-    - Authentication with 
-  - [ ] … affect the permissions of internal users like access to
-    - Cloud resources on AWS and GCP
-    - GitLab repositories, projects and groups, administration
-    - an EC2 instance via SSH
-    - GitHub issues, pull requests, commits, commit statuses, wikis, repositories, organizations
-  - [ ] … affect the permissions of external users like access to
-    - TDR snapshots
-  - [ ] … affect permissions of service or bot accounts
-    - Cloud resources on AWS and GCP
-  - [ ] … affect audit logging in the system, like
-    - adding, removing or changing a log message that represents an auditable event
-    - changing the routing of log messages through the system
-  - [ ] … affect monitoring of the system
-  - [ ] … introduce a new software dependency like
-    - Python packages on PYPI
-    - Command-line utilities
-    - Docker images
-    - Terraform providers
-  - [ ] … add an interface that exposes sensitive or confidential data at the security boundary
-  - [ ] … affect the encryption of data at rest
-  - [ ] … require persistence of sensitive or confidential data that might require encryption at rest
-  - [ ] … require unencrypted transmission of data within the security boundary
-  - [ ] … affect the network security layer; for example by 
-    - modifying, adding or removing firewall rules
-    - modifying, adding or removing security groups
-    - changing or adding a port a service, proxy or load balancer listens on
-- [ ] Documentation on any unchecked boxes is provided in comments below

--- a/.github/PULL_REQUEST_TEMPLATE/backport.md
+++ b/.github/PULL_REQUEST_TEMPLATE/backport.md
@@ -32,6 +32,7 @@ Uncheck the *before every review* checklists. Update the `N reviews` label.
 
 - [ ] Actually approved the PR
 - [ ] Decided if PR can be labeled `no sandbox`
+- [ ] A comment to this PR details the completed security design review <sub>or this PR is a promotion or a backport</sub>
 - [ ] PR title is appropriate as title of merge commit
 - [ ] Moved ticket to *Approved* column
 - [ ] PR is assigned to current operator

--- a/.github/PULL_REQUEST_TEMPLATE/backport.md
+++ b/.github/PULL_REQUEST_TEMPLATE/backport.md
@@ -18,9 +18,9 @@ This is the PR template for backport PRs against `develop`.
 ### Author (before every review)
 
 - [ ] Merged `develop` into PR branch to integrate upstream changes
-- [ ] Ran `make requirements_update` <sub>or this PR does not touch requirements*.txt, common.mk, Makefile and Dockerfile</sub>
-- [ ] Added `R` tag to commit title <sub>or this PR does not touch requirements*.txt</sub>
-- [ ] Added `reqs` label to PR <sub>or this PR does not touch requirements*.txt</sub>
+- [ ] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
+- [ ] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
+- [ ] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
 
 
 ### System administrator (after requesting changes)
@@ -51,8 +51,8 @@ Uncheck the *before every review* checklists. Update the `N reviews` label.
 - [ ] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
 - [ ] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
 - [ ] Reviewed build logs for anomalies in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
-- [ ] Title of merge commit starts with title from this PR
-- [ ] Added PR reference (this PR) to merge commit title
+- [ ] The title of the merge commit starts with the title of this PR
+- [ ] Added PR # reference (to this PR) to merge commit title
 - [ ] Collected commit title tags in merge commit title <sub>but exclude any `p` tags</sub>
 - [ ] Pushed merge commit to GitHub
 

--- a/.github/PULL_REQUEST_TEMPLATE/backport.md
+++ b/.github/PULL_REQUEST_TEMPLATE/backport.md
@@ -54,7 +54,7 @@ Uncheck the *before every review* checklists. Update the `N reviews` label.
 - [ ] Reviewed build logs for anomalies in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
 - [ ] The title of the merge commit starts with the title of this PR
 - [ ] Added PR # reference (to this PR) to merge commit title
-- [ ] Collected commit title tags in merge commit title <sub>but exclude any `p` tags</sub>
+- [ ] Collected commit title tags in merge commit title <sub>but excluded any `p` tags</sub>
 - [ ] Pushed merge commit to GitHub
 
 

--- a/.github/PULL_REQUEST_TEMPLATE/backport.md
+++ b/.github/PULL_REQUEST_TEMPLATE/backport.md
@@ -35,7 +35,7 @@ Uncheck the *before every review* checklists. Update the `N reviews` label.
 - [ ] A comment to this PR details the completed security design review <sub>or this PR is a promotion or a backport</sub>
 - [ ] PR title is appropriate as title of merge commit
 - [ ] Moved ticket to *Approved* column
-- [ ] PR is assigned to current operator
+- [ ] PR is assigned to only the operator
 
 
 ### Operator (before pushing merge the commit)

--- a/.github/PULL_REQUEST_TEMPLATE/hotfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/hotfix.md
@@ -66,12 +66,12 @@ Connected issue: #0000
 
 ### Operator (reindex)
 
-- [ ] Deleted unreferenced indices in `prod` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `prod`</sub>
-- [ ] Considered deindexing individual sources in `prod` <sub>or this PR does not merely remove sources from existing catalogs in `prod`</sub>
-- [ ] Considered indexing individual sources in `prod` <sub>or this PR does not merely add sources to existing catalogs in `prod`</sub>
-- [ ] Started reindex in `prod` <sub>or neither this PR nor a prior failed promotion requires it</sub>
-- [ ] Checked for and triaged indexing failures in `prod` <sub>or neither this PR nor a prior failed promotion requires it</sub>
-- [ ] Emptied fail queues in `prod` deployment <sub>or neither this PR nor a prior failed promotion requires it</sub>
+- [ ] Deindexed all unreferenced catalogs in `prod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:prod`</sub>
+- [ ] Deindexed specific sources in `prod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:prod`</sub>
+- [ ] Indexed specific sources in `prod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:prod`</sub>
+- [ ] Started reindex in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
+- [ ] Checked for, triaged and possibly requeued messages in both fail queues in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
+- [ ] Emptied fail queues in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
 - [ ] Created backport PR and linked to it in a comment on this PR
 
 

--- a/.github/PULL_REQUEST_TEMPLATE/hotfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/hotfix.md
@@ -51,7 +51,7 @@ Connected issue: #0000
 - [ ] Pushed PR branch to GitHub
 - [ ] The title of the merge commit starts with the title of this PR
 - [ ] Added PR # reference to merge commit title
-- [ ] Collected commit title tags in merge commit title <sub>but exclude any `p` tags</sub>
+- [ ] Collected commit title tags in merge commit title <sub>but excluded any `p` tags</sub>
 - [ ] Moved connected issue to *Merged prod* column in ZenHub
 - [ ] Pushed merge commit to GitHub
 

--- a/.github/PULL_REQUEST_TEMPLATE/hotfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/hotfix.md
@@ -41,7 +41,7 @@ Connected issue: #0000
 - [ ] A comment to this PR details the completed security design review <sub>or this PR is a promotion or a backport</sub>
 - [ ] PR title is appropriate as title of merge commit
 - [ ] Moved ticket to *Approved* column
-- [ ] PR is assigned to current operator
+- [ ] PR is assigned to only the operator
 
 
 ### Operator (before pushing merge the commit)

--- a/.github/PULL_REQUEST_TEMPLATE/hotfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/hotfix.md
@@ -23,15 +23,15 @@ Connected issue: #0000
 - [ ] Added `h` tag to commit title <sub>or this PR does not include a temporary hotfix</sub>
 - [ ] Added `H` tag to commit title <sub>or this PR does not include a permanent hotfix</sub>
 - [ ] Added `hotfix` label to PR
-- [ ] Added `partial` label to PR <sub>or this PR is a permanent hotfix</sub>
+- [ ] This PR is labeled `partial` <sub>or represents a permanent hotfix</sub>
 
 
 ### Author (before every review)
 
 - [ ] Rebased PR branch on `prod`, squashed old fixups
-- [ ] Ran `make requirements_update` <sub>or this PR does not touch requirements*.txt, common.mk, Makefile and Dockerfile</sub>
-- [ ] Added `R` tag to commit title <sub>or this PR does not touch requirements*.txt</sub>
-- [ ] Added `reqs` label to PR <sub>or this PR does not touch requirements*.txt</sub>
+- [ ] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
+- [ ] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
+- [ ] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
 
 
 ### System administrator (after approval)
@@ -48,8 +48,8 @@ Connected issue: #0000
 - [ ] Squashed PR branch and rebased onto `prod`
 - [ ] Sanity-checked history
 - [ ] Pushed PR branch to GitHub
-- [ ] Title of merge commit starts with title from this PR
-- [ ] Added PR reference to merge commit title
+- [ ] The title of the merge commit starts with the title of this PR
+- [ ] Added PR # reference to merge commit title
 - [ ] Collected commit title tags in merge commit title <sub>but exclude any `p` tags</sub>
 - [ ] Moved connected issue to *Merged prod* column in ZenHub
 - [ ] Pushed merge commit to GitHub

--- a/.github/PULL_REQUEST_TEMPLATE/hotfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/hotfix.md
@@ -38,6 +38,7 @@ Connected issue: #0000
 
 - [ ] Actually approved the PR
 - [ ] Labeled PR as `no sandbox`
+- [ ] A comment to this PR details the completed security design review <sub>or this PR is a promotion or a backport</sub>
 - [ ] PR title is appropriate as title of merge commit
 - [ ] Moved ticket to *Approved* column
 - [ ] PR is assigned to current operator

--- a/.github/PULL_REQUEST_TEMPLATE/promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/promotion.md
@@ -38,6 +38,7 @@ Connected issue: #0000
 
 - [ ] Actually approved the PR
 - [ ] Labeled PR as `no sandbox`
+- [ ] A comment to this PR details the completed security design review <sub>or this PR is a promotion or a backport</sub>
 - [ ] Moved ticket to *Approved* column
 - [ ] PR is assigned to current operator
 

--- a/.github/PULL_REQUEST_TEMPLATE/promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/promotion.md
@@ -28,7 +28,10 @@ Connected issue: #0000
 
 ### Author (upgrading deployments)
 
-- [ ] Added `upgrade` label to PR <sub>or this PR does not require upgrading deployments</sub>
+- [ ] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
+- [ ] This PR is labeled `deploy:shared` <sub>or does not modify `image_manifests.json`, and does not require deploying the `shared` component for any other reason</sub>
+- [ ] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
+- [ ] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>
 
 
 ### System administrator (after approval)
@@ -42,21 +45,21 @@ Connected issue: #0000
 ### Operator (before pushing merge the commit)
 
 - [ ] Pushed PR branch to GitHub
-- [ ] Selected `prod.shared` and ran `CI_COMMIT_REF_NAME=prod make -C terraform/shared apply` <sub>or this PR does not change any Docker image versions</sub>
-- [ ] Selected `prod.gitlab` and ran `CI_COMMIT_REF_NAME=prod make -C terraform/gitlab apply` <sub>or this PR does not include any changes to files in terraform/gitlab</sub>
-- [ ] Assigned system administrator <sub>or this PR does not include any changes to files in terraform/gitlab</sub>
-- [ ] Checked the items in the next section <sub>or this PR includes changes to files in terraform/gitlab</sub>
+- [ ] Ran `_select prod.shared && CI_COMMIT_REF_NAME=prod make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
+- [ ] Ran `_select prod.gitlab && CI_COMMIT_REF_NAME=prod make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
+- [ ] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
+- [ ] Assigned system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>
 
 
 ### System administrator
 
-- [ ] Background migrations for `prod.gitlab` are complete <sub>or this PR does not include any changes to files in terraform/gitlab</sub>
+- [ ] Background migrations for `prod.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
 - [ ] PR is assigned to operator
 
 
 ### Operator (before pushing merge the commit)
 
-- [ ] Selected `prod.gitlab` and ran `make -C terraform/gitlab/runner` <sub>or this PR does not change `azul_docker_version`</sub>
+- [ ] Ran `_select prod.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
 - [ ] Title of merge commit starts with title from this PR
 - [ ] Added PR reference to merge commit title
 - [ ] Collected commit title tags in merge commit title <sub>but exclude any `p` tags</sub>

--- a/.github/PULL_REQUEST_TEMPLATE/promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/promotion.md
@@ -63,7 +63,7 @@ Connected issue: #0000
 - [ ] Ran `_select prod.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
 - [ ] The title of the merge commit starts with the title of this PR
 - [ ] Added PR # reference to merge commit title
-- [ ] Collected commit title tags in merge commit title <sub>but exclude any `p` tags</sub>
+- [ ] Collected commit title tags in merge commit title <sub>but excluded any `p` tags</sub>
 - [ ] Pushed merge commit to GitHub
 
 

--- a/.github/PULL_REQUEST_TEMPLATE/promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/promotion.md
@@ -21,7 +21,8 @@ Connected issue: #0000
 
 ### Author (reindex, API changes)
 
-- [ ] Added `reindex` label to PR <sub>or this PR does not require reindexing</sub>
+- [ ] PR is labeled `reindex:prod` <sub>or this PR does not require reindexing `prod`</sub>
+- [ ] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `prod` <sub>or requires a full reindex or is not labeled`reindex:prod`</sub>
 - [ ] PR and connected issue are labeled `API` <sub>or this PR does not modify a REST API</sub>
 
 
@@ -75,12 +76,12 @@ Connected issue: #0000
 
 ### Operator (reindex)
 
-- [ ] Deleted unreferenced indices in `prod` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `prod`</sub>
-- [ ] Considered deindexing individual sources in `prod` <sub>or this PR does not merely remove sources from existing catalogs in `prod`</sub>
-- [ ] Considered indexing individual sources in `prod` <sub>or this PR does not merely add sources to existing catalogs in `prod`</sub>
+- [ ] Deindexed all unreferenced catalogs in `prod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:prod`</sub>
+- [ ] Deindexed specific sources in `prod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:prod`</sub>
+- [ ] Indexed specific sources in `prod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:prod`</sub>
 - [ ] Started reindex in `prod` <sub>or this PR does not require reindexing `prod`</sub>
-- [ ] Checked for and triaged indexing failures in `prod` <sub>or this PR does not require reindexing `prod`</sub>
-- [ ] Emptied fail queues in `prod` deployment <sub>or this PR does not require reindexing `prod`</sub>
+- [ ] Checked for, triaged and possibly requeued messages in both fail queues in `prod` <sub>or this PR does not require reindexing `prod`</sub>
+- [ ] Emptied fail queues in `prod` <sub>or this PR does not require reindexing `prod`</sub>
 
 
 ### Operator

--- a/.github/PULL_REQUEST_TEMPLATE/promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/promotion.md
@@ -21,9 +21,9 @@ Connected issue: #0000
 
 ### Author (reindex, API changes)
 
-- [ ] PR is labeled `reindex:prod` <sub>or this PR does not require reindexing `prod`</sub>
+- [ ] This PR is labeled `reindex:prod` <sub>or does not require reindexing `prod`</sub>
 - [ ] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `prod` <sub>or requires a full reindex or is not labeled`reindex:prod`</sub>
-- [ ] PR and connected issue are labeled `API` <sub>or this PR does not modify a REST API</sub>
+- [ ] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
 
 
 ### Author (upgrading deployments)
@@ -60,8 +60,8 @@ Connected issue: #0000
 ### Operator (before pushing merge the commit)
 
 - [ ] Ran `_select prod.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
-- [ ] Title of merge commit starts with title from this PR
-- [ ] Added PR reference to merge commit title
+- [ ] The title of the merge commit starts with the title of this PR
+- [ ] Added PR # reference to merge commit title
 - [ ] Collected commit title tags in merge commit title <sub>but exclude any `p` tags</sub>
 - [ ] Pushed merge commit to GitHub
 

--- a/.github/PULL_REQUEST_TEMPLATE/promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/promotion.md
@@ -40,7 +40,7 @@ Connected issue: #0000
 - [ ] Labeled PR as `no sandbox`
 - [ ] A comment to this PR details the completed security design review <sub>or this PR is a promotion or a backport</sub>
 - [ ] Moved ticket to *Approved* column
-- [ ] PR is assigned to current operator
+- [ ] PR is assigned to only the operator
 
 
 ### Operator (before pushing merge the commit)
@@ -55,7 +55,7 @@ Connected issue: #0000
 ### System administrator
 
 - [ ] Background migrations for `prod.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
-- [ ] PR is assigned to operator
+- [ ] PR is assigned to only the operator
 
 
 ### Operator (before pushing merge the commit)
@@ -90,7 +90,7 @@ Connected issue: #0000
 
 ### Operator
 
-- [ ] PR is assigned to system administrator
+- [ ] PR is assigned to only the system administrator
 
 
 ### System administrator

--- a/.github/PULL_REQUEST_TEMPLATE/upgrade.md
+++ b/.github/PULL_REQUEST_TEMPLATE/upgrade.md
@@ -111,6 +111,8 @@ Connected issue: #0000
 ### Operator
 
 - [ ] Ran `script/export_inspector_findings.py` against `anvilprod`, imported results to [Google Sheet](https://docs.google.com/spreadsheets/d/1RWF7g5wRKWPGovLw4jpJGX_XMi8aWLXLOvvE5rxqgH8) and posted screenshot of relevant<sup>1</sup> findings as a comment on the connected issue.
+- [ ] Propagated the `reindex:partial` and `reindex:prod` labels to the next promotion PR <sub>or this PR carries none of these labels</sub>
+- [ ] Propagated any specific instructions related to the `reindex:partial` and `reindex:prod` labels from the description of this PR to that of the next promotion PR <sub>or this PR carries none of these labels</sub>
 - [ ] PR is assigned to system administrator
 
 <sup>1</sup>A relevant finding is a high or critical vulnerability in an image

--- a/.github/PULL_REQUEST_TEMPLATE/upgrade.md
+++ b/.github/PULL_REQUEST_TEMPLATE/upgrade.md
@@ -31,10 +31,10 @@ Connected issue: #0000
 ### Author (before every review)
 
 - [ ] Rebased PR branch on `develop`, squashed old fixups
-- [ ] Ran `make requirements_update` <sub>or this PR does not touch requirements*.txt, common.mk, Makefile and Dockerfile</sub>
-- [ ] Added `R` tag to commit title <sub>or this PR does not touch requirements*.txt</sub>
-- [ ] Added `reqs` label to PR <sub>or this PR does not touch requirements*.txt</sub>
-- [ ] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>
+- [ ] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
+- [ ] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
+- [ ] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
+- [ ] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
 
 
 ### System administrator (after approval)
@@ -84,8 +84,8 @@ Connected issue: #0000
 - [ ] Reviewed build logs for anomalies in `sandbox` deployment
 - [ ] Reviewed build logs for anomalies in `anvilbox` deployment
 - [ ] Reviewed build logs for anomalies in `hammerbox` deployment
-- [ ] Title of merge commit starts with title from this PR
-- [ ] Added PR reference to merge commit title
+- [ ] The title of the merge commit starts with the title of this PR
+- [ ] Added PR # reference to merge commit title
 - [ ] Collected commit title tags in merge commit title <sub>but exclude any `p` tags</sub>
 - [ ] Moved connected issue to Merged column in ZenHub
 - [ ] Pushed merge commit to GitHub

--- a/.github/PULL_REQUEST_TEMPLATE/upgrade.md
+++ b/.github/PULL_REQUEST_TEMPLATE/upgrade.md
@@ -87,7 +87,7 @@ Connected issue: #0000
 - [ ] Reviewed build logs for anomalies in `hammerbox` deployment
 - [ ] The title of the merge commit starts with the title of this PR
 - [ ] Added PR # reference to merge commit title
-- [ ] Collected commit title tags in merge commit title <sub>but exclude any `p` tags</sub>
+- [ ] Collected commit title tags in merge commit title <sub>but excluded any `p` tags</sub>
 - [ ] Moved connected issue to Merged column in ZenHub
 - [ ] Pushed merge commit to GitHub
 

--- a/.github/PULL_REQUEST_TEMPLATE/upgrade.md
+++ b/.github/PULL_REQUEST_TEMPLATE/upgrade.md
@@ -44,7 +44,7 @@ Connected issue: #0000
 - [ ] A comment to this PR details the completed security design review <sub>or this PR is a promotion or a backport</sub>
 - [ ] PR title is appropriate as title of merge commit
 - [ ] Moved ticket to *Approved* column
-- [ ] PR is assigned to current operator
+- [ ] PR is assigned to only the operator
 
 
 ### Operator (before pushing merge the commit)
@@ -67,7 +67,7 @@ Connected issue: #0000
 - [ ] Background migrations for `dev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
 - [ ] Background migrations for `anvildev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
 - [ ] Background migrations for `anvilprod.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
-- [ ] PR is assigned to operator
+- [ ] PR is assigned to only the operator
 
 
 ### Operator (before pushing merge the commit)
@@ -117,7 +117,7 @@ Connected issue: #0000
 - [ ] Ran `script/export_inspector_findings.py` against `anvilprod`, imported results to [Google Sheet](https://docs.google.com/spreadsheets/d/1RWF7g5wRKWPGovLw4jpJGX_XMi8aWLXLOvvE5rxqgH8) and posted screenshot of relevant<sup>1</sup> findings as a comment on the connected issue.
 - [ ] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial` and `reindex:prod` labels to the next promotion PR <sub>or this PR carries none of these labels</sub>
 - [ ] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial` and `reindex:prod` labels from the description of this PR to that of the next promotion PR <sub>or this PR carries none of these labels</sub>
-- [ ] PR is assigned to system administrator
+- [ ] PR is assigned to only the system administrator
 
 <sup>1</sup>A relevant finding is a high or critical vulnerability in an image
 that is used within the security boundary. Images not used within the boundary

--- a/.github/PULL_REQUEST_TEMPLATE/upgrade.md
+++ b/.github/PULL_REQUEST_TEMPLATE/upgrade.md
@@ -41,6 +41,7 @@ Connected issue: #0000
 
 - [ ] Actually approved the PR
 - [ ] Labeled connected issue as `no demo`
+- [ ] A comment to this PR details the completed security design review <sub>or this PR is a promotion or a backport</sub>
 - [ ] PR title is appropriate as title of merge commit
 - [ ] Moved ticket to *Approved* column
 - [ ] PR is assigned to current operator

--- a/.github/PULL_REQUEST_TEMPLATE/upgrade.md
+++ b/.github/PULL_REQUEST_TEMPLATE/upgrade.md
@@ -19,10 +19,13 @@ Connected issue: #0000
 
 ### Author (upgrading deployments)
 
-- [ ] Ran `make image_manifests.json` and committed any resulting changes <sub>or this PR does not modify `azul_docker_images` or any other variables referenced in the definition of that variable</sub>
 - [ ] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
 - [ ] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
-- [ ] Added `upgrade` label to PR <sub>or this PR does not require upgrading deployments</sub>
+- [ ] Ran `make image_manifests.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
+- [ ] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
+- [ ] This PR is labeled `deploy:shared` <sub>or does not modify `image_manifests.json`, and does not require deploying the `shared` component for any other reason</sub>
+- [ ] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
+- [ ] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>
 
 
 ### Author (before every review)
@@ -48,29 +51,29 @@ Connected issue: #0000
 - [ ] Squashed PR branch and rebased onto `develop`
 - [ ] Sanity-checked history
 - [ ] Pushed PR branch to GitHub
-- [ ] Selected `dev.shared` and ran `CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR does not change any Docker image versions</sub>
-- [ ] Selected `dev.gitlab` and ran `CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR does not include any changes to files in terraform/gitlab</sub>
-- [ ] Selected `anvildev.shared` and ran `CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR does not change any Docker image versions</sub>
-- [ ] Selected `anvildev.gitlab` and ran `CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR does not include any changes to files in terraform/gitlab</sub>
-- [ ] Selected `anvilprod.shared` and ran `CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR does not change any Docker image versions</sub>
-- [ ] Selected `anvilprod.gitlab` and ran `CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR does not include any changes to files in terraform/gitlab</sub>
-- [ ] Assigned system administrator <sub>or this PR does not include any changes to files in terraform/gitlab</sub>
-- [ ] Checked the items in the next section <sub>or this PR includes changes to files in terraform/gitlab</sub>
+- [ ] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
+- [ ] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
+- [ ] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
+- [ ] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
+- [ ] Ran `_select anvilprod.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
+- [ ] Ran `_select anvilprod.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
+- [ ] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
+- [ ] Assigned system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>
 
 
 ### System administrator
 
-- [ ] Background migrations for `dev.gitlab` are complete <sub>or this PR does not include any changes to files in terraform/gitlab</sub>
-- [ ] Background migrations for `anvildev.gitlab` are complete <sub>or this PR does not include any changes to files in terraform/gitlab</sub>
-- [ ] Background migrations for `anvilprod.gitlab` are complete <sub>or this PR does not include any changes to files in terraform/gitlab</sub>
+- [ ] Background migrations for `dev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
+- [ ] Background migrations for `anvildev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
+- [ ] Background migrations for `anvilprod.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
 - [ ] PR is assigned to operator
 
 
 ### Operator (before pushing merge the commit)
 
-- [ ] Selected `dev.gitlab` and ran `make -C terraform/gitlab/runner` <sub>or this PR does not change `azul_docker_version`</sub>
-- [ ] Selected `anvildev.gitlab` and ran `make -C terraform/gitlab/runner` <sub>or this PR does not change `azul_docker_version`</sub>
-- [ ] Selected `anvilprod.gitlab` and ran `make -C terraform/gitlab/runner` <sub>or this PR does not change `azul_docker_version`</sub>
+- [ ] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
+- [ ] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
+- [ ] Ran `_select anvilprod.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
 - [ ] Added `sandbox` label
 - [ ] Pushed PR branch to GitLab `dev`
 - [ ] Pushed PR branch to GitLab `anvildev`
@@ -99,9 +102,9 @@ Connected issue: #0000
 - [ ] Reviewed build logs for anomalies on GitLab `anvildev`
 - [ ] Build passes on GitLab `anvilprod`
 - [ ] Reviewed build logs for anomalies on GitLab `anvilprod`
-- [ ] Selected `dev.shared` and ran `make -C terraform/shared apply` <sub>or this PR does not change any Docker image versions</sub>
-- [ ] Selected `anvildev.shared` and ran `make -C terraform/shared apply` <sub>or this PR does not change any Docker image versions</sub>
-- [ ] Selected `anvilprod.shared` and ran `make -C terraform/shared apply` <sub>or this PR does not change any Docker image versions</sub>
+- [ ] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
+- [ ] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
+- [ ] Ran `_select anvilprod.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
 - [ ] Deleted PR branch from GitHub
 - [ ] Deleted PR branch from GitLab `dev`
 - [ ] Deleted PR branch from GitLab `anvildev`
@@ -111,8 +114,8 @@ Connected issue: #0000
 ### Operator
 
 - [ ] Ran `script/export_inspector_findings.py` against `anvilprod`, imported results to [Google Sheet](https://docs.google.com/spreadsheets/d/1RWF7g5wRKWPGovLw4jpJGX_XMi8aWLXLOvvE5rxqgH8) and posted screenshot of relevant<sup>1</sup> findings as a comment on the connected issue.
-- [ ] Propagated the `reindex:partial` and `reindex:prod` labels to the next promotion PR <sub>or this PR carries none of these labels</sub>
-- [ ] Propagated any specific instructions related to the `reindex:partial` and `reindex:prod` labels from the description of this PR to that of the next promotion PR <sub>or this PR carries none of these labels</sub>
+- [ ] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial` and `reindex:prod` labels to the next promotion PR <sub>or this PR carries none of these labels</sub>
+- [ ] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial` and `reindex:prod` labels from the description of this PR to that of the next promotion PR <sub>or this PR carries none of these labels</sub>
 - [ ] PR is assigned to system administrator
 
 <sup>1</sup>A relevant finding is a high or critical vulnerability in an image

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -54,10 +54,13 @@ title is `Fix: ` followed by the issue title
 
 ### Author (upgrading deployments)
 
-- [ ] Ran `make image_manifests.json` and committed any resulting changes <sub>or this PR does not modify `azul_docker_images` or any other variables referenced in the definition of that variable</sub>
 - [ ] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
 - [ ] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
-- [ ] Added `upgrade` label to PR <sub>or this PR does not require upgrading deployments</sub>
+- [ ] Ran `make image_manifests.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
+- [ ] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
+- [ ] This PR is labeled `deploy:shared` <sub>or does not modify `image_manifests.json`, and does not require deploying the `shared` component for any other reason</sub>
+- [ ] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
+- [ ] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>
 
 
 ### Author (operator tasks)
@@ -118,6 +121,29 @@ Uncheck the *before every review* checklists. Update the `N reviews` label.
 - [ ] Squashed PR branch and rebased onto `develop`
 - [ ] Sanity-checked history
 - [ ] Pushed PR branch to GitHub
+- [ ] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
+- [ ] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
+- [ ] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
+- [ ] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
+- [ ] Ran `_select anvilprod.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
+- [ ] Ran `_select anvilprod.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
+- [ ] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
+- [ ] Assigned system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>
+
+
+### System administrator
+
+- [ ] Background migrations for `dev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
+- [ ] Background migrations for `anvildev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
+- [ ] Background migrations for `anvilprod.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
+- [ ] PR is assigned to operator
+
+
+### Operator (before pushing merge the commit)
+
+- [ ] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
+- [ ] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
+- [ ] Ran `_select anvilprod.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
 - [ ] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
 - [ ] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
 - [ ] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
@@ -163,6 +189,9 @@ Uncheck the *before every review* checklists. Update the `N reviews` label.
 - [ ] Reviewed build logs for anomalies on GitLab `anvildev`<sup>1</sup>
 - [ ] Build passes on GitLab `anvilprod`<sup>1</sup>
 - [ ] Reviewed build logs for anomalies on GitLab `anvilprod`<sup>1</sup>
+- [ ] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
+- [ ] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
+- [ ] Ran `_select anvilprod.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
 - [ ] Deleted PR branch from GitHub
 - [ ] Deleted PR branch from GitLab `dev`
 - [ ] Deleted PR branch from GitLab `anvildev`
@@ -197,8 +226,8 @@ pushed determines this checklist item.
 
 ### Operator
 
-- [ ] Propagated the `reindex:partial` and `reindex:prod` labels to the next promotion PR <sub>or this PR carries none of these labels</sub>
-- [ ] Propagated any specific instructions related to the `reindex:partial` and `reindex:prod` labels from the description of this PR to that of the next promotion PR <sub>or this PR carries none of these labels</sub>
+- [ ] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial` and `reindex:prod` labels to the next promotion PR <sub>or this PR carries none of these labels</sub>
+- [ ] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial` and `reindex:prod` labels from the description of this PR to that of the next promotion PR <sub>or this PR carries none of these labels</sub>
 - [ ] PR is assigned to no one
 
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,7 +36,10 @@ title is `Fix: ` followed by the issue title
 ### Author (reindex, API changes)
 
 - [ ] Added `r` tag to commit title <sub>or this PR does not require reindexing</sub>
-- [ ] Added `reindex` label to PR <sub>or this PR does not require reindexing</sub>
+- [ ] PR is labeled `reindex:dev` <sub>or this PR does not require reindexing `dev`</sub>
+- [ ] PR is labeled `reindex:anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
+- [ ] PR is labeled `reindex:anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
+- [ ] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
 - [ ] PR and connected issue are labeled `API` <sub>or this PR does not modify a REST API</sub>
 - [ ] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
 - [ ] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>
@@ -109,7 +112,7 @@ Uncheck the *before every review* checklists. Update the `N reviews` label.
 
 ### Operator (before pushing merge the commit)
 
-- [ ] Checked `reindex` label and `r` commit title tag
+- [ ] Checked `reindex:…` labels and `r` commit title tag
 - [ ] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
 - [ ] PR has checklist items for upgrading instructions <sub>or PR is not labeled `upgrade`</sub>
 - [ ] Squashed PR branch and rebased onto `develop`
@@ -128,12 +131,12 @@ Uncheck the *before every review* checklists. Update the `N reviews` label.
 - [ ] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
 - [ ] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
 - [ ] Deleted unreferenced indices in `hammerbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilprod`</sub>
-- [ ] Started reindex in `sandbox` <sub>or this PR does not require reindexing `dev`</sub>
-- [ ] Started reindex in `anvilbox` <sub>or this PR does not require reindexing `anvildev`</sub>
-- [ ] Started reindex in `hammerbox` <sub>or this PR does not require reindexing `anvilprod`</sub>
-- [ ] Checked for failures in `sandbox` <sub>or this PR does not require reindexing `dev`</sub>
-- [ ] Checked for failures in `anvilbox` <sub>or this PR does not require reindexing `anvildev`</sub>
-- [ ] Checked for failures in `hammerbox` <sub>or this PR does not require reindexing `anvilprod`</sub>
+- [ ] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
+- [ ] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
+- [ ] Started reindex in `hammerbox` <sub>or this PR is not labeled `reindex:anvilprod`</sub>
+- [ ] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
+- [ ] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
+- [ ] Checked for failures in `hammerbox` <sub>or this PR is not labeled `reindex:anvilprod`</sub>
 - [ ] Title of merge commit starts with title from this PR
 - [ ] Added PR reference to merge commit title
 - [ ] Collected commit title tags in merge commit title <sub>but only include `p` if the PR is labeled `partial`</sub>
@@ -172,28 +175,30 @@ pushed determines this checklist item.
 
 ### Operator (reindex)
 
-- [ ] Deleted unreferenced indices in `dev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
-- [ ] Deleted unreferenced indices in `anvildev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
-- [ ] Deleted unreferenced indices in `anvilprod` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilprod`</sub>
-- [ ] Considered deindexing individual sources in `dev` <sub>or this PR does not merely remove sources from existing catalogs in `dev`</sub>
-- [ ] Considered deindexing individual sources in `anvildev` <sub>or this PR does not merely remove sources from existing catalogs in `anvildev`</sub>
-- [ ] Considered deindexing individual sources in `anvilprod` <sub>or this PR does not merely remove sources from existing catalogs in `anvilprod`</sub>
-- [ ] Considered indexing individual sources in `dev` <sub>or this PR does not merely add sources to existing catalogs in `dev`</sub>
-- [ ] Considered indexing individual sources in `anvildev` <sub>or this PR does not merely add sources to existing catalogs in `anvildev`</sub>
-- [ ] Considered indexing individual sources in `anvilprod` <sub>or this PR does not merely add sources to existing catalogs in `anvilprod`</sub>
+- [ ] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
+- [ ] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
+- [ ] Deindexed all unreferenced catalogs in `anvilprod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvilprod`</sub>
+- [ ] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
+- [ ] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
+- [ ] Deindexed specific sources in `anvilprod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvilprod`</sub>
+- [ ] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
+- [ ] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
+- [ ] Indexed specific sources in `anvilprod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvilprod`</sub>
 - [ ] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
 - [ ] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
 - [ ] Started reindex in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
-- [ ] Checked for and triaged indexing failures in `dev` <sub>or this PR does not require reindexing `dev`</sub>
-- [ ] Checked for and triaged indexing failures in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
-- [ ] Checked for and triaged indexing failures in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
-- [ ] Emptied fail queues in `dev` deployment <sub>or this PR does not require reindexing `dev`</sub>
-- [ ] Emptied fail queues in `anvildev` deployment <sub>or this PR does not require reindexing `anvildev`</sub>
-- [ ] Emptied fail queues in `anvilprod` deployment <sub>or this PR does not require reindexing `anvilprod`</sub>
+- [ ] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
+- [ ] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
+- [ ] Checked for, triaged and possibly requeued messages in both fail queues in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
+- [ ] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
+- [ ] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
+- [ ] Emptied fail queues in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
 
 
 ### Operator
 
+- [ ] Propagated the `reindex:partial` and `reindex:prod` labels to the next promotion PR <sub>or this PR carries none of these labels</sub>
+- [ ] Propagated any specific instructions related to the `reindex:partial` and `reindex:prod` labels from the description of this PR to that of the next promotion PR <sub>or this PR carries none of these labels</sub>
 - [ ] PR is assigned to no one
 
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,6 +33,13 @@ Connected issues: #0000
 title is `Fix: ` followed by the issue title
 
 
+### Author (chains)
+
+- [ ] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
+- [ ] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
+- [ ] This PR is labeled `chained` <sub>or is not chained to another PR</sub>
+
+
 ### Author (reindex, API changes)
 
 - [ ] Added `r` tag to commit title <sub>or this PR does not require reindexing</sub>
@@ -43,13 +50,6 @@ title is `Fix: ` followed by the issue title
 - [ ] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
 - [ ] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
 - [ ] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>
-
-
-### Author (chains)
-
-- [ ] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
-- [ ] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
-- [ ] This PR is labeled `chained` <sub>or is not chained to another PR</sub>
 
 
 ### Author (upgrading deployments)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -166,7 +166,7 @@ Uncheck the *before every review* checklists. Update the `N reviews` label.
 - [ ] Checked for failures in `hammerbox` <sub>or this PR is not labeled `reindex:anvilprod`</sub>
 - [ ] The title of the merge commit starts with the title of this PR
 - [ ] Added PR # reference to merge commit title
-- [ ] Collected commit title tags in merge commit title <sub>but only include `p` if the PR is labeled `partial`</sub>
+- [ ] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
 - [ ] Moved connected issues to Merged column in ZenHub
 - [ ] Pushed merge commit to GitHub
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,8 +26,8 @@ Connected issues: #0000
 ### Author (partiality)
 
 - [ ] Added `p` tag to titles of partial commits
-- [ ] Added `partial` label to PR <sub>or this PR completely resolves all connected issues</sub>
-- [ ] All connected issues are resolved partially <sub>or this PR does not have the `partial` label</sub>
+- [ ] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
+- [ ] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>
 
 <sup>1</sup> when the issue title describes a problem, the corresponding PR
 title is `Fix: ` followed by the issue title
@@ -36,20 +36,20 @@ title is `Fix: ` followed by the issue title
 ### Author (reindex, API changes)
 
 - [ ] Added `r` tag to commit title <sub>or this PR does not require reindexing</sub>
-- [ ] PR is labeled `reindex:dev` <sub>or this PR does not require reindexing `dev`</sub>
-- [ ] PR is labeled `reindex:anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
-- [ ] PR is labeled `reindex:anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
+- [ ] This PR is labeled `reindex:dev` <sub>or does not require reindexing `dev`</sub>
+- [ ] This PR is labeled `reindex:anvildev` <sub>or does not require reindexing `anvildev`</sub>
+- [ ] This PR is labeled `reindex:anvilprod` <sub>or does not require reindexing `anvilprod`</sub>
 - [ ] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
-- [ ] PR and connected issue are labeled `API` <sub>or this PR does not modify a REST API</sub>
+- [ ] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
 - [ ] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
 - [ ] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>
 
 
 ### Author (chains)
 
-- [ ] This PR is blocked by previous PR in the chain <sub>or this PR is not chained to another PR</sub>
-- [ ] Added `base` label to the blocking PR <sub>or this PR is not chained to another PR</sub>
-- [ ] Added `chained` label to this PR <sub>or this PR is not chained to another PR</sub>
+- [ ] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
+- [ ] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
+- [ ] This PR is labeled `chained` <sub>or is not chained to another PR</sub>
 
 
 ### Author (upgrading deployments)
@@ -77,10 +77,10 @@ title is `Fix: ` followed by the issue title
 ### Author (before every review)
 
 - [ ] Rebased PR branch on `develop`, squashed old fixups
-- [ ] Ran `make requirements_update` <sub>or this PR does not touch requirements*.txt, common.mk, Makefile and Dockerfile</sub>
-- [ ] Added `R` tag to commit title <sub>or this PR does not touch requirements*.txt</sub>
-- [ ] Added `reqs` label to PR <sub>or this PR does not touch requirements*.txt</sub>
-- [ ] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>
+- [ ] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
+- [ ] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
+- [ ] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
+- [ ] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
 
 
 ### Peer reviewer (after requesting changes)
@@ -163,8 +163,8 @@ Uncheck the *before every review* checklists. Update the `N reviews` label.
 - [ ] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
 - [ ] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
 - [ ] Checked for failures in `hammerbox` <sub>or this PR is not labeled `reindex:anvilprod`</sub>
-- [ ] Title of merge commit starts with title from this PR
-- [ ] Added PR reference to merge commit title
+- [ ] The title of the merge commit starts with the title of this PR
+- [ ] Added PR # reference to merge commit title
 - [ ] Collected commit title tags in merge commit title <sub>but only include `p` if the PR is labeled `partial`</sub>
 - [ ] Moved connected issues to Merged column in ZenHub
 - [ ] Pushed merge commit to GitHub

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -107,6 +107,7 @@ Uncheck the *before every review* checklists. Update the `N reviews` label.
 - [ ] Labeled connected issues as `demo` or `no demo`
 - [ ] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
 - [ ] Decided if PR can be labeled `no sandbox`
+- [ ] A comment to this PR details the completed security design review <sub>or this PR is a promotion or a backport</sub>
 - [ ] PR title is appropriate as title of merge commit
 - [ ] `N reviews` label is accurate
 - [ ] Moved ticket to *Approved* column

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -93,7 +93,7 @@ Uncheck the *Author (before every review)* checklists.
 - [ ] PR is not a draft
 - [ ] Ticket is in *Review requested* column
 - [ ] Requested review from system administrator
-- [ ] PR is assigned to system administrator
+- [ ] PR is assigned to only the system administrator
 
 
 ### System administrator (after requesting changes)
@@ -111,7 +111,7 @@ Uncheck the *before every review* checklists. Update the `N reviews` label.
 - [ ] PR title is appropriate as title of merge commit
 - [ ] `N reviews` label is accurate
 - [ ] Moved ticket to *Approved* column
-- [ ] PR is assigned to current operator
+- [ ] PR is assigned to only the operator
 
 
 ### Operator (before pushing merge the commit)
@@ -137,7 +137,7 @@ Uncheck the *before every review* checklists. Update the `N reviews` label.
 - [ ] Background migrations for `dev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
 - [ ] Background migrations for `anvildev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
 - [ ] Background migrations for `anvilprod.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
-- [ ] PR is assigned to operator
+- [ ] PR is assigned to only the operator
 
 
 ### Operator (before pushing merge the commit)

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -737,11 +737,9 @@ def main():
             },
             iif(t in (T.default, T.upgrade, T.hotfix), {
                 'type': 'cli',
-                'content': (
-                    'Moved connected issue to *Merged prod* column in ZenHub'
-                    if t is t.hotfix else
-                    f'Moved connected {t.issues} to Merged column in ZenHub'
-                )
+                'content': iif(t is t.hotfix,
+                               'Moved connected issue to *Merged prod* column in ZenHub',
+                               f'Moved connected {t.issues} to Merged column in ZenHub')
             }),
             {
                 'type': 'cli',

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -270,13 +270,13 @@ def main():
                 },
                 {
                     'type': 'cli',
-                    'content': 'Added `partial` label to PR',
-                    'alt': 'or this PR completely resolves all connected issues'
+                    'content': 'This PR is labeled `partial`',
+                    'alt': 'or completely resolves all connected issues'
                 },
                 {
                     'type': 'cli',
-                    'content': 'All connected issues are resolved partially',
-                    'alt': 'or this PR does not have the `partial` label'
+                    'content': 'This PR partially resolves each of the connected issues',
+                    'alt': 'or does not have the `partial` label'
                 }
             ]),
             iif(t is T.default, {
@@ -297,8 +297,8 @@ def main():
                 *[
                     {
                         'type': 'cli',
-                        'content': f'PR is labeled `reindex:{d}`',
-                        'alt': f'or this PR does not require reindexing `{d}`'
+                        'content': f'This PR is labeled `reindex:{d}`',
+                        'alt': f'or does not require reindexing `{d}`'
                     }
                     for d in t.target_deployments
                 ],
@@ -315,7 +315,7 @@ def main():
                 },
                 {
                     'type': 'cli',
-                    'content': 'PR and connected issue are labeled `API`',
+                    'content': 'This PR and its connected issues are labeled `API`',
                     'alt': 'or this PR does not modify a REST API'
                 },
                 *iif(t is T.default, [
@@ -339,17 +339,17 @@ def main():
                 {
                     'type': 'cli',
                     'content': 'This PR is blocked by previous PR in the chain',
+                    'alt': 'or is not chained to another PR'
+                },
+                {
+                    'type': 'cli',
+                    'content': 'The blocking PR is labeled `base`',
                     'alt': 'or this PR is not chained to another PR'
                 },
                 {
                     'type': 'cli',
-                    'content': 'Added `base` label to the blocking PR',
-                    'alt': 'or this PR is not chained to another PR'
-                },
-                {
-                    'type': 'cli',
-                    'content': 'Added `chained` label to this PR',
-                    'alt': 'or this PR is not chained to another PR'
+                    'content': 'This PR is labeled `chained`',
+                    'alt': 'or is not chained to another PR'
                 }
             ]),
             *iif(t not in (T.hotfix, T.backport), [
@@ -441,8 +441,8 @@ def main():
                         },
                         {
                             'type': 'cli',
-                            'content': 'Added `partial` label to PR',
-                            'alt': 'or this PR is a permanent hotfix'
+                            'content': 'This PR is labeled `partial`',
+                            'alt': 'or represents a permanent hotfix'
                         },
                     ] if t is T.hotfix else [
                     ]),
@@ -461,22 +461,22 @@ def main():
                 {
                     'type': 'cli',
                     'content': 'Ran `make requirements_update`',
-                    'alt': 'or this PR does not touch requirements*.txt, common.mk, Makefile and Dockerfile'
+                    'alt': 'or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`'
                 },
                 {
                     'type': 'cli',
                     'content': 'Added `R` tag to commit title',
-                    'alt': 'or this PR does not touch requirements*.txt'
+                    'alt': 'or this PR does not modify `requirements*.txt`'
                 },
                 {
                     'type': 'cli',
-                    'content': 'Added `reqs` label to PR',
-                    'alt': 'or this PR does not touch requirements*.txt'
+                    'content': 'This PR is labeled `reqs`',
+                    'alt': 'or does not modify `requirements*.txt`'
                 },
                 iif(t in (T.default, T.upgrade), {
                     'type': 'cli',
                     'content': '`make integration_test` passes in personal deployment',
-                    'alt': 'or this PR does not touch functionality that could break the IT'
+                    'alt': 'or this PR does not modify functionality that could affect the IT outcome'
                 })
             ]),
             *iif(t is T.default, [
@@ -712,11 +712,13 @@ def main():
             ))),
             {
                 'type': 'cli',
-                'content': 'Title of merge commit starts with title from this PR'
+                'content': 'The title of the merge commit starts with the title of this PR'
             },
             {
                 'type': 'cli',
-                'content': f"Added PR reference {iif(t is T.backport, '(this PR) ')}to merge commit title"
+                'content': 'Added PR # reference '
+                           + iif(t is T.backport, '(to this PR) ')
+                           + 'to merge commit title'
             },
             {
                 'type': 'cli',

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -527,7 +527,7 @@ def main():
                 },
                 {
                     'type': 'cli',
-                    'content': 'PR is assigned to system administrator'
+                    'content': 'PR is assigned to only the system administrator'
                 }
             ]),
             *iif(t in (T.default, T.backport), [
@@ -589,7 +589,7 @@ def main():
             },
             {
                 'type': 'cli',
-                'content': 'PR is assigned to current operator'
+                'content': 'PR is assigned to only the operator'
             },
             {
                 'type': 'h2',
@@ -671,7 +671,7 @@ def main():
                 ],
                 {
                     'type': 'cli',
-                    'content': 'PR is assigned to operator',
+                    'content': 'PR is assigned to only the operator',
                 },
                 {
                     'type': 'h2',
@@ -927,7 +927,7 @@ def main():
             {
                 'type': 'cli',
                 'content': 'PR is assigned to '
-                           + iif(t in (T.upgrade, T.promotion), 'system administrator', 'no one')
+                           + iif(t in (T.upgrade, T.promotion), 'only the system administrator', 'no one')
             },
             iif(t is T.upgrade, {
                 'type': 'p',

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -284,6 +284,27 @@ def main():
                 'content': '<sup>1</sup> when the issue title describes a problem, the corresponding PR title is '
                            '`Fix: ` followed by the issue title'
             }),
+            *iif(t is T.default, [
+                {
+                    'type': 'h2',
+                    'content': 'Author (chains)'
+                },
+                {
+                    'type': 'cli',
+                    'content': 'This PR is blocked by previous PR in the chain',
+                    'alt': 'or is not chained to another PR'
+                },
+                {
+                    'type': 'cli',
+                    'content': 'The blocking PR is labeled `base`',
+                    'alt': 'or this PR is not chained to another PR'
+                },
+                {
+                    'type': 'cli',
+                    'content': 'This PR is labeled `chained`',
+                    'alt': 'or is not chained to another PR'
+                }
+            ]),
             *iif(t in (T.default, T.promotion), [
                 {
                     'type': 'h2',
@@ -330,27 +351,6 @@ def main():
                         'alt': 'or this PR does not modify a REST API'
                     }
                 ])
-            ]),
-            *iif(t is T.default, [
-                {
-                    'type': 'h2',
-                    'content': 'Author (chains)'
-                },
-                {
-                    'type': 'cli',
-                    'content': 'This PR is blocked by previous PR in the chain',
-                    'alt': 'or is not chained to another PR'
-                },
-                {
-                    'type': 'cli',
-                    'content': 'The blocking PR is labeled `base`',
-                    'alt': 'or this PR is not chained to another PR'
-                },
-                {
-                    'type': 'cli',
-                    'content': 'This PR is labeled `chained`',
-                    'alt': 'or is not chained to another PR'
-                }
             ]),
             *iif(t not in (T.hotfix, T.backport), [
                 {

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -549,6 +549,11 @@ def main():
                     'Labeled PR as `no sandbox`'
                 )
             }),
+            {
+                'type': 'cli',
+                'content': 'A comment to this PR details the completed security design review',
+                'alt': 'or this PR is a promotion or a backport'
+            },
             iif(t is not T.promotion, {
                 'type': 'cli',
                 'content': 'PR title is appropriate as title of merge commit'

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -732,8 +732,8 @@ def main():
                 'type': 'cli',
                 'content': 'Collected commit title tags in merge commit title',
                 'alt': iif(t is T.default,
-                           'but only include `p` if the PR is labeled `partial`',
-                           'but exclude any `p` tags')
+                           'but only included `p` if the PR is also labeled `partial`',
+                           'but excluded any `p` tags')
             },
             iif(t in (T.default, T.upgrade, T.hotfix), {
                 'type': 'cli',

--- a/.github/replies/README.md
+++ b/.github/replies/README.md
@@ -1,0 +1,10 @@
+The other Markdown files in this directory each represent a GitHub *saved
+reply*, i.e., a template for comments to GitHub issues and pull requests. There
+is an outstanding [request][1] to add the ability for teams to track saved
+replies as source code in their repositories. Until that feature is available,
+each user has to manually add each of the saved replies in this folder to their
+GitHub account settings, as described in the [GitHub documentation][2].
+
+[1]: https://github.com/orgs/community/discussions/4974
+
+[2]: https://docs.github.com/en/get-started/writing-on-github/working-with-saved-replies

--- a/.github/replies/security_design_review.md
+++ b/.github/replies/security_design_review.md
@@ -1,0 +1,38 @@
+### Security design review
+
+- [ ] Security design review completed; this PR does **not** …
+  - [ ] … affect authentication; for example:
+    - OAuth 2.0 with the application (API or Swagger UI)
+    - Authentication of developers with Google Cloud APIs
+    - Authentication of developers with AWS APIs
+    - Authentication with a GitLab instance in the system
+    - Password and 2FA authentication with GitHub
+    - API access token authentication with GitHub
+    - Authentication with Terra 
+  - [ ] … affect the permissions of internal users like access to
+    - Cloud resources on AWS and GCP
+    - GitLab repositories, projects and groups, administration
+    - an EC2 instance via SSH
+    - GitHub issues, pull requests, commits, commit statuses, wikis, repositories, organizations
+  - [ ] … affect the permissions of external users like access to
+    - TDR snapshots
+  - [ ] … affect permissions of service or bot accounts
+    - Cloud resources on AWS and GCP
+  - [ ] … affect audit logging in the system, like
+    - adding, removing or changing a log message that represents an auditable event
+    - changing the routing of log messages through the system
+  - [ ] … affect monitoring of the system
+  - [ ] … introduce a new software dependency like
+    - Python packages on PYPI
+    - Command-line utilities
+    - Docker images
+    - Terraform providers
+  - [ ] … add an interface that exposes sensitive or confidential data at the security boundary
+  - [ ] … affect the encryption of data at rest
+  - [ ] … require persistence of sensitive or confidential data that might require encryption at rest
+  - [ ] … require unencrypted transmission of data within the security boundary
+  - [ ] … affect the network security layer; for example by 
+    - modifying, adding or removing firewall rules
+    - modifying, adding or removing security groups
+    - changing or adding a port a service, proxy or load balancer listens on
+- [ ] Documentation on any unchecked boxes is provided in comments below

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -1012,6 +1012,8 @@ class Config:
         if deployment in {'prod'}:
             assert self.is_shared_deployment(deployment)
             return True
+        else:
+            return False
 
     @property
     def is_sandbox_deployment(self) -> bool:
@@ -1412,8 +1414,14 @@ class Config:
     def cloudwatch_dashboard_template(self) -> str:
         return f'{config.project_root}/terraform/cloudwatch_dashboard.template.json'
 
+    class SecurityContact(TypedDict):
+        name: str
+        title: str
+        email_address: str
+        phone_number: str
+
     @property
-    def security_contact(self) -> Optional[dict[str]]:
+    def security_contact(self) -> SecurityContact | None:
         value = self.environ.get('azul_security_contact')
         if value is None:
             return None

--- a/src/azul/template.py
+++ b/src/azul/template.py
@@ -32,7 +32,9 @@ def emit_text(*, remove: bool = False):
         with open('/dev/null', 'a') as f:
             yield f
     else:
-        f = tempfile.NamedTemporaryFile(mode='w+', dir=os.path.dirname(path), encoding='utf-8', delete=False)
+        f = tempfile.NamedTemporaryFile(mode='w+',
+                                        dir=os.path.dirname(path),
+                                        encoding='utf-8', delete=False)
         try:
             yield f
         except BaseException:


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=promotion.md`,
`&template=hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to
switch the template.
-->

Connected issues: #5978 


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [ ] ~For each connected issue, there is at least one commit whose title references that issue~ all commits together resolve the issue so I opted for leaving the ticket reference off the title instead of doing 13 split commits


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] Added `partial` label to PR <sub>or this PR completely resolves all connected issues</sub>
- [x] All connected issues are resolved partially <sub>or this PR does not have the `partial` label</sub>

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR <sub>or this PR does not require reindexing</sub>
- [x] PR and connected issue are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or this PR is not chained to another PR</sub>
- [x] Added `base` label to the blocking PR <sub>or this PR is not chained to another PR</sub>
- [x] Added `chained` label to this PR <sub>or this PR is not chained to another PR</sub>


### Author (upgrading deployments)

- [x] Ran `make image_manifests.json` and committed any resulting changes <sub>or this PR does not modify `azul_docker_images` or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `upgrade` label to PR <sub>or this PR does not require upgrading deployments</sub>


### Author (operator tasks)

- [x] Added checklist items for additional operator tasks <sub>or this PR does not require additional tasks</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the `prod` branch has no temporary hotfixes for any connected issues</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not touch requirements*.txt, common.mk, Makefile and Dockerfile</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not touch requirements*.txt</sub>
- [x] Added `reqs` label to PR <sub>or this PR does not touch requirements*.txt</sub>
- [ ] ~`make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>~ it's unlikely that my changes break IT but not impossible, using my privilege as lead to rely on the `sandbox` build to verify this for me. The approved queue is currently short so this should be OK.


### Peer reviewer (after requesting changes)

Uncheck the *Author (before every review)* checklists.


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] Requested review from system administrator
- [x] PR is assigned to system administrator


### System administrator (after requesting changes)

Uncheck the *before every review* checklists. Update the `N reviews` label.


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved ticket to *Approved* column
- [x] PR is assigned to current operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] PR has checklist items for upgrading instructions <sub>or PR is not labeled `upgrade`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Deleted unreferenced indices in `hammerbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilprod`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Started reindex in `hammerbox` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for failures in `hammerbox` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Title of merge commit starts with title from this PR
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only include `p` if the PR is labeled `partial`</sub>
- [x] Moved connected issues to Merged column in ZenHub
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed merge commit to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed merge commit to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes on GitLab `dev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `dev`<sup>1</sup>
- [x] Build passes on GitLab `anvildev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvildev`<sup>1</sup>
- [x] Build passes on GitLab `anvilprod`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvilprod`<sup>1</sup>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Deleted PR branch from GitLab `anvilprod`

<sup>1</sup> When pushing the merge commit is skipped due to the PR being
labelled `no sandbox`, the next build triggered by a PR whose merge commit *is*
pushed determines this checklist item.


### Operator (reindex)

- [x] Deleted unreferenced indices in `dev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvildev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Deleted unreferenced indices in `anvilprod` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilprod`</sub>
- [x] Considered deindexing individual sources in `dev` <sub>or this PR does not merely remove sources from existing catalogs in `dev`</sub>
- [x] Considered deindexing individual sources in `anvildev` <sub>or this PR does not merely remove sources from existing catalogs in `anvildev`</sub>
- [x] Considered deindexing individual sources in `anvilprod` <sub>or this PR does not merely remove sources from existing catalogs in `anvilprod`</sub>
- [x] Considered indexing individual sources in `dev` <sub>or this PR does not merely add sources to existing catalogs in `dev`</sub>
- [x] Considered indexing individual sources in `anvildev` <sub>or this PR does not merely add sources to existing catalogs in `anvildev`</sub>
- [x] Considered indexing individual sources in `anvilprod` <sub>or this PR does not merely add sources to existing catalogs in `anvilprod`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Started reindex in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Checked for and triaged indexing failures in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for and triaged indexing failures in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for and triaged indexing failures in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Emptied fail queues in `dev` deployment <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` deployment <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `anvilprod` deployment <sub>or this PR does not require reindexing `anvilprod`</sub>


### Operator

- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
