### PR TITLE
 All bucket names should default to qualified_bucket_name() (#4655)

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -20,6 +20,22 @@ reverted. This is all fairly informal and loosely defined. Hopefully we won't
 have too many entries in this file.
 
 
+#4655 All bucket names should default to qualified_bucket_name()
+================================================================
+
+Check the value of ``AZUL_S3_BUCKET`` in every personal deployments. If the
+value is either
+
+``edu-ucsc-gi-platform-anvil-dev-storage-{AZUL_DEPLOYMENT_STAGE}.{AWS_DEFAULT_REGION}``
+
+or
+
+``edu-ucsc-gi-platform-hca-dev-storage-{AZUL_DEPLOYMENT_STAGE}.{AWS_DEFAULT_REGION}``
+
+remove the variable from ``environment.py`` for that deployment and redeploy.
+Otherwise, consult with the system administrator.
+
+
 #6218 Delete hammerbox ES domain
 ================================
 

--- a/deployments/anvilbox/environment.py
+++ b/deployments/anvilbox/environment.py
@@ -121,8 +121,6 @@ def env() -> Mapping[str, Optional[str]]:
         'AZUL_SUBDOMAIN_TEMPLATE': '*.{AZUL_DEPLOYMENT_STAGE}',
         'AZUL_PRIVATE_API': '0',
 
-        'AZUL_S3_BUCKET': 'edu-ucsc-gi-platform-anvil-dev-storage-{AZUL_DEPLOYMENT_STAGE}.{AWS_DEFAULT_REGION}',
-
         'AZUL_CATALOGS': json.dumps({
             f'{catalog}{suffix}': dict(atlas=atlas,
                                        internal=internal,

--- a/deployments/anvildev/environment.py
+++ b/deployments/anvildev/environment.py
@@ -95,8 +95,6 @@ def env() -> Mapping[str, Optional[str]]:
         'AZUL_DOMAIN_NAME': 'anvil.gi.ucsc.edu',
         'AZUL_PRIVATE_API': '0',
 
-        'AZUL_S3_BUCKET': 'edu-ucsc-gi-platform-anvil-dev-storage-{AZUL_DEPLOYMENT_STAGE}.{AWS_DEFAULT_REGION}',
-
         'AZUL_CATALOGS': json.dumps({
             f'{catalog}{suffix}': dict(atlas=atlas,
                                        internal=internal,

--- a/deployments/anvilprod/environment.py
+++ b/deployments/anvilprod/environment.py
@@ -731,8 +731,6 @@ def env() -> Mapping[str, Optional[str]]:
         'AZUL_DOMAIN_NAME': 'explore.anvilproject.org',
         'AZUL_PRIVATE_API': '0',
 
-        'AZUL_S3_BUCKET': 'edu-ucsc-gi-platform-anvil-prod-storage-{AZUL_DEPLOYMENT_STAGE}.{AWS_DEFAULT_REGION}',
-
         'AZUL_CATALOGS': json.dumps({
             f'{catalog}{suffix}': dict(atlas=atlas,
                                        internal=internal,

--- a/deployments/dev/environment.py
+++ b/deployments/dev/environment.py
@@ -217,8 +217,6 @@ def env() -> Mapping[str, Optional[str]]:
         'AZUL_DOMAIN_NAME': '{AZUL_DEPLOYMENT_STAGE}.singlecell.gi.ucsc.edu',
         'AZUL_DRS_DOMAIN_NAME': 'drs.dev.singlecell.gi.ucsc.edu',
 
-        'AZUL_S3_BUCKET': 'edu-ucsc-gi-platform-hca-dev-storage-{AZUL_DEPLOYMENT_STAGE}.{AWS_DEFAULT_REGION}',
-
         'AZUL_CATALOGS': json.dumps({
             f'{catalog}{suffix}': dict(atlas=atlas,
                                        internal=internal,

--- a/deployments/hammerbox/environment.py
+++ b/deployments/hammerbox/environment.py
@@ -758,8 +758,6 @@ def env() -> Mapping[str, Optional[str]]:
         'AZUL_SUBDOMAIN_TEMPLATE': '*.{AZUL_DEPLOYMENT_STAGE}',
         'AZUL_PRIVATE_API': '0',
 
-        'AZUL_S3_BUCKET': 'edu-ucsc-gi-platform-anvil-prod-storage-{AZUL_DEPLOYMENT_STAGE}.{AWS_DEFAULT_REGION}',
-
         'AZUL_CATALOGS': json.dumps({
             f'{catalog}{suffix}': dict(atlas=atlas,
                                        internal=internal,

--- a/deployments/prod/environment.py
+++ b/deployments/prod/environment.py
@@ -1116,8 +1116,6 @@ def env() -> Mapping[str, Optional[str]]:
 
         'AZUL_DOMAIN_NAME': 'azul.data.humancellatlas.org',
 
-        'AZUL_S3_BUCKET': 'edu-ucsc-gi-platform-hca-prod-storage-{AZUL_DEPLOYMENT_STAGE}.{AWS_DEFAULT_REGION}',
-
         'AZUL_CATALOGS': base64.b64encode(bz2.compress(json.dumps({
             f'{catalog}{suffix}': dict(atlas=atlas,
                                        internal=internal,

--- a/deployments/sandbox/environment.py
+++ b/deployments/sandbox/environment.py
@@ -243,8 +243,6 @@ def env() -> Mapping[str, Optional[str]]:
         'AZUL_SUBDOMAIN_TEMPLATE': '*.{AZUL_DEPLOYMENT_STAGE}',
         'AZUL_DRS_DOMAIN_NAME': 'drs.{AZUL_DEPLOYMENT_STAGE}.dev.singlecell.gi.ucsc.edu',
 
-        'AZUL_S3_BUCKET': 'edu-ucsc-gi-platform-hca-dev-storage-{AZUL_DEPLOYMENT_STAGE}.{AWS_DEFAULT_REGION}',
-
         'AZUL_CATALOGS': json.dumps({
             f'{catalog}{suffix}': dict(atlas=atlas,
                                        internal=internal,

--- a/environment.py
+++ b/environment.py
@@ -590,11 +590,6 @@ def env() -> Mapping[str, Optional[str]]:
         'AZUL_CONTRIBUTION_CONCURRENCY': '64',
         'AZUL_AGGREGATION_CONCURRENCY': '64',
 
-        # The name of the S3 bucket where the manifest API stores the downloadable
-        # content requested by client.
-        #
-        'AZUL_S3_BUCKET': None,
-
         # Collect and monitor important health metrics of the deployment (1 yes, 0 no).
         # Typically only enabled on main deployments.
         #

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -187,26 +187,29 @@ class Config:
     def share_es_domain(self) -> bool:
         return self._boolean(self.environ['AZUL_SHARE_ES_DOMAIN'])
 
-    @property
-    def s3_bucket(self) -> str:
-        return self.environ['AZUL_S3_BUCKET']
-
     def qualified_bucket_name(self,
                               *,
                               account_name: str,
                               region_name: str,
-                              bucket_name: str
+                              bucket_name: str,
+                              deployment_name: str | None = None
                               ) -> str:
         # Allow wildcard for use in ARN patterns
         if bucket_name != '*':
             self._validate_term(bucket_name, name='bucket_name')
-        return f'edu-ucsc-gi-{account_name}-{bucket_name}.{region_name}'
+        components = ['edu', 'ucsc', 'gi', account_name, bucket_name]
+        if deployment_name is not None:
+            self.validate_deployment_name(deployment_name)
+            components.append(deployment_name)
+        return '-'.join(components) + '.' + region_name
 
     aws_config_term = 'awsconfig'
 
     logs_term = 'logs'
 
     shared_term = 'shared'
+
+    storage_term = 'storage'
 
     current = object()
 

--- a/src/azul/deployment.py
+++ b/src/azul/deployment.py
@@ -525,10 +525,15 @@ class AWS:
             events.register_first(self._response_event_name, self._log_client_response)
         return resource
 
-    def qualified_bucket_name(self, bucket_name: str) -> str:
+    def qualified_bucket_name(self,
+                              bucket_name: str,
+                              *,
+                              deployment_name: str | None = None
+                              ) -> str:
         return config.qualified_bucket_name(account_name=config.aws_account_name,
                                             region_name=self.region_name,
-                                            bucket_name=bucket_name)
+                                            bucket_name=bucket_name,
+                                            deployment_name=deployment_name)
 
     @property
     def shared_bucket(self):
@@ -537,6 +542,11 @@ class AWS:
     @property
     def logs_bucket(self):
         return self.qualified_bucket_name(config.logs_term)
+
+    @property
+    def storage_bucket(self):
+        return self.qualified_bucket_name(config.storage_term,
+                                          deployment_name=config.deployment_stage)
 
     # An ELB account ID, which varies depending on region, is needed to specify
     # the principal in bucket policies for buckets storing LB access logs.

--- a/src/azul/deployment.py
+++ b/src/azul/deployment.py
@@ -56,6 +56,9 @@ from azul.types import (
 )
 
 if TYPE_CHECKING:
+    from mypy_boto3_dynamodb import (
+        DynamoDBClient,
+    )
     from mypy_boto3_ecr import (
         ECRClient,
     )
@@ -209,7 +212,7 @@ class AWS:
         return self.client('ec2')
 
     @property
-    def dynamodb(self):
+    def dynamodb(self) -> 'DynamoDBClient':
         return self.client('dynamodb', azul_logging=True)
 
     @property

--- a/src/azul/health.py
+++ b/src/azul/health.py
@@ -55,6 +55,7 @@ from azul.service.storage_service import (
 )
 from azul.types import (
     JSON,
+    MutableJSON,
 )
 
 log = logging.getLogger(__name__)
@@ -183,11 +184,11 @@ class Health:
         return json
 
     @health_property
-    def other_lambdas(self):
+    def other_lambdas(self) -> JSON:
         """
         Indicates whether the companion REST API responds to HTTP requests.
         """
-        response = {
+        response: MutableJSON = {
             lambda_name: self._lambda(lambda_name)
             for lambda_name in config.lambda_names()
             if lambda_name != self.lambda_name

--- a/src/azul/health.py
+++ b/src/azul/health.py
@@ -51,6 +51,7 @@ from azul.plugins import (
     MetadataPlugin,
 )
 from azul.service.storage_service import (
+    StorageObjectNotFound,
     StorageService,
 )
 from azul.types import (
@@ -124,7 +125,7 @@ class HealthController(AppController):
         else:
             try:
                 cache = json.loads(self.storage_service.get(f'health/{self.lambda_name}'))
-            except self.storage_service.client.exceptions.NoSuchKey:
+            except StorageObjectNotFound:
                 raise NotFoundError('Cached health object does not exist')
             else:
                 max_age = 2 * 60

--- a/src/azul/indexer/lambda_iam_policy.py
+++ b/src/azul/indexer/lambda_iam_policy.py
@@ -120,7 +120,7 @@ policy = {
                 "s3:PutObject"
             ],
             "Resource": [
-                f"arn:aws:s3:::{config.s3_bucket}/health/*",
+                "${aws_s3_bucket.%s.arn}/health/*" % config.storage_term,
             ]
         },
         {

--- a/src/azul/service/lambda_iam_policy.py
+++ b/src/azul/service/lambda_iam_policy.py
@@ -75,7 +75,7 @@ policy = {
                 "s3:GetObjectTagging"
             ],
             "Resource": [
-                f"arn:aws:s3:::{config.s3_bucket}/*",
+                "${aws_s3_bucket.%s.arn}/*" % config.storage_term,
                 f"arn:aws:s3:::{aws.shared_bucket}/*"
             ]
         },
@@ -95,7 +95,7 @@ policy = {
                 "s3:ListBucket"  # Without this, GetObject and HeadObject yield 403 for missing keys, not 404
             ],
             "Resource": [
-                f"arn:aws:s3:::{config.s3_bucket}",
+                "${aws_s3_bucket.%s.arn}" % config.storage_term,
                 f"arn:aws:s3:::{aws.shared_bucket}"
             ]
         },

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -16,10 +16,7 @@ from copy import (
 import csv
 from datetime import (
     datetime,
-    timedelta,
-    timezone,
 )
-import email.utils
 from hashlib import (
     sha256,
 )
@@ -51,7 +48,6 @@ from tempfile import (
 )
 import time
 from typing import (
-    Any,
     IO,
     Optional,
     Protocol,
@@ -84,9 +80,6 @@ from more_itertools import (
     one,
 )
 import msgpack
-from werkzeug.http import (
-    parse_dict_header,
-)
 
 from azul import (
     CatalogName,
@@ -737,13 +730,13 @@ class ManifestService(ElasticsearchService):
         """
         object_key = generator_cls.s3_object_key(manifest_key)
         try:
-            response = self.storage_service.head(object_key)
+            time_left = self.storage_service.time_until_object_expires(object_key,
+                                                                       expiration=config.manifest_expiration)
         except StorageObjectNotFound:
             log.info('Cached manifest not found: %s', manifest_key)
             return None
         else:
-            seconds_until_expire = self._get_seconds_until_expire(response)
-            if seconds_until_expire > config.manifest_expiration_margin:
+            if time_left > config.manifest_expiration_margin:
                 tagging = self.storage_service.get_object_tagging(object_key)
                 try:
                     encoded_file_name = tagging[self.file_name_tag]
@@ -765,39 +758,6 @@ class ManifestService(ElasticsearchService):
             else:
                 log.info('Cached manifest is about to expire: %s', object_key)
                 return None
-
-    @classmethod
-    def _get_seconds_until_expire(cls, head_response: Mapping[str, Any]) -> float:
-        """
-        Get the number of seconds before a cached manifest is past its expiration.
-
-        :param head_response: A storage service object header dict
-
-        :return: time to expiration in seconds
-        """
-        # example Expiration: 'expiry-date="Fri, 21 Dec 2012 00:00:00 GMT", rule-id="Rule for testfile.txt"'
-        now = datetime.now(timezone.utc)
-        expiration = parse_dict_header(head_response['Expiration'])
-        expiry_datetime = email.utils.parsedate_to_datetime(expiration['expiry-date'])
-        expiry_seconds = (expiry_datetime - now).total_seconds()
-        # Verify the 'Expiration' value is what is expected given the
-        # 'LastModified' value, the number of days before expiration, and that
-        # AWS rounds the expiration up to midnight UTC.
-        last_modified = head_response['LastModified']
-        last_modified_floor = last_modified.replace(hour=0,
-                                                    minute=0,
-                                                    second=0,
-                                                    microsecond=0)
-        expiration_in_days = config.manifest_expiration
-        if not last_modified == last_modified_floor:
-            expiration_in_days += 1
-        expected_date = last_modified_floor + timedelta(days=expiration_in_days)
-        if expiry_datetime == expected_date:
-            log.debug('Manifest object expires in %s seconds, on %s', expiry_seconds, expiry_datetime)
-        else:
-            log.error('The actual object expiration (%s) does not match expected value (%s)',
-                      expiration, expected_date)
-        return expiry_seconds
 
     def command_lines(self,
                       manifest: Optional[Manifest],

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -22,9 +22,6 @@ from urllib.parse import (
     urlencode,
 )
 
-from azul import (
-    config,
-)
 from azul.deployment import (
     aws,
 )
@@ -174,12 +171,6 @@ class StorageService:
                 'Key': key,
                 **({} if file_name is None else {'ResponseContentDisposition': f'attachment;filename="{file_name}"'})
             })
-
-    def create_bucket(self):
-        self._s3.create_bucket(Bucket=self.bucket_name,
-                               CreateBucketConfiguration={
-                                   'LocationConstraint': config.region
-                               })
 
     def put_object_tagging(self, object_key: str, tagging: Tagging = None):
         deadline = time.time() + 60

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -54,7 +54,9 @@ Tagging = Mapping[str, str]
 
 class StorageService:
 
-    def __init__(self, bucket_name=config.s3_bucket):
+    def __init__(self, bucket_name: str | None = None):
+        if bucket_name is None:
+            bucket_name = aws.storage_bucket
         self.bucket_name = bucket_name
 
     @property

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -176,8 +176,8 @@ class StorageService:
                 **({} if file_name is None else {'ResponseContentDisposition': f'attachment;filename="{file_name}"'})
             })
 
-    def create_bucket(self, bucket_name: Optional[str] = None):
-        self._s3.create_bucket(Bucket=(bucket_name or self.bucket_name),
+    def create_bucket(self):
+        self._s3.create_bucket(Bucket=self.bucket_name,
                                CreateBucketConfiguration={
                                    'LocationConstraint': config.region
                                })

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -35,7 +35,6 @@ if TYPE_CHECKING:
     )
     from mypy_boto3_s3.service_resource import (
         MultipartUpload,
-        S3ServiceResource,
     )
 
 log = getLogger(__name__)
@@ -66,10 +65,6 @@ class StorageService:
     @property
     def _s3(self) -> S3Client:
         return aws.s3
-
-    @property
-    def resource(self) -> S3ServiceResource:
-        return aws.resource('s3')
 
     def head(self, object_key: str) -> dict:
         try:
@@ -118,7 +113,8 @@ class StorageService:
         return self.load_multipart_upload(object_key, upload_id)
 
     def load_multipart_upload(self, object_key, upload_id) -> MultipartUpload:
-        return self.resource.MultipartUpload(self.bucket_name, object_key, upload_id)
+        s3 = aws.resource('s3')
+        return s3.MultipartUpload(self.bucket_name, object_key, upload_id)
 
     def upload_multipart_part(self,
                               buffer: IO[bytes],

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -57,10 +57,9 @@ class StorageObjectNotFound(Exception):
 
 class StorageService:
 
-    def __init__(self, bucket_name: str | None = None):
-        if bucket_name is None:
-            bucket_name = aws.storage_bucket
-        self.bucket_name = bucket_name
+    @property
+    def bucket_name(self):
+        return aws.storage_bucket
 
     @property
     def _s3(self) -> S3Client:

--- a/terraform/s3.tf.json.template.py
+++ b/terraform/s3.tf.json.template.py
@@ -21,8 +21,8 @@ tf_config = {
     },
     'resource': {
         'aws_s3_bucket': {
-            'storage': {
-                'bucket': config.s3_bucket,
+            config.storage_term: {
+                'bucket': aws.storage_bucket,
                 'force_destroy': True
             }
         },

--- a/test/dynamodb_test_case.py
+++ b/test/dynamodb_test_case.py
@@ -24,11 +24,7 @@ from azul_test_case import (
 )
 
 
-@mock_dynamodb
 class DynamoDBTestCase(AzulUnitTestCase, metaclass=ABCMeta):
-    """
-    Don't forget to decorate concrete subclasses with @mock_dynamodb as well!
-    """
     # Moto's dynamodb backend doesn't support government regions.
     _aws_test_region = 'ap-south-1'
 
@@ -50,6 +46,7 @@ class DynamoDBTestCase(AzulUnitTestCase, metaclass=ABCMeta):
 
     def setUp(self):
         super().setUp()
+        self.addPatch(mock_dynamodb())
         self.dynamodb.create_table(TableName=self._dynamodb_table_name(),
                                    BillingMode='PAY_PER_REQUEST',
                                    AttributeDefinitions=[

--- a/test/dynamodb_test_case.py
+++ b/test/dynamodb_test_case.py
@@ -1,9 +1,19 @@
+from abc import (
+    ABCMeta,
+    abstractmethod,
+)
 from collections.abc import (
     Mapping,
 )
 
 from moto import (
     mock_dynamodb,
+)
+from mypy_boto3_dynamodb import (
+    DynamoDBClient,
+)
+from mypy_boto3_dynamodb.literals import (
+    ScalarAttributeTypeType,
 )
 
 from azul.deployment import (
@@ -15,31 +25,41 @@ from azul_test_case import (
 
 
 @mock_dynamodb
-class DynamoDBTestCase(AzulUnitTestCase):
+class DynamoDBTestCase(AzulUnitTestCase, metaclass=ABCMeta):
     """
     Don't forget to decorate concrete subclasses with @mock_dynamodb as well!
     """
     # Moto's dynamodb backend doesn't support government regions.
     _aws_test_region = 'ap-south-1'
 
-    ddb_table_name: str = NotImplemented
-    ddb_attrs: Mapping[str, str] = NotImplemented
-    ddb_hash_key: str = NotImplemented
+    @abstractmethod
+    def _dynamodb_table_name(self) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _dynamodb_atttributes(self) -> Mapping[str, ScalarAttributeTypeType]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _dynamodb_hash_key(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def dynamodb(self) -> DynamoDBClient:
+        return aws.dynamodb
 
     def setUp(self):
         super().setUp()
-        self.ddb_client = aws.dynamodb
-
-        self.ddb_client.create_table(TableName=self.ddb_table_name,
-                                     BillingMode='PAY_PER_REQUEST',
-                                     AttributeDefinitions=[
-                                         dict(AttributeName=attr_name, AttributeType=attr_type)
-                                         for attr_name, attr_type in self.ddb_attrs.items()
-                                     ],
-                                     KeySchema=[
-                                         dict(AttributeName=self.ddb_hash_key, KeyType='HASH')
-                                     ])
+        self.dynamodb.create_table(TableName=self._dynamodb_table_name(),
+                                   BillingMode='PAY_PER_REQUEST',
+                                   AttributeDefinitions=[
+                                       dict(AttributeName=attr_name, AttributeType=attr_type)
+                                       for attr_name, attr_type in self._dynamodb_atttributes().items()
+                                   ],
+                                   KeySchema=[
+                                       dict(AttributeName=self._dynamodb_hash_key(), KeyType='HASH')
+                                   ])
 
     def tearDown(self):
-        self.ddb_client.delete_table(TableName=self.ddb_table_name)
+        self.dynamodb.delete_table(TableName=self._dynamodb_table_name())
         super().tearDown()

--- a/test/health_check_test_case.py
+++ b/test/health_check_test_case.py
@@ -23,7 +23,6 @@ from furl import (
     furl,
 )
 from moto import (
-    mock_s3,
     mock_sqs,
     mock_sts,
 )
@@ -127,11 +126,9 @@ class HealthCheckTestCase(LocalAppTestCase,
                 self.assertEqual(200, response.status_code)
                 self.assertEqual(expected_response, response.json())
 
-    @mock_s3
     @mock_sts
     @mock_sqs
     def test_cached_health(self):
-        self.storage_service.create_bucket()
         # No health object is available in S3 bucket, yielding an error
         with self._mock():
             response = self._test('/health/cached')

--- a/test/health_check_test_case.py
+++ b/test/health_check_test_case.py
@@ -52,7 +52,7 @@ from es_test_case import (
     ElasticsearchTestCase,
 )
 from service import (
-    StorageServiceTestMixin,
+    StorageServiceTestCase,
 )
 from sqs_test_case import (
     SqsTestCase,
@@ -73,7 +73,7 @@ def setUpModule():
 
 class HealthCheckTestCase(LocalAppTestCase,
                           ElasticsearchTestCase,
-                          StorageServiceTestMixin,
+                          StorageServiceTestCase,
                           SqsTestCase,
                           metaclass=ABCMeta):
 

--- a/test/service/__init__.py
+++ b/test/service/__init__.py
@@ -12,6 +12,8 @@ from typing import (
     ClassVar,
     Optional,
     Union,
+    cast,
+    get_args,
 )
 from unittest.mock import (
     MagicMock,
@@ -30,6 +32,12 @@ from moto import (
     mock_s3,
     mock_sts,
 )
+from mypy_boto3_s3.client import (
+    S3Client,
+)
+from mypy_boto3_s3.literals import (
+    BucketLocationConstraintType,
+)
 
 from app_test_case import (
     LocalAppTestCase,
@@ -37,6 +45,10 @@ from app_test_case import (
 from azul import (
     JSON,
     cached_property,
+    config,
+)
+from azul.deployment import (
+    aws,
 )
 from azul.indexer import (
     Bundle,
@@ -196,7 +208,25 @@ class DocumentCloningTestCase(WebServiceTestCase, metaclass=ABCMeta):
                                     doc_type=DocumentType.aggregate))
 
 
-class StorageServiceTestCase(AzulUnitTestCase):
+class S3TestCase(AzulUnitTestCase):
+
+    @property
+    def _s3(self) -> S3Client:
+        return aws.s3
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.addPatch(mock_sts())
+        self.addPatch(mock_s3())
+
+    def _create_test_bucket(self, bucket_name: str):
+        assert config.region in get_args(BucketLocationConstraintType)
+        location = cast(BucketLocationConstraintType, config.region)
+        self._s3.create_bucket(Bucket=bucket_name,
+                               CreateBucketConfiguration={'LocationConstraint': location})
+
+
+class StorageServiceTestCase(S3TestCase):
     """
     A mixin for test cases that utilize StorageService.
     """
@@ -207,9 +237,7 @@ class StorageServiceTestCase(AzulUnitTestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.addPatch(mock_sts())
-        self.addPatch(mock_s3())
-        self.storage_service.create_bucket()
+        self._create_test_bucket(self.storage_service.bucket_name)
 
 
 @deprecated('Instead of decorating your test case, or its test methods in it, '

--- a/test/service/__init__.py
+++ b/test/service/__init__.py
@@ -189,7 +189,7 @@ class DocumentCloningTestCase(WebServiceTestCase, metaclass=ABCMeta):
                                     doc_type=DocumentType.aggregate))
 
 
-class StorageServiceTestMixin:
+class StorageServiceTestCase:
     """
     A mixin for test cases that utilize StorageService.
     """

--- a/test/service/__init__.py
+++ b/test/service/__init__.py
@@ -26,6 +26,10 @@ from more_itertools import (
     flatten,
     one,
 )
+from moto import (
+    mock_s3,
+    mock_sts,
+)
 
 from app_test_case import (
     LocalAppTestCase,
@@ -57,6 +61,9 @@ from azul.service.storage_service import (
 from azul.types import (
     AnyJSON,
     JSONs,
+)
+from azul_test_case import (
+    AzulUnitTestCase,
 )
 from indexer import (
     IndexerTestCase,
@@ -189,7 +196,7 @@ class DocumentCloningTestCase(WebServiceTestCase, metaclass=ABCMeta):
                                     doc_type=DocumentType.aggregate))
 
 
-class StorageServiceTestCase:
+class StorageServiceTestCase(AzulUnitTestCase):
     """
     A mixin for test cases that utilize StorageService.
     """
@@ -197,6 +204,12 @@ class StorageServiceTestCase:
     @cached_property
     def storage_service(self) -> StorageService:
         return StorageService()
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.addPatch(mock_sts())
+        self.addPatch(mock_s3())
+        self.storage_service.create_bucket()
 
 
 @deprecated('Instead of decorating your test case, or its test methods in it, '

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -124,7 +124,7 @@ from pfb_test_case import (
 )
 from service import (
     DocumentCloningTestCase,
-    StorageServiceTestMixin,
+    StorageServiceTestCase,
     WebServiceTestCase,
 )
 
@@ -138,7 +138,7 @@ def setUpModule():
 
 @mock_s3
 class ManifestTestCase(WebServiceTestCase,
-                       StorageServiceTestMixin,
+                       StorageServiceTestCase,
                        metaclass=ABCMeta):
 
     def setUp(self):

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -56,10 +56,6 @@ from more_itertools import (
     first,
     one,
 )
-from moto import (
-    mock_s3,
-    mock_sts,
-)
 import requests
 from requests import (
     Response,
@@ -142,10 +138,7 @@ class ManifestTestCase(WebServiceTestCase,
 
     def setUp(self):
         super().setUp()
-        self.addPatch(mock_sts())
-        self.addPatch(mock_s3())
         self.addPatch(patch.object(PagedManifestGenerator, 'page_size', 1))
-        self.storage_service.create_bucket()
         self._setup_indices()
         self._setup_git_commit()
 

--- a/test/service/test_portal_service.py
+++ b/test/service/test_portal_service.py
@@ -45,11 +45,14 @@ def setUpModule():
 @mock_sts
 @mock_dynamodb
 class TestPortalService(VersionTableTestCase):
-    dummy_db = [
-        {
-            "spam": "eggs"
-        }
-    ]
+
+    @property
+    def dummy_db(self) -> JSONs:
+        return [
+            {
+                "spam": "eggs"
+            }
+        ]
 
     @cached_property
     def plugin_db(self) -> JSONs:
@@ -83,14 +86,16 @@ class TestPortalService(VersionTableTestCase):
             ]
         }]
 
-    demultiplex_db = [
-        {
-            'integrations': [
-                {'entity_ids': ['good']},
-                {}
-            ]
-        }
-    ]
+    @property
+    def demultiplex_db(self) -> JSONs:
+        return [
+            {
+                'integrations': [
+                    {'entity_ids': ['good']},
+                    {}
+                ]
+            }
+        ]
 
     def setUp(self):
         super().setUp()

--- a/test/service/test_portal_service.py
+++ b/test/service/test_portal_service.py
@@ -3,18 +3,10 @@ import json
 from botocore.exceptions import (
     ClientError,
 )
-from moto import (
-    mock_dynamodb,
-    mock_s3,
-    mock_sts,
-)
 
 from azul import (
     cached_property,
     config,
-)
-from azul.deployment import (
-    aws,
 )
 from azul.logging import (
     configure_test_logging,
@@ -31,6 +23,9 @@ from azul.types import (
 from azul.version_service import (
     NoSuchObjectVersion,
 )
+from service import (
+    S3TestCase,
+)
 from version_table_test_case import (
     VersionTableTestCase,
 )
@@ -41,10 +36,7 @@ def setUpModule():
     configure_test_logging()
 
 
-@mock_s3
-@mock_sts
-@mock_dynamodb
-class TestPortalService(VersionTableTestCase):
+class TestPortalService(VersionTableTestCase, S3TestCase):
 
     @property
     def dummy_db(self) -> JSONs:
@@ -99,22 +91,17 @@ class TestPortalService(VersionTableTestCase):
 
     def setUp(self):
         super().setUp()
-
         self.portal_service = PortalService()
-        self.s3_client = aws.s3
-        self.s3_client.create_bucket(Bucket=self.portal_service.bucket,
-                                     CreateBucketConfiguration={
-                                         'LocationConstraint': config.region
-                                     })
-        self.s3_client.put_bucket_versioning(Bucket=self.portal_service.bucket,
-                                             VersioningConfiguration={
-                                                 'Status': 'Enabled',
-                                                 'MFADelete': 'Disabled'
-                                             })
+        self._create_test_bucket(self.portal_service.bucket)
+        self._s3.put_bucket_versioning(Bucket=self.portal_service.bucket,
+                                       VersioningConfiguration={
+                                           'Status': 'Enabled',
+                                           'MFADelete': 'Disabled'
+                                       })
 
     def download_db(self) -> JSONs:
-        response = self.s3_client.get_object(Bucket=self.portal_service.bucket,
-                                             Key=self.portal_service.object_key)
+        response = self._s3.get_object(Bucket=self.portal_service.bucket,
+                                       Key=self.portal_service.object_key)
         return json.loads(response['Body'].read().decode())
 
     def test_demultiplex(self):

--- a/test/service/test_source_cache.py
+++ b/test/service/test_source_cache.py
@@ -1,10 +1,16 @@
 import time
+from typing import (
+    Mapping,
+)
 from unittest import (
     mock,
 )
 
 from moto import (
     mock_dynamodb,
+)
+from mypy_boto3_dynamodb.literals import (
+    ScalarAttributeTypeType,
 )
 
 from azul.service.source_service import (
@@ -19,9 +25,15 @@ from dynamodb_test_case import (
 
 @mock_dynamodb
 class TestSourceCache(DynamoDBTestCase):
-    ddb_table_name = SourceService.table_name
-    ddb_attrs = {SourceService.key_attribute: 'S'}
-    ddb_hash_key = SourceService.key_attribute
+
+    def _dynamodb_table_name(self) -> str:
+        return SourceService.table_name
+
+    def _dynamodb_atttributes(self) -> Mapping[str, ScalarAttributeTypeType]:
+        return {SourceService.key_attribute: 'S'}
+
+    def _dynamodb_hash_key(self) -> str:
+        return SourceService.key_attribute
 
     wait = 2
 
@@ -30,13 +42,10 @@ class TestSourceCache(DynamoDBTestCase):
         key = 'foo'
         value = [{'bar': 'baz'}]
         service = SourceService()
-
         with self.assertRaises(NotFound):
             service._get('nil')
-
         service._put(key, value)
         self.assertEqual(service._get(key), value)
-
         time.sleep(self.wait + 1)
         with self.assertRaises(Expired):
             service._get(key)

--- a/test/service/test_storage_service.py
+++ b/test/service/test_storage_service.py
@@ -17,7 +17,7 @@ from azul_test_case import (
     AzulUnitTestCase,
 )
 from service import (
-    StorageServiceTestMixin,
+    StorageServiceTestCase,
 )
 
 
@@ -28,7 +28,7 @@ def setUpModule():
 
 @mock_s3
 @mock_sts
-class StorageServiceTest(AzulUnitTestCase, StorageServiceTestMixin):
+class StorageServiceTest(AzulUnitTestCase, StorageServiceTestCase):
     """
     Functional Test for Storage Service
     """

--- a/test/service/test_storage_service.py
+++ b/test/service/test_storage_service.py
@@ -10,6 +10,9 @@ import requests
 from azul.logging import (
     configure_test_logging,
 )
+from azul.service.storage_service import (
+    StorageObjectNotFound,
+)
 from azul_test_case import (
     AzulUnitTestCase,
 )
@@ -57,7 +60,7 @@ class StorageServiceTest(AzulUnitTestCase, StorageServiceTestMixin):
         self.storage_service.create_bucket()
 
         # NOTE: Ensure that the key does not exist before writing.
-        with self.assertRaises(self.storage_service.client.exceptions.NoSuchKey):
+        with self.assertRaises(StorageObjectNotFound):
             self.storage_service.get(sample_key)
 
         self.storage_service.put(sample_key, sample_content)
@@ -71,7 +74,7 @@ class StorageServiceTest(AzulUnitTestCase, StorageServiceTestMixin):
 
         self.storage_service.create_bucket()
 
-        with self.assertRaises(self.storage_service.client.exceptions.NoSuchKey):
+        with self.assertRaises(StorageObjectNotFound):
             self.storage_service.get(sample_key)
 
     @mock_s3

--- a/test/service/test_storage_service.py
+++ b/test/service/test_storage_service.py
@@ -1,10 +1,6 @@
 import json
 import tempfile
 
-from moto import (
-    mock_s3,
-    mock_sts,
-)
 import requests
 
 from azul.logging import (
@@ -12,9 +8,6 @@ from azul.logging import (
 )
 from azul.service.storage_service import (
     StorageObjectNotFound,
-)
-from azul_test_case import (
-    AzulUnitTestCase,
 )
 from service import (
     StorageServiceTestCase,
@@ -26,16 +19,10 @@ def setUpModule():
     configure_test_logging()
 
 
-@mock_s3
-@mock_sts
-class StorageServiceTest(AzulUnitTestCase, StorageServiceTestCase):
+class StorageServiceTest(StorageServiceTestCase):
     """
     Functional Test for Storage Service
     """
-
-    def setUp(self) -> None:
-        super().setUp()
-        self.storage_service.create_bucket()
 
     def test_upload_tags(self):
         object_key = 'test_file'

--- a/test/service/test_storage_service.py
+++ b/test/service/test_storage_service.py
@@ -26,16 +26,18 @@ def setUpModule():
     configure_test_logging()
 
 
+@mock_s3
+@mock_sts
 class StorageServiceTest(AzulUnitTestCase, StorageServiceTestMixin):
     """
     Functional Test for Storage Service
     """
 
-    @mock_s3
-    @mock_sts
-    def test_upload_tags(self):
+    def setUp(self) -> None:
+        super().setUp()
         self.storage_service.create_bucket()
 
+    def test_upload_tags(self):
         object_key = 'test_file'
         with tempfile.NamedTemporaryFile('w') as f:
             f.write('some contents')
@@ -51,13 +53,9 @@ class StorageServiceTest(AzulUnitTestCase, StorageServiceTestMixin):
                     self.assertEqual(tags,
                                      upload_tags)
 
-    @mock_s3
-    @mock_sts
     def test_simple_get_put(self):
         sample_key = 'foo-simple'
         sample_content = b'bar'
-
-        self.storage_service.create_bucket()
 
         # NOTE: Ensure that the key does not exist before writing.
         with self.assertRaises(StorageObjectNotFound):
@@ -67,23 +65,16 @@ class StorageServiceTest(AzulUnitTestCase, StorageServiceTestMixin):
 
         self.assertEqual(sample_content, self.storage_service.get(sample_key))
 
-    @mock_s3
-    @mock_sts
     def test_simple_get_unknown_item(self):
         sample_key = 'foo-simple'
-
-        self.storage_service.create_bucket()
 
         with self.assertRaises(StorageObjectNotFound):
             self.storage_service.get(sample_key)
 
-    @mock_s3
-    @mock_sts
     def test_presigned_url(self):
         sample_key = 'foo-presigned-url'
         sample_content = json.dumps({'a': 1})
 
-        self.storage_service.create_bucket()
         self.storage_service.put(sample_key, sample_content.encode())
 
         for file_name in None, 'foo.json':

--- a/test/version_table_test_case.py
+++ b/test/version_table_test_case.py
@@ -1,3 +1,11 @@
+from typing import (
+    Mapping,
+)
+
+from mypy_boto3_dynamodb.literals import (
+    ScalarAttributeTypeType,
+)
+
 from azul import (
     config,
 )
@@ -10,6 +18,12 @@ from dynamodb_test_case import (
 
 
 class VersionTableTestCase(DynamoDBTestCase):
-    ddb_table_name = config.dynamo_object_version_table_name
-    ddb_hash_key = VersionService.key_name
-    ddb_attrs = {VersionService.key_name: 'S'}
+
+    def _dynamodb_table_name(self) -> str:
+        return config.dynamo_object_version_table_name
+
+    def _dynamodb_atttributes(self) -> Mapping[str, ScalarAttributeTypeType]:
+        return {VersionService.key_name: 'S'}
+
+    def _dynamodb_hash_key(self) -> str:
+        return VersionService.key_name


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Connected issues: #4655


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make image_manifests.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `image_manifests.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved ticket to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for `dev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for `anvildev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Notified team members on Slack about the necessary upgrade to their deployments
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
