### PR TITLE
Emit replicas for HCA links (#6073)

### DIFF
--- a/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T11:33:44.698028Z.results.json
+++ b/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T11:33:44.698028Z.results.json
@@ -1,5 +1,81 @@
 [
     {
+        "_id": "bundles_aaa96233-bf27-44c7-82df-b4dc15ad4d9d_50b88c774d130ce5cb9e680241549c2df665efca",
+        "_index": "azul_v2_dev_test_replica",
+        "_score": 1.0,
+        "_type": "_doc",
+        "_source": {
+            "contents": {
+                "describedBy": "https://schema.humancellatlas.org/system/1.1.3/links",
+                "links": [
+                    {
+                        "input_type": "biomaterial",
+                        "inputs": [
+                            "412898c5-5b9b-4907-b07c-e9b89666e204"
+                        ],
+                        "output_type": "file",
+                        "outputs": [
+                            "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
+                            "70d1af4a-82c8-478a-8960-e9028b3616ca"
+                        ],
+                        "process": "771ddaf6-3a4f-4314-97fe-6294ff8e25a4",
+                        "protocols": [
+                            {
+                                "protocol_id": "61e629ed-0135-4492-ac8a-5c4ab3ccca8a",
+                                "protocol_type": "sequencing_protocol"
+                            },
+                            {
+                                "protocol_id": "9c32cf70-3ed7-4720-badc-5ee71e8a38af",
+                                "protocol_type": "library_preparation_protocol"
+                            }
+                        ]
+                    },
+                    {
+                        "input_type": "biomaterial",
+                        "inputs": [
+                            "7b07b9d0-cc0e-4098-9f64-f4a569f7d746"
+                        ],
+                        "output_type": "biomaterial",
+                        "outputs": [
+                            "a21dc760-a500-4236-bcff-da34a0e873d2"
+                        ],
+                        "process": "4674255d-5ecd-4860-9b8d-beae98772cd9",
+                        "protocols": []
+                    },
+                    {
+                        "input_type": "biomaterial",
+                        "inputs": [
+                            "a21dc760-a500-4236-bcff-da34a0e873d2"
+                        ],
+                        "output_type": "biomaterial",
+                        "outputs": [
+                            "412898c5-5b9b-4907-b07c-e9b89666e204"
+                        ],
+                        "process": "4c28e079-59af-4bd3-8c8b-763ea0beba98",
+                        "protocols": [
+                            {
+                                "protocol_id": "31e708d3-79df-49b8-a3df-b1d694963468",
+                                "protocol_type": "dissociation_protocol"
+                            },
+                            {
+                                "protocol_id": "5bd4ba68-4c0e-4d22-840d-afc025e7badc",
+                                "protocol_type": "enrichment_protocol"
+                            }
+                        ]
+                    }
+                ],
+                "schema_type": "link_bundle",
+                "schema_version": "1.1.3"
+            },
+            "entity_id": "aaa96233-bf27-44c7-82df-b4dc15ad4d9d",
+            "hub_ids": [
+                "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
+                "70d1af4a-82c8-478a-8960-e9028b3616ca"
+            ],
+            "replica_type": "links"
+        }
+    },
+    {
         "_index": "azul_v2_dev_test_bundles",
         "_type": "_doc",
         "_id": "aaa96233-bf27-44c7-82df-b4dc15ad4d9d_aaa96233-bf27-44c7-82df-b4dc15ad4d9d_2018-11-02T11:33:44.698028Z_exists",

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -1270,11 +1270,11 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
                            num_expected_old_contributions: int = 0,
                            old_hits_by_id: HitsById | None = None
                            ) -> None:
-        num_actual_old_contributions = 0
-        hits = self._get_all_hits()
         # Two files, one project, one cell suspension, one sample, and one bundle.
         num_new_contribs = 6
         num_total_contribs = num_new_contribs + num_expected_old_contributions
+
+        hits = self._get_all_hits()
         self._assert_hit_counts(hits,
                                 num_contribs=num_total_contribs,
                                 num_aggs=num_new_contribs,
@@ -1291,6 +1291,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
             else:
                 assert False, doc_type
 
+        num_actual_old_contributions = 0
         for hit in hits:
             qualifier, doc_type = self._parse_index_name(hit)
             if doc_type is DocumentType.replica:

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -130,11 +130,7 @@ class DCP1IndexerTestCase(DCP1CannedBundleTestCase, IndexerTestCase):
     def metadata_plugin(self) -> MetadataPlugin:
         return MetadataPlugin.load(self.catalog).create()
 
-    def _num_expected_replicas(self,
-                               *,
-                               num_contribs: int,
-                               num_dups: int = 0
-                               ) -> int:
+    def _num_replicas(self, *, num_contribs: int, num_dups: int = 0) -> int:
         """
         :param num_contribs: Number of contributions written to the indices
 
@@ -168,7 +164,7 @@ class DCP1IndexerTestCase(DCP1CannedBundleTestCase, IndexerTestCase):
             # By default, assume 1 aggregate per contribution.
             num_aggs = num_contribs
         if num_replicas is None:
-            num_replicas = self._num_expected_replicas(num_contribs=num_contribs)
+            num_replicas = self._num_replicas(num_contribs=num_contribs)
         expected = {
             DocumentType.contribution: num_contribs,
             DocumentType.aggregate: num_aggs,
@@ -306,7 +302,7 @@ class TestDCP1Indexer(DCP1IndexerTestCase):
                     self._assert_hit_counts(hits,
                                             num_contribs=size * 2,
                                             num_aggs=0,
-                                            num_replicas=self._num_expected_replicas(num_contribs=size))
+                                            num_replicas=self._num_replicas(num_contribs=size))
                     docs_by_entity: dict[EntityReference, list[Contribution]] = defaultdict(list)
                     for hit in hits:
                         qualifier, doc_type = self._parse_index_name(hit)
@@ -487,9 +483,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
                                 num_aggs=num_expected_aggregates,
                                 # These deletion markers do not affect the number of replicas because we don't
                                 # support deleting replicas.
-                                num_replicas=self._num_expected_replicas(
-                                    num_contribs=num_expected_addition_contributions
-                                ))
+                                num_replicas=self._num_replicas(num_contribs=num_expected_addition_contributions))
 
     def test_bundle_delete_downgrade(self):
         """
@@ -1197,9 +1191,9 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         # Deletions neither add nor remove replicas from the index because their
         # contents is not updated. New and old replicas for `links.json` are
         # identical.
-        num_replicas = self._num_expected_replicas(num_contribs=max(num_expected_new_deleted_contributions,
-                                                                    num_expected_new_contributions) + num_old_contribs,
-                                                   num_dups=1 if num_new_contribs > 0 and num_old_contribs > 0 else 0)
+        num_replicas = self._num_replicas(num_contribs=max(num_expected_new_deleted_contributions,
+                                                           num_expected_new_contributions) + num_old_contribs,
+                                          num_dups=1 if num_new_contribs > 0 and num_old_contribs > 0 else 0)
         self._assert_hit_counts(hits,
                                 num_contribs=num_old_contribs + num_new_contribs,
                                 num_aggs=num_old_contribs,
@@ -1264,10 +1258,9 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         self._assert_hit_counts(hits,
                                 num_contribs=num_total_contribs,
                                 num_aggs=num_new_contribs,
-                                num_replicas=self._num_expected_replicas(
-                                    num_contribs=num_total_contribs,
-                                    # New and old replicas for `links.json` are identical.
-                                    num_dups=1 if num_expected_old_contributions > 0 else 0)
+                                num_replicas=self._num_replicas(num_contribs=num_total_contribs,
+                                                                # New and old replicas for `links.json` are identical.
+                                                                num_dups=1 if num_expected_old_contributions > 0 else 0)
                                 )
 
         def get_version(source, doc_type):
@@ -1368,7 +1361,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
                                 num_aggs=num_contribs - 2,
                                 # The sample contributions from each bundle are identical and yield a single replica,
                                 # but the project contributions have different schema versions and thus yield two.
-                                num_replicas=self._num_expected_replicas(num_contribs=num_contribs, num_dups=1))
+                                num_replicas=self._num_replicas(num_contribs=num_contribs, num_dups=1))
         for hit in hits:
             qualifier, doc_type = self._parse_index_name(hit)
             if doc_type is DocumentType.replica:

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -140,9 +140,11 @@ class DCP1IndexerTestCase(DCP1CannedBundleTestCase, IndexerTestCase):
         :param num_dups: How many of those contributions had identical contents
                          with another contribution
         """
-        if num_additions > 0:
-            num_additions -= num_dups
-        return num_additions if config.enable_replicas else 0
+        if config.enable_replicas:
+            assert num_dups <= num_additions
+            return num_additions - num_dups
+        else:
+            return 0
 
     def _assert_hit_counts(self,
                            hits: list[JSON],

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -481,14 +481,17 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
 
         self.assertEqual(num_addition_contribs, len(actual_addition_contribs))
         self.assertEqual(num_deletion_contribs, len(actual_deletion_contribs))
+
+        # Deletion notifications add deletion markers to the contributions index
+        # instead of removing the existing contributions.
+        num_contribs = num_addition_contribs + num_deletion_contribs
+        # These deletion markers do not affect the number of replicas because we
+        # don't support deleting replicas.
+        num_replicas = self._num_replicas(num_additions=num_addition_contribs)
         self._assert_hit_counts(hits,
-                                # Deletion notifications add deletion markers to the contributions index
-                                # instead of removing the existing contributions.
-                                num_contribs=num_addition_contribs + num_deletion_contribs,
+                                num_contribs=num_contribs,
                                 num_aggs=0,
-                                # These deletion markers do not affect the number of replicas because we don't
-                                # support deleting replicas.
-                                num_replicas=self._num_replicas(num_additions=num_addition_contribs))
+                                num_replicas=num_replicas)
 
     def test_bundle_delete_downgrade(self):
         """

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -310,13 +310,17 @@ class TestDCP1Indexer(DCP1IndexerTestCase):
 
                     hits = self._get_all_hits()
                     # Twice the number of contributions because deletions create
-                    # new documents instead of removing them. The aggregates are
-                    # removed when the deletions cause their contents to become
-                    # emtpy. Deletions do not affect the number of replicas.
+                    # new documents instead of removing them.
+                    num_contribs = size * 2
+                    # The aggregates are removed when the deletions cause their
+                    # contents to become emtpy.
+                    num_aggs = 0
+                    # Deletions do not affect the number of replicas.
+                    num_replicas = self._num_replicas(num_additions=size)
                     self._assert_hit_counts(hits,
-                                            num_contribs=size * 2,
-                                            num_aggs=0,
-                                            num_replicas=self._num_replicas(num_additions=size))
+                                            num_contribs=num_contribs,
+                                            num_aggs=num_aggs,
+                                            num_replicas=num_replicas)
                     docs_by_entity: dict[EntityReference, list[Contribution]] = defaultdict(list)
                     for hit in hits:
                         qualifier, doc_type = self._parse_index_name(hit)

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -273,7 +273,11 @@ class TestDCP1Indexer(DCP1IndexerTestCase):
             self.bundle_fqid(uuid='2a87dc5c-0c3c-4d91-a348-5d784ab48b92',
                              version='2018-03-29T10:39:45.437487Z'): 258
         }
-        self.assertTrue(min(bundle_sizes.values()) < IndexWriter.bulk_threshold < max(bundle_sizes.values()))
+        self.assertTrue(
+            min(bundle_sizes.values())
+            < IndexWriter.bulk_threshold
+            < max(bundle_sizes.values())
+        )
 
         field_types = self.index_service.catalogued_field_types()
         aggregate_cls = self.metadata_plugin.aggregate_class()

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -462,7 +462,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         self._assert_index_counts(just_deletion=False)
 
     def _assert_index_counts(self, *, just_deletion: bool):
-        # Five entities (two files, one project, one sample and one bundle)
+        # Two files, a project, a cell suspension, a sample, and a bundle
         num_expected_addition_contributions = 0 if just_deletion else 6
         num_expected_deletion_contributions = 6
         num_expected_aggregates = 0

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -1175,12 +1175,14 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
                                 ignore_aggregates=True)
         self._assert_new_bundle(num_expected_old_contributions=6)
 
+    HitsById = Mapping[tuple[str, DocumentType], JSON]
+
     def _assert_old_bundle(self,
                            *,
                            num_expected_new_contributions: int,
                            num_expected_new_deleted_contributions: int,
                            ignore_aggregates: bool = False
-                           ) -> Mapping[tuple[str, DocumentType], JSON]:
+                           ) -> HitsById:
         """
         Assert that the old bundle is still indexed correctly
 
@@ -1257,7 +1259,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
 
     def _assert_new_bundle(self,
                            num_expected_old_contributions: int = 0,
-                           old_hits_by_id: Optional[Mapping[tuple[str, DocumentType], JSON]] = None
+                           old_hits_by_id: HitsById | None = None
                            ) -> None:
         num_actual_old_contributions = 0
         hits = self._get_all_hits()

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -463,31 +463,32 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
 
     def _assert_index_counts(self, *, just_deletion: bool):
         # Two files, a project, a cell suspension, a sample, and a bundle
-        num_expected_addition_contributions = 0 if just_deletion else 6
-        num_expected_deletion_contributions = 6
-        num_expected_aggregates = 0
+        num_entities = 6
+        num_addition_contribs = 0 if just_deletion else num_entities
+        num_deletion_contribs = num_entities
+
         hits = self._get_all_hits()
-        actual_addition_contributions = [
+        actual_addition_contribs = [
             h
             for h in hits
             if h['_source'].get('bundle_deleted') is False
         ]
-        actual_deletion_contributions = [
+        actual_deletion_contribs = [
             h
             for h in hits
             if h['_source'].get('bundle_deleted') is True
         ]
 
-        self.assertEqual(len(actual_addition_contributions), num_expected_addition_contributions)
-        self.assertEqual(len(actual_deletion_contributions), num_expected_deletion_contributions)
+        self.assertEqual(num_addition_contribs, len(actual_addition_contribs))
+        self.assertEqual(num_deletion_contribs, len(actual_deletion_contribs))
         self._assert_hit_counts(hits,
                                 # Deletion notifications add deletion markers to the contributions index
                                 # instead of removing the existing contributions.
-                                num_contribs=num_expected_addition_contributions + num_expected_deletion_contributions,
-                                num_aggs=num_expected_aggregates,
+                                num_contribs=num_addition_contribs + num_deletion_contribs,
+                                num_aggs=0,
                                 # These deletion markers do not affect the number of replicas because we don't
                                 # support deleting replicas.
-                                num_replicas=self._num_replicas(num_additions=num_expected_addition_contributions))
+                                num_replicas=self._num_replicas(num_additions=num_addition_contribs))
 
     def test_bundle_delete_downgrade(self):
         """

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -131,6 +131,7 @@ class DCP1IndexerTestCase(DCP1CannedBundleTestCase, IndexerTestCase):
         return MetadataPlugin.load(self.catalog).create()
 
     def _num_expected_replicas(self,
+                               *,
                                num_contribs: int,
                                num_bundles: Optional[int] = None
                                ) -> int:
@@ -169,7 +170,8 @@ class DCP1IndexerTestCase(DCP1CannedBundleTestCase, IndexerTestCase):
             # By default, assume 1 aggregate per contribution.
             num_aggs = num_contribs
         if num_replicas is None:
-            num_replicas = self._num_expected_replicas(num_contribs, num_bundles)
+            num_replicas = self._num_expected_replicas(num_contribs=num_contribs,
+                                                       num_bundles=num_bundles)
         expected = {
             DocumentType.contribution: num_contribs,
             DocumentType.aggregate: num_aggs,
@@ -304,7 +306,7 @@ class TestDCP1Indexer(DCP1IndexerTestCase):
                     self._assert_hit_counts(hits,
                                             num_contribs=size * 2,
                                             num_aggs=0,
-                                            num_replicas=self._num_expected_replicas(size))
+                                            num_replicas=self._num_expected_replicas(num_contribs=size))
                     docs_by_entity: dict[EntityReference, list[Contribution]] = defaultdict(list)
                     for hit in hits:
                         qualifier, doc_type = self._parse_index_name(hit)
@@ -485,7 +487,8 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
                                 num_aggs=num_expected_aggregates,
                                 # These deletion markers do not affect the number of replicas because we don't
                                 # support deleting replicas.
-                                num_replicas=self._num_expected_replicas(num_expected_addition_contributions))
+                                num_replicas=self._num_expected_replicas(
+                                    num_contribs=num_expected_addition_contributions))
 
     def test_bundle_delete_downgrade(self):
         """
@@ -1192,8 +1195,8 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         num_new_contribs = num_expected_new_contributions + num_expected_new_deleted_contributions * 2
         # Deletions neither add nor remove replicas from the index because their
         # contents is not updated
-        num_replicas = self._num_expected_replicas(max(num_expected_new_deleted_contributions,
-                                                       num_expected_new_contributions) + num_old_contribs,
+        num_replicas = self._num_expected_replicas(num_contribs=max(num_expected_new_deleted_contributions,
+                                                                    num_expected_new_contributions) + num_old_contribs,
                                                    num_bundles=2 if num_new_contribs > 0 else 1)
         self._assert_hit_counts(hits,
                                 num_contribs=num_old_contribs + num_new_contribs,

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -158,13 +158,17 @@ class DCP1IndexerTestCase(DCP1CannedBundleTestCase, IndexerTestCase):
         """
         Verify that the indices contain the correct number of hits of each
         document type
-        :param hits: Hits from ElasticSearch
+
+        :param hits: Hits from Elasticsearch
+
         :param num_contribs: Expected number of contributions
-        :param num_aggs: Expected number of aggregates. If unspecified, `num_contribs`
-                         becomes the default.
-        :param num_replicas: Expected number of replicas. If unspecified, `num_contribs`
-                             is used to calculate it, assuming all contributions have
-                             distinct contents.
+
+        :param num_aggs: Expected number of aggregates. If unspecified,
+                         ``num_contribs`` becomes the default.
+
+        :param num_replicas: Expected number of replicas. If unspecified,
+                             ``num_contribs`` is used to calculate it, assuming
+                             all contributions have distinct contents.
         """
         if num_aggs is None:
             # By default, assume 1 aggregate per contribution.

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -1190,9 +1190,6 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         contribution
         :param ignore_aggregates: Don't consider aggregates when counting docs in index
         """
-        num_actual_new_contributions = 0
-        num_actual_new_deleted_contributions = 0
-        hits = self._get_all_hits()
         # Two files, one project, one cell suspension, one sample, and one bundle
         num_old_contribs = 6
         # Deletions add new contributions to the index instead of removing the old ones,
@@ -1204,10 +1201,15 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         num_replicas = self._num_replicas(num_additions=max(num_expected_new_deleted_contributions,
                                                             num_expected_new_contributions) + num_old_contribs,
                                           num_dups=1 if num_new_contribs > 0 and num_old_contribs > 0 else 0)
+
+        hits = self._get_all_hits()
         self._assert_hit_counts(hits,
                                 num_contribs=num_old_contribs + num_new_contribs,
                                 num_aggs=num_old_contribs,
                                 num_replicas=num_replicas)
+
+        num_actual_new_contributions = 0
+        num_actual_new_deleted_contributions = 0
         hits_by_id = {}
         for hit in hits:
             qualifier, doc_type = self._parse_index_name(hit)

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -130,17 +130,19 @@ class DCP1IndexerTestCase(DCP1CannedBundleTestCase, IndexerTestCase):
     def metadata_plugin(self) -> MetadataPlugin:
         return MetadataPlugin.load(self.catalog).create()
 
-    def _num_replicas(self, *, num_contribs: int, num_dups: int = 0) -> int:
+    def _num_replicas(self, *, num_additions: int, num_dups: int = 0) -> int:
         """
-        :param num_contribs: Number of contributions written to the indices
+        The number of replicas the index is expected to contain.
+
+        :param num_additions: Number of addition contributions written to the
+                              indices
 
         :param num_dups: How many of those contributions had identical contents
                          with another contribution
-        :return: How many replicas the indices are expected to contain
         """
-        if num_contribs > 0:
-            num_contribs -= num_dups
-        return num_contribs if config.enable_replicas else 0
+        if num_additions > 0:
+            num_additions -= num_dups
+        return num_additions if config.enable_replicas else 0
 
     def _assert_hit_counts(self,
                            hits: list[JSON],
@@ -164,7 +166,7 @@ class DCP1IndexerTestCase(DCP1CannedBundleTestCase, IndexerTestCase):
             # By default, assume 1 aggregate per contribution.
             num_aggs = num_contribs
         if num_replicas is None:
-            num_replicas = self._num_replicas(num_contribs=num_contribs)
+            num_replicas = self._num_replicas(num_additions=num_contribs)
         expected = {
             DocumentType.contribution: num_contribs,
             DocumentType.aggregate: num_aggs,
@@ -302,7 +304,7 @@ class TestDCP1Indexer(DCP1IndexerTestCase):
                     self._assert_hit_counts(hits,
                                             num_contribs=size * 2,
                                             num_aggs=0,
-                                            num_replicas=self._num_replicas(num_contribs=size))
+                                            num_replicas=self._num_replicas(num_additions=size))
                     docs_by_entity: dict[EntityReference, list[Contribution]] = defaultdict(list)
                     for hit in hits:
                         qualifier, doc_type = self._parse_index_name(hit)
@@ -483,7 +485,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
                                 num_aggs=num_expected_aggregates,
                                 # These deletion markers do not affect the number of replicas because we don't
                                 # support deleting replicas.
-                                num_replicas=self._num_replicas(num_contribs=num_expected_addition_contributions))
+                                num_replicas=self._num_replicas(num_additions=num_expected_addition_contributions))
 
     def test_bundle_delete_downgrade(self):
         """
@@ -1191,8 +1193,8 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         # Deletions neither add nor remove replicas from the index because their
         # contents is not updated. New and old replicas for `links.json` are
         # identical.
-        num_replicas = self._num_replicas(num_contribs=max(num_expected_new_deleted_contributions,
-                                                           num_expected_new_contributions) + num_old_contribs,
+        num_replicas = self._num_replicas(num_additions=max(num_expected_new_deleted_contributions,
+                                                            num_expected_new_contributions) + num_old_contribs,
                                           num_dups=1 if num_new_contribs > 0 and num_old_contribs > 0 else 0)
         self._assert_hit_counts(hits,
                                 num_contribs=num_old_contribs + num_new_contribs,
@@ -1258,7 +1260,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         self._assert_hit_counts(hits,
                                 num_contribs=num_total_contribs,
                                 num_aggs=num_new_contribs,
-                                num_replicas=self._num_replicas(num_contribs=num_total_contribs,
+                                num_replicas=self._num_replicas(num_additions=num_total_contribs,
                                                                 # New and old replicas for `links.json` are identical.
                                                                 num_dups=1 if num_expected_old_contributions > 0 else 0)
                                 )
@@ -1361,7 +1363,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
                                 num_aggs=num_contribs - 2,
                                 # The sample contributions from each bundle are identical and yield a single replica,
                                 # but the project contributions have different schema versions and thus yield two.
-                                num_replicas=self._num_replicas(num_contribs=num_contribs, num_dups=1))
+                                num_replicas=self._num_replicas(num_additions=num_contribs, num_dups=1))
         for hit in hits:
             qualifier, doc_type = self._parse_index_name(hit)
             if doc_type is DocumentType.replica:

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -1180,6 +1180,8 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
                                    newer version of the bundle. If False, expect
                                    no such effects. If True, expect additions
                                    by such a bundle. If None, expect deletions.
+
+        :return: A dictionary with all hits from the old bundle
         """
         # Two files, a project, a cell suspension, a sample, and a bundle
         num_entities = 6

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -1401,15 +1401,22 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
 
         hits = self._get_all_hits()
         file_uuids = set()
-        # Two bundles, each with 1 sample, 1 cell suspension, 1 project, 1 bundle and 2 files.
-        num_contribs = (1 + 1 + 1 + 1 + 2) * 2
+        # Two files, a project, a cell suspension, a sample, and a bundle
+        num_entities = 6
+        # Two bundles
+        num_contribs = num_entities * 2
+        # Both bundles share the same sample and the project, so they get
+        # aggregated only once
+        num_aggs = num_contribs - 2
+        # The sample contributions from each bundle are identical and yield a
+        # single replica, but the project contributions have different schema
+        # versions and thus yield two.
+        num_replicas = self._num_replicas(num_additions=num_contribs,
+                                          num_dups=1)
         self._assert_hit_counts(hits,
                                 num_contribs=num_contribs,
-                                # Both bundles share the same sample and the project, so they get aggregated only once
-                                num_aggs=num_contribs - 2,
-                                # The sample contributions from each bundle are identical and yield a single replica,
-                                # but the project contributions have different schema versions and thus yield two.
-                                num_replicas=self._num_replicas(num_additions=num_contribs, num_dups=1))
+                                num_aggs=num_aggs,
+                                num_replicas=num_replicas)
         for hit in hits:
             qualifier, doc_type = self._parse_index_name(hit)
             if doc_type is DocumentType.replica:

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -495,11 +495,13 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         to the previous bundle.
         """
         self._index_canned_bundle(self.old_bundle)
-        old_hits_by_id = self._assert_old_bundle()
+        old_hits_by_id = self._assert_old_bundle(num_expected_new_contributions=0,
+                                                 num_expected_new_deleted_contributions=0)
         self._index_canned_bundle(self.new_bundle)
         self._assert_new_bundle(num_expected_old_contributions=6, old_hits_by_id=old_hits_by_id)
         self._index_canned_bundle(self.new_bundle, delete=True)
-        self._assert_old_bundle(num_expected_new_deleted_contributions=6)
+        self._assert_old_bundle(num_expected_new_contributions=0,
+                                num_expected_new_deleted_contributions=6)
 
     def test_multi_entity_contributing_bundles(self):
         """
@@ -1155,7 +1157,8 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         Updating a bundle with a future version should overwrite the old version.
         """
         self._index_canned_bundle(self.old_bundle)
-        old_hits_by_id = self._assert_old_bundle()
+        old_hits_by_id = self._assert_old_bundle(num_expected_new_contributions=0,
+                                                 num_expected_new_deleted_contributions=0)
         self._index_canned_bundle(self.new_bundle)
         self._assert_new_bundle(num_expected_old_contributions=6, old_hits_by_id=old_hits_by_id)
 
@@ -1167,12 +1170,15 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         self._index_canned_bundle(self.new_bundle)
         self._assert_new_bundle(num_expected_old_contributions=0)
         self._index_canned_bundle(self.old_bundle)
-        self._assert_old_bundle(num_expected_new_contributions=6, ignore_aggregates=True)
+        self._assert_old_bundle(num_expected_new_contributions=6,
+                                num_expected_new_deleted_contributions=0,
+                                ignore_aggregates=True)
         self._assert_new_bundle(num_expected_old_contributions=6)
 
     def _assert_old_bundle(self,
-                           num_expected_new_contributions: int = 0,
-                           num_expected_new_deleted_contributions: int = 0,
+                           *,
+                           num_expected_new_contributions: int,
+                           num_expected_new_deleted_contributions: int,
                            ignore_aggregates: bool = False
                            ) -> Mapping[tuple[str, DocumentType], JSON]:
         """

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -1297,6 +1297,7 @@ class TestManifests(DCP1ManifestTestCase, PFBTestCase):
         expected = [
             bundle.metadata_files[d]
             for d in [
+                'links.json',
                 'cell_suspension_0.json',
                 'project_0.json',
                 'sequence_file_0.json',
@@ -1309,7 +1310,11 @@ class TestManifests(DCP1ManifestTestCase, PFBTestCase):
         response = list(map(json.loads, response.content.decode().splitlines()))
 
         def sort_key(hca_doc: JSON) -> str:
-            return hca_doc['provenance']['document_id']
+            try:
+                return hca_doc['provenance']['document_id']
+            except KeyError:
+                assert hca_doc['schema_type'] == 'link_bundle'
+                return ''
 
         expected.sort(key=sort_key)
         response.sort(key=sort_key)


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=promotion.md`,
`&template=hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to
switch the template.
-->

Connected issues: #6073


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or this PR does not require reindexing</sub>
- [x] This PR is labeled `reindex:dev` <sub>or does not require reindexing `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or does not require reindexing `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or does not require reindexing `anvilprod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] Ran `make image_manifests.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `image_manifests.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (operator tasks)

- [x] Added checklist items for additional operator tasks <sub>or this PR does not require additional tasks</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the `prod` branch has no temporary hotfixes for any connected issues</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after requesting changes)

Uncheck the *Author (before every review)* checklists.


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] Requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after requesting changes)

Uncheck the *before every review* checklists. Update the `N reviews` label.


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review <sub>or this PR is a promotion or a backport</sub>
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved ticket to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] PR has checklist items for upgrading instructions <sub>or PR is not labeled `upgrade`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvilprod.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvilprod.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] Assigned system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for `dev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for `anvildev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for `anvilprod.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvilprod.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Deleted unreferenced indices in `hammerbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilprod`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Started reindex in `hammerbox` <sub>or this PR is not labeled `reindex:anvilprod`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `hammerbox` <sub>or this PR is not labeled `reindex:anvilprod`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to Merged column in ZenHub
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed merge commit to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed merge commit to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes on GitLab `dev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `dev`<sup>1</sup>
- [x] Build passes on GitLab `anvildev`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvildev`<sup>1</sup>
- [x] Build passes on GitLab `anvilprod`<sup>1</sup>
- [x] Reviewed build logs for anomalies on GitLab `anvilprod`<sup>1</sup>
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvilprod.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Deleted PR branch from GitLab `anvilprod`

<sup>1</sup> When pushing the merge commit is skipped due to the PR being
labelled `no sandbox`, the next build triggered by a PR whose merge commit *is*
pushed determines this checklist item.


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvilprod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvilprod`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `anvilprod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvilprod`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `anvilprod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvilprod`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Started reindex in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial` and `reindex:prod` labels to the next promotion PR <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial` and `reindex:prod` labels from the description of this PR to that of the next promotion PR <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
