### PR TITLE
Fix: update_subgraph_counts.py fails for ANVIL_T2T_CHRY dataset (#6206)

### DIFF
--- a/deployments/anvilprod/environment.py
+++ b/deployments/anvilprod/environment.py
@@ -383,7 +383,7 @@ anvil5_sources = mkdict(anvil4_sources, 262, mkdelta([
     # @formatter:on
 ]))
 
-anvil6_sources = mkdict(anvil5_sources, 255, mkdelta([
+anvil6_sources = mkdict(anvil5_sources, 256, mkdelta([
     # @formatter:off
     mksrc('datarepo-38af6304', 'ANVIL_1000G_PRIMED_data_model_20240410_ANV5_202404101419', 14695),
     mksrc('datarepo-ed4892b5', 'ANVIL_ALSCompute_Collection_GRU_20231016_ANV5_202404081553', 14593),
@@ -616,6 +616,7 @@ anvil6_sources = mkdict(anvil5_sources, 255, mkdelta([
     mksrc('datarepo-4a4eec27', 'ANVIL_PAGE_SoL_HMB_WGS_20221220_ANV5_202403040445', 234, pop),
     mksrc('datarepo-a1f917db', 'ANVIL_PAGE_Stanford_Global_Reference_Panel_GRU_WGS_20221128_ANV5_202403040453', 78, pop), # noqa E501
     mksrc('datarepo-6264931f', 'ANVIL_PAGE_WHI_HMB_IRB_WGS_20221019_ANV5_202403040500', 235, pop),
+    mksrc('datarepo-e5b16a5a', 'ANVIL_T2T_CHRY_20240301_ANV5_202403040508', 309979),
     mksrc('datarepo-f3817357', 'ANVIL_ccdg_asc_ndd_daly_talkowski_AGRE_asd_exome_20221102_ANV5_202403040528', 850),
     mksrc('datarepo-23635d1c', 'ANVIL_ccdg_asc_ndd_daly_talkowski_IBIS_asd_exome_20221024_ANV5_202403040537', 241),
     mksrc('datarepo-ecf311e7', 'ANVIL_ccdg_asc_ndd_daly_talkowski_TASC_asd_exome_20221117_ANV5_202403040544', 3175),

--- a/deployments/hammerbox/environment.py
+++ b/deployments/hammerbox/environment.py
@@ -396,7 +396,7 @@ anvil5_sources = mkdict(anvil4_sources, 262, mkdelta([
     # @formatter:on
 ]))
 
-anvil6_sources = mkdict(anvil5_sources, 255, mkdelta([
+anvil6_sources = mkdict(anvil5_sources, 256, mkdelta([
     # @formatter:off
     mksrc('datarepo-38af6304', 'ANVIL_1000G_PRIMED_data_model_20240410_ANV5_202404101419', 14695),
     mksrc('datarepo-ed4892b5', 'ANVIL_ALSCompute_Collection_GRU_20231016_ANV5_202404081553', 14593),
@@ -629,6 +629,7 @@ anvil6_sources = mkdict(anvil5_sources, 255, mkdelta([
     mksrc('datarepo-4a4eec27', 'ANVIL_PAGE_SoL_HMB_WGS_20221220_ANV5_202403040445', 234, pop),
     mksrc('datarepo-a1f917db', 'ANVIL_PAGE_Stanford_Global_Reference_Panel_GRU_WGS_20221128_ANV5_202403040453', 78, pop), # noqa E501
     mksrc('datarepo-6264931f', 'ANVIL_PAGE_WHI_HMB_IRB_WGS_20221019_ANV5_202403040500', 235, pop),
+    mksrc('datarepo-e5b16a5a', 'ANVIL_T2T_CHRY_20240301_ANV5_202403040508', 309979),
     mksrc('datarepo-f3817357', 'ANVIL_ccdg_asc_ndd_daly_talkowski_AGRE_asd_exome_20221102_ANV5_202403040528', 850),
     mksrc('datarepo-23635d1c', 'ANVIL_ccdg_asc_ndd_daly_talkowski_IBIS_asd_exome_20221024_ANV5_202403040537', 241),
     mksrc('datarepo-ecf311e7', 'ANVIL_ccdg_asc_ndd_daly_talkowski_TASC_asd_exome_20221117_ANV5_202403040544', 3175),

--- a/scripts/update_subgraph_counts.py
+++ b/scripts/update_subgraph_counts.py
@@ -96,7 +96,8 @@ class SubgraphCounter:
         best_prefix, best_count = first(self.partition_sizes.items())
         ideal_size = 16
         for prefix, count in sorted(self.partition_sizes.items()):
-            if count > 0 and abs(count - ideal_size) < abs(best_count - ideal_size):
+            assert count > 0, self.partition_sizes
+            if abs(count - ideal_size) < abs(best_count - ideal_size):
                 best_prefix, best_count = prefix, count
         return best_prefix
 
@@ -137,7 +138,7 @@ def generate_sources(catalog: CatalogName,
         if len(default_prefix) > 0:
             counter_prefix = Prefix(common='', partition=len(default_prefix))
             prefixed_counter = SubgraphCounter.for_source(plugin, source, counter_prefix)
-            if prefixed_counter.partition_sizes.get(default_prefix, 0) == 0:
+            if default_prefix not in prefixed_counter.partition_sizes:
                 explicit_prefix = prefixed_counter.ideal_common_prefix()
         return SourceSpecArgs(project=source.spec.project,
                               snapshot=source.spec.name,

--- a/src/azul/indexer/__init__.py
+++ b/src/azul/indexer/__init__.py
@@ -79,6 +79,8 @@ class Prefix:
     partition: int
     of_everything: ClassVar['Prefix']
 
+    digits = '0123456789abcdef'
+
     def __attrs_post_init__(self):
         validate_uuid_prefix(self.common)
         assert ':' not in self.common, self.common
@@ -152,11 +154,25 @@ class Prefix:
         >>> len(list(Prefix.parse('/2').partition_prefixes()))
         256
         """
-        partition_prefixes = map(''.join, product('0123456789abcdef',
+        partition_prefixes = map(''.join, product(self.digits,
                                                   repeat=self.partition))
         for partition_prefix in partition_prefixes:
             validate_uuid_prefix(self.common + partition_prefix)
             yield partition_prefix
+
+    @property
+    def num_partitions(self) -> int:
+        """
+        Equivalent to `len(self.partition_prefixes())`, but more efficient.
+
+        >>> Prefix.parse('aa/0').num_partitions
+        1
+        >>> Prefix.parse('/3').num_partitions
+        4096
+        >>> Prefix.parse('aa/3').num_partitions
+        4096
+        """
+        return len(self.digits) ** self.partition
 
     def __str__(self):
         """
@@ -165,6 +181,17 @@ class Prefix:
         True
         """
         return f'{self.common}/{self.partition}'
+
+    def __len__(self):
+        """
+        >>> len(Prefix.parse('aa/0'))
+        2
+        >>> len(Prefix.parse('/3'))
+        3
+        >>> len(Prefix.parse('aa/3'))
+        5
+        """
+        return len(self.common) + self.partition
 
 
 Prefix.of_everything = Prefix.parse('/0')

--- a/src/azul/plugins/__init__.py
+++ b/src/azul/plugins/__init__.py
@@ -594,10 +594,10 @@ class RepositoryPlugin(Plugin[BUNDLE],
 
     def list_partitions(self, source: SOURCE_REF) -> Optional[Mapping[str, int]]:
         """
-        Return the number of bundles in each partition of the given source, or
-        return None if that information cannot be retrieved inexpensively. Each
-        key in the returned mapping is the full prefix of a partition, including
-        the common prefix if one is configured.
+        Return the number of bundles in each non-empty partition of the given
+        source, or return None if that information cannot be retrieved
+        inexpensively. Each key in the returned mapping is the full prefix of a
+        partition, including the common prefix if one is configured.
 
         Subclasses may optionally implement this method to facilitate
         integration test coverage of the partition sizes of their sources.

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -325,7 +325,7 @@ class IntegrationTestCase(AzulTestCase, metaclass=ABCMeta):
                         # across all partitions simultaneously, we can check
                         # whether the chosen partition is an outlier by
                         # determining the *average* partition size.
-                        num_bundles = sum(counts.values()) / len(counts)
+                        num_bundles = sum(counts.values()) / prefix.num_partitions
             else:
                 # Sources too small to be split into more than one partition may
                 # have as few as one bundle in total

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -300,7 +300,7 @@ class IntegrationTestCase(AzulTestCase, metaclass=ABCMeta):
         partition_prefix = self.random.choice(partition_prefixes)
         effective_prefix = prefix.common + partition_prefix
         fqids = self.azul_client.list_bundles(catalog, source, partition_prefix)
-        bundle_count = len(fqids)
+        num_bundles = len(fqids)
         partition = f'Partition {effective_prefix!r} of source {source.spec}'
         if not config.is_sandbox_or_personal_deployment:
             # For sources that use partitioning, 512 is the desired partition
@@ -325,7 +325,7 @@ class IntegrationTestCase(AzulTestCase, metaclass=ABCMeta):
                         # across all partitions simultaneously, we can check
                         # whether the chosen partition is an outlier by
                         # determining the *average* partition size.
-                        bundle_count = sum(counts.values()) / len(counts)
+                        num_bundles = sum(counts.values()) / len(counts)
             else:
                 # Sources too small to be split into more than one partition may
                 # have as few as one bundle in total
@@ -340,8 +340,8 @@ class IntegrationTestCase(AzulTestCase, metaclass=ABCMeta):
             upper = 64
             lower = 1
 
-        self.assertLessEqual(bundle_count, upper, partition + ' is too large')
-        self.assertGreaterEqual(bundle_count, lower, partition + ' is too small')
+        self.assertLessEqual(num_bundles, upper, partition + ' is too large')
+        self.assertGreaterEqual(num_bundles, lower, partition + ' is too small')
 
         return source, partition_prefix, fqids
 


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Connected issues: #6206


## Notes

 - Manually index  `ANVIL_T2T_CHRY_20240301_ANV5_202403040508` in catalog `anvil6` in deployments `hammerbox` and `anvilprod`.

## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make image_manifests.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `image_manifests.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved ticket to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for `dev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for `anvildev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
