### PR TITLE
Encode entity type in replica document ID (#5992)

### DIFF
--- a/environment.py
+++ b/environment.py
@@ -418,10 +418,6 @@ def env() -> Mapping[str, Optional[str]]:
         #
         'AZUL_SHARE_ES_DOMAIN': '0',
 
-        # Prefix to describe ES indices
-        #
-        'AZUL_INDEX_PREFIX': 'azul',
-
         # The number of nodes in the AWS-hosted Elasticsearch cluster
         #
         'AZUL_ES_INSTANCE_COUNT': None,

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -762,10 +762,6 @@ class Config:
         return int(self.environ['AZUL_ES_VOLUME_SIZE'])
 
     @property
-    def index_prefix(self) -> str:
-        return self._term_from_env('AZUL_INDEX_PREFIX')
-
-    @property
     def enable_replicas(self) -> bool:
         return self._boolean(self.environ['AZUL_ENABLE_REPLICAS'])
 

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -1199,8 +1199,8 @@ class Config:
         return cls.term_re.fullmatch(term) is not None
 
     @classmethod
-    def validate_entity_type(cls, entity_type: str) -> None:
-        cls._validate_term(entity_type, name='entity_type')
+    def validate_qualifier(cls, qualifier: str) -> None:
+        cls._validate_term(qualifier, name='qualifier')
 
     def secrets_manager_secret_name(self, *args):
         return '/'.join(['dcp', 'azul', self.deployment_stage, *args])

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -686,13 +686,13 @@ class Config:
     @classmethod
     def validate_prefix(cls, prefix):
         require(cls._is_valid_qualifier(prefix),
-                f'Prefix {prefix!r} is to short, '
+                f'Prefix {prefix!r} is too short, '
                 f'too long or contains invalid characters.')
 
     @classmethod
     def validate_deployment_name(cls, deployment_name):
         require(cls._is_valid_qualifier(deployment_name),
-                f'Deployment name {deployment_name!r} is to short, '
+                f'Deployment name {deployment_name!r} is too short, '
                 f'too long or contains invalid characters.')
 
     @classmethod

--- a/src/azul/indexer/document.py
+++ b/src/azul/indexer/document.py
@@ -1532,11 +1532,8 @@ class Replica(Document[ReplicaCoordinates[E]]):
 
     @classmethod
     def field_types(cls, field_types: FieldTypes) -> FieldTypes:
-        return {
-            **super().field_types(pass_thru_json),
-            'replica_type': pass_thru_str,
-            'hub_ids': pass_thru_str
-        }
+        # Replicas do not undergo translation
+        raise NotImplementedError
 
     def to_json(self) -> JSON:
         return dict(super().to_json(),

--- a/src/azul/indexer/document.py
+++ b/src/azul/indexer/document.py
@@ -237,7 +237,7 @@ class IndexName:
                *,
                catalog: CatalogName,
                entity_type: str,
-               doc_type: 'DocumentType'
+               doc_type: DocumentType
                ) -> Self:
         return cls(prefix=config.index_prefix,
                    version=2,

--- a/src/azul/indexer/document.py
+++ b/src/azul/indexer/document.py
@@ -401,7 +401,7 @@ class DocumentCoordinates(Generic[E], metaclass=ABCMeta):
     be generic in E, the type of EntityReference.
     """
     entity: E
-    doc_type: DocumentType
+    doc_type: ClassVar[DocumentType]
 
     @property
     def index_name(self) -> str:
@@ -465,7 +465,7 @@ class DocumentCoordinates(Generic[E], metaclass=ABCMeta):
 
 @attr.s(frozen=True, auto_attribs=True, kw_only=True, slots=True)
 class ContributionCoordinates(DocumentCoordinates[E], Generic[E]):
-    doc_type: DocumentType = attr.ib(init=False, default=DocumentType.contribution)
+    doc_type: ClassVar[DocumentType] = DocumentType.contribution
     bundle: BundleFQID
     deleted: bool
 
@@ -530,7 +530,7 @@ class AggregateCoordinates(DocumentCoordinates[CataloguedEntityReference]):
     Document coordinates for aggregates. Aggregate coordinates always carry a
     catalog.
     """
-    doc_type: DocumentType = attr.ib(init=False, default=DocumentType.aggregate)
+    doc_type: ClassVar[DocumentType] = DocumentType.aggregate
 
     @classmethod
     def _from_index(cls,
@@ -562,7 +562,7 @@ class ReplicaCoordinates(DocumentCoordinates[E], Generic[E]):
     contents of the underlying metadata document.
     """
 
-    doc_type: DocumentType = attr.ib(init=False, default=DocumentType.replica)
+    doc_type: ClassVar[DocumentType] = DocumentType.replica
 
     #: A hash of the replica's JSON document
     content_hash: str

--- a/src/azul/indexer/document.py
+++ b/src/azul/indexer/document.py
@@ -192,12 +192,12 @@ class IndexName:
         >>> IndexName(prefix='_', version=2, deployment='dev', catalog='foo', entity_type='bar')
         Traceback (most recent call last):
         ...
-        azul.RequirementError: Prefix '_' is to short, too long or contains invalid characters.
+        azul.RequirementError: Prefix '_' is too short, too long or contains invalid characters.
 
         >>> IndexName(prefix='azul', version=2, deployment='_', catalog='foo', entity_type='bar')
         Traceback (most recent call last):
         ...
-        azul.RequirementError: Deployment name '_' is to short, too long or contains invalid characters.
+        azul.RequirementError: Deployment name '_' is too short, too long or contains invalid characters.
 
         >>> IndexName(prefix='azul', version=2, deployment='dev', catalog='_', entity_type='bar')
         Traceback (most recent call last):

--- a/src/azul/indexer/document_service.py
+++ b/src/azul/indexer/document_service.py
@@ -111,4 +111,6 @@ class DocumentService:
                          *,
                          forward: bool
                          ) -> AnyMutableJSON:
-        return Document.translate_fields(doc, self.field_types(catalog), forward=forward)
+        return Document.translate_fields(doc,
+                                         self.field_types(catalog),
+                                         forward=forward)

--- a/src/azul/indexer/index_service.py
+++ b/src/azul/indexer/index_service.py
@@ -80,6 +80,7 @@ from azul.indexer.document import (
     IndexName,
     OpType,
     Replica,
+    ReplicaCoordinates,
     VersionType,
 )
 from azul.indexer.document_service import (
@@ -177,7 +178,7 @@ class IndexService(DocumentService):
         ] + (
             [
                 IndexName.create(catalog=catalog,
-                                 qualifier='replica',
+                                 qualifier=ReplicaCoordinates.index_qualifier,
                                  doc_type=DocumentType.replica)
             ]
             if config.enable_replicas else

--- a/src/azul/indexer/index_service.py
+++ b/src/azul/indexer/index_service.py
@@ -638,11 +638,15 @@ class IndexService(DocumentService):
         log.info('Read %i contribution(s)', len(contributions))
         if log.isEnabledFor(logging.DEBUG):
             entity_ref = attrgetter('entity')
+            contributions_by_entity = cast(
+                Iterator[tuple[EntityReference, Iterator[Contribution]]],
+                groupby(sorted(contributions, key=entity_ref), key=entity_ref)
+            )
             log.debug(
                 'Number of contributions read, by entity: %r',
                 {
                     f'{entity.entity_type}/{entity.entity_id}': sum(1 for _ in contribution_group)
-                    for entity, contribution_group in groupby(sorted(contributions, key=entity_ref), key=entity_ref)
+                    for entity, contribution_group in contributions_by_entity
                 }
             )
         return contributions

--- a/src/azul/indexer/index_service.py
+++ b/src/azul/indexer/index_service.py
@@ -401,8 +401,8 @@ class IndexService(DocumentService):
     def delete_indices(self, catalog: CatalogName):
         es_client = ESClientFactory.get()
         for index_name in self.index_names(catalog):
-            if es_client.indices.exists(index=index_name):
-                es_client.indices.delete(index=index_name)
+            if es_client.indices.exists(index=str(index_name)):
+                es_client.indices.delete(index=str(index_name))
 
     def contribute(self,
                    catalog: CatalogName,

--- a/src/azul/indexer/index_service.py
+++ b/src/azul/indexer/index_service.py
@@ -170,14 +170,14 @@ class IndexService(DocumentService):
     def index_names(self, catalog: CatalogName) -> list[IndexName]:
         return [
             IndexName.create(catalog=catalog,
-                             entity_type=entity_type,
+                             qualifier=entity_type,
                              doc_type=doc_type)
             for entity_type in self.entity_types(catalog)
             for doc_type in (DocumentType.contribution, DocumentType.aggregate)
         ] + (
             [
                 IndexName.create(catalog=catalog,
-                                 entity_type='replica',
+                                 qualifier='replica',
                                  doc_type=DocumentType.replica)
             ]
             if config.enable_replicas else
@@ -581,7 +581,7 @@ class IndexService(DocumentService):
         entity_ids_by_index: dict[str, MutableSet[str]] = defaultdict(set)
         for entity in tallies.keys():
             index = str(IndexName.create(catalog=entity.catalog,
-                                         entity_type=entity.entity_type,
+                                         qualifier=entity.entity_type,
                                          doc_type=DocumentType.contribution))
             entity_ids_by_index[index].add(entity.entity_id)
 

--- a/src/azul/indexer/transform.py
+++ b/src/azul/indexer/transform.py
@@ -127,8 +127,7 @@ class Transformer(metaclass=ABCMeta):
 
     def _replica(self, contents: MutableJSON, entity: EntityReference) -> Replica:
         coordinates = ReplicaCoordinates(content_hash=json_hash(contents).hexdigest(),
-                                         entity=attr.evolve(entity,
-                                                            entity_type='replica'))
+                                         entity=entity)
         return Replica(coordinates=coordinates,
                        version=None,
                        replica_type=self.replica_type(entity),

--- a/src/azul/indexer/transform.py
+++ b/src/azul/indexer/transform.py
@@ -57,7 +57,8 @@ class Transformer(metaclass=ABCMeta):
     @abstractmethod
     def replica_type(self, entity: EntityReference) -> str:
         """
-        The type of replica emitted by this transformer.
+        The name of the type of replica emitted by this transformer for a given
+        entity.
 
         See :py:attr:`Replica.replica_type`
         """

--- a/src/azul/plugins/metadata/hca/indexer/transform.py
+++ b/src/azul/plugins/metadata/hca/indexer/transform.py
@@ -512,10 +512,7 @@ class BaseTransformer(Transformer, metaclass=ABCMeta):
         else:
             assert isinstance(entity, api.Entity), entity
             replica = self._replica(entity.json, entity_ref)
-        return (
-            self._contribution(contribution, entity_ref),
-            replica
-        )
+        return self._contribution(contribution, entity_ref), replica
 
     def _find_ancestor_samples(self,
                                entity: api.LinkedEntity,

--- a/src/azul/service/elasticsearch_service.py
+++ b/src/azul/service/elasticsearch_service.py
@@ -671,5 +671,5 @@ class ElasticsearchService(DocumentService):
         """
         return Search(using=self._es_client,
                       index=str(IndexName.create(catalog=catalog,
-                                                 entity_type=entity_type,
+                                                 qualifier=entity_type,
                                                  doc_type=DocumentType.aggregate)))

--- a/src/azul/service/elasticsearch_service.py
+++ b/src/azul/service/elasticsearch_service.py
@@ -661,7 +661,10 @@ class ElasticsearchService(DocumentService):
                              document_slice=document_slice).wrap(chain)
         return chain
 
-    def create_request(self, catalog, entity_type) -> Search:
+    def create_request(self,
+                       catalog: CatalogName,
+                       entity_type: str
+                       ) -> Search:
         """
         Create an Elasticsearch request against the index containing aggregate
         documents for the given entity type in the given catalog.

--- a/test/indexer/__init__.py
+++ b/test/indexer/__init__.py
@@ -191,12 +191,12 @@ class IndexerTestCase(CatalogTestCase,
             )
 
         for hit in hits:
-            entity_type, doc_type = self._parse_index_name(hit)
+            qualifier, doc_type = self._parse_index_name(hit)
             if not (
                 # Replicas may contain (intentionally) unsorted metadata
                 doc_type is DocumentType.replica
                 # DUOS contributions contain no lists
-                or is_duos_contribution(entity_type, doc_type)
+                or is_duos_contribution(qualifier, doc_type)
             ):
                 self._verify_sorted_lists(hit['_source'])
         return hits
@@ -204,7 +204,7 @@ class IndexerTestCase(CatalogTestCase,
     def _parse_index_name(self, hit) -> tuple[str, DocumentType]:
         index_name = IndexName.parse(hit['_index'])
         index_name.validate()
-        return index_name.entity_type, index_name.doc_type
+        return index_name.qualifier, index_name.doc_type
 
     def _load_canned_result(self, bundle_fqid: BundleFQID) -> MutableJSONs:
         """
@@ -216,7 +216,7 @@ class IndexerTestCase(CatalogTestCase,
         for hit in expected_hits:
             index_name = IndexName.parse(hit['_index'])
             index_name = IndexName.create(catalog=self.catalog,
-                                          entity_type=index_name.entity_type,
+                                          qualifier=index_name.qualifier,
                                           doc_type=index_name.doc_type)
             hit['_index'] = str(index_name)
         return expected_hits

--- a/test/indexer/data/826dea02-e274-affe-aabc-eb3db63ad068.results.json
+++ b/test/indexer/data/826dea02-e274-affe-aabc-eb3db63ad068.results.json
@@ -433,7 +433,7 @@
     {
         "_index": "azul_v2_nadove4_test_replica",
         "_type": "_doc",
-        "_id": "1509ef40-d1ba-440d-b298-16b7c173dcd4_e7a2881e67a92734fcf2f98e7f2c215a5b6c0a6d",
+        "_id": "sequencingactivity_1509ef40-d1ba-440d-b298-16b7c173dcd4_e7a2881e67a92734fcf2f98e7f2c215a5b6c0a6d",
         "_score": 1.0,
         "_source": {
             "entity_id": "1509ef40-d1ba-440d-b298-16b7c173dcd4",
@@ -863,7 +863,7 @@
     {
         "_index": "azul_v2_nadove4_test_replica",
         "_type": "_doc",
-        "_id": "15b76f9c-6b46-433f-851d-34e89f1b9ba6_ed0a841f18d24d3955ace40a353ad640e1da60f1",
+        "_id": "file_15b76f9c-6b46-433f-851d-34e89f1b9ba6_ed0a841f18d24d3955ace40a353ad640e1da60f1",
         "_score": 1.0,
         "_source": {
             "entity_id": "15b76f9c-6b46-433f-851d-34e89f1b9ba6",
@@ -893,7 +893,7 @@
     {
         "_index": "azul_v2_nadove4_test_replica",
         "_type": "_doc",
-        "_id": "15d85d30-ad4a-4f50-87a8-a27f59dd1b5f_92347daeeff2cbb94cd3bf9f73bb40e8c52a1e40",
+        "_id": "diagnosis_15d85d30-ad4a-4f50-87a8-a27f59dd1b5f_92347daeeff2cbb94cd3bf9f73bb40e8c52a1e40",
         "_score": 1.0,
         "_source": {
             "entity_id": "15d85d30-ad4a-4f50-87a8-a27f59dd1b5f",
@@ -1469,7 +1469,7 @@
     {
         "_index": "azul_v2_nadove4_test_replica",
         "_type": "_doc",
-        "_id": "2370f948-2783-4eb6-afea-e022897f4dcf_f10ae38d485330bf8fc7a95f7eb06626b984ad6a",
+        "_id": "dataset_2370f948-2783-4eb6-afea-e022897f4dcf_f10ae38d485330bf8fc7a95f7eb06626b984ad6a",
         "_score": 1.0,
         "_source": {
             "entity_id": "2370f948-2783-4eb6-afea-e022897f4dcf",
@@ -1723,7 +1723,7 @@
     {
         "_index": "azul_v2_nadove4_test_replica",
         "_type": "_doc",
-        "_id": "3b17377b-16b1-431c-9967-e5d01fc5923f_33d8fab596f5af223936ba8f7ef6d218e4932cde",
+        "_id": "file_3b17377b-16b1-431c-9967-e5d01fc5923f_33d8fab596f5af223936ba8f7ef6d218e4932cde",
         "_score": 1.0,
         "_source": {
             "entity_id": "3b17377b-16b1-431c-9967-e5d01fc5923f",
@@ -2184,7 +2184,7 @@
     {
         "_index": "azul_v2_nadove4_test_replica",
         "_type": "_doc",
-        "_id": "816e364e-1193-4e5b-a91a-14e4b009157c_5eabdcb475879b310467a4d8c31cab38deff5e6f",
+        "_id": "sequencingactivity_816e364e-1193-4e5b-a91a-14e4b009157c_5eabdcb475879b310467a4d8c31cab38deff5e6f",
         "_score": 1.0,
         "_source": {
             "entity_id": "816e364e-1193-4e5b-a91a-14e4b009157c",
@@ -2930,7 +2930,7 @@
     {
         "_index": "azul_v2_nadove4_test_replica",
         "_type": "_doc",
-        "_id": "826dea02-e274-4ffe-aabc-eb3db63ad068_a990d631b61245811f3401dfa59a2d47edac01a5",
+        "_id": "biosample_826dea02-e274-4ffe-aabc-eb3db63ad068_a990d631b61245811f3401dfa59a2d47edac01a5",
         "_score": 1.0,
         "_source": {
             "entity_id": "826dea02-e274-4ffe-aabc-eb3db63ad068",
@@ -3506,7 +3506,7 @@
     {
         "_index": "azul_v2_nadove4_test_replica",
         "_type": "_doc",
-        "_id": "939a4bd3-86ed-4a8a-81f4-fbe0ee673461_0a85e766a03e5aedfa1bbcf0932e376dba5cd431",
+        "_id": "diagnosis_939a4bd3-86ed-4a8a-81f4-fbe0ee673461_0a85e766a03e5aedfa1bbcf0932e376dba5cd431",
         "_score": 1.0,
         "_source": {
             "entity_id": "939a4bd3-86ed-4a8a-81f4-fbe0ee673461",
@@ -4080,7 +4080,7 @@
     {
         "_index": "azul_v2_nadove4_test_replica",
         "_type": "_doc",
-        "_id": "bfd991f2-2797-4083-972a-da7c6d7f1b2e_ef7dbf88444d1f5f24e887821dbae7d1dc182e55",
+        "_id": "donor_bfd991f2-2797-4083-972a-da7c6d7f1b2e_ef7dbf88444d1f5f24e887821dbae7d1dc182e55",
         "_score": 1.0,
         "_source": {
             "entity_id": "bfd991f2-2797-4083-972a-da7c6d7f1b2e",

--- a/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T11:33:44.698028Z.results.json
+++ b/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T11:33:44.698028Z.results.json
@@ -3362,7 +3362,7 @@
         }
     },
     {
-        "_id": "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb_4628c80cede8a4dd39584f8b50619edacc7f62e7",
+        "_id": "files_0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb_4628c80cede8a4dd39584f8b50619edacc7f62e7",
         "_index": "azul_v2_dev_test_replica",
         "_score": 1.0,
         "_source": {
@@ -3391,7 +3391,7 @@
         "_type": "_doc"
     },
     {
-        "_id": "412898c5-5b9b-4907-b07c-e9b89666e204_f8ca7504548249c223277135af497beb5fba29df",
+        "_id": "cell_suspensions_412898c5-5b9b-4907-b07c-e9b89666e204_f8ca7504548249c223277135af497beb5fba29df",
         "_index": "azul_v2_dev_test_replica",
         "_score": 1.0,
         "_source": {
@@ -3427,7 +3427,7 @@
         "_type": "_doc"
     },
     {
-        "_id": "70d1af4a-82c8-478a-8960-e9028b3616ca_8ee6fbddb7c933ebe39b31b977c51af21687f036",
+        "_id": "files_70d1af4a-82c8-478a-8960-e9028b3616ca_8ee6fbddb7c933ebe39b31b977c51af21687f036",
         "_index": "azul_v2_dev_test_replica",
         "_score": 1.0,
         "_source": {
@@ -3456,7 +3456,7 @@
         "_type": "_doc"
     },
     {
-        "_id": "a21dc760-a500-4236-bcff-da34a0e873d2_0bb754590d94de62d6fb15bdbac5f64f54072cb0",
+        "_id": "samples_a21dc760-a500-4236-bcff-da34a0e873d2_0bb754590d94de62d6fb15bdbac5f64f54072cb0",
         "_index": "azul_v2_dev_test_replica",
         "_score": 1.0,
         "_source": {
@@ -3506,7 +3506,7 @@
         "_type": "_doc"
     },
     {
-        "_id": "e8642221-4c2c-4fd7-b926-a68bce363c88_42d51043dcd0030b5ee9ce47fa30c85bcc92bac6",
+        "_id": "projects_e8642221-4c2c-4fd7-b926-a68bce363c88_42d51043dcd0030b5ee9ce47fa30c85bcc92bac6",
         "_index": "azul_v2_dev_test_replica",
         "_score": 1.0,
         "_source": {

--- a/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T11:33:44.698028Z.results.json
+++ b/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T11:33:44.698028Z.results.json
@@ -1,6 +1,6 @@
 [
     {
-        "_index": "azul_bundles_dev",
+        "_index": "azul_v2_dev_test_bundles",
         "_type": "_doc",
         "_id": "aaa96233-bf27-44c7-82df-b4dc15ad4d9d_aaa96233-bf27-44c7-82df-b4dc15ad4d9d_2018-11-02T11:33:44.698028Z_exists",
         "_ignored": ["contents.projects.project_description.keyword"],
@@ -270,7 +270,7 @@
         }
     },
     {
-        "_index": "azul_files_dev",
+        "_index": "azul_v2_dev_test_files",
         "_type": "_doc",
         "_id": "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb_aaa96233-bf27-44c7-82df-b4dc15ad4d9d_2018-11-02T11:33:44.698028Z_exists",
         "_ignored": ["contents.projects.project_description.keyword"],
@@ -513,7 +513,7 @@
         }
     },
     {
-        "_index": "azul_files_dev",
+        "_index": "azul_v2_dev_test_files",
         "_type": "_doc",
         "_id": "70d1af4a-82c8-478a-8960-e9028b3616ca_aaa96233-bf27-44c7-82df-b4dc15ad4d9d_2018-11-02T11:33:44.698028Z_exists",
         "_ignored": ["contents.projects.project_description.keyword"],
@@ -756,7 +756,7 @@
         }
     },
     {
-        "_index": "azul_samples_dev",
+        "_index": "azul_v2_dev_test_samples",
         "_type": "_doc",
         "_id": "a21dc760-a500-4236-bcff-da34a0e873d2_aaa96233-bf27-44c7-82df-b4dc15ad4d9d_2018-11-02T11:33:44.698028Z_exists",
         "_ignored": ["contents.projects.project_description.keyword"],
@@ -1024,7 +1024,7 @@
         }
     },
     {
-        "_index": "azul_projects_dev",
+        "_index": "azul_v2_dev_test_projects",
         "_type": "_doc",
         "_id": "e8642221-4c2c-4fd7-b926-a68bce363c88_aaa96233-bf27-44c7-82df-b4dc15ad4d9d_2018-11-02T11:33:44.698028Z_exists",
         "_ignored": ["contents.projects.project_description.keyword"],
@@ -1294,7 +1294,7 @@
         }
     },
     {
-        "_index": "azul_bundles_aggregate_dev",
+        "_index": "azul_v2_dev_test_bundles_aggregate",
         "_type": "_doc",
         "_id": "aaa96233-bf27-44c7-82df-b4dc15ad4d9d",
         "_score": 1.0,
@@ -1621,7 +1621,7 @@
         }
     },
     {
-        "_index": "azul_files_aggregate_dev",
+        "_index": "azul_v2_dev_test_files_aggregate",
         "_type": "_doc",
         "_id": "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
         "_score": 1.0,
@@ -1921,7 +1921,7 @@
         }
     },
     {
-        "_index": "azul_files_aggregate_dev",
+        "_index": "azul_v2_dev_test_files_aggregate",
         "_type": "_doc",
         "_id": "70d1af4a-82c8-478a-8960-e9028b3616ca",
         "_score": 1.0,
@@ -2221,7 +2221,7 @@
         }
     },
     {
-        "_index": "azul_samples_aggregate_dev",
+        "_index": "azul_v2_dev_test_samples_aggregate",
         "_type": "_doc",
         "_id": "a21dc760-a500-4236-bcff-da34a0e873d2",
         "_score": 1.0,
@@ -2481,7 +2481,7 @@
         }
     },
     {
-        "_index": "azul_projects_aggregate_dev",
+        "_index": "azul_v2_dev_test_projects_aggregate",
         "_type": "_doc",
         "_id": "e8642221-4c2c-4fd7-b926-a68bce363c88",
         "_ignored": ["contents.projects.project_description.keyword"],
@@ -2808,7 +2808,7 @@
         }
     },
     {
-        "_index": "azul_cell_suspensions_dev",
+        "_index": "azul_v2_dev_test_cell_suspensions",
         "_type": "_doc",
         "_id": "412898c5-5b9b-4907-b07c-e9b89666e204_aaa96233-bf27-44c7-82df-b4dc15ad4d9d_2018-11-02T11:33:44.698028Z_exists",
         "_ignored": ["contents.projects.project_description.keyword"],
@@ -3076,7 +3076,7 @@
         }
     },
     {
-        "_index": "azul_cell_suspensions_aggregate_dev",
+        "_index": "azul_v2_dev_test_cell_suspensions_aggregate",
         "_type": "_doc",
         "_id": "412898c5-5b9b-4907-b07c-e9b89666e204",
         "_score": 1.0,

--- a/test/indexer/test_anvil.py
+++ b/test/indexer/test_anvil.py
@@ -119,7 +119,7 @@ class TestAnvilIndexer(AnvilIndexerTestCase, TDRPluginTestCase[tdr_anvil.Plugin]
                         self._index_canned_bundle(bundle)
                         hits = self._get_all_hits()
                         hits.sort(key=itemgetter('_id'))
-                        self.assertEqual(expected_hits, hits)
+                        self.assertElasticEqual(expected_hits, hits)
                     finally:
                         self.index_service.delete_indices(self.catalog)
 

--- a/test/indexer/test_anvil.py
+++ b/test/indexer/test_anvil.py
@@ -167,12 +167,12 @@ class TestAnvilIndexerWithIndexesSetUp(AnvilIndexerTestCase):
         hits = self._get_all_hits()
         doc_counts: dict[DocumentType, int] = defaultdict(int)
         for hit in hits:
-            entity_type, doc_type = self._parse_index_name(hit)
-            if entity_type == 'bundles':
+            qualifier, doc_type = self._parse_index_name(hit)
+            if qualifier == 'bundles':
                 continue
-            elif entity_type in {'datasets', 'replica'}:
+            elif qualifier in {'datasets', 'replica'}:
                 doc_counts[doc_type] += 1
-                if entity_type == 'datasets' and doc_type is DocumentType.aggregate:
+                if qualifier == 'datasets' and doc_type is DocumentType.aggregate:
                     self.assertEqual(2, hit['_source']['num_contributions'])
                     self.assertEqual(sorted(b.uuid for b in bundles),
                                      sorted(b['uuid'] for b in hit['_source']['bundles']))
@@ -183,7 +183,7 @@ class TestAnvilIndexerWithIndexesSetUp(AnvilIndexerTestCase):
                     # This field is populated only in the DUOS bundle
                     self.assertEqual('Study description from DUOS', contents['description'])
             else:
-                self.fail(entity_type)
+                self.fail(qualifier)
         self.assertDictEqual(doc_counts, {
             DocumentType.aggregate: 1,
             DocumentType.contribution: 2,

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -380,7 +380,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         if config.enable_replicas:
             coordinates.append(
                 ReplicaCoordinates(
-                    entity=attr.evolve(entity, entity_type='replica'),
+                    entity=entity,
                     content_hash=json_hash(entity_contents).hexdigest()
                 ).with_catalog(self.catalog)
             )

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -129,11 +129,6 @@ class DCP1IndexerTestCase(DCP1CannedBundleTestCase, IndexerTestCase):
     def metadata_plugin(self) -> MetadataPlugin:
         return MetadataPlugin.load(self.catalog).create()
 
-    def _parse_index_name(self, hit) -> tuple[str, DocumentType]:
-        index_name = IndexName.parse(hit['_index'])
-        index_name.validate()
-        return index_name.entity_type, index_name.doc_type
-
     def _num_expected_replicas(self,
                                num_contribs: int,
                                num_bundles: int = 1

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -224,7 +224,7 @@ class TestDCP1Indexer(DCP1IndexerTestCase):
                                         contributions = []
                                         replicas = []
                                         for hit in hits:
-                                            entity_type, doc_type = self._parse_index_name(hit)
+                                            qualifier, doc_type = self._parse_index_name(hit)
                                             if doc_type is DocumentType.replica:
                                                 entity_id = ReplicaCoordinates.from_hit(hit).entity.entity_id
                                                 replicas.append(entity_id)
@@ -241,7 +241,7 @@ class TestDCP1Indexer(DCP1IndexerTestCase):
                                                 # plugin, verbatim
                                                 actual = hit['_source']['contents']
                                                 self.assertEqual(expected, actual)
-                                            elif doc_type is DocumentType.contribution and entity_type != 'bundles':
+                                            elif doc_type is DocumentType.contribution and qualifier != 'bundles':
                                                 entity_id = ContributionCoordinates.from_hit(hit).entity.entity_id
                                                 contributions.append(entity_id)
                                         contributions.sort()
@@ -278,7 +278,7 @@ class TestDCP1Indexer(DCP1IndexerTestCase):
                     hits = self._get_all_hits()
                     self._assert_hit_counts(hits, size)
                     for hit in hits:
-                        entity_type, doc_type = self._parse_index_name(hit)
+                        qualifier, doc_type = self._parse_index_name(hit)
                         if doc_type is DocumentType.aggregate:
                             doc = aggregate_cls.from_index(field_types, hit)
                             self.assertNotEqual(doc.contents, {})
@@ -304,7 +304,7 @@ class TestDCP1Indexer(DCP1IndexerTestCase):
                                             num_replicas=self._num_expected_replicas(size))
                     docs_by_entity: dict[EntityReference, list[Contribution]] = defaultdict(list)
                     for hit in hits:
-                        entity_type, doc_type = self._parse_index_name(hit)
+                        qualifier, doc_type = self._parse_index_name(hit)
                         if doc_type is DocumentType.contribution:
                             doc = Contribution.from_index(field_types, hit)
                             docs_by_entity[doc.entity].append(doc)
@@ -345,8 +345,8 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
                      entity_type: Optional[EntityType] = None,
                      ) -> Iterable[JSON]:
         for hit in hits:
-            hit_entity_type, hit_doc_type = self._parse_index_name(hit)
-            if entity_type in (None, hit_entity_type) and doc_type in (None, hit_doc_type):
+            qualifier, hit_doc_type = self._parse_index_name(hit)
+            if entity_type in (None, qualifier) and doc_type in (None, hit_doc_type):
                 yield hit
 
     def test_duplicate_notification(self):
@@ -1018,7 +1018,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         self._index_canned_bundle(bundle)
         hits = self._get_all_hits()
         for hit in hits:
-            entity_type, doc_type = self._parse_index_name(hit)
+            qualifier, doc_type = self._parse_index_name(hit)
             contents = hit['_source']['contents']
             for file in contents.get('files', ()):
                 if file['file_format'] == 'Rds':
@@ -1029,7 +1029,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
                     expected_cell_count = self.translated_bool_null
                 if (
                     doc_type is DocumentType.aggregate and
-                    entity_type not in ('bundles', 'files')
+                    qualifier not in ('bundles', 'files')
                 ):
                     expected_source = [expected_source]
                 self.assertEqual(expected_source, file['file_source'])
@@ -1049,9 +1049,9 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         files = set()
         contributed_analyses = set()
         for hit in hits:
-            entity_type, doc_type = self._parse_index_name(hit)
+            qualifier, doc_type = self._parse_index_name(hit)
             contents = hit['_source']['contents']
-            if entity_type == 'files' and doc_type in (DocumentType.aggregate, DocumentType.contribution):
+            if qualifier == 'files' and doc_type in (DocumentType.aggregate, DocumentType.contribution):
                 file = one(contents['files'])
                 files.add(
                     (
@@ -1060,7 +1060,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
                         null_bool.from_index(file['is_intermediate'])
                     )
                 )
-            elif entity_type == 'projects' and doc_type is DocumentType.aggregate:
+            elif qualifier == 'projects' and doc_type is DocumentType.aggregate:
                 self.assertEqual([], contents['matrices'])
                 for file in one(contents['contributed_analyses'])['file']:
                     contributed_analyses.add(
@@ -1110,27 +1110,27 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         self._assert_hit_counts(hits, sum(num_expected.values()))
         num_contribs, num_aggregates = Counter(), Counter()
         for hit in hits:
-            entity_type, doc_type = self._parse_index_name(hit)
+            qualifier, doc_type = self._parse_index_name(hit)
             source = hit['_source']
             contents = source['contents']
             if doc_type is DocumentType.aggregate:
-                num_aggregates[entity_type] += 1
+                num_aggregates[qualifier] += 1
                 bundle = one(source['bundles'])
                 actual_fqid = self.bundle_fqid(uuid=bundle['uuid'],
                                                version=bundle['version'])
                 self.assertEqual(analysis_bundle, actual_fqid)
-                if entity_type == 'files':
+                if qualifier == 'files':
                     self.assertEqual(1, len(contents['files']))
-                elif entity_type == 'bundles':
+                elif qualifier == 'bundles':
                     self.assertEqual(num_files, len(contents['files']))
                 else:
                     self.assertEqual(num_files, sum(file['count'] for file in contents['files']))
             elif doc_type is DocumentType.contribution:
-                num_contribs[entity_type] += 1
+                num_contribs[qualifier] += 1
                 actual_fqid = self.bundle_fqid(uuid=source['bundle_uuid'],
                                                version=source['bundle_version'])
                 self.assertEqual(analysis_bundle, actual_fqid)
-                self.assertEqual(1 if entity_type == 'files' else num_files, len(contents['files']))
+                self.assertEqual(1 if qualifier == 'files' else num_files, len(contents['files']))
             elif doc_type is DocumentType.replica:
                 continue
             else:
@@ -1193,7 +1193,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
                                 num_replicas=num_replicas)
         hits_by_id = {}
         for hit in hits:
-            entity_type, doc_type = self._parse_index_name(hit)
+            qualifier, doc_type = self._parse_index_name(hit)
             if (
                 doc_type is DocumentType.replica
                 or (doc_type is DocumentType.aggregate and ignore_aggregates)
@@ -1216,7 +1216,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
                 self.assertEqual('Single cell transcriptome patterns.', get(project['project_title']))
                 self.assertEqual('Single of human pancreas', get(project['project_short_name']))
                 self.assertIn('John Dear', get(project['laboratory']))
-                if doc_type is DocumentType.aggregate and entity_type != 'projects':
+                if doc_type is DocumentType.aggregate and qualifier != 'projects':
                     self.assertIn('Farmers Trucks', project['institutions'])
                 elif doc_type is DocumentType.contribution:
                     self.assertIn('Farmers Trucks', [c.get('institution') for c in project['contributors']])
@@ -1261,7 +1261,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
                 assert False, doc_type
 
         for hit in hits:
-            entity_type, doc_type = self._parse_index_name(hit)
+            qualifier, doc_type = self._parse_index_name(hit)
             if doc_type is DocumentType.replica:
                 continue
             source = hit['_source']
@@ -1284,7 +1284,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
                 self.assertNotEqual(old_project['project_title'], project['project_title'])
                 self.assertNotEqual(old_project['project_short_name'], project['project_short_name'])
                 self.assertNotEqual(old_project['laboratory'], project['laboratory'])
-                if doc_type is DocumentType.aggregate and entity_type != 'projects':
+                if doc_type is DocumentType.aggregate and qualifier != 'projects':
                     self.assertNotEqual(old_project['institutions'], project['institutions'])
                 elif doc_type is DocumentType.contribution:
                     self.assertNotEqual(old_project['contributors'], project['contributors'])
@@ -1298,7 +1298,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
                              get(project['project_short_name']))
             self.assertNotIn('Sarah Teichmann', project['laboratory'])
             self.assertIn('Molecular Atlas', project['laboratory'])
-            if doc_type is DocumentType.aggregate and entity_type != 'projects':
+            if doc_type is DocumentType.aggregate and qualifier != 'projects':
                 self.assertNotIn('Farmers Trucks', project['institutions'])
             elif doc_type is DocumentType.contribution:
                 self.assertNotIn('Farmers Trucks', [c.get('institution') for c in project['contributors']])
@@ -1353,18 +1353,18 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
                                 num_replicas=self._num_expected_replicas(num_contribs=num_contribs - 1,
                                                                          num_bundles=2))
         for hit in hits:
-            entity_type, doc_type = self._parse_index_name(hit)
+            qualifier, doc_type = self._parse_index_name(hit)
             if doc_type is DocumentType.replica:
                 continue
             contents = hit['_source']['contents']
             if doc_type is DocumentType.aggregate:
                 self.assertEqual(hit['_id'], hit['_source']['entity_id'])
-            if entity_type == 'files':
+            if qualifier == 'files':
                 contents = hit['_source']['contents']
                 self.assertEqual(1, len(contents['files']))
                 if doc_type is DocumentType.aggregate:
                     file_uuids.add(contents['files'][0]['uuid'])
-            elif entity_type in ('samples', 'projects'):
+            elif qualifier in ('samples', 'projects'):
                 if doc_type is DocumentType.aggregate:
                     self.assertEqual(2, len(hit['_source']['bundles']))
                     # All four files are fastqs so they are grouped together
@@ -1373,13 +1373,13 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
                     self.assertEqual(2, len(contents['files']))
                 else:
                     assert False, doc_type
-            elif entity_type == 'bundles':
+            elif qualifier == 'bundles':
                 if doc_type is DocumentType.aggregate:
                     self.assertEqual(1, len(hit['_source']['bundles']))
                     self.assertEqual(2, len(contents['files']))
                 else:
                     self.assertEqual(2, len(contents['files']))
-            elif entity_type == 'cell_suspensions':
+            elif qualifier == 'cell_suspensions':
                 if doc_type is DocumentType.aggregate:
                     self.assertEqual(1, len(hit['_source']['bundles']))
                     self.assertEqual(1, len(contents['files']))
@@ -1406,8 +1406,8 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         hits = self._get_all_hits()
         zarrs = []
         for hit in hits:
-            entity_type, doc_type = self._parse_index_name(hit)
-            if entity_type == 'files':
+            qualifier, doc_type = self._parse_index_name(hit)
+            if qualifier == 'files':
                 file = one(hit['_source']['contents']['files'])
                 if len(file['related_files']) > 0:
                     self.assertEqual(file['file_format'], 'matrix')
@@ -1438,18 +1438,18 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         file_names, aggregate_file_names = set(), set()
         entities_with_matrix_files = set()
         for hit in hits:
-            entity_type, doc_type = self._parse_index_name(hit)
+            qualifier, doc_type = self._parse_index_name(hit)
             if doc_type is DocumentType.replica:
                 continue
             files = hit['_source']['contents']['files']
             if doc_type is DocumentType.aggregate:
-                if entity_type == 'files':
+                if qualifier == 'files':
                     aggregate_file_names.add(one(files)['name'])
                 else:
                     for file in files:
                         # FIXME: need for one() is odd, file_format is a group field
                         #        https://github.com/DataBiosphere/azul/issues/612
-                        if entity_type == 'bundles':
+                        if qualifier == 'bundles':
                             if file['file_format'] == 'matrix':
                                 entities_with_matrix_files.add(hit['_source']['entity_id'])
                         else:
@@ -1481,12 +1481,12 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         expected_cell_count = 380
         documents_with_cell_suspension = 0
         for hit in hits:
-            entity_type, doc_type = self._parse_index_name(hit)
+            qualifier, doc_type = self._parse_index_name(hit)
             contents = hit['_source']['contents']
             if doc_type is DocumentType.replica:
                 continue
             cell_suspensions = contents['cell_suspensions']
-            if entity_type == 'files' and contents['files'][0]['file_format'] == 'pdf':
+            if qualifier == 'files' and contents['files'][0]['file_format'] == 'pdf':
                 # The PDF files in that bundle aren't linked to a specimen
                 self.assertEqual(0, len(cell_suspensions))
             else:
@@ -1508,7 +1508,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
                 for cell_suspension in cell_suspensions:
                     self.assertEqual({'bone marrow', 'temporal lobe'}, set(cell_suspension['organ_part']))
                     self.assertEqual({'Plasma cells'}, set(cell_suspension['selected_cell_type']))
-                if entity_type == 'cell_suspensions':
+                if qualifier == 'cell_suspensions':
                     counted_cell_count += one(cell_suspensions)['total_estimated_cells']
                     self.assertEqual(1, len(cell_suspensions))
                 else:
@@ -1537,7 +1537,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         self.assertGreater(len(hits), 0)
         for hit in hits:
             contents = hit['_source']['contents']
-            entity_type, doc_type = self._parse_index_name(hit)
+            qualifier, doc_type = self._parse_index_name(hit)
             if doc_type is DocumentType.aggregate:
                 cell_suspensions = contents['cell_suspensions']
                 self.assertEqual(1, len(cell_suspensions))
@@ -1546,7 +1546,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
                 # why each data file and bundle should only have a cell count of
                 # 1. Both bundles refer to the same specimen and project, so the
                 # cell count for those should be 2.
-                expected_cells = 1 if entity_type in ('files', 'cell_suspensions', 'bundles') else 2
+                expected_cells = 1 if qualifier in ('files', 'cell_suspensions', 'bundles') else 2
                 self.assertEqual(expected_cells, cell_suspensions[0]['total_estimated_cells'])
                 self.assertEqual(one(contents['analysis_protocols'])['workflow'], ['smartseq2_v2.1.0'])
             elif doc_type is DocumentType.contribution:
@@ -1570,7 +1570,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         hits = self._get_all_hits()
         self.assertGreater(len(hits), 0)
         for hit in hits:
-            entity_type, doc_type = self._parse_index_name(hit)
+            qualifier, doc_type = self._parse_index_name(hit)
             if doc_type is DocumentType.aggregate:
                 contents = hit['_source']['contents']
                 cell_suspensions = contents['cell_suspensions']
@@ -1583,7 +1583,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
                 self.assertEqual(10000, cell_suspensions[0]['total_estimated_cells'])
                 sample = one(contents['samples'])
                 self.assertEqual(sample['organ'], sample['effective_organ'])
-                if entity_type == 'samples':
+                if qualifier == 'samples':
                     self.assertTrue(sample['effective_organ'] in {'Brain 1', 'Brain 2', 'Brain 3'})
                 else:
                     self.assertEqual(set(sample['effective_organ']), {'Brain 1', 'Brain 2', 'Brain 3'})
@@ -1602,7 +1602,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         for hit in hits:
             source = hit['_source']
             contents = source['contents']
-            entity_type, doc_type = self._parse_index_name(hit)
+            qualifier, doc_type = self._parse_index_name(hit)
             if doc_type is DocumentType.replica:
                 continue
             specimen_diseases = contents['specimens'][0]['disease']
@@ -1626,17 +1626,17 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         for hit in hits:
 
             contents = hit['_source']['contents']
-            entity_type, doc_type = self._parse_index_name(hit)
+            qualifier, doc_type = self._parse_index_name(hit)
             if doc_type is DocumentType.replica:
                 continue
             aggregate = doc_type is DocumentType.aggregate
 
-            if entity_type != 'files' or one(contents['files'])['file_format'] != 'pdf':
+            if qualifier != 'files' or one(contents['files'])['file_format'] != 'pdf':
                 inner_cell_suspensions += len(contents['cell_suspensions'])
 
             for specimen in contents['specimens']:
                 inner_specimens += 1
-                expect_list = aggregate and entity_type != 'specimens'
+                expect_list = aggregate and qualifier != 'specimens'
                 self.assertEqual(['skin of body'] if expect_list else 'skin of body', specimen['organ'])
                 self.assertEqual(['skin epidermis'], specimen['organ_part'])
 
@@ -1668,7 +1668,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         self._index_canned_bundle(bundle_fqid)
         hits = self._get_all_hits()
         for hit in hits:
-            entity_type, doc_type = self._parse_index_name(hit)
+            qualifier, doc_type = self._parse_index_name(hit)
             if doc_type is DocumentType.replica:
                 continue
             contents = hit['_source']['contents']
@@ -1679,7 +1679,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
                 'array_express': ['E-AAAA-00'],
                 'insdc_study': ['PRJNA000000']
             }
-            if entity_type == 'projects':
+            if qualifier == 'projects':
                 expected_accessions = [
                     {'namespace': namespace, 'accession': accession}
                     for namespace, accessions in accessions_by_namespace.items()
@@ -1708,28 +1708,28 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         ]
         actual = NestedDict(2, list)
         for hit in sorted(hits, key=lambda d: d['_id']):
-            entity_type, doc_type = self._parse_index_name(hit)
+            qualifier, doc_type = self._parse_index_name(hit)
             if doc_type is DocumentType.replica:
                 continue
             contents = hit['_source']['contents']
             for inner_entity_type, field_name in field_paths:
                 for inner_entity in contents[inner_entity_type]:
                     value = inner_entity[field_name]
-                    insort(actual[doc_type][entity_type][inner_entity_type], value)
+                    insort(actual[doc_type][qualifier][inner_entity_type], value)
 
         expected = NestedDict(1, dict)
         for doc_type in DocumentType.contribution, DocumentType.aggregate:
-            for entity_type in self.index_service.entity_types(self.catalog):
-                expected[doc_type][entity_type] = {
+            for qualifier in self.index_service.entity_types(self.catalog):
+                expected[doc_type][qualifier] = {
                     'cell_suspensions': [0, 20000, 20000],
                     'files': [2100, 15000, 15000],
                     'projects': [10000, 10000, 10000]
-                } if entity_type == 'cell_suspensions' else {
+                } if qualifier == 'cell_suspensions' else {
                     # project.estimated_cell_count is aggregated using max, not sum
                     'cell_suspensions': [40000],
                     'files': [17100],
                     'projects': [10000]
-                } if doc_type is DocumentType.aggregate and entity_type == 'projects' else {
+                } if doc_type is DocumentType.aggregate and qualifier == 'projects' else {
                     'cell_suspensions': [20000, 20000] if doc_type is DocumentType.aggregate else [0, 20000, 20000],
                     'files': [2100, 15000],
                     'projects': [10000, 10000]
@@ -1791,8 +1791,8 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         hits = self._get_all_hits()
         sources = defaultdict(list)
         for hit in hits:
-            entity_type, doc_type = self._parse_index_name(hit)
-            sources[entity_type, doc_type].append(hit['_source'])
+            qualifier, doc_type = self._parse_index_name(hit)
+            sources[qualifier, doc_type].append(hit['_source'])
             # bundle has 240 imaging_protocol_0.json['target'] items, each with
             # an assay_type of 'in situ sequencing'
             if doc_type is DocumentType.aggregate:
@@ -1814,8 +1814,8 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
                         'samples': 1,
                     },
                     {
-                        entity_type: len(sources)
-                        for (entity_type, _doc_type), sources in sources.items()
+                        qualifier: len(sources)
+                        for (qualifier, _doc_type), sources in sources.items()
                         if _doc_type is doc_type
                     }
                 )
@@ -1840,10 +1840,10 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         hits = self._get_all_hits()
         for hit in hits:
             contents = hit['_source']['contents']
-            entity_type, doc_type = self._parse_index_name(hit)
+            qualifier, doc_type = self._parse_index_name(hit)
             aggregate = doc_type is DocumentType.aggregate
             contribution = doc_type is DocumentType.contribution
-            if entity_type == 'samples':
+            if qualifier == 'samples':
                 sample = one(contents['samples'])
                 sample_entity_type = sample['entity_type']
                 if aggregate:
@@ -1880,12 +1880,12 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         hits = self._get_all_hits()
         for hit in hits:
             contents = hit['_source']['contents']
-            entity_type, doc_type = self._parse_index_name(hit)
+            qualifier, doc_type = self._parse_index_name(hit)
             if doc_type in [DocumentType.contribution, DocumentType.aggregate]:
                 cell_suspension = one(contents['cell_suspensions'])
                 self.assertEqual(cell_suspension['organ'], ['embryo', 'immune system'])
                 self.assertEqual(cell_suspension['organ_part'], ['skin epidermis', self.translated_str_null])
-            if doc_type is DocumentType.aggregate and entity_type != 'samples':
+            if doc_type is DocumentType.aggregate and qualifier != 'samples':
                 self.assertEqual(one(contents['samples'])['entity_type'], sample_entity_types)
             elif doc_type in (DocumentType.aggregate, DocumentType.contribution):
                 for sample in contents['samples']:
@@ -1946,8 +1946,8 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         hits = self._get_all_hits()
         for hit in hits:
             contents = hit['_source']['contents']
-            entity_type, doc_type = self._parse_index_name(hit)
-            if entity_type == 'projects':
+            qualifier, doc_type = self._parse_index_name(hit)
+            if qualifier == 'projects':
                 if doc_type is DocumentType.aggregate:
                     self.assertElasticEqual([aggregate_donor], contents['donors'])
                 elif doc_type is DocumentType.contribution:
@@ -1972,13 +1972,13 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         hits = self._get_all_hits()
         for hit in hits:
             contents = hit['_source']['contents']
-            entity_type, doc_type = self._parse_index_name(hit)
+            qualifier, doc_type = self._parse_index_name(hit)
             if doc_type is DocumentType.aggregate:
                 # bundle aggregates keep individual files
-                num_inner_files = 2 if entity_type == 'bundles' else 1
+                num_inner_files = 2 if qualifier == 'bundles' else 1
             elif doc_type is DocumentType.contribution:
                 # one inner file per file contribution
-                num_inner_files = 1 if entity_type == 'files' else 2
+                num_inner_files = 1 if qualifier == 'files' else 2
             elif doc_type is DocumentType.replica:
                 continue
             else:
@@ -1994,7 +1994,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
 
         # Check that the dynamic mapping has the related_files field disabled
         index = str(IndexName.create(catalog=self.catalog,
-                                     entity_type='files',
+                                     qualifier='files',
                                      doc_type=DocumentType.aggregate))
         mapping = self.es_client.indices.get_mapping(index=index)
         contents = mapping[index]['mappings']['properties']['contents']

--- a/test/indexer/test_projects.py
+++ b/test/indexer/test_projects.py
@@ -62,7 +62,7 @@ class TestDataExtractorTestCase(DCP1IndexerTestCase):
                 def index_name(entity_type):
                     doc_type = DocumentType.aggregate if aggregate else DocumentType.contribution
                     return str(IndexName.create(catalog=self.catalog,
-                                                entity_type=entity_type,
+                                                qualifier=entity_type,
                                                 doc_type=doc_type))
 
                 total_projects = self.es_client.count(index=index_name('projects'))

--- a/test/service/__init__.py
+++ b/test/service/__init__.py
@@ -185,7 +185,7 @@ class DocumentCloningTestCase(WebServiceTestCase, metaclass=ABCMeta):
     @property
     def _index_name(self):
         return str(IndexName.create(catalog=self.catalog,
-                                    entity_type='files',
+                                    qualifier='files',
                                     doc_type=DocumentType.aggregate))
 
 

--- a/test/service/test_response.py
+++ b/test/service/test_response.py
@@ -152,7 +152,7 @@ class TestIndexResponse(IndexResponseTestCase):
         }
         # Tests are assumed to only ever run with the azul dev index
         results = self.es_client.search(index=str(IndexName.create(catalog=self.catalog,
-                                                                   entity_type=entity_type,
+                                                                   qualifier=entity_type,
                                                                    doc_type=DocumentType.aggregate)),
                                         body=body)
         return self._index_service.translate_fields(catalog=self.catalog,


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=promotion.md`,
`&template=hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to
switch the template.
-->

Connected issues: #5992


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] Added `partial` label to PR <sub>or this PR completely resolves all connected issues</sub>
- [x] All connected issues are resolved partially <sub>or this PR does not have the `partial` label</sub>

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or this PR does not require reindexing</sub>
- [x] Added `reindex` label to PR <sub>or this PR does not require reindexing</sub>
- [x] PR and connected issue are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or this PR is not chained to another PR</sub>
- [x] Added `base` label to the blocking PR <sub>or this PR is not chained to another PR</sub>
- [x] Added `chained` label to this PR <sub>or this PR is not chained to another PR</sub>


### Author (upgrading deployments)

- [x] Ran `make image_manifests.json` and committed any resulting changes <sub>or this PR does not modify `azul_docker_images` or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `upgrade` label to PR <sub>or this PR does not require upgrading deployments</sub>


### Author (operator tasks)

- [x] Added checklist items for additional operator tasks <sub>or this PR does not require additional tasks</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the `prod` branch has no temporary hotfixes for any connected issues</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not touch requirements*.txt, common.mk, Makefile and Dockerfile</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not touch requirements*.txt</sub>
- [x] Added `reqs` label to PR <sub>or this PR does not touch requirements*.txt</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not touch functionality that could break the IT</sub>


### Peer reviewer (after requesting changes)

Uncheck the *Author (before every review)* checklists.


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] Requested review from system administrator
- [x] PR is assigned to system administrator


### System administrator (after requesting changes)

Uncheck the *before every review* checklists. Update the `N reviews` label.


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved ticket to *Approved* column
- [x] PR is assigned to current operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex` label and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] PR has checklist items for upgrading instructions <sub>or PR is not labeled `upgrade`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Deleted unreferenced indices in `hammerbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilprod`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Started reindex in `hammerbox` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for failures in `hammerbox` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Title of merge commit starts with title from this PR
- [x] Added PR reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only include `p` if the PR is labeled `partial`</sub>
- [x] Moved connected issues to Merged column in ZenHub
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed merge commit to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed merge commit to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes on GitLab `dev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `dev`<sup>1</sup>
- [x] Build passes on GitLab `anvildev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvildev`<sup>1</sup>
- [x] Build passes on GitLab `anvilprod`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvilprod`<sup>1</sup>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Deleted PR branch from GitLab `anvilprod`

<sup>1</sup> When pushing the merge commit is skipped due to the PR being
labelled `no sandbox`, the next build triggered by a PR whose merge commit *is*
pushed determines this checklist item.


### Operator (reindex)

- [x] Deleted unreferenced indices in `dev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvildev` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Deleted unreferenced indices in `anvilprod` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilprod`</sub>
- [x] Considered deindexing individual sources in `dev` <sub>or this PR does not merely remove sources from existing catalogs in `dev`</sub>
- [x] Considered deindexing individual sources in `anvildev` <sub>or this PR does not merely remove sources from existing catalogs in `anvildev`</sub>
- [x] Considered deindexing individual sources in `anvilprod` <sub>or this PR does not merely remove sources from existing catalogs in `anvilprod`</sub>
- [x] Considered indexing individual sources in `dev` <sub>or this PR does not merely add sources to existing catalogs in `dev`</sub>
- [x] Considered indexing individual sources in `anvildev` <sub>or this PR does not merely add sources to existing catalogs in `anvildev`</sub>
- [x] Considered indexing individual sources in `anvilprod` <sub>or this PR does not merely add sources to existing catalogs in `anvilprod`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Started reindex in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Checked for and triaged indexing failures in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for and triaged indexing failures in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for and triaged indexing failures in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Emptied fail queues in `dev` deployment <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` deployment <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `anvilprod` deployment <sub>or this PR does not require reindexing `anvilprod`</sub>


### Operator

- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
