### PR TITLE
Fix: Promotions fail in hammerbox with dirty requirements (#6239)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/anvilprod-promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/anvilprod-promotion.md
@@ -78,6 +78,7 @@ Connected issue: #0000
 - [ ] Reviewed build logs for anomalies on GitLab `anvilprod`
 - [ ] Ran `_select anvilprod.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
 - [ ] Deleted PR branch from GitHub
+- [ ] Deleted PR branch from GitLab `anvilprod`
 - [ ] Moved connected issue to *Merged stable* column on ZenHub
 - [ ] Moved promoted issues from *Merged lower* to *Merged stable* column on ZenHub
 - [ ] Moved promoted issues from *Lower* to *Stable* column on ZenHub

--- a/.github/PULL_REQUEST_TEMPLATE/prod-hotfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/prod-hotfix.md
@@ -62,7 +62,6 @@ Connected issue: #0000
 - [ ] Build passes on GitLab `prod`
 - [ ] Reviewed build logs for anomalies on GitLab `prod`
 - [ ] Deleted PR branch from GitHub
-- [ ] Deleted PR branch from GitLab `prod`
 
 
 ### Operator (reindex)

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -879,7 +879,7 @@ def emit(t: T, target_branch: str):
                     'content': f'Deleted PR branch from GitLab `{d}`'
                 }
                 for d, s in t.target_deployments(target_branch).items()
-                if t is not t.promotion
+                if s is not None
             ),
             *iif(t is T.promotion, [
                 {

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,7 +77,7 @@ test:
   timeout: 1h 30m
   script:
     - make format
-    - test "$AZUL_IS_SANDBOX" = 1 && make requirements_update
+    - python -m azul -t config.is_lower_sandbox_deployment && make requirements_update
     - make -C lambdas openapi
     - make environment.boot
     - make -C .github

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,7 +77,7 @@ test:
   timeout: 1h 30m
   script:
     - make format
-    - python -m azul -t config.is_lower_sandbox_deployment && make requirements_update
+    - python -m azul -t config.deployment.is_lower_sandbox && make requirements_update
     - make -C lambdas openapi
     - make environment.boot
     - make -C .github

--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -20,6 +20,12 @@ reverted. This is all fairly informal and loosely defined. Hopefully we won't
 have too many entries in this file.
 
 
+#6239 Promotions fail in hammerbox with dirty requirements
+==========================================================
+
+Remove the variable ``AZUL_IS_SANDBOX`` from all personal deployments.
+
+
 #4655 All bucket names should default to qualified_bucket_name()
 ================================================================
 

--- a/deployments/anvilbox/environment.py
+++ b/deployments/anvilbox/environment.py
@@ -112,8 +112,6 @@ def env() -> Mapping[str, Optional[str]]:
         #
         'AZUL_DEPLOYMENT_STAGE': 'anvilbox' if is_sandbox else None,
 
-        'AZUL_IS_SANDBOX': str(int(is_sandbox)),
-
         # This deployment uses a subdomain of the `anvildev` deployment's
         # domain.
         #

--- a/deployments/hammerbox/environment.py
+++ b/deployments/hammerbox/environment.py
@@ -749,8 +749,6 @@ def env() -> Mapping[str, Optional[str]]:
         #
         'AZUL_DEPLOYMENT_STAGE': 'hammerbox' if is_sandbox else None,
 
-        'AZUL_IS_SANDBOX': str(int(is_sandbox)),
-
         # This deployment uses a subdomain of the `anvilprod` deployment's
         # domain.
         #

--- a/deployments/sandbox/environment.py
+++ b/deployments/sandbox/environment.py
@@ -235,8 +235,6 @@ def env() -> Mapping[str, Optional[str]]:
         #
         'AZUL_DEPLOYMENT_STAGE': 'sandbox' if is_sandbox else None,
 
-        'AZUL_IS_SANDBOX': str(int(is_sandbox)),
-
         # This deployment uses a subdomain of the `dev` deployment's domain.
         #
         'AZUL_DOMAIN_NAME': 'dev.singlecell.gi.ucsc.edu',

--- a/environment
+++ b/environment
@@ -102,8 +102,8 @@ _logout() {
 }
 
 _logout_completely() {
-  # We don't use `&&` between function invocations because failing to log out of
-  # one realm shouldn't prevent us from attempting to log out of the others.
+	# We don't use `&&` between function invocations because failing to log out of
+	# one realm shouldn't prevent us from attempting to log out of the others.
 	_logout_google
 	_logout
 	_logout_docker_ecr
@@ -256,6 +256,64 @@ _revenv() {
 		echo >&2 "_revenv failed"
 		return 1
 	fi
+}
+
+_clone() {
+	if [[ -z "$1" || -z "$2" ]]; then
+		echo "Need two arguments: the name of the deployment to select in the"
+		echo "project clone and the name of the branch to check out in it."
+		return 1
+	fi
+  if [ -n "$VIRTUAL_ENV" ]; then
+    echo "Run 'deactivate' first"
+    return 2
+  fi
+  if [ "$(basename "$PWD")" != azul ]; then
+    echo "The name of the current project directory must be 'azul'"
+    return 3
+  fi
+  deployment="$1"
+  branch="$2"
+  (
+    set -e
+    git worktree add "../azul.${deployment}" "${branch}"
+    cd "../azul.${deployment}"
+    (cd terraform/gitlab/vpn && git submodule update --init easy-rsa)
+    rsync -rvlm \
+      -f '+ */' \
+      -f '+ environment.local.py' \
+      -f '+ /deployments/*.local/environment*.py' \
+      -f '- *' \
+      ../azul/ \
+      .
+    source environment
+    _link "${deployment}"
+    _refresh
+    make virtualenv
+    source .venv/bin/activate
+    make requirements envhook
+    deactivate
+    rsync -av ../azul/.idea .
+    mv .idea/azul.iml ".idea/azul.${deployment}.iml"
+    sed -e '/<component name="ProjectId".*/d' \
+        -e s#\<module\ name=\"azul\"#\<module\ name=\""azul.${deployment}"\"#g \
+        -i '' \
+        .idea/workspace.xml
+    sed -e s#.idea/azul.iml#.idea/azul."${deployment}".iml#g \
+        -i '' \
+        .idea/modules.xml
+    echo ""
+    echo "You can now open the directory"
+    echo ""
+    pwd
+    echo ""
+    echo "as a project in PyCharm. Be sure to verify that the right .venv "
+    echo "is configured as the Python interpreter in the project settings."
+    echo ""
+    echo "To remove the clone, close the project in PyCharm, delete the"
+    echo "project directory, and run 'git worktree prune'"
+    echo ""
+  )
 }
 
 # We disable `envhook.py` to avoid redundancy. The `envhook.py` script imports

--- a/environment.py
+++ b/environment.py
@@ -840,12 +840,6 @@ def env() -> Mapping[str, Optional[str]]:
         #
         'azul_browser_sites': json.dumps({}),
 
-        # 1 if current deployment is a main deployment with the sole purpose of
-        # testing feature branches in GitLab before they are merged to the
-        # develop branch, 0 otherwise. Personal deployments have this set to 0.
-        #
-        'AZUL_IS_SANDBOX': '0',
-
         # A list of names of AWS IAM roles that should be given permission to
         # manage incidents with AWS support as defined in CIS rule 1.20:
         #

--- a/scripts/update_subgraph_counts.py
+++ b/scripts/update_subgraph_counts.py
@@ -82,7 +82,7 @@ class SubgraphCounter:
         try:
             func = getattr(environment, 'common_prefix')
         except AttributeError:
-            assert not config.is_sandbox_or_personal_deployment, environment.__path__
+            assert not config.is_sandbox_or_personal_deployment(), environment.__path__
             return ''
         else:
             return func(self.count)

--- a/scripts/update_subgraph_counts.py
+++ b/scripts/update_subgraph_counts.py
@@ -82,7 +82,7 @@ class SubgraphCounter:
         try:
             func = getattr(environment, 'common_prefix')
         except AttributeError:
-            assert not config.is_sandbox_or_personal_deployment(), environment.__path__
+            assert config.deployment.is_main, environment.__path__
             return ''
         else:
             return func(self.count)

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -47,11 +47,11 @@ from azul.caching import (
 from azul.collections import (
     atuple,
 )
-from azul.json_freeze import (
-    freeze,
-)
 from azul.types import (
     JSON,
+)
+from azul.vendored.frozendict import (
+    frozendict,
 )
 
 log = logging.getLogger(__name__)
@@ -975,7 +975,7 @@ class Config:
         return self._boolean(self.environ['AZUL_PRIVATE_API'])
 
     @property
-    def _shared_deployments(self) -> Mapping[Optional[str], Sequence[str]]:
+    def _shared_deployments(self) -> Mapping[Optional[str], Sequence['Deployment']]:
         """
         Maps a branch name to a sequence of names of shared deployments the
         branch can be deployed to. The key of None signifies any other branch
@@ -987,14 +987,14 @@ class Config:
         deployments = json.loads(self.environ['azul_shared_deployments'])
         require(all(isinstance(v, list) and v for v in deployments.values()),
                 'Invalid value for azul_shared_deployments')
-        return freeze({
-            k if k else None: v
+        return frozendict(
+            (k if k else None, tuple(self.Deployment(n) for n in v))
             for k, v in deployments.items()
-        })
+        )
 
     def shared_deployments_for_branch(self,
-                                      branch: Optional[str]
-                                      ) -> Optional[Sequence[str]]:
+                                      branch: str | None,
+                                      ) -> Sequence['Deployment'] | None:
         """
         The list of names of shared deployments the given branch can be deployed
         to or `None` of no such deployments exist. An argument of `None`
@@ -1009,107 +1009,100 @@ class Config:
         except KeyError:
             return None if branch is None else deployments.get(None)
 
-    def is_shared_deployment(self, deployment: str | None = None) -> bool:
-        """
-        Returns `True` if the deployment of the specified name is a shared
-        deployment, or `False` if it is a personal deployment. If no argument is
-        passed, or if the argument is `None`, the current deployment's name is
-        used instead.
-        """
-        if deployment is None:
-            deployment = self.deployment_stage
-        return deployment in set(chain.from_iterable(self._shared_deployments.values()))
-
-    #: The set of branches that are used for development and that are usually
-    #: deployed to personal, lower and main deployments, but never stable ones.
-    #: The set member ``None`` represents a feature branch or detached HEAD.
-    #:
-    unstable_branches = {'develop', None}
-
-    def is_stable_deployment(self, deployment: str | None = None) -> bool:
-        """
-        Returns `True` if the deployment of the specified name must be kept
-        functional for public use at all times. If no argument is passed, or if
-        the argument is `None`, the current deployment's name is used instead.
-        """
-        if deployment is None:
-            deployment = self.deployment_stage
-        if self.is_sandbox_deployment(deployment):
-            return False
-        else:
-            branches = set(
-                branch
-                for branch, deployments in self._shared_deployments.items()
-                if deployment in deployments
-            )
-            return bool(branches) and branches.isdisjoint(self.unstable_branches)
-
-    def is_sandbox_deployment(self, deployment: str | None = None) -> bool:
-        """
-        Returns `True` if the deployment of the specified name is a shared
-        deployment primarily used for testing branches prior to merging. If no
-        argument is passed, or if the argument is `None`, the current
-        deployment's name is used instead.
-        """
-        if deployment is None:
-            deployment = self.deployment_stage
-        return 'box' in deployment
-
-    def is_personal_deployment(self, deployment: str | None = None) -> bool:
-        """
-        Returns `True` if the deployment of the specified name is a deployment
-        managed by an individual developer. If no argument is passed, or if the
-        argument is `None`, the current deployment's name is used instead.
-        """
-        return not self.is_shared_deployment(deployment)
-
-    def is_sandbox_or_personal_deployment(self,
-                                          deployment: str | None = None
-                                          ) -> bool:
-        """
-        Returns `True` if the deployment of the specified name is managed by an
-        individual developer or if it is a shared deployment primarily used for
-        testing branches prior to merging. If no argument is passed, or if the
-        argument is `None`, the current deployment's name is used instead.
-        """
-        return (
-            self.is_sandbox_deployment(deployment)
-            or self.is_personal_deployment(deployment)
-        )
-
-    def is_main_deployment(self, deployment: str | None = None) -> bool:
-        """
-        Returns `True` if the deployment of the specified name is a main
-        deployment. If no argument is passed, or if the argument is `None`, the
-        current deployment's name is used instead. Main deployments are deployed
-        from long-lived (as opposed to feature) branches and serve some
-        public-facing purpose, be that testing (a lower deployment) or
-        production (a stable deployment).
-        """
-        return not self.is_sandbox_or_personal_deployment(deployment)
-
-    def is_lower_deployment(self, deployment: str | None = None) -> bool:
-        """
-        Returns `True` if the current deployment is a main deployment that is
-        not stable.
-        """
-        if deployment is None:
-            deployment = self.deployment_stage
-        return (
-            self.is_main_deployment(deployment)
-            and not self.is_stable_deployment(deployment)
-        )
-
     @property
-    def is_lower_sandbox_deployment(self) -> bool:
-        """
-        Returns `True` if the current deployment is a sandbox for a lower
-        deployment.
-        """
-        return (
-            self.is_sandbox_deployment()
-            and self.is_lower_deployment(self.main_deployment_stage)
-        )
+    def deployment(self) -> 'Deployment':
+        return self.Deployment(self.deployment_stage)
+
+    @attr.s(frozen=True, kw_only=False, auto_attribs=True)
+    class Deployment:
+        name: str
+
+        @property
+        def is_shared(self) -> bool:
+            """
+            ``True`` if this deployment is a shared deployment, or ``False`` if
+            it is a personal deployment.
+            """
+            return self in set(chain.from_iterable(config._shared_deployments.values()))
+
+        #: The set of branches that are used for development and that are
+        #: usually deployed to personal, lower and main deployments, but never
+        #: stable ones. The set member ``None`` represents a feature branch or
+        #: detached HEAD.
+        #:
+        unstable_branches = {'develop', None}
+
+        @property
+        def is_stable(self) -> bool:
+            """
+            ``True`` if this deployment must be kept functional for public use
+            at all times.
+            """
+            if self.is_sandbox:
+                return False
+            else:
+                branches = set(
+                    branch
+                    for branch, deployments in config._shared_deployments.items()
+                    if self in deployments
+                )
+                return bool(branches) and branches.isdisjoint(self.unstable_branches)
+
+        @property
+        def is_sandbox(self) -> bool:
+            """
+            ``True`` if this deployment is a shared deployment primarily used
+            for testing branches prior to merging.
+            """
+            return 'box' in self.name
+
+        @property
+        def is_personal(self) -> bool:
+            """
+            ``True`` if this deployment is managed by an individual developer.
+            """
+            return not self.is_shared
+
+        @property
+        def is_sandbox_or_personal(self) -> bool:
+            """
+            ``True`` if this deployment is managed by an individual developer or
+            is a shared deployment primarily used for testing branches prior to
+            merging.
+            """
+            return self.is_sandbox or self.is_personal
+
+        @property
+        def is_main(self) -> bool:
+            """
+            ``True`` if this deployment is a main deployment.
+
+            Main deployments are deployed from long-lived (as opposed to
+            feature) branches and serve some public-facing purpose, be that
+            testing (a lower deployment) or production (a stable deployment).
+            """
+            return not self.is_sandbox_or_personal
+
+        @property
+        def is_lower(self) -> bool:
+            """
+            ``True`` if this deployment is an unstable main deployment.
+            """
+            return self.is_main and not self.is_stable
+
+        @property
+        def is_lower_sandbox(self) -> bool:
+            """
+            ``True`` if this deployment is a sandbox for a lower deployment.
+
+            Note: This method currently only works for the current deployment,
+                  i.e., the one created obtained from ``config.deployment``
+            """
+            require(self.name == config.deployment_stage, exception=NotImplementedError)
+            return (
+                self.is_sandbox
+                and config.Deployment(config.main_deployment_stage).is_lower
+            )
 
     class BrowserSite(TypedDict):
         domain: str

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -1049,7 +1049,7 @@ class Config:
         Returns True if the current deployment is a shared deployment primarily
         used for testing feature branches.
         """
-        return self._boolean(self.environ['AZUL_IS_SANDBOX'])
+        return 'box' in self.deployment_stage
 
     @property
     def is_sandbox_or_personal_deployment(self) -> bool:

--- a/src/azul/indexer/index_service.py
+++ b/src/azul/indexer/index_service.py
@@ -45,7 +45,6 @@ from azul import (
     CatalogName,
     cache,
     config,
-    freeze,
 )
 from azul.deployment import (
     aws,
@@ -88,6 +87,9 @@ from azul.indexer.document_service import (
 )
 from azul.indexer.transform import (
     Transformer,
+)
+from azul.json_freeze import (
+    freeze,
 )
 from azul.logging import (
     silenced_es_logger,

--- a/src/azul/portal_service.py
+++ b/src/azul/portal_service.py
@@ -285,4 +285,4 @@ class PortalService:
 
     @property
     def _expiration_tag(self) -> tuple[str, str]:
-        return 'expires', str(config.is_sandbox_or_personal_deployment()).lower()
+        return 'expires', str(config.deployment.is_sandbox_or_personal).lower()

--- a/src/azul/portal_service.py
+++ b/src/azul/portal_service.py
@@ -285,4 +285,4 @@ class PortalService:
 
     @property
     def _expiration_tag(self) -> tuple[str, str]:
-        return 'expires', str(config.is_sandbox_or_personal_deployment).lower()
+        return 'expires', str(config.is_sandbox_or_personal_deployment()).lower()

--- a/terraform/gitlab/gitlab.tf.json.template.py
+++ b/terraform/gitlab/gitlab.tf.json.template.py
@@ -187,7 +187,7 @@ vpc_cidr = config.vpc_cidr
 
 vpn_subnet = config.vpn_subnet
 
-split_tunnel = not config.is_stable_deployment
+split_tunnel = not config.is_stable_deployment()
 
 # The public key of that keypair
 #

--- a/terraform/gitlab/gitlab.tf.json.template.py
+++ b/terraform/gitlab/gitlab.tf.json.template.py
@@ -187,7 +187,7 @@ vpc_cidr = config.vpc_cidr
 
 vpn_subnet = config.vpn_subnet
 
-split_tunnel = not config.is_stable_deployment()
+split_tunnel = not config.deployment.is_stable
 
 # The public key of that keypair
 #

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -305,7 +305,7 @@ class IntegrationTestCase(AzulTestCase, metaclass=ABCMeta):
         fqids = self.azul_client.list_bundles(catalog, source, partition_prefix)
         num_bundles = len(fqids)
         partition = f'Partition {effective_prefix!r} of source {source.spec}'
-        if not config.is_sandbox_or_personal_deployment:
+        if not config.is_sandbox_or_personal_deployment():
             # For sources that use partitioning, 512 is the desired partition
             # size. In practice, we observe the reindex succeeding with sizes
             # >700 without the partition size becoming a limiting factor. From
@@ -532,7 +532,7 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
         self.azul_client.reset_indexer(catalogs=config.integration_test_catalogs,
                                        # Can't purge the queues in stable deployment as
                                        # they may contain work for non-IT catalogs.
-                                       purge_queues=not config.is_stable_deployment,
+                                       purge_queues=not config.is_stable_deployment(),
                                        delete_indices=True,
                                        create_indices=True)
 
@@ -1754,7 +1754,7 @@ class PortalExpirationIntegrationTest(PortalTestCase):
 # FIXME: Re-enable when SlowDown error can be avoided
 #        https://github.com/DataBiosphere/azul/issues/4285
 @unittest.skip('Test disabled. FIXME #4285')
-@unittest.skipUnless(config.is_sandbox_or_personal_deployment,
+@unittest.skipUnless(config.is_sandbox_or_personal_deployment(),
                      'Test would pollute portal DB')
 class PortalRegistrationIntegrationTest(PortalTestCase, AlwaysTearDownTestCase):
 

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -305,7 +305,7 @@ class IntegrationTestCase(AzulTestCase, metaclass=ABCMeta):
         fqids = self.azul_client.list_bundles(catalog, source, partition_prefix)
         num_bundles = len(fqids)
         partition = f'Partition {effective_prefix!r} of source {source.spec}'
-        if not config.is_sandbox_or_personal_deployment():
+        if not config.deployment.is_sandbox_or_personal:
             # For sources that use partitioning, 512 is the desired partition
             # size. In practice, we observe the reindex succeeding with sizes
             # >700 without the partition size becoming a limiting factor. From
@@ -532,7 +532,7 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
         self.azul_client.reset_indexer(catalogs=config.integration_test_catalogs,
                                        # Can't purge the queues in stable deployment as
                                        # they may contain work for non-IT catalogs.
-                                       purge_queues=not config.is_stable_deployment(),
+                                       purge_queues=not config.deployment.is_stable,
                                        delete_indices=True,
                                        create_indices=True)
 
@@ -1754,7 +1754,7 @@ class PortalExpirationIntegrationTest(PortalTestCase):
 # FIXME: Re-enable when SlowDown error can be avoided
 #        https://github.com/DataBiosphere/azul/issues/4285
 @unittest.skip('Test disabled. FIXME #4285')
-@unittest.skipUnless(config.is_sandbox_or_personal_deployment(),
+@unittest.skipUnless(config.deployment.is_sandbox_or_personal,
                      'Test would pollute portal DB')
 class PortalRegistrationIntegrationTest(PortalTestCase, AlwaysTearDownTestCase):
 

--- a/test/test_check_branch.py
+++ b/test/test_check_branch.py
@@ -38,8 +38,8 @@ class TestCheckBranch(AzulUnitTestCase):
                              "Detached head cannot be deployed to 'prod', "
                              "only personal deployments.")
 
-            check_branch('prod', 'hannes.local')
-            check_branch('develop', 'hannes.local')
+            check_branch('prod', 'hannes')
+            check_branch('develop', 'hannes')
 
             expect_exception('prod', 'dev',
                              "Branch 'prod' cannot be deployed to 'dev', "


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Connected issues: #6239 


## Notes

Deploying the `gitlab` and `shared` components should result in an empty plan.

Update: The `shared` plan was not empty. The `null_resource.repository_…` resources triggered because of the change to `azul_terraform_keep_unused` from `False` to `True` (a positive edge). I don't think there's a way to only trigger on negative edges.


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make image_manifests.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `image_manifests.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved ticket to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for `dev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for `anvildev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
