### PR TITLE
Track replica hub IDs (#5360)

### DIFF
--- a/environment.py
+++ b/environment.py
@@ -187,6 +187,10 @@ def env() -> Mapping[str, Optional[str]]:
         # Whether to create and populate an index for replica documents.
         'AZUL_ENABLE_REPLICAS': '1',
 
+        # Maximum number of conflicts to allow before giving when writing
+        # replica documents.
+        'AZUL_REPLICA_CONFLICT_LIMIT': '10',
+
         # The name of the current deployment. This variable controls the name of
         # all cloud resources and is the main vehicle for isolating cloud
         # resources between deployments.

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -765,6 +765,10 @@ class Config:
     def enable_replicas(self) -> bool:
         return self._boolean(self.environ['AZUL_ENABLE_REPLICAS'])
 
+    @property
+    def replica_conflict_limit(self) -> int:
+        return int(self.environ['AZUL_REPLICA_CONFLICT_LIMIT'])
+
     # Because this property is relatively expensive to produce and frequently
     # used we are applying aggressive caching here, knowing very well that
     # this eliminates the option to reconfigure the running process by

--- a/src/azul/indexer/document.py
+++ b/src/azul/indexer/document.py
@@ -1100,6 +1100,10 @@ class OpType(Enum):
     #: Remove the document from the index or fail if it does not exist
     delete = auto()
 
+    #: Modify a document in the index via a scripted update or fail if it does
+    #: not exist
+    update = auto()
+
 
 C = TypeVar('C', bound=DocumentCoordinates)
 
@@ -1326,11 +1330,7 @@ class Document(Generic[C]):
                 if op_type is OpType.delete else
                 {
                     '_source' if bulk else 'body':
-                        self.translate_fields(doc=self.to_json(),
-                                              field_types=field_types[coordinates.entity.catalog],
-                                              forward=True)
-                        if self.needs_translation else
-                        self.to_json()
+                        self._body(field_types[coordinates.entity.catalog])
                 }
             ),
             '_id' if bulk else 'id': self.coordinates.document_id
@@ -1360,6 +1360,15 @@ class Document(Generic[C]):
     @property
     def op_type(self) -> OpType:
         raise NotImplementedError
+
+    def _body(self, field_types: FieldTypes) -> JSON:
+        assert self.op_type is not OpType.update
+        body = self.to_json()
+        if self.needs_translation:
+            body = self.translate_fields(doc=body,
+                                         field_types=field_types,
+                                         forward=True)
+        return body
 
 
 class DocumentSource(SourceRef[SimpleSourceSpec, SourceRef]):
@@ -1555,11 +1564,34 @@ class Replica(Document[ReplicaCoordinates[E]]):
     def to_json(self) -> JSON:
         return dict(super().to_json(),
                     replica_type=self.replica_type,
-                    hub_ids=self.hub_ids)
+                    # Ensure that index contents is deterministic for unit tests
+                    hub_ids=sorted(set(self.hub_ids)))
 
     @property
     def op_type(self) -> OpType:
-        return OpType.create
+        if self.version_type is VersionType.create_only:
+            return OpType.create
+        elif self.version_type is VersionType.none:
+            return OpType.update
+        else:
+            assert False, self.version_type
+
+    def _body(self, field_types: FieldTypes) -> JSON:
+        if self.op_type is OpType.update:
+            return {
+                'script': {
+                    'source': '''
+                        Stream stream = Stream.concat(ctx._source.hub_ids.stream(),
+                                                      params.hub_ids.stream());
+                        ctx._source.hub_ids = stream.sorted().distinct().collect(Collectors.toList());
+                    ''',
+                    'params': {
+                        'hub_ids': self.hub_ids
+                    }
+                }
+            }
+        else:
+            return super()._body(field_types)
 
 
 CataloguedContribution = Contribution[CataloguedEntityReference]

--- a/src/azul/indexer/index_controller.py
+++ b/src/azul/indexer/index_controller.py
@@ -191,9 +191,8 @@ class IndexController(AppController):
                             log.warning('Deletion of replicas is not supported')
                         else:
                             log.info('Writing %i replicas to index.', len(replicas))
-                            num_written, num_present = self.index_service.replicate(catalog, replicas)
-                            log.info('Successfully wrote %i replicas; %i were already present',
-                                     num_written, num_present)
+                            num_written = self.index_service.replicate(catalog, replicas)
+                            log.info('Successfully wrote %i replicas', num_written)
                     else:
                         log.info('No replicas to write.')
 

--- a/src/azul/indexer/index_controller.py
+++ b/src/azul/indexer/index_controller.py
@@ -185,10 +185,15 @@ class IndexController(AppController):
                                for entity, num_contributions in tallies.items()]
 
                     if replicas:
-                        log.info('Writing %i replicas to index.', len(replicas))
-                        num_written, num_present = self.index_service.replicate(catalog, replicas)
-                        log.info('Successfully wrote %i replicas; %i were already present',
-                                 num_written, num_present)
+                        if delete:
+                            # FIXME: Replica index does not support deletions
+                            #        https://github.com/DataBiosphere/azul/issues/5846
+                            log.warning('Deletion of replicas is not supported')
+                        else:
+                            log.info('Writing %i replicas to index.', len(replicas))
+                            num_written, num_present = self.index_service.replicate(catalog, replicas)
+                            log.info('Successfully wrote %i replicas; %i were already present',
+                                     num_written, num_present)
                     else:
                         log.info('No replicas to write.')
 

--- a/src/azul/indexer/index_service.py
+++ b/src/azul/indexer/index_service.py
@@ -227,7 +227,8 @@ class IndexService(DocumentService):
             #        number of contributions per bundle.
             # https://github.com/DataBiosphere/azul/issues/610
             tallies.update(self.contribute(catalog, contributions))
-            self.replicate(catalog, replicas)
+        # FIXME: Replica index does not support deletions
+        #        https://github.com/DataBiosphere/azul/issues/5846
         self.aggregate(tallies)
 
     def deep_transform(self,

--- a/src/azul/indexer/index_service.py
+++ b/src/azul/indexer/index_service.py
@@ -513,19 +513,26 @@ class IndexService(DocumentService):
             writer.write(replicas)
             retry_replicas = []
             for r in replicas:
-                if r.coordinates in writer.retries:
-                    conflicts = writer.conflicts[r.coordinates]
-                    if conflicts == 0:
+                if r.version_type is VersionType.create_only:
+                    if r.coordinates in writer.retries:
                         retry_replicas.append(r)
-                    elif conflicts == 1:
-                        # FIXME: Track replica hub IDs
-                        #        https://github.com/DataBiosphere/azul/issues/5360
-                        writer.conflicts.pop(r.coordinates)
-                        num_present += 1
                     else:
-                        assert False, (conflicts, r.coordinates)
+                        num_written += 1
+                elif r.version_type is VersionType.none:
+                    if r.coordinates in writer.retries:
+                        retry_replicas.append(r)
+                        conflicts = writer.conflicts[r.coordinates]
+                        if conflicts in (0, 1):
+                            num_present += conflicts
+                        else:
+                            assert False, (conflicts, r.coordinates)
+                    else:
+                        # Replica was already counted in `num_present`, so
+                        # incrementing `num_written` would result in an incorrect
+                        # final count
+                        pass
                 else:
-                    num_written += 1
+                    assert False, r.version_type
             replicas = retry_replicas
 
         writer.raise_on_errors()
@@ -856,8 +863,6 @@ class IndexWriter:
     def _write_individually(self, documents: Iterable[Document]):
         log.info('Writing documents individually')
         for doc in documents:
-            if isinstance(doc, Replica):
-                assert doc.version_type is VersionType.create_only, doc
             try:
                 method = getattr(self.es_client, doc.op_type.name)
                 method(refresh=self.refresh, **doc.to_index(self.catalog, self.field_types))
@@ -917,6 +922,8 @@ class IndexWriter:
         if isinstance(doc, Aggregate):
             log.debug('Successfully wrote %s with %i contribution(s).',
                       coordinates, doc.num_contributions)
+        elif isinstance(doc, Replica) and doc.version_type is VersionType.none:
+            log.debug('Successfully updated %s.', coordinates)
         else:
             log.debug('Successfully wrote %s.', coordinates)
 

--- a/src/azul/indexer/transform.py
+++ b/src/azul/indexer/transform.py
@@ -125,14 +125,18 @@ class Transformer(metaclass=ABCMeta):
                             source=self.bundle.fqid.source,
                             contents=contents)
 
-    def _replica(self, contents: MutableJSON, entity: EntityReference) -> Replica:
+    def _replica(self,
+                 contents: MutableJSON,
+                 entity: EntityReference,
+                 hub_ids: list[EntityID]
+                 ) -> Replica:
         coordinates = ReplicaCoordinates(content_hash=json_hash(contents).hexdigest(),
                                          entity=entity)
         return Replica(coordinates=coordinates,
                        version=None,
                        replica_type=self.replica_type(entity),
                        contents=contents,
-                       hub_ids=[])
+                       hub_ids=hub_ids)
 
     @classmethod
     @abstractmethod

--- a/src/azul/plugins/metadata/hca/indexer/transform.py
+++ b/src/azul/plugins/metadata/hca/indexer/transform.py
@@ -503,7 +503,8 @@ class BaseTransformer(Transformer, metaclass=ABCMeta):
 
     def _add_replica(self,
                      contribution: MutableJSON,
-                     entity: Union[api.Entity, DatedEntity]
+                     entity: Union[api.Entity, DatedEntity],
+                     hub_ids: list[EntityID]
                      ) -> Transform:
         entity_ref = EntityReference(entity_id=str(entity.document_id),
                                      entity_type=self.entity_type())
@@ -511,7 +512,7 @@ class BaseTransformer(Transformer, metaclass=ABCMeta):
             replica = None
         else:
             assert isinstance(entity, api.Entity), entity
-            replica = self._replica(entity.json, entity_ref)
+            replica = self._replica(entity.json, entity_ref, hub_ids)
         return self._contribution(contribution, entity_ref), replica
 
     def _find_ancestor_samples(self,
@@ -1465,7 +1466,8 @@ class FileTransformer(PartitionedTransformer[api.File]):
                         additional_contents = self.matrix_stratification_values(file)
                         for entity_type, values in additional_contents.items():
                             contents[entity_type].extend(values)
-                yield self._add_replica(contents, file)
+                hub_ids = list(map(str, visitor.files))
+                yield self._add_replica(contents, file, hub_ids)
 
     def matrix_stratification_values(self, file: api.File) -> JSON:
         """
@@ -1560,7 +1562,8 @@ class CellSuspensionTransformer(PartitionedTransformer):
                             ),
                             dates=[self._date(cell_suspension)],
                             projects=[self._project(self._api_project)])
-            yield self._add_replica(contents, cell_suspension)
+            hub_ids = list(map(str, visitor.files))
+            yield self._add_replica(contents, cell_suspension, hub_ids)
 
 
 class SampleTransformer(PartitionedTransformer):
@@ -1605,7 +1608,8 @@ class SampleTransformer(PartitionedTransformer):
                             ),
                             dates=[self._date(sample)],
                             projects=[self._project(self._api_project)])
-            yield self._add_replica(contents, sample)
+            hub_ids = list(map(str, visitor.files))
+            yield self._add_replica(contents, sample, hub_ids)
 
 
 class BundleAsEntity(DatedEntity):
@@ -1705,7 +1709,8 @@ class SingletonTransformer(BaseTransformer, metaclass=ABCMeta):
                         contributed_analyses=contributed_analyses,
                         dates=[self._date(self._singleton_entity())],
                         projects=[self._project(self._api_project)])
-        return self._add_replica(contents, self._singleton_entity())
+        hub_ids = list(map(str, visitor.files))
+        return self._add_replica(contents, self._singleton_entity(), hub_ids)
 
 
 class ProjectTransformer(SingletonTransformer):

--- a/test/indexer/__init__.py
+++ b/test/indexer/__init__.py
@@ -70,8 +70,11 @@ from es_test_case import (
 
 class ForcedRefreshIndexService(IndexService):
 
-    def _create_writer(self, catalog: Optional[CatalogName]) -> IndexWriter:
-        writer = super()._create_writer(catalog)
+    def _create_writer(self,
+                       doc_type: DocumentType,
+                       catalog: Optional[CatalogName]
+                       ) -> IndexWriter:
+        writer = super()._create_writer(doc_type, catalog)
         # With a single client thread, refresh=True is faster than
         # refresh="wait_for". The latter would limit the request rate to
         # 1/refresh_interval. That's only one request per second with

--- a/test/indexer/data/826dea02-e274-affe-aabc-eb3db63ad068.results.json
+++ b/test/indexer/data/826dea02-e274-affe-aabc-eb3db63ad068.results.json
@@ -1481,10 +1481,7 @@
         "_source": {
             "entity_id": "2370f948-2783-4eb6-afea-e022897f4dcf",
             "replica_type": "anvil_dataset",
-            "hub_ids": [
-                "15b76f9c-6b46-433f-851d-34e89f1b9ba6",
-                "3b17377b-16b1-431c-9967-e5d01fc5923f"
-            ],
+            "hub_ids": [],
             "contents": {
                 "consent_group": [
                     "DS-BDIS"

--- a/test/indexer/data/826dea02-e274-affe-aabc-eb3db63ad068.results.json
+++ b/test/indexer/data/826dea02-e274-affe-aabc-eb3db63ad068.results.json
@@ -438,7 +438,9 @@
         "_source": {
             "entity_id": "1509ef40-d1ba-440d-b298-16b7c173dcd4",
             "replica_type": "anvil_sequencingactivity",
-            "hub_ids": [],
+            "hub_ids": [
+                "15b76f9c-6b46-433f-851d-34e89f1b9ba6"
+            ],
             "contents": {
                 "activity_type": "Sequencing",
                 "assay_type": [],
@@ -868,7 +870,9 @@
         "_source": {
             "entity_id": "15b76f9c-6b46-433f-851d-34e89f1b9ba6",
             "replica_type": "anvil_file",
-            "hub_ids": [],
+            "hub_ids": [
+                "15b76f9c-6b46-433f-851d-34e89f1b9ba6"
+            ],
             "contents": {
                 "data_modality": [],
                 "datarepo_row_id": "15b76f9c-6b46-433f-851d-34e89f1b9ba6",
@@ -898,7 +902,10 @@
         "_source": {
             "entity_id": "15d85d30-ad4a-4f50-87a8-a27f59dd1b5f",
             "replica_type": "anvil_diagnosis",
-            "hub_ids": [],
+            "hub_ids": [
+                "15b76f9c-6b46-433f-851d-34e89f1b9ba6",
+                "3b17377b-16b1-431c-9967-e5d01fc5923f"
+            ],
             "contents": {
                 "datarepo_row_id": "15d85d30-ad4a-4f50-87a8-a27f59dd1b5f",
                 "diagnosis_age_lower_bound": null,
@@ -1474,7 +1481,10 @@
         "_source": {
             "entity_id": "2370f948-2783-4eb6-afea-e022897f4dcf",
             "replica_type": "anvil_dataset",
-            "hub_ids": [],
+            "hub_ids": [
+                "15b76f9c-6b46-433f-851d-34e89f1b9ba6",
+                "3b17377b-16b1-431c-9967-e5d01fc5923f"
+            ],
             "contents": {
                 "consent_group": [
                     "DS-BDIS"
@@ -1747,7 +1757,9 @@
                 "crc32": ""
             },
             "replica_type": "anvil_file",
-            "hub_ids": []
+            "hub_ids": [
+                "3b17377b-16b1-431c-9967-e5d01fc5923f"
+            ]
         }
     },
     {
@@ -2189,7 +2201,9 @@
         "_source": {
             "entity_id": "816e364e-1193-4e5b-a91a-14e4b009157c",
             "replica_type": "anvil_sequencingactivity",
-            "hub_ids": [],
+            "hub_ids": [
+                "3b17377b-16b1-431c-9967-e5d01fc5923f"
+            ],
             "contents": {
                 "activity_type": "Sequencing",
                 "assay_type": [],
@@ -2935,7 +2949,10 @@
         "_source": {
             "entity_id": "826dea02-e274-4ffe-aabc-eb3db63ad068",
             "replica_type": "anvil_biosample",
-            "hub_ids": [],
+            "hub_ids": [
+                "15b76f9c-6b46-433f-851d-34e89f1b9ba6",
+                "3b17377b-16b1-431c-9967-e5d01fc5923f"
+            ],
             "contents": {
                 "anatomical_site": null,
                 "apriori_cell_type": [],
@@ -3511,7 +3528,10 @@
         "_source": {
             "entity_id": "939a4bd3-86ed-4a8a-81f4-fbe0ee673461",
             "replica_type": "anvil_diagnosis",
-            "hub_ids": [],
+            "hub_ids": [
+                "15b76f9c-6b46-433f-851d-34e89f1b9ba6",
+                "3b17377b-16b1-431c-9967-e5d01fc5923f"
+            ],
             "contents": {
                 "datarepo_row_id": "939a4bd3-86ed-4a8a-81f4-fbe0ee673461",
                 "diagnosis_age_lower_bound": null,
@@ -4099,7 +4119,10 @@
                 "version": "2022-06-01T00:00:00.000000Z"
             },
             "replica_type": "anvil_donor",
-            "hub_ids": []
+            "hub_ids": [
+                "15b76f9c-6b46-433f-851d-34e89f1b9ba6",
+                "3b17377b-16b1-431c-9967-e5d01fc5923f"
+            ]
         }
     }
 ]

--- a/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T11:33:44.698028Z.results.json
+++ b/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T11:33:44.698028Z.results.json
@@ -3386,7 +3386,9 @@
             },
             "entity_id": "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
             "replica_type": "file",
-            "hub_ids": []
+            "hub_ids": [
+                "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb"
+            ]
         },
         "_type": "_doc"
     },
@@ -3422,7 +3424,10 @@
             },
             "entity_id": "412898c5-5b9b-4907-b07c-e9b89666e204",
             "replica_type": "cell_suspension",
-            "hub_ids": []
+            "hub_ids": [
+                "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
+                "70d1af4a-82c8-478a-8960-e9028b3616ca"
+            ]
         },
         "_type": "_doc"
     },
@@ -3451,7 +3456,9 @@
             },
             "entity_id": "70d1af4a-82c8-478a-8960-e9028b3616ca",
             "replica_type": "file",
-            "hub_ids": []
+            "hub_ids": [
+                "70d1af4a-82c8-478a-8960-e9028b3616ca"
+            ]
         },
         "_type": "_doc"
     },
@@ -3501,7 +3508,10 @@
             },
             "entity_id": "a21dc760-a500-4236-bcff-da34a0e873d2",
             "replica_type": "sample",
-            "hub_ids": []
+            "hub_ids": [
+                "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
+                "70d1af4a-82c8-478a-8960-e9028b3616ca"
+            ]
         },
         "_type": "_doc"
     },
@@ -3580,7 +3590,10 @@
             },
             "entity_id": "e8642221-4c2c-4fd7-b926-a68bce363c88",
             "replica_type": "project",
-            "hub_ids": []
+            "hub_ids": [
+                "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
+                "70d1af4a-82c8-478a-8960-e9028b3616ca"
+            ]
         },
         "_type": "_doc"
     }

--- a/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T11:33:44.698028Z.results.json
+++ b/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T11:33:44.698028Z.results.json
@@ -3590,10 +3590,7 @@
             },
             "entity_id": "e8642221-4c2c-4fd7-b926-a68bce363c88",
             "replica_type": "project",
-            "hub_ids": [
-                "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
-                "70d1af4a-82c8-478a-8960-e9028b3616ca"
-            ]
+            "hub_ids": []
         },
         "_type": "_doc"
     }

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -61,7 +61,9 @@ from azul.indexer.document import (
     EntityReference,
     EntityType,
     IndexName,
+    Replica,
     ReplicaCoordinates,
+    VersionType,
     null_bool,
     null_int,
     null_str,
@@ -2111,6 +2113,31 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         contributor['institution'] += ' || LabMED'
         with self.assertRaisesRegex(RequirementError, "'||' is disallowed"):
             self._index_bundle(bundle)
+
+    def test_replica_update(self):
+        contents = {'replica': {}}
+        coordinates = ReplicaCoordinates(content_hash=json_hash(contents).hexdigest(),
+                                         entity=CataloguedEntityReference(catalog=self.catalog,
+                                                                          entity_type='replica',
+                                                                          entity_id='foo'))
+        replica = Replica(version=None,
+                          replica_type='file',
+                          contents=contents,
+                          hub_ids=[],
+                          coordinates=coordinates)
+
+        for case, hub_ids, expected_hub_ids in [
+            ('New replica', ['1', '1'], ['1']),
+            ('Additional hub IDs', ['3', '2', '1'], ['1', '2', '3']),
+            ('Redundant hub IDs', ['1', '2'], ['1', '2', '3'])
+        ]:
+            with self.subTest(case):
+                replica.hub_ids[:] = hub_ids
+                replica.version_type = VersionType.create_only
+                self.index_service.replicate(self.catalog, [replica])
+                hit = one(self._get_all_hits())
+                self.assertEqual(hit['_id'], coordinates.document_id)
+                self.assertEqual(hit['_source']['hub_ids'], expected_hub_ids)
 
 
 class TestIndexManagement(AzulUnitTestCase):

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -63,7 +63,6 @@ from azul.indexer.document import (
     IndexName,
     Replica,
     ReplicaCoordinates,
-    VersionType,
     null_bool,
     null_int,
     null_str,
@@ -402,11 +401,8 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         expected_tallies_2[entity] = 1
         self.assertEqual(expected_tallies_2, tallies_2)
 
-        # All writes were logged as overwrites, except one. There are 1 fewer
-        # replicas than contributions.
-        num_replicas = num_contributions - 2 if config.enable_replicas else 0
-        self.assertEqual(num_contributions - 1 + num_replicas,
-                         len(logs.output))
+        # All writes were logged as overwrites, except one.
+        self.assertEqual(num_contributions - 1, len(logs.output))
         message_re = re.compile(r'^WARNING:azul\.indexer\.index_service:'
                                 r'Document .* exists. '
                                 r'Retrying with overwrite\.$')
@@ -2133,7 +2129,6 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         ]:
             with self.subTest(case):
                 replica.hub_ids[:] = hub_ids
-                replica.version_type = VersionType.create_only
                 self.index_service.replicate(self.catalog, [replica])
                 hit = one(self._get_all_hits())
                 self.assertEqual(hit['_id'], coordinates.document_id)


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=promotion.md`,
`&template=hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to
switch the template.
-->

Connected issues: #5360, #5975


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] Added `partial` label to PR <sub>or this PR completely resolves all connected issues</sub>
- [x] All connected issues are resolved partially <sub>or this PR does not have the `partial` label</sub>

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR <sub>or this PR does not require reindexing</sub>
- [x] PR and connected issue are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or this PR is not chained to another PR</sub>
- [x] Added `base` label to the blocking PR <sub>or this PR is not chained to another PR</sub>
- [x] Added `chained` label to this PR <sub>or this PR is not chained to another PR</sub>


### Author (upgrading deployments)

- [x] Ran `make image_manifests.json` and committed any resulting changes <sub>or this PR does not modify `azul_docker_images` or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `upgrade` label to PR <sub>or this PR does not require upgrading deployments</sub>


### Author (operator tasks)

- [x] Added checklist items for additional operator tasks <sub>or this PR does not require additional tasks</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the `prod` branch has no temporary hotfixes for any connected issues</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not touch requirements*.txt, common.mk, Makefile and Dockerfile</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not touch requirements*.txt</sub>
- [x] Added `reqs` label to PR <sub>or this PR does not touch requirements*.txt</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>


### Peer reviewer (after requesting changes)

Uncheck the *Author (before every review)* checklists.


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] Requested review from system administrator
- [x] PR is assigned to system administrator


### System administrator (after requesting changes)

Uncheck the *before every review* checklists. Update the `N reviews` label.


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved ticket to *Approved* column
- [x] PR is assigned to current operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] PR has checklist items for upgrading instructions <sub>or PR is not labeled `upgrade`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Deleted unreferenced indices in `hammerbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilprod`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Started reindex in `hammerbox` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for failures in `hammerbox` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Title of merge commit starts with title from this PR
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only include `p` if the PR is labeled `partial`</sub>
- [x] Moved connected issues to Merged column in ZenHub
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed merge commit to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed merge commit to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes on GitLab `dev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `dev`<sup>1</sup>
- [x] Build passes on GitLab `anvildev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvildev`<sup>1</sup>
- [x] Build passes on GitLab `anvilprod`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvilprod`<sup>1</sup>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Deleted PR branch from GitLab `anvilprod`

<sup>1</sup> When pushing the merge commit is skipped due to the PR being
labelled `no sandbox`, the next build triggered by a PR whose merge commit *is*
pushed determines this checklist item.


### Operator (reindex)

- [x] Deleted unreferenced indices in `dev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvildev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Deleted unreferenced indices in `anvilprod` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilprod`</sub>
- [x] Considered deindexing individual sources in `dev` <sub>or this PR does not merely remove sources from existing catalogs in `dev`</sub>
- [x] Considered deindexing individual sources in `anvildev` <sub>or this PR does not merely remove sources from existing catalogs in `anvildev`</sub>
- [x] Considered deindexing individual sources in `anvilprod` <sub>or this PR does not merely remove sources from existing catalogs in `anvilprod`</sub>
- [x] Considered indexing individual sources in `dev` <sub>or this PR does not merely add sources to existing catalogs in `dev`</sub>
- [x] Considered indexing individual sources in `anvildev` <sub>or this PR does not merely add sources to existing catalogs in `anvildev`</sub>
- [x] Considered indexing individual sources in `anvilprod` <sub>or this PR does not merely add sources to existing catalogs in `anvilprod`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Started reindex in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Checked for and triaged indexing failures in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for and triaged indexing failures in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for and triaged indexing failures in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Emptied fail queues in `dev` deployment <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` deployment <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `anvilprod` deployment <sub>or this PR does not require reindexing `anvilprod`</sub>


### Operator

- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
