### PR TITLE
Fix: Spurious update to opensearch_cluster_settings yields 401 (#6278)

### DIFF
--- a/scripts/manage_cluster_settings.py
+++ b/scripts/manage_cluster_settings.py
@@ -1,0 +1,25 @@
+from azul import (
+    require,
+)
+from azul.es import (
+    ESClientFactory,
+)
+from azul.logging import (
+    configure_script_logging,
+)
+
+configure_script_logging()
+
+
+def main():
+    es = ESClientFactory.get()
+    response = es.cluster.put_settings(body={
+        'persistent': {
+            'action.auto_create_index': False
+        }
+    })
+    require(response['acknowledged'], 'Failed to update cluster settings', response)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/rename_resources.py
+++ b/scripts/rename_resources.py
@@ -19,6 +19,9 @@ from azul.terraform import (
 log = logging.getLogger(__name__)
 
 renamed: dict[str, Optional[str]] = {
+    # FIXME: Remove the following entry
+    #        https://github.com/DataBiosphere/azul/pull/6285
+    'opensearch_cluster_settings.index': None
 }
 
 

--- a/src/azul/terraform.py
+++ b/src/azul/terraform.py
@@ -784,11 +784,13 @@ class Chalice:
         # and less intrusive fix.
         #
         deployment = resources['aws_api_gateway_deployment'][app_name]
+        stage_name = deployment.pop('stage_name')
+        require(stage_name == config.deployment_stage,
+                'The TF config from Chalice does not match the selected deployment',
+                stage_name, config.deployment_stage)
         del deployment['lifecycle']['create_before_destroy']
         assert not deployment['lifecycle'], deployment
         del deployment['lifecycle']
-        stage_name = deployment.pop('stage_name')
-        assert stage_name == config.deployment_stage, stage_name
         deployment['triggers'] = {'redeployment': deployment.pop('stage_description')}
 
         return {

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -34,18 +34,18 @@ validate: config
 	terraform validate
 
 .PHONY: rename_resources
-rename_resources: config
+rename_resources: validate
 	python $(project_root)/scripts/rename_resources.py
 
 .PHONY: import_resources
 import_resources: rename_resources
 
 .PHONY: plan
-plan: validate import_resources
+plan: import_resources
 	terraform plan
 
 .PHONY: apply
-apply: validate import_resources
+apply: import_resources
 ifeq ($(AZUL_PRIVATE_API),1)
 	# For private API we need the VPC endpoints to be created first so that the
 	# aws_lb_target_group_attachment can iterate over the network_interface_ids.
@@ -54,7 +54,7 @@ endif
 	terraform apply
 
 .PHONY: auto_apply
-auto_apply: validate import_resources
+auto_apply: import_resources
 ifeq ($(AZUL_PRIVATE_API),1)
 	# See `apply` above
 	terraform apply -auto-approve -target aws_vpc_endpoint.indexer -target aws_vpc_endpoint.service
@@ -64,11 +64,11 @@ endif
 	terraform apply -auto-approve plan.bin
 
 .PHONY: destroy
-destroy: validate import_resources
+destroy: import_resources
 	terraform destroy
 
 .PHONY: auto_destroy
-auto_destroy: validate import_resources
+auto_destroy: import_resources
 	@echo '!!! All resources will be deleted in 10s, hit Ctrl-C to cancel !!!'; sleep 10
 	terraform destroy -auto-approve
 

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -4,10 +4,10 @@ all: apply
 include ../common.mk
 
 .PHONY: clean
-clean: check_env git_clean
+clean: check_env check_branch git_clean
 
 .PHONY: state
-state: check_terraform check_branch check_aws
+state: check_terraform check_aws
 
 .PHONY: initable
 initable: clean state providers.tf.json backend.tf.json

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -14,8 +14,7 @@ initable: clean state providers.tf.json backend.tf.json
 
 .PHONY: init
 init: initable
-	terraform init -reconfigure
-	$(MAKE) check_providers_clean
+	terraform init -reconfigure -lockfile=readonly
 
 .PHONY: check_schema
 check_schema: init
@@ -79,8 +78,3 @@ provider_update: initable
 	                         -platform=linux_arm64 \
 	                         -platform=darwin_amd64 \
 	                         -platform=darwin_arm64
-
-.PHONY: check_providers_clean
-check_providers_clean:
-	git diff --exit-code --name-only .terraform.lock.hcl \
-	&& git diff --cached --exit-code --name-only .terraform.lock.hcl

--- a/terraform/elasticsearch.tf.json.template.py
+++ b/terraform/elasticsearch.tf.json.template.py
@@ -191,6 +191,6 @@ emit_tf(None if config.share_es_domain else {
                     ],
                 }
             }
-        } if domain else {}
+        }
     ]
 })

--- a/terraform/elasticsearch.tf.json.template.py
+++ b/terraform/elasticsearch.tf.json.template.py
@@ -24,34 +24,34 @@ emit_tf(None if config.share_es_domain else {
             }
         }
     ],
-    "resource": [
+    'resource': [
         *({
-            "aws_cloudwatch_log_group": {
-                f"{log}_log": {
-                    "name": f"/aws/aes/domains/{domain}/{log}-logs",
-                    "retention_in_days": config.audit_log_retention_days
+            'aws_cloudwatch_log_group': {
+                f'{log}_log': {
+                    'name': f'/aws/aes/domains/{domain}/{log}-logs',
+                    'retention_in_days': config.audit_log_retention_days
                 }
             }
         } for log in logs.keys()),
         {
-            "aws_cloudwatch_log_resource_policy": {
-                "index": {
-                    "policy_name": domain,
-                    "policy_document": json.dumps(
+            'aws_cloudwatch_log_resource_policy': {
+                'index': {
+                    'policy_name': domain,
+                    'policy_document': json.dumps(
                         {
-                            "Version": "2012-10-17",
-                            "Statement": [
+                            'Version': '2012-10-17',
+                            'Statement': [
                                 {
-                                    "Effect": "Allow",
-                                    "Principal": {
-                                        "Service": "es.amazonaws.com"
+                                    'Effect': 'Allow',
+                                    'Principal': {
+                                        'Service': 'es.amazonaws.com'
                                     },
-                                    "Action": [
-                                        "logs:PutLogEvents",
-                                        "logs:CreateLogStream"
+                                    'Action': [
+                                        'logs:PutLogEvents',
+                                        'logs:CreateLogStream'
                                     ],
-                                    "Resource": [
-                                        "${aws_cloudwatch_log_group." + log + "_log.arn}:*" for log in logs.keys()
+                                    'Resource': [
+                                        '${aws_cloudwatch_log_group.' + log + '_log.arn}:*' for log in logs.keys()
                                     ]
                                 }
                             ]
@@ -61,62 +61,62 @@ emit_tf(None if config.share_es_domain else {
             }
         },
         {
-            "aws_elasticsearch_domain": {
-                "index": {
-                    "access_policies": json.dumps({
-                        "Version": "2012-10-17",
-                        "Statement": [
+            'aws_elasticsearch_domain': {
+                'index': {
+                    'access_policies': json.dumps({
+                        'Version': '2012-10-17',
+                        'Statement': [
                             {
-                                "Effect": "Allow",
-                                "Principal": {
-                                    "AWS": "arn:aws:iam::${local.account_id}:root"
+                                'Effect': 'Allow',
+                                'Principal': {
+                                    'AWS': 'arn:aws:iam::${local.account_id}:root'
                                 },
-                                "Action": "es:*",
-                                "Resource": "arn:aws:es:${local.region}:${local.account_id}:domain/" + domain + "/*"
+                                'Action': 'es:*',
+                                'Resource': 'arn:aws:es:${local.region}:${local.account_id}:domain/' + domain + '/*'
                             }
                         ]
                     }),
-                    "advanced_options": {
-                        "rest.action.multi.allow_explicit_index": "true",
-                        "override_main_response_version": "false"
+                    'advanced_options': {
+                        'rest.action.multi.allow_explicit_index': 'true',
+                        'override_main_response_version': 'false'
                     },
-                    "cluster_config": {
-                        "instance_count": config.es_instance_count,
-                        "instance_type": config.es_instance_type,
+                    'cluster_config': {
+                        'instance_count': config.es_instance_count,
+                        'instance_type': config.es_instance_type,
                         # Needed for using multiple subnets (1 per zone) in the VPC
-                        "zone_awareness_enabled": True
+                        'zone_awareness_enabled': True
                     },
-                    "domain_name": domain,
-                    "ebs_options": {
-                        "ebs_enabled": "true",
-                        "volume_size": config.es_volume_size,
-                        "volume_type": "gp2"
+                    'domain_name': domain,
+                    'ebs_options': {
+                        'ebs_enabled': 'true',
+                        'volume_size': config.es_volume_size,
+                        'volume_type': 'gp2'
                     } if config.es_volume_size else {
-                        "ebs_enabled": "false",
+                        'ebs_enabled': 'false',
                     },
-                    "vpc_options": {
-                        "subnet_ids": [
-                            f"${{data.aws_subnet.gitlab_private_{zone}.id}}"
+                    'vpc_options': {
+                        'subnet_ids': [
+                            f'${{data.aws_subnet.gitlab_private_{zone}.id}}'
                             for zone in range(vpc.num_zones)
                         ],
-                        "security_group_ids": ["${aws_security_group.elasticsearch.id}"]
+                        'security_group_ids': ['${aws_security_group.elasticsearch.id}']
                     },
-                    "elasticsearch_version": "7.10",
-                    "log_publishing_options": [
+                    'elasticsearch_version': '7.10',
+                    'log_publishing_options': [
                         {
-                            "cloudwatch_log_group_arn": "${aws_cloudwatch_log_group." + log + "_log.arn}",
-                            "enabled": "true" if enabled else "false",
-                            "log_type": log_type
+                            'cloudwatch_log_group_arn': '${aws_cloudwatch_log_group.' + log + '_log.arn}',
+                            'enabled': 'true' if enabled else 'false',
+                            'log_type': log_type
                         } for log, (log_type, enabled) in logs.items()
                     ],
-                    "lifecycle": {
-                        "ignore_changes": [
+                    'lifecycle': {
+                        'ignore_changes': [
                             # Quoting AWS support:
                             #
                             # > Please note that with automated snapshots
-                            # > disabled, the "automatedSnapshotStartHour"
+                            # > disabled, the 'automatedSnapshotStartHour'
                             # > parameter of the domain configuration is set
-                            # > to "-1" from the service end (this can only
+                            # > to '-1' from the service end (this can only
                             # > be done from the service side). Please ensure
                             # > that this parameter is not overriden to a
                             # > different value from your end, else the
@@ -134,19 +134,19 @@ emit_tf(None if config.share_es_domain else {
                             # safer to me. The property is deprecated
                             # anyways.
                             #
-                            "snapshot_options"
+                            'snapshot_options'
                         ]
                     },
-                    "encrypt_at_rest": {
-                        "enabled": True
+                    'encrypt_at_rest': {
+                        'enabled': True
                     },
-                    "node_to_node_encryption": {
-                        "enabled": True
+                    'node_to_node_encryption': {
+                        'enabled': True
                     }
                 }
             },
-            "opensearch_cluster_settings": {
-                "index": {
+            'opensearch_cluster_settings': {
+                'index': {
                     # Disable the automatic creation of indexes when documents
                     # are indexed. We create indexes explicitly before any
                     # documents are indexed so a missing index would be
@@ -164,22 +164,22 @@ emit_tf(None if config.share_es_domain else {
                     #
                     # https://github.com/opensearch-project/terraform-provider-opensearch/issues/60#issuecomment-2041280397
                     #
-                    "action_auto_create_index": False,
-                    "lifecycle": {
-                        "ignore_changes": [
-                            "cluster_routing_allocation_disk_watermark_low",
-                            "cluster_routing_allocation_disk_watermark_high"
+                    'action_auto_create_index': False,
+                    'lifecycle': {
+                        'ignore_changes': [
+                            'cluster_routing_allocation_disk_watermark_low',
+                            'cluster_routing_allocation_disk_watermark_high'
                         ]
                     }
                 }
             },
-            "aws_security_group": {
-                "elasticsearch": {
-                    "name": config.qualified_resource_name("elasticsearch"),
-                    "vpc_id": "${data.aws_vpc.gitlab.id}",
-                    "ingress": [
-                        vpc.security_rule(cidr_blocks=["${data.aws_vpc.gitlab.cidr_block}"],
-                                          protocol="tcp",
+            'aws_security_group': {
+                'elasticsearch': {
+                    'name': config.qualified_resource_name('elasticsearch'),
+                    'vpc_id': '${data.aws_vpc.gitlab.id}',
+                    'ingress': [
+                        vpc.security_rule(cidr_blocks=['${data.aws_vpc.gitlab.cidr_block}'],
+                                          protocol='tcp',
                                           from_port=443,
                                           to_port=443)
                     ],

--- a/terraform/elasticsearch.tf.json.template.py
+++ b/terraform/elasticsearch.tf.json.template.py
@@ -25,14 +25,17 @@ emit_tf(None if config.share_es_domain else {
         }
     ],
     'resource': [
-        *({
-            'aws_cloudwatch_log_group': {
-                f'{log}_log': {
-                    'name': f'/aws/aes/domains/{domain}/{log}-logs',
-                    'retention_in_days': config.audit_log_retention_days
+        *(
+            {
+                'aws_cloudwatch_log_group': {
+                    f'{log}_log': {
+                        'name': f'/aws/aes/domains/{domain}/{log}-logs',
+                        'retention_in_days': config.audit_log_retention_days
+                    }
                 }
             }
-        } for log in logs.keys()),
+            for log in logs.keys()
+        ),
         {
             'aws_cloudwatch_log_resource_policy': {
                 'index': {
@@ -91,7 +94,9 @@ emit_tf(None if config.share_es_domain else {
                         'ebs_enabled': 'true',
                         'volume_size': config.es_volume_size,
                         'volume_type': 'gp2'
-                    } if config.es_volume_size else {
+                    }
+                    if config.es_volume_size else
+                    {
                         'ebs_enabled': 'false',
                     },
                     'vpc_options': {
@@ -107,7 +112,8 @@ emit_tf(None if config.share_es_domain else {
                             'cloudwatch_log_group_arn': '${aws_cloudwatch_log_group.' + log + '_log.arn}',
                             'enabled': 'true' if enabled else 'false',
                             'log_type': log_type
-                        } for log, (log_type, enabled) in logs.items()
+                        }
+                        for log, (log_type, enabled) in logs.items()
                     ],
                     'lifecycle': {
                         'ignore_changes': [

--- a/terraform/providers.tf.json.template.py
+++ b/terraform/providers.tf.json.template.py
@@ -25,6 +25,8 @@ emit_tf(tag_resources=False, config={
                 'source': 'hashicorp/aws',
                 'version': '5.11.0'
             },
+            # FIXME: Remove the provider
+            #        https://github.com/DataBiosphere/azul/pull/6285
             'opensearch': {
                 'source': 'opensearch-project/opensearch',
                 'version': '2.2.1'


### PR DESCRIPTION
Connected issues: #6278


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make image_manifests.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `image_manifests.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved ticket to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for `dev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for `anvildev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
