### PR TITLE
Fix: CloudWatch dashboard in anvilprod and hammerbox omits two ES nodes (#6271)

### DIFF
--- a/scripts/elasticsearch_nodes.py
+++ b/scripts/elasticsearch_nodes.py
@@ -29,6 +29,9 @@ from azul.es import (
 from azul.logging import (
     configure_script_logging,
 )
+from azul.modules import (
+    load_module,
+)
 
 log = logging.getLogger(__name__)
 
@@ -77,8 +80,9 @@ def node_placeholder_count() -> int:
     Return the number of unique ES node ID placeholders found in the Cloudwatch
     dashboard template file.
     """
-    with open(config.cloudwatch_dashboard_template) as f:
-        body = json.load(f)
+    module = load_module(config.cloudwatch_dashboard_template,
+                         'cloudwatch_dashboard_template')
+    body = module.dashboard_body
     filters = [
         # Indexing from end so we don't have to deal with the `...` placeholder.
         # The last three elements are the `Client ID` dimension name, its value

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -1489,7 +1489,7 @@ class Config:
 
     @property
     def cloudwatch_dashboard_template(self) -> str:
-        return f'{config.project_root}/terraform/cloudwatch_dashboard.template.json'
+        return f'{config.project_root}/terraform/cloudwatch_dashboard.template.json.py'
 
     class SecurityContact(TypedDict):
         name: str

--- a/terraform/cloudwatch.tf.json.template.py
+++ b/terraform/cloudwatch.tf.json.template.py
@@ -12,6 +12,7 @@ from azul.deployment import (
 )
 from azul.modules import (
     load_app_module,
+    load_module,
 )
 from azul.queues import (
     Queues,
@@ -37,9 +38,9 @@ def alarm_resource_name(threshold: MetricThreshold) -> str:
 def dashboard_body() -> str:
     # To minify the template and confirm it is valid JSON before deployment we
     # parse the template file as JSON and then convert it back to a string.
-    with open(config.cloudwatch_dashboard_template) as f:
-        body = json.load(f)
-    body = json.dumps(body)
+    module = load_module(config.cloudwatch_dashboard_template,
+                         'cloudwatch_dashboard_template')
+    body = json.dumps(module.dashboard_body)
 
     def prod_qualified_resource_name(name: str) -> str:
         resource, _, suffix = config.unqualified_resource_name_and_suffix(name)

--- a/terraform/cloudwatch.tf.json.template.py
+++ b/terraform/cloudwatch.tf.json.template.py
@@ -2,7 +2,6 @@ import json
 
 from azul import (
     config,
-    require,
 )
 from azul.chalice import (
     MetricThreshold,
@@ -13,9 +12,6 @@ from azul.deployment import (
 from azul.modules import (
     load_app_module,
     load_module,
-)
-from azul.queues import (
-    Queues,
 )
 from azul.terraform import (
     emit_tf,
@@ -36,38 +32,9 @@ def alarm_resource_name(threshold: MetricThreshold) -> str:
 
 
 def dashboard_body() -> str:
-    # To minify the template and confirm it is valid JSON before deployment we
-    # parse the template file as JSON and then convert it back to a string.
     module = load_module(config.cloudwatch_dashboard_template,
                          'cloudwatch_dashboard_template')
     body = json.dumps(module.dashboard_body)
-
-    def prod_qualified_resource_name(name: str) -> str:
-        resource, _, suffix = config.unqualified_resource_name_and_suffix(name)
-        return config.qualified_resource_name(resource, suffix=suffix, stage='prod')
-
-    queues = Queues()
-    qualified_resource_names = [
-        *config.all_queue_names,
-        *queues.functions_by_queue().values()
-    ]
-    replacements = {
-        '542754589326': config.aws_account_id,
-        'us-east-1': config.region,
-        'azul-index-prod': config.es_domain,
-        **{
-            prod_qualified_resource_name(name): name
-            for name in qualified_resource_names
-        }
-    }
-    # Reverse sorted so that if any keys are substrings of other keys (e.g.
-    # 'foo' and 'foo_bar'), the longer string is processed before the substring.
-    replacements = dict(reversed(sorted(replacements.items())))
-
-    for old, new in replacements.items():
-        require(old in body,
-                'Missing placeholder', old, config.cloudwatch_dashboard_template)
-        body = body.replace(old, new)
     return body
 
 

--- a/terraform/cloudwatch_dashboard.template.json.py
+++ b/terraform/cloudwatch_dashboard.template.json.py
@@ -1,8 +1,16 @@
 from textwrap import (
     dedent,
 )
+
+from more_itertools import (
+    flatten,
+)
+
 from azul import (
     config,
+)
+from azul.deployment import (
+    aws,
 )
 
 dashboard_body = {
@@ -318,7 +326,7 @@ dashboard_body = {
                 'metrics': [
                     [
                         {
-                            'expression': 'm2 + m4 + m6 + m8',
+                            'expression': ' + '.join(f'm{2 + i * 2}' for i in range(aws.es_instance_count)),
                             'label': 'Primary',
                             'id': 'e1',
                             'region': config.region,
@@ -327,7 +335,7 @@ dashboard_body = {
                     ],
                     [
                         {
-                            'expression': 'm3 + m5 + m7 + m9',
+                            'expression': ' + '.join(f'm{3 + i * 2}' for i in range(aws.es_instance_count)),
                             'label': 'Replica',
                             'id': 'e2',
                             'region': config.region,
@@ -377,90 +385,39 @@ dashboard_body = {
                             'visible': False
                         }
                     ],
-                    [
-                        '...',
-                        'Primary',
-                        '.',
-                        '.',
-                        '.',
-                        '${local.nodes[1]}',
-                        '.',
-                        '.',
-                        {
-                            'id': 'm4',
-                            'visible': False
-                        }
-                    ],
-                    [
-                        '...',
-                        'Replica',
-                        '.',
-                        '.',
-                        '.',
-                        '.',
-                        '.',
-                        '.',
-                        {
-                            'id': 'm5',
-                            'visible': False
-                        }
-                    ],
-                    [
-                        '...',
-                        'Primary',
-                        '.',
-                        '.',
-                        '.',
-                        '${local.nodes[2]}',
-                        '.',
-                        '.',
-                        {
-                            'id': 'm6',
-                            'visible': False
-                        }
-                    ],
-                    [
-                        '...',
-                        'Replica',
-                        '.',
-                        '.',
-                        '.',
-                        '.',
-                        '.',
-                        '.',
-                        {
-                            'id': 'm7',
-                            'visible': False
-                        }
-                    ],
-                    [
-                        '...',
-                        'Primary',
-                        '.',
-                        '.',
-                        '.',
-                        '${local.nodes[3]}',
-                        '.',
-                        '.',
-                        {
-                            'id': 'm8',
-                            'visible': False
-                        }
-                    ],
-                    [
-                        '...',
-                        'Replica',
-                        '.',
-                        '.',
-                        '.',
-                        '.',
-                        '.',
-                        '.',
-                        {
-                            'id': 'm9',
-                            'visible': False
-                        }
-                    ]
+                    *flatten((
+                        [
+                            [
+                                '...',
+                                'Primary',
+                                '.',
+                                '.',
+                                '.',
+                                '${local.nodes[%d]}' % i,
+                                '.',
+                                '.',
+                                {
+                                    'id': f'm{2 + i * 2}',
+                                    'visible': False
+                                }
+                            ],
+                            [
+                                '...',
+                                'Replica',
+                                '.',
+                                '.',
+                                '.',
+                                '.',
+                                '.',
+                                '.',
+                                {
+                                    'id': f'm{3 + i * 2}',
+                                    'visible': False
+                                }
+                            ]
+                        ]
+                        for i in range(1, aws.es_instance_count)
+                    ))
                 ],
                 'view': 'timeSeries',
                 'stacked': False,
@@ -512,24 +469,15 @@ dashboard_body = {
                         'ClientId',
                         config.aws_account_id
                     ],
-                    [
-                        '...',
-                        '${local.nodes[1]}',
-                        '.',
-                        '.'
-                    ],
-                    [
-                        '...',
-                        '${local.nodes[2]}',
-                        '.',
-                        '.'
-                    ],
-                    [
-                        '...',
-                        '${local.nodes[3]}',
-                        '.',
-                        '.'
-                    ]
+                    *(
+                        [
+                            '...',
+                            '${local.nodes[%d]}' % i,
+                            '.',
+                            '.'
+                        ]
+                        for i in range(1, aws.es_instance_count)
+                    )
                 ],
                 'region': config.region,
                 'title': 'ES JVM memory pressure [%]',
@@ -546,7 +494,8 @@ dashboard_body = {
                 'metrics': [
                     [
                         {
-                            'expression': 'DIFF(m1+m2+m3+m4)/4/1000/60/5*100',
+                            'expression': 'DIFF(%s)/4/1000/60/5*100' %
+                                          '+'.join(f'm{i + 1}' for i in range(aws.es_instance_count)),
                             'label': 'Old generation',
                             'id': 'e2',
                             'region': config.region,
@@ -555,7 +504,10 @@ dashboard_body = {
                     ],
                     [
                         {
-                            'expression': 'DIFF(m5+m6+m7+m8)/4/1000/60/5*100',
+                            'expression': 'DIFF(%s)/4/1000/60/5*100' % '+'.join(
+                                f'm{i + aws.es_instance_count + 1}'
+                                for i in range(aws.es_instance_count)
+                            ),
                             'label': 'Young generation',
                             'id': 'e1',
                             'region': config.region,
@@ -577,36 +529,19 @@ dashboard_body = {
                             'visible': False
                         }
                     ],
-                    [
-                        '...',
-                        '${local.nodes[1]}',
-                        '.',
-                        '.',
-                        {
-                            'id': 'm2',
-                            'visible': False
-                        }
-                    ],
-                    [
-                        '...',
-                        '${local.nodes[2]}',
-                        '.',
-                        '.',
-                        {
-                            'id': 'm3',
-                            'visible': False
-                        }
-                    ],
-                    [
-                        '...',
-                        '${local.nodes[3]}',
-                        '.',
-                        '.',
-                        {
-                            'id': 'm4',
-                            'visible': False
-                        }
-                    ],
+                    *(
+                        [
+                            '...',
+                            '${local.nodes[%d]}' % i,
+                            '.',
+                            '.',
+                            {
+                                'id': f'm{i + 1}',
+                                'visible': False
+                            }
+                        ]
+                        for i in range(1, aws.es_instance_count)
+                    ),
                     [
                         '.',
                         'JVMGCYoungCollectionTime',
@@ -617,40 +552,23 @@ dashboard_body = {
                         '.',
                         '.',
                         {
-                            'id': 'm5',
+                            'id': f'm{aws.es_instance_count + 1}',
                             'visible': False
                         }
                     ],
-                    [
-                        '...',
-                        '${local.nodes[1]}',
-                        '.',
-                        '.',
-                        {
-                            'id': 'm6',
-                            'visible': False
-                        }
-                    ],
-                    [
-                        '...',
-                        '${local.nodes[2]}',
-                        '.',
-                        '.',
-                        {
-                            'id': 'm7',
-                            'visible': False
-                        }
-                    ],
-                    [
-                        '...',
-                        '${local.nodes[3]}',
-                        '.',
-                        '.',
-                        {
-                            'id': 'm8',
-                            'visible': False
-                        }
-                    ]
+                    *(
+                        [
+                            '...',
+                            '${local.nodes[%d]}' % i,
+                            '.',
+                            '.',
+                            {
+                                'id': f'm{i + aws.es_instance_count + 1}',
+                                'visible': False
+                            }
+                        ]
+                        for i in range(1, aws.es_instance_count)
+                    )
                 ],
                 'view': 'timeSeries',
                 'stacked': True,

--- a/terraform/cloudwatch_dashboard.template.json.py
+++ b/terraform/cloudwatch_dashboard.template.json.py
@@ -1,4 +1,4 @@
-{
+dashboard_body = {
     "widgets": [
         {
             "height": 6,
@@ -9,7 +9,7 @@
             "properties": {
                 "query": "SOURCE '/aws/lambda/azul-indexer-prod-aggregate_retry' | SOURCE '/aws/lambda/azul-indexer-prod-aggregate' | filter @message like /Attempt \\d+ of handling \\d+ contribution\\(s\\) for entity/\n       or @message like /Deferring aggregation of \\d+ contribution\\(s\\) to entity/\n       or @message like /Successfully aggregated \\d+ contribution\\(s\\) to entity/\n| parse 'of handling * contribution(s) for entity' as attempts\n| parse 'Deferring aggregation of * contribution(s) to entity' as deferrals\n| parse 'Successfully aggregated * contribution(s) to entity' as successes\n| stats sum(successes) as Successes, \n        sum(attempts) - sum(successes) - sum(deferrals) as Failures, \n        sum(deferrals) as Deferrals \n        by bin(5min)\n",
                 "region": "us-east-1",
-                "stacked": true,
+                "stacked": True,
                 "title": "Aggregation outcomes in # of contributions",
                 "view": "timeSeries"
             }
@@ -37,7 +37,7 @@
                         "azul-notifications-prod",
                         {
                             "id": "nv",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -47,7 +47,7 @@
                         ".",
                         {
                             "id": "ni",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -57,7 +57,7 @@
                         ".",
                         {
                             "id": "nd",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -76,7 +76,7 @@
                         "azul-notifications_retry-prod",
                         {
                             "id": "nrv",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -86,7 +86,7 @@
                         ".",
                         {
                             "id": "nri",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -96,7 +96,7 @@
                         ".",
                         {
                             "id": "nrd",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -115,7 +115,7 @@
                         "azul-notifications_fail-prod",
                         {
                             "id": "nfv",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -125,7 +125,7 @@
                         ".",
                         {
                             "id": "nfi",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -135,7 +135,7 @@
                         ".",
                         {
                             "id": "nfd",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -154,7 +154,7 @@
                         "azul-tallies-prod.fifo",
                         {
                             "id": "tv",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -164,7 +164,7 @@
                         ".",
                         {
                             "id": "ti",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -174,7 +174,7 @@
                         ".",
                         {
                             "id": "td",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -193,7 +193,7 @@
                         "azul-tallies_retry-prod.fifo",
                         {
                             "id": "trv",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -203,7 +203,7 @@
                         ".",
                         {
                             "id": "tri",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -213,7 +213,7 @@
                         ".",
                         {
                             "id": "trd",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -232,7 +232,7 @@
                         "azul-tallies_fail-prod.fifo",
                         {
                             "id": "tfv",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -242,7 +242,7 @@
                         ".",
                         {
                             "id": "tfi",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -252,12 +252,12 @@
                         ".",
                         {
                             "id": "tfd",
-                            "visible": false
+                            "visible": False
                         }
                     ]
                 ],
                 "view": "timeSeries",
-                "stacked": false,
+                "stacked": False,
                 "region": "us-east-1",
                 "title": "Queue lengths",
                 "period": 300,
@@ -273,7 +273,7 @@
             "properties": {
                 "query": "SOURCE '/aws/lambda/azul-indexer-prod-contribute' | SOURCE '/aws/lambda/azul-indexer-prod-contribute_retry' | fields strcontains(@message, 'Worker successfully handled') as success,\n\n       strcontains(@message,'Worker failed to handle message') as failure,\n\n       strcontains(@message,'Task timed out after') as timeout\n\n| filter failure > 0 or success > 0 or timeout > 0\n| stats sum(success) as Successes, sum(failure + timeout) as Failures by bin(5min)",
                 "region": "us-east-1",
-                "stacked": true,
+                "stacked": True,
                 "title": "Contribution outcomes in # of notifications",
                 "view": "timeSeries"
             }
@@ -330,7 +330,7 @@
                         "542754589326",
                         {
                             "id": "m2",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -344,7 +344,7 @@
                         ".",
                         {
                             "id": "m3",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -358,7 +358,7 @@
                         ".",
                         {
                             "id": "m4",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -372,7 +372,7 @@
                         ".",
                         {
                             "id": "m5",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -386,7 +386,7 @@
                         ".",
                         {
                             "id": "m6",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -400,7 +400,7 @@
                         ".",
                         {
                             "id": "m7",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -414,7 +414,7 @@
                         ".",
                         {
                             "id": "m8",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -428,12 +428,12 @@
                         ".",
                         {
                             "id": "m9",
-                            "visible": false
+                            "visible": False
                         }
                     ]
                 ],
                 "view": "timeSeries",
-                "stacked": false,
+                "stacked": False,
                 "region": "us-east-1",
                 "period": 300,
                 "stat": "Maximum",
@@ -449,7 +449,7 @@
             "properties": {
                 "query": "SOURCE '/aws/lambda/azul-indexer-prod-aggregate' | SOURCE '/aws/lambda/azul-indexer-prod-aggregate_retry' | SOURCE '/aws/lambda/azul-indexer-prod-contribute' | SOURCE '/aws/lambda/azul-indexer-prod-contribute_retry' | filter @message like 'TransportError'\n| fields strcontains(@log, 'contribute') as contribute, 1 - contribute as aggregate\n| stats sum(contribute) as Contribution, sum(aggregate) as Aggregation by bin(5min)",
                 "region": "us-east-1",
-                "stacked": false,
+                "stacked": False,
                 "title": "ES TransportErrors",
                 "view": "timeSeries"
             }
@@ -462,7 +462,7 @@
             "type": "metric",
             "properties": {
                 "view": "timeSeries",
-                "stacked": true,
+                "stacked": True,
                 "metrics": [
                     [
                         "AWS/ES",
@@ -536,7 +536,7 @@
                         "542754589326",
                         {
                             "id": "m1",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -546,7 +546,7 @@
                         ".",
                         {
                             "id": "m2",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -556,7 +556,7 @@
                         ".",
                         {
                             "id": "m3",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -566,7 +566,7 @@
                         ".",
                         {
                             "id": "m4",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -580,7 +580,7 @@
                         ".",
                         {
                             "id": "m5",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -590,7 +590,7 @@
                         ".",
                         {
                             "id": "m6",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -600,7 +600,7 @@
                         ".",
                         {
                             "id": "m7",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -610,12 +610,12 @@
                         ".",
                         {
                             "id": "m8",
-                            "visible": false
+                            "visible": False
                         }
                     ]
                 ],
                 "view": "timeSeries",
-                "stacked": true,
+                "stacked": True,
                 "region": "us-east-1",
                 "period": 300,
                 "stat": "Maximum",
@@ -623,10 +623,10 @@
                 "yAxis": {
                     "left": {
                         "label": "% of wall clock time",
-                        "showUnits": false
+                        "showUnits": False
                     },
                     "right": {
-                        "showUnits": false
+                        "showUnits": False
                     }
                 }
             }
@@ -640,7 +640,7 @@
             "properties": {
                 "query": "SOURCE '/aws/lambda/azul-indexer-prod-contribute' | SOURCE '/aws/lambda/azul-indexer-prod-contribute_retry' | fields @log\n| parse 'It took *s to download' as duration\n| filter ispresent(duration)\n| fields strcontains(@log, '_retry') as is_retry\n| stats avg(duration * (1 - is_retry)) as Initial, avg(duration * is_retry) as Retry by bin(5m)",
                 "region": "us-east-1",
-                "stacked": false,
+                "stacked": False,
                 "title": "Subgraph download time, average [s]",
                 "view": "timeSeries"
             }
@@ -685,7 +685,7 @@
                     ]
                 ],
                 "view": "timeSeries",
-                "stacked": false,
+                "stacked": False,
                 "region": "us-east-1",
                 "stat": "Sum",
                 "period": 300,
@@ -742,7 +742,7 @@
                     ]
                 ],
                 "view": "timeSeries",
-                "stacked": false,
+                "stacked": False,
                 "region": "us-east-1",
                 "stat": "Sum",
                 "period": 300,
@@ -789,7 +789,7 @@
                     ]
                 ],
                 "view": "timeSeries",
-                "stacked": false,
+                "stacked": False,
                 "region": "us-east-1",
                 "stat": "Sum",
                 "period": 300,
@@ -836,7 +836,7 @@
                     ]
                 ],
                 "view": "timeSeries",
-                "stacked": false,
+                "stacked": False,
                 "region": "us-east-1",
                 "stat": "Maximum",
                 "period": 300,
@@ -894,7 +894,7 @@
                         "azul-indexer-prod-aggregate",
                         {
                             "id": "m1",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -902,7 +902,7 @@
                         "azul-indexer-prod-aggregate_retry",
                         {
                             "id": "m2",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -910,7 +910,7 @@
                         "azul-indexer-prod-contribute",
                         {
                             "id": "m3",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -918,19 +918,19 @@
                         "azul-indexer-prod-contribute_retry",
                         {
                             "id": "m4",
-                            "visible": false
+                            "visible": False
                         }
                     ]
                 ],
                 "view": "timeSeries",
-                "stacked": false,
+                "stacked": False,
                 "region": "us-east-1",
                 "stat": "Average",
                 "period": 300,
                 "title": "Lambda duration [s]",
                 "yAxis": {
                     "left": {
-                        "showUnits": false
+                        "showUnits": False
                     }
                 }
             }
@@ -944,7 +944,7 @@
             "properties": {
                 "query": "SOURCE '/aws/lambda/azul-indexer-prod-contribute' | SOURCE '/aws/lambda/azul-indexer-prod-contribute_retry' | filter @message like 'Exceeded rate limits'\n| sort @timestamp desc\n| stats count(@requestId) as trips by bin(5min)",
                 "region": "us-east-1",
-                "stacked": false,
+                "stacked": False,
                 "title": "BQ rate limit trips",
                 "view": "timeSeries"
             }
@@ -958,7 +958,7 @@
             "properties": {
                 "query": "SOURCE '/aws/lambda/azul-indexer-prod-contribute' | SOURCE '/aws/lambda/azul-indexer-prod-contribute_retry' | filter ispresent(stats.totalSlotMs)\n| stats sum(stats.totalSlotMs) / 1000 / 3600 * 12 as `slot hours` by bin(5min)\n",
                 "region": "us-east-1",
-                "stacked": false,
+                "stacked": False,
                 "title": "BQ slot-hours (pro-rated)",
                 "view": "timeSeries"
             }
@@ -972,7 +972,7 @@
             "properties": {
                 "query": "SOURCE '/aws/lambda/azul-indexer-prod-contribute' | SOURCE '/aws/lambda/azul-indexer-prod-contribute_retry' | filter @message like 'Exceeded rate limits'\n| parse 'BigQuery job error during attempt *. Retrying in *s.' as a, d\n| filter ispresent(d)\n| stats avg(d) as Delay by bin(5min)",
                 "region": "us-east-1",
-                "stacked": false,
+                "stacked": False,
                 "title": "BQ rate limit back-off, average [s]",
                 "view": "timeSeries"
             }
@@ -1000,7 +1000,7 @@
                         "azul-notifications-prod",
                         {
                             "id": "nv",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1010,7 +1010,7 @@
                         ".",
                         {
                             "id": "ni",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1020,7 +1020,7 @@
                         ".",
                         {
                             "id": "nd",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1039,7 +1039,7 @@
                         "azul-notifications_retry-prod",
                         {
                             "id": "nrv",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1049,7 +1049,7 @@
                         ".",
                         {
                             "id": "nri",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1059,7 +1059,7 @@
                         ".",
                         {
                             "id": "nrd",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1078,7 +1078,7 @@
                         "azul-notifications_fail-prod",
                         {
                             "id": "nfv",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1088,7 +1088,7 @@
                         ".",
                         {
                             "id": "nfi",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1098,7 +1098,7 @@
                         ".",
                         {
                             "id": "nfd",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1117,7 +1117,7 @@
                         "azul-tallies-prod.fifo",
                         {
                             "id": "tv",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1127,7 +1127,7 @@
                         ".",
                         {
                             "id": "ti",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1137,7 +1137,7 @@
                         ".",
                         {
                             "id": "td",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1156,7 +1156,7 @@
                         "azul-tallies_retry-prod.fifo",
                         {
                             "id": "trv",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1166,7 +1166,7 @@
                         ".",
                         {
                             "id": "tri",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1176,7 +1176,7 @@
                         ".",
                         {
                             "id": "trd",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1195,7 +1195,7 @@
                         "azul-tallies_fail-prod.fifo",
                         {
                             "id": "tfv",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1205,7 +1205,7 @@
                         ".",
                         {
                             "id": "tfi",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1215,12 +1215,12 @@
                         ".",
                         {
                             "id": "tfd",
-                            "visible": false
+                            "visible": False
                         }
                     ]
                 ],
                 "view": "timeSeries",
-                "stacked": false,
+                "stacked": False,
                 "region": "us-east-1",
                 "title": "Queue length Δ",
                 "period": 300,
@@ -1282,7 +1282,7 @@
                         "azul-notifications-prod",
                         {
                             "id": "m1",
-                            "visible": false,
+                            "visible": False,
                             "region": "us-east-1"
                         }
                     ],
@@ -1293,7 +1293,7 @@
                         "azul-notifications_retry-prod",
                         {
                             "id": "m2",
-                            "visible": false,
+                            "visible": False,
                             "region": "us-east-1"
                         }
                     ],
@@ -1304,7 +1304,7 @@
                         "azul-tallies-prod.fifo",
                         {
                             "id": "m3",
-                            "visible": false,
+                            "visible": False,
                             "region": "us-east-1"
                         }
                     ],
@@ -1315,13 +1315,13 @@
                         "azul-tallies_retry-prod.fifo",
                         {
                             "id": "m4",
-                            "visible": false,
+                            "visible": False,
                             "region": "us-east-1"
                         }
                     ]
                 ],
                 "view": "timeSeries",
-                "stacked": false,
+                "stacked": False,
                 "region": "us-east-1",
                 "title": "Idle queue polling threads",
                 "period": 300,
@@ -1337,7 +1337,7 @@
             "properties": {
                 "query": "SOURCE '/aws/lambda/azul-indexer-prod-aggregate_retry' | SOURCE '/aws/lambda/azul-indexer-prod-aggregate' | filter @message like /Attempt \\d+ of handling \\d+ contribution\\(s\\) for entity/\n       or @message like /Deferring \\d+ tallies/\n       or @message like /Successfully referred \\d+ tallies/\n| field strcontains(@message,'Attempt') and strcontains(@message,'contribution(s) for entity') as attempts\n| parse 'Deferring * tallies' as deferrals\n| parse 'Successfully referred * tallies' as successes\n| stats sum(successes) as Successes,\n        sum(attempts) - sum(successes) - sum(deferrals) as Failures,\n        sum(deferrals) as Deferrals\n        by bin(5min)\n",
                 "region": "us-east-1",
-                "stacked": true,
+                "stacked": True,
                 "title": "Aggregation outcomes in # of tallies",
                 "view": "timeSeries"
             }
@@ -1351,7 +1351,7 @@
             "properties": {
                 "query": "SOURCE '/aws/lambda/azul-indexer-prod-contribute' | SOURCE '/aws/lambda/azul-indexer-prod-contribute_retry' | fields stats.cacheHit, strcontains(@log, 'retry') as is_retry\n| filter @message like 'Job info: '\n| sort @timestamp desc\n| stats sum(stats.cacheHit * (1 - is_retry)) / sum(1 - is_retry) * 100 as Initial, \n        sum(stats.cacheHit * is_retry ) / sum(is_retry) * 100 as Retry by bin(5min)",
                 "region": "us-east-1",
-                "stacked": false,
+                "stacked": False,
                 "title": "BQ cache utilization [%]",
                 "view": "timeSeries"
             }
@@ -1379,7 +1379,7 @@
                         "azul-notifications-prod",
                         {
                             "id": "nv",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1389,7 +1389,7 @@
                         ".",
                         {
                             "id": "ni",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1399,7 +1399,7 @@
                         ".",
                         {
                             "id": "nd",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1409,7 +1409,7 @@
                         "azul-notifications_retry-prod",
                         {
                             "id": "nrv",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1419,7 +1419,7 @@
                         ".",
                         {
                             "id": "nri",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1429,7 +1429,7 @@
                         ".",
                         {
                             "id": "nrd",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1448,7 +1448,7 @@
                         "azul-tallies-prod.fifo",
                         {
                             "id": "tv",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1458,7 +1458,7 @@
                         ".",
                         {
                             "id": "ti",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1468,7 +1468,7 @@
                         ".",
                         {
                             "id": "td",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1478,7 +1478,7 @@
                         "azul-tallies_retry-prod.fifo",
                         {
                             "id": "trv",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1488,7 +1488,7 @@
                         ".",
                         {
                             "id": "tri",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1498,12 +1498,12 @@
                         ".",
                         {
                             "id": "trd",
-                            "visible": false
+                            "visible": False
                         }
                     ]
                 ],
                 "view": "timeSeries",
-                "stacked": false,
+                "stacked": False,
                 "region": "us-east-1",
                 "title": "ETA [h]",
                 "period": 300,
@@ -1519,7 +1519,7 @@
             "properties": {
                 "query": "SOURCE '/aws/lambda/azul-indexer-prod-aggregate' | SOURCE '/aws/lambda/azul-indexer-prod-aggregate_retry' | SOURCE '/aws/lambda/azul-indexer-prod-contribute' | SOURCE '/aws/lambda/azul-indexer-prod-contribute_retry' | filter @message like 'Task timed out'\n| fields strcontains(@log, 'aggregate') == 0 and strcontains(@log, 'retry') == 0 as c\n| fields strcontains(@log, 'aggregate') == 0 and strcontains(@log, 'retry') == 1 as cr\n| fields strcontains(@log, 'aggregate') == 1 and strcontains(@log, 'retry') == 0 as a\n| fields strcontains(@log, 'aggregate') == 1 and strcontains(@log, 'retry') == 1 as ar\n| stats sum(c) as contribute, \n        sum(cr) as contribute_retry,\n        sum(a) as aggregate,\n        sum(ar) as aggregate_retry\n        by bin(5min)",
                 "region": "us-east-1",
-                "stacked": false,
+                "stacked": False,
                 "title": "Lambda timeouts",
                 "view": "timeSeries"
             }
@@ -1564,7 +1564,7 @@
                     ]
                 ],
                 "view": "timeSeries",
-                "stacked": false,
+                "stacked": False,
                 "region": "us-east-1",
                 "title": "In-flight messages",
                 "period": 300,
@@ -1615,7 +1615,7 @@
                         {
                             "label": "contribute",
                             "id": "m1",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1624,7 +1624,7 @@
                         {
                             "label": "contribute_retry",
                             "id": "m2",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1633,7 +1633,7 @@
                         {
                             "label": "aggregate",
                             "id": "m3",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1642,7 +1642,7 @@
                         {
                             "label": "aggregate_retry",
                             "id": "m4",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1652,7 +1652,7 @@
                         "azul-indexer-prod-contribute",
                         {
                             "id": "m5",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1660,7 +1660,7 @@
                         "azul-indexer-prod-contribute_retry",
                         {
                             "id": "m6",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1668,7 +1668,7 @@
                         "azul-indexer-prod-aggregate",
                         {
                             "id": "m7",
-                            "visible": false
+                            "visible": False
                         }
                     ],
                     [
@@ -1676,12 +1676,12 @@
                         "azul-indexer-prod-aggregate_retry",
                         {
                             "id": "m8",
-                            "visible": false
+                            "visible": False
                         }
                     ]
                 ],
                 "view": "timeSeries",
-                "stacked": false,
+                "stacked": False,
                 "region": "us-east-1",
                 "stat": "Sum",
                 "period": 300,
@@ -1697,7 +1697,7 @@
             "properties": {
                 "query": "SOURCE '/aws/lambda/azul-indexer-prod-aggregate' | SOURCE '/aws/lambda/azul-indexer-prod-aggregate_retry' | SOURCE '/aws/lambda/azul-indexer-prod-contribute' | SOURCE '/aws/lambda/azul-indexer-prod-contribute_retry' | filter @message like 'Task timed out' or @message like 'START' \n| fields strcontains(@message, 'Task timed out') == 1 as timeout\n| fields strcontains(@message, 'START') == 1 as attempt\n| fields strcontains(@log, 'aggregate') == 0 and strcontains(@log, 'retry') == 0 as c\n| fields strcontains(@log, 'aggregate') == 0 and strcontains(@log, 'retry') == 1 as cr\n| fields strcontains(@log, 'aggregate') == 1 and strcontains(@log, 'retry') == 0 as a\n| fields strcontains(@log, 'aggregate') == 1 and strcontains(@log, 'retry') == 1 as ar\n| stats sum(c*timeout) * 100 / sum(c*attempt) as contribute, \n        sum(cr*timeout) * 100 / sum(cr*attempt) as contribute_retry,\n        sum(a*timeout) * 100 / sum(a*attempt) as aggregate,\n        sum(ar*timeout) * 100 / sum(ar*attempt) as aggregate_retry\n        by bin(5min)",
                 "region": "us-east-1",
-                "stacked": false,
+                "stacked": False,
                 "title": "Lambda timeout rate [%]",
                 "view": "timeSeries"
             }

--- a/terraform/cloudwatch_dashboard.template.json.py
+++ b/terraform/cloudwatch_dashboard.template.json.py
@@ -1,1705 +1,1822 @@
+from textwrap import (
+    dedent,
+)
+
 dashboard_body = {
-    "widgets": [
+    'widgets': [
         {
-            "height": 6,
-            "width": 12,
-            "y": 6,
-            "x": 12,
-            "type": "log",
-            "properties": {
-                "query": "SOURCE '/aws/lambda/azul-indexer-prod-aggregate_retry' | SOURCE '/aws/lambda/azul-indexer-prod-aggregate' | filter @message like /Attempt \\d+ of handling \\d+ contribution\\(s\\) for entity/\n       or @message like /Deferring aggregation of \\d+ contribution\\(s\\) to entity/\n       or @message like /Successfully aggregated \\d+ contribution\\(s\\) to entity/\n| parse 'of handling * contribution(s) for entity' as attempts\n| parse 'Deferring aggregation of * contribution(s) to entity' as deferrals\n| parse 'Successfully aggregated * contribution(s) to entity' as successes\n| stats sum(successes) as Successes, \n        sum(attempts) - sum(successes) - sum(deferrals) as Failures, \n        sum(deferrals) as Deferrals \n        by bin(5min)\n",
-                "region": "us-east-1",
-                "stacked": True,
-                "title": "Aggregation outcomes in # of contributions",
-                "view": "timeSeries"
+            'height': 6,
+            'width': 12,
+            'y': 6,
+            'x': 12,
+            'type': 'log',
+            'properties': {
+                'query': dedent('''\
+                    SOURCE '/aws/lambda/azul-indexer-prod-aggregate_retry'
+                    | SOURCE '/aws/lambda/azul-indexer-prod-aggregate'
+                    | filter @message like /Attempt \\d+ of handling \\d+ contribution\\(s\\) for entity/
+                          or @message like /Deferring aggregation of \\d+ contribution\\(s\\) to entity/
+                          or @message like /Successfully aggregated \\d+ contribution\\(s\\) to entity/
+                    | parse 'of handling * contribution(s) for entity' as attempts
+                    | parse 'Deferring aggregation of * contribution(s) to entity' as deferrals
+                    | parse 'Successfully aggregated * contribution(s) to entity' as successes
+                    | stats sum(successes) as Successes,
+                            sum(attempts) - sum(successes) - sum(deferrals) as Failures,
+                            sum(deferrals) as Deferrals
+                            by bin(5min)
+                '''),
+                'region': 'us-east-1',
+                'stacked': True,
+                'title': 'Aggregation outcomes in # of contributions',
+                'view': 'timeSeries'
             }
         },
         {
-            "height": 6,
-            "width": 12,
-            "y": 12,
-            "x": 0,
-            "type": "metric",
-            "properties": {
-                "metrics": [
+            'height': 6,
+            'width': 12,
+            'y': 12,
+            'x': 0,
+            'type': 'metric',
+            'properties': {
+                'metrics': [
                     [
                         {
-                            "expression": "nv+ni+nd",
-                            "label": "notifications",
-                            "id": "n",
-                            "region": "us-east-1"
+                            'expression': 'nv+ni+nd',
+                            'label': 'notifications',
+                            'id': 'n',
+                            'region': 'us-east-1'
                         }
                     ],
                     [
-                        "AWS/SQS",
-                        "ApproximateNumberOfMessagesVisible",
-                        "QueueName",
-                        "azul-notifications-prod",
+                        'AWS/SQS',
+                        'ApproximateNumberOfMessagesVisible',
+                        'QueueName',
+                        'azul-notifications-prod',
                         {
-                            "id": "nv",
-                            "visible": False
+                            'id': 'nv',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "ApproximateNumberOfMessagesNotVisible",
-                        ".",
-                        ".",
+                        '.',
+                        'ApproximateNumberOfMessagesNotVisible',
+                        '.',
+                        '.',
                         {
-                            "id": "ni",
-                            "visible": False
+                            'id': 'ni',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "ApproximateNumberOfMessagesDelayed",
-                        ".",
-                        ".",
+                        '.',
+                        'ApproximateNumberOfMessagesDelayed',
+                        '.',
+                        '.',
                         {
-                            "id": "nd",
-                            "visible": False
-                        }
-                    ],
-                    [
-                        {
-                            "expression": "nrv+nri+nrd",
-                            "label": "notifications_retry",
-                            "id": "nr",
-                            "region": "us-east-1",
-                            "color": "#ff7f0e"
-                        }
-                    ],
-                    [
-                        "AWS/SQS",
-                        "ApproximateNumberOfMessagesVisible",
-                        "QueueName",
-                        "azul-notifications_retry-prod",
-                        {
-                            "id": "nrv",
-                            "visible": False
-                        }
-                    ],
-                    [
-                        ".",
-                        "ApproximateNumberOfMessagesNotVisible",
-                        ".",
-                        ".",
-                        {
-                            "id": "nri",
-                            "visible": False
-                        }
-                    ],
-                    [
-                        ".",
-                        "ApproximateNumberOfMessagesDelayed",
-                        ".",
-                        ".",
-                        {
-                            "id": "nrd",
-                            "visible": False
+                            'id': 'nd',
+                            'visible': False
                         }
                     ],
                     [
                         {
-                            "expression": "nfv+nfi+nfd",
-                            "label": "notifications_fail",
-                            "id": "nf",
-                            "region": "us-east-1",
-                            "color": "#9467bd"
+                            'expression': 'nrv+nri+nrd',
+                            'label': 'notifications_retry',
+                            'id': 'nr',
+                            'region': 'us-east-1',
+                            'color': '#ff7f0e'
                         }
                     ],
                     [
-                        "AWS/SQS",
-                        "ApproximateNumberOfMessagesVisible",
-                        "QueueName",
-                        "azul-notifications_fail-prod",
+                        'AWS/SQS',
+                        'ApproximateNumberOfMessagesVisible',
+                        'QueueName',
+                        'azul-notifications_retry-prod',
                         {
-                            "id": "nfv",
-                            "visible": False
+                            'id': 'nrv',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "ApproximateNumberOfMessagesNotVisible",
-                        ".",
-                        ".",
+                        '.',
+                        'ApproximateNumberOfMessagesNotVisible',
+                        '.',
+                        '.',
                         {
-                            "id": "nfi",
-                            "visible": False
+                            'id': 'nri',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "ApproximateNumberOfMessagesDelayed",
-                        ".",
-                        ".",
+                        '.',
+                        'ApproximateNumberOfMessagesDelayed',
+                        '.',
+                        '.',
                         {
-                            "id": "nfd",
-                            "visible": False
-                        }
-                    ],
-                    [
-                        {
-                            "expression": "tv+ti+td",
-                            "label": "tallies",
-                            "id": "t",
-                            "region": "us-east-1",
-                            "color": "#2ca02c"
-                        }
-                    ],
-                    [
-                        "AWS/SQS",
-                        "ApproximateNumberOfMessagesVisible",
-                        "QueueName",
-                        "azul-tallies-prod.fifo",
-                        {
-                            "id": "tv",
-                            "visible": False
-                        }
-                    ],
-                    [
-                        ".",
-                        "ApproximateNumberOfMessagesNotVisible",
-                        ".",
-                        ".",
-                        {
-                            "id": "ti",
-                            "visible": False
-                        }
-                    ],
-                    [
-                        ".",
-                        "ApproximateNumberOfMessagesDelayed",
-                        ".",
-                        ".",
-                        {
-                            "id": "td",
-                            "visible": False
+                            'id': 'nrd',
+                            'visible': False
                         }
                     ],
                     [
                         {
-                            "expression": "trv+tri+trd",
-                            "label": "tallies_retry",
-                            "id": "tr",
-                            "region": "us-east-1",
-                            "color": "#d62728"
+                            'expression': 'nfv+nfi+nfd',
+                            'label': 'notifications_fail',
+                            'id': 'nf',
+                            'region': 'us-east-1',
+                            'color': '#9467bd'
                         }
                     ],
                     [
-                        "AWS/SQS",
-                        "ApproximateNumberOfMessagesVisible",
-                        "QueueName",
-                        "azul-tallies_retry-prod.fifo",
+                        'AWS/SQS',
+                        'ApproximateNumberOfMessagesVisible',
+                        'QueueName',
+                        'azul-notifications_fail-prod',
                         {
-                            "id": "trv",
-                            "visible": False
+                            'id': 'nfv',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "ApproximateNumberOfMessagesNotVisible",
-                        ".",
-                        ".",
+                        '.',
+                        'ApproximateNumberOfMessagesNotVisible',
+                        '.',
+                        '.',
                         {
-                            "id": "tri",
-                            "visible": False
+                            'id': 'nfi',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "ApproximateNumberOfMessagesDelayed",
-                        ".",
-                        ".",
+                        '.',
+                        'ApproximateNumberOfMessagesDelayed',
+                        '.',
+                        '.',
                         {
-                            "id": "trd",
-                            "visible": False
+                            'id': 'nfd',
+                            'visible': False
                         }
                     ],
                     [
                         {
-                            "expression": "tfv+tfi+tfd",
-                            "label": "tallies_fail",
-                            "id": "tf",
-                            "region": "us-east-1",
-                            "color": "#f7b6d2"
+                            'expression': 'tv+ti+td',
+                            'label': 'tallies',
+                            'id': 't',
+                            'region': 'us-east-1',
+                            'color': '#2ca02c'
                         }
                     ],
                     [
-                        "AWS/SQS",
-                        "ApproximateNumberOfMessagesVisible",
-                        "QueueName",
-                        "azul-tallies_fail-prod.fifo",
+                        'AWS/SQS',
+                        'ApproximateNumberOfMessagesVisible',
+                        'QueueName',
+                        'azul-tallies-prod.fifo',
                         {
-                            "id": "tfv",
-                            "visible": False
+                            'id': 'tv',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "ApproximateNumberOfMessagesNotVisible",
-                        ".",
-                        ".",
+                        '.',
+                        'ApproximateNumberOfMessagesNotVisible',
+                        '.',
+                        '.',
                         {
-                            "id": "tfi",
-                            "visible": False
+                            'id': 'ti',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "ApproximateNumberOfMessagesDelayed",
-                        ".",
-                        ".",
+                        '.',
+                        'ApproximateNumberOfMessagesDelayed',
+                        '.',
+                        '.',
                         {
-                            "id": "tfd",
-                            "visible": False
+                            'id': 'td',
+                            'visible': False
+                        }
+                    ],
+                    [
+                        {
+                            'expression': 'trv+tri+trd',
+                            'label': 'tallies_retry',
+                            'id': 'tr',
+                            'region': 'us-east-1',
+                            'color': '#d62728'
+                        }
+                    ],
+                    [
+                        'AWS/SQS',
+                        'ApproximateNumberOfMessagesVisible',
+                        'QueueName',
+                        'azul-tallies_retry-prod.fifo',
+                        {
+                            'id': 'trv',
+                            'visible': False
+                        }
+                    ],
+                    [
+                        '.',
+                        'ApproximateNumberOfMessagesNotVisible',
+                        '.',
+                        '.',
+                        {
+                            'id': 'tri',
+                            'visible': False
+                        }
+                    ],
+                    [
+                        '.',
+                        'ApproximateNumberOfMessagesDelayed',
+                        '.',
+                        '.',
+                        {
+                            'id': 'trd',
+                            'visible': False
+                        }
+                    ],
+                    [
+                        {
+                            'expression': 'tfv+tfi+tfd',
+                            'label': 'tallies_fail',
+                            'id': 'tf',
+                            'region': 'us-east-1',
+                            'color': '#f7b6d2'
+                        }
+                    ],
+                    [
+                        'AWS/SQS',
+                        'ApproximateNumberOfMessagesVisible',
+                        'QueueName',
+                        'azul-tallies_fail-prod.fifo',
+                        {
+                            'id': 'tfv',
+                            'visible': False
+                        }
+                    ],
+                    [
+                        '.',
+                        'ApproximateNumberOfMessagesNotVisible',
+                        '.',
+                        '.',
+                        {
+                            'id': 'tfi',
+                            'visible': False
+                        }
+                    ],
+                    [
+                        '.',
+                        'ApproximateNumberOfMessagesDelayed',
+                        '.',
+                        '.',
+                        {
+                            'id': 'tfd',
+                            'visible': False
                         }
                     ]
                 ],
-                "view": "timeSeries",
-                "stacked": False,
-                "region": "us-east-1",
-                "title": "Queue lengths",
-                "period": 300,
-                "stat": "Maximum"
+                'view': 'timeSeries',
+                'stacked': False,
+                'region': 'us-east-1',
+                'title': 'Queue lengths',
+                'period': 300,
+                'stat': 'Maximum'
             }
         },
         {
-            "height": 6,
-            "width": 12,
-            "y": 0,
-            "x": 0,
-            "type": "log",
-            "properties": {
-                "query": "SOURCE '/aws/lambda/azul-indexer-prod-contribute' | SOURCE '/aws/lambda/azul-indexer-prod-contribute_retry' | fields strcontains(@message, 'Worker successfully handled') as success,\n\n       strcontains(@message,'Worker failed to handle message') as failure,\n\n       strcontains(@message,'Task timed out after') as timeout\n\n| filter failure > 0 or success > 0 or timeout > 0\n| stats sum(success) as Successes, sum(failure + timeout) as Failures by bin(5min)",
-                "region": "us-east-1",
-                "stacked": True,
-                "title": "Contribution outcomes in # of notifications",
-                "view": "timeSeries"
+            'height': 6,
+            'width': 12,
+            'y': 0,
+            'x': 0,
+            'type': 'log',
+            'properties': {
+                'query': dedent('''\
+                    SOURCE '/aws/lambda/azul-indexer-prod-contribute'
+                    | SOURCE '/aws/lambda/azul-indexer-prod-contribute_retry'
+                    | fields strcontains(@message, 'Worker successfully handled') as success,
+                             strcontains(@message,'Worker failed to handle message') as failure,
+                             strcontains(@message,'Task timed out after') as timeout
+                    | filter failure > 0 or success > 0 or timeout > 0
+                    | stats sum(success) as Successes,
+                            sum(failure + timeout) as Failures
+                            by bin(5min)
+                '''),
+                'region': 'us-east-1',
+                'stacked': True,
+                'title': 'Contribution outcomes in # of notifications',
+                'view': 'timeSeries'
             }
         },
         {
-            "height": 6,
-            "width": 12,
-            "y": 24,
-            "x": 12,
-            "type": "metric",
-            "properties": {
-                "metrics": [
+            'height': 6,
+            'width': 12,
+            'y': 24,
+            'x': 12,
+            'type': 'metric',
+            'properties': {
+                'metrics': [
                     [
                         {
-                            "expression": "m2 + m4 + m6 + m8",
-                            "label": "Primary",
-                            "id": "e1",
-                            "region": "us-east-1",
-                            "color": "#2ca02c"
+                            'expression': 'm2 + m4 + m6 + m8',
+                            'label': 'Primary',
+                            'id': 'e1',
+                            'region': 'us-east-1',
+                            'color': '#2ca02c'
                         }
                     ],
                     [
                         {
-                            "expression": "m3 + m5 + m7 + m9",
-                            "label": "Replica",
-                            "id": "e2",
-                            "region": "us-east-1",
-                            "color": "#1f77b4"
+                            'expression': 'm3 + m5 + m7 + m9',
+                            'label': 'Replica',
+                            'id': 'e2',
+                            'region': 'us-east-1',
+                            'color': '#1f77b4'
                         }
                     ],
                     [
-                        "AWS/ES",
-                        "Shards.unassigned",
-                        "DomainName",
-                        "azul-index-prod",
-                        "ClientId",
-                        "542754589326",
+                        'AWS/ES',
+                        'Shards.unassigned',
+                        'DomainName',
+                        'azul-index-prod',
+                        'ClientId',
+                        '542754589326',
                         {
-                            "id": "m1",
-                            "label": "Unassigned",
-                            "color": "#d62728"
+                            'id': 'm1',
+                            'label': 'Unassigned',
+                            'color': '#d62728'
                         }
                     ],
                     [
-                        ".",
-                        "ShardCount",
-                        "ShardRole",
-                        "Primary",
-                        "DomainName",
-                        "azul-index-prod",
-                        "NodeId",
-                        "${local.nodes[0]}",
-                        "ClientId",
-                        "542754589326",
+                        '.',
+                        'ShardCount',
+                        'ShardRole',
+                        'Primary',
+                        'DomainName',
+                        'azul-index-prod',
+                        'NodeId',
+                        '${local.nodes[0]}',
+                        'ClientId',
+                        '542754589326',
                         {
-                            "id": "m2",
-                            "visible": False
+                            'id': 'm2',
+                            'visible': False
                         }
                     ],
                     [
-                        "...",
-                        "Replica",
-                        ".",
-                        ".",
-                        ".",
-                        ".",
-                        ".",
-                        ".",
+                        '...',
+                        'Replica',
+                        '.',
+                        '.',
+                        '.',
+                        '.',
+                        '.',
+                        '.',
                         {
-                            "id": "m3",
-                            "visible": False
+                            'id': 'm3',
+                            'visible': False
                         }
                     ],
                     [
-                        "...",
-                        "Primary",
-                        ".",
-                        ".",
-                        ".",
-                        "${local.nodes[1]}",
-                        ".",
-                        ".",
+                        '...',
+                        'Primary',
+                        '.',
+                        '.',
+                        '.',
+                        '${local.nodes[1]}',
+                        '.',
+                        '.',
                         {
-                            "id": "m4",
-                            "visible": False
+                            'id': 'm4',
+                            'visible': False
                         }
                     ],
                     [
-                        "...",
-                        "Replica",
-                        ".",
-                        ".",
-                        ".",
-                        ".",
-                        ".",
-                        ".",
+                        '...',
+                        'Replica',
+                        '.',
+                        '.',
+                        '.',
+                        '.',
+                        '.',
+                        '.',
                         {
-                            "id": "m5",
-                            "visible": False
+                            'id': 'm5',
+                            'visible': False
                         }
                     ],
                     [
-                        "...",
-                        "Primary",
-                        ".",
-                        ".",
-                        ".",
-                        "${local.nodes[2]}",
-                        ".",
-                        ".",
+                        '...',
+                        'Primary',
+                        '.',
+                        '.',
+                        '.',
+                        '${local.nodes[2]}',
+                        '.',
+                        '.',
                         {
-                            "id": "m6",
-                            "visible": False
+                            'id': 'm6',
+                            'visible': False
                         }
                     ],
                     [
-                        "...",
-                        "Replica",
-                        ".",
-                        ".",
-                        ".",
-                        ".",
-                        ".",
-                        ".",
+                        '...',
+                        'Replica',
+                        '.',
+                        '.',
+                        '.',
+                        '.',
+                        '.',
+                        '.',
                         {
-                            "id": "m7",
-                            "visible": False
+                            'id': 'm7',
+                            'visible': False
                         }
                     ],
                     [
-                        "...",
-                        "Primary",
-                        ".",
-                        ".",
-                        ".",
-                        "${local.nodes[3]}",
-                        ".",
-                        ".",
+                        '...',
+                        'Primary',
+                        '.',
+                        '.',
+                        '.',
+                        '${local.nodes[3]}',
+                        '.',
+                        '.',
                         {
-                            "id": "m8",
-                            "visible": False
+                            'id': 'm8',
+                            'visible': False
                         }
                     ],
                     [
-                        "...",
-                        "Replica",
-                        ".",
-                        ".",
-                        ".",
-                        ".",
-                        ".",
-                        ".",
+                        '...',
+                        'Replica',
+                        '.',
+                        '.',
+                        '.',
+                        '.',
+                        '.',
+                        '.',
                         {
-                            "id": "m9",
-                            "visible": False
+                            'id': 'm9',
+                            'visible': False
                         }
                     ]
                 ],
-                "view": "timeSeries",
-                "stacked": False,
-                "region": "us-east-1",
-                "period": 300,
-                "stat": "Maximum",
-                "title": "ES shards"
+                'view': 'timeSeries',
+                'stacked': False,
+                'region': 'us-east-1',
+                'period': 300,
+                'stat': 'Maximum',
+                'title': 'ES shards'
             }
         },
         {
-            "height": 6,
-            "width": 12,
-            "y": 12,
-            "x": 12,
-            "type": "log",
-            "properties": {
-                "query": "SOURCE '/aws/lambda/azul-indexer-prod-aggregate' | SOURCE '/aws/lambda/azul-indexer-prod-aggregate_retry' | SOURCE '/aws/lambda/azul-indexer-prod-contribute' | SOURCE '/aws/lambda/azul-indexer-prod-contribute_retry' | filter @message like 'TransportError'\n| fields strcontains(@log, 'contribute') as contribute, 1 - contribute as aggregate\n| stats sum(contribute) as Contribution, sum(aggregate) as Aggregation by bin(5min)",
-                "region": "us-east-1",
-                "stacked": False,
-                "title": "ES TransportErrors",
-                "view": "timeSeries"
+            'height': 6,
+            'width': 12,
+            'y': 12,
+            'x': 12,
+            'type': 'log',
+            'properties': {
+                'query': dedent('''\
+                    SOURCE '/aws/lambda/azul-indexer-prod-aggregate'
+                    | SOURCE '/aws/lambda/azul-indexer-prod-aggregate_retry'
+                    | SOURCE '/aws/lambda/azul-indexer-prod-contribute'
+                    | SOURCE '/aws/lambda/azul-indexer-prod-contribute_retry'
+                    | filter @message like 'TransportError'
+                    | fields strcontains(@log, 'contribute') as contribute, 1 - contribute as aggregate
+                    | stats sum(contribute) as Contribution, sum(aggregate) as Aggregation by bin(5min)
+                '''),
+                'region': 'us-east-1',
+                'stacked': False,
+                'title': 'ES TransportErrors',
+                'view': 'timeSeries'
             }
         },
         {
-            "height": 6,
-            "width": 12,
-            "y": 30,
-            "x": 12,
-            "type": "metric",
-            "properties": {
-                "view": "timeSeries",
-                "stacked": True,
-                "metrics": [
+            'height': 6,
+            'width': 12,
+            'y': 30,
+            'x': 12,
+            'type': 'metric',
+            'properties': {
+                'view': 'timeSeries',
+                'stacked': True,
+                'metrics': [
                     [
-                        "AWS/ES",
-                        "JVMMemoryPressure",
-                        "DomainName",
-                        "azul-index-prod",
-                        "NodeId",
-                        "${local.nodes[0]}",
-                        "ClientId",
-                        "542754589326"
+                        'AWS/ES',
+                        'JVMMemoryPressure',
+                        'DomainName',
+                        'azul-index-prod',
+                        'NodeId',
+                        '${local.nodes[0]}',
+                        'ClientId',
+                        '542754589326'
                     ],
                     [
-                        "...",
-                        "${local.nodes[1]}",
-                        ".",
-                        "."
+                        '...',
+                        '${local.nodes[1]}',
+                        '.',
+                        '.'
                     ],
                     [
-                        "...",
-                        "${local.nodes[2]}",
-                        ".",
-                        "."
+                        '...',
+                        '${local.nodes[2]}',
+                        '.',
+                        '.'
                     ],
                     [
-                        "...",
-                        "${local.nodes[3]}",
-                        ".",
-                        "."
+                        '...',
+                        '${local.nodes[3]}',
+                        '.',
+                        '.'
                     ]
                 ],
-                "region": "us-east-1",
-                "title": "ES JVM memory pressure [%]",
-                "period": 300
+                'region': 'us-east-1',
+                'title': 'ES JVM memory pressure [%]',
+                'period': 300
             }
         },
         {
-            "height": 6,
-            "width": 12,
-            "y": 36,
-            "x": 12,
-            "type": "metric",
-            "properties": {
-                "metrics": [
+            'height': 6,
+            'width': 12,
+            'y': 36,
+            'x': 12,
+            'type': 'metric',
+            'properties': {
+                'metrics': [
                     [
                         {
-                            "expression": "DIFF(m1+m2+m3+m4)/4/1000/60/5*100",
-                            "label": "Old generation",
-                            "id": "e2",
-                            "region": "us-east-1",
-                            "stat": "Maximum"
+                            'expression': 'DIFF(m1+m2+m3+m4)/4/1000/60/5*100',
+                            'label': 'Old generation',
+                            'id': 'e2',
+                            'region': 'us-east-1',
+                            'stat': 'Maximum'
                         }
                     ],
                     [
                         {
-                            "expression": "DIFF(m5+m6+m7+m8)/4/1000/60/5*100",
-                            "label": "Young generation",
-                            "id": "e1",
-                            "region": "us-east-1",
-                            "stat": "Maximum",
-                            "yAxis": "left"
+                            'expression': 'DIFF(m5+m6+m7+m8)/4/1000/60/5*100',
+                            'label': 'Young generation',
+                            'id': 'e1',
+                            'region': 'us-east-1',
+                            'stat': 'Maximum',
+                            'yAxis': 'left'
                         }
                     ],
                     [
-                        "AWS/ES",
-                        "JVMGCOldCollectionTime",
-                        "DomainName",
-                        "azul-index-prod",
-                        "NodeId",
-                        "${local.nodes[0]}",
-                        "ClientId",
-                        "542754589326",
+                        'AWS/ES',
+                        'JVMGCOldCollectionTime',
+                        'DomainName',
+                        'azul-index-prod',
+                        'NodeId',
+                        '${local.nodes[0]}',
+                        'ClientId',
+                        '542754589326',
                         {
-                            "id": "m1",
-                            "visible": False
+                            'id': 'm1',
+                            'visible': False
                         }
                     ],
                     [
-                        "...",
-                        "${local.nodes[1]}",
-                        ".",
-                        ".",
+                        '...',
+                        '${local.nodes[1]}',
+                        '.',
+                        '.',
                         {
-                            "id": "m2",
-                            "visible": False
+                            'id': 'm2',
+                            'visible': False
                         }
                     ],
                     [
-                        "...",
-                        "${local.nodes[2]}",
-                        ".",
-                        ".",
+                        '...',
+                        '${local.nodes[2]}',
+                        '.',
+                        '.',
                         {
-                            "id": "m3",
-                            "visible": False
+                            'id': 'm3',
+                            'visible': False
                         }
                     ],
                     [
-                        "...",
-                        "${local.nodes[3]}",
-                        ".",
-                        ".",
+                        '...',
+                        '${local.nodes[3]}',
+                        '.',
+                        '.',
                         {
-                            "id": "m4",
-                            "visible": False
+                            'id': 'm4',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "JVMGCYoungCollectionTime",
-                        ".",
-                        ".",
-                        ".",
-                        "${local.nodes[0]}",
-                        ".",
-                        ".",
+                        '.',
+                        'JVMGCYoungCollectionTime',
+                        '.',
+                        '.',
+                        '.',
+                        '${local.nodes[0]}',
+                        '.',
+                        '.',
                         {
-                            "id": "m5",
-                            "visible": False
+                            'id': 'm5',
+                            'visible': False
                         }
                     ],
                     [
-                        "...",
-                        "${local.nodes[1]}",
-                        ".",
-                        ".",
+                        '...',
+                        '${local.nodes[1]}',
+                        '.',
+                        '.',
                         {
-                            "id": "m6",
-                            "visible": False
+                            'id': 'm6',
+                            'visible': False
                         }
                     ],
                     [
-                        "...",
-                        "${local.nodes[2]}",
-                        ".",
-                        ".",
+                        '...',
+                        '${local.nodes[2]}',
+                        '.',
+                        '.',
                         {
-                            "id": "m7",
-                            "visible": False
+                            'id': 'm7',
+                            'visible': False
                         }
                     ],
                     [
-                        "...",
-                        "${local.nodes[3]}",
-                        ".",
-                        ".",
+                        '...',
+                        '${local.nodes[3]}',
+                        '.',
+                        '.',
                         {
-                            "id": "m8",
-                            "visible": False
+                            'id': 'm8',
+                            'visible': False
                         }
                     ]
                 ],
-                "view": "timeSeries",
-                "stacked": True,
-                "region": "us-east-1",
-                "period": 300,
-                "stat": "Maximum",
-                "title": "ES JVM garbage collection time",
-                "yAxis": {
-                    "left": {
-                        "label": "% of wall clock time",
-                        "showUnits": False
+                'view': 'timeSeries',
+                'stacked': True,
+                'region': 'us-east-1',
+                'period': 300,
+                'stat': 'Maximum',
+                'title': 'ES JVM garbage collection time',
+                'yAxis': {
+                    'left': {
+                        'label': '% of wall clock time',
+                        'showUnits': False
                     },
-                    "right": {
-                        "showUnits": False
+                    'right': {
+                        'showUnits': False
                     }
                 }
             }
         },
         {
-            "height": 6,
-            "width": 12,
-            "y": 30,
-            "x": 0,
-            "type": "log",
-            "properties": {
-                "query": "SOURCE '/aws/lambda/azul-indexer-prod-contribute' | SOURCE '/aws/lambda/azul-indexer-prod-contribute_retry' | fields @log\n| parse 'It took *s to download' as duration\n| filter ispresent(duration)\n| fields strcontains(@log, '_retry') as is_retry\n| stats avg(duration * (1 - is_retry)) as Initial, avg(duration * is_retry) as Retry by bin(5m)",
-                "region": "us-east-1",
-                "stacked": False,
-                "title": "Subgraph download time, average [s]",
-                "view": "timeSeries"
+            'height': 6,
+            'width': 12,
+            'y': 30,
+            'x': 0,
+            'type': 'log',
+            'properties': {
+                'query': dedent('''\
+                    SOURCE '/aws/lambda/azul-indexer-prod-contribute'
+                    | SOURCE '/aws/lambda/azul-indexer-prod-contribute_retry'
+                    | fields @log
+                    | parse 'It took *s to download' as duration
+                    | filter ispresent(duration)
+                    | fields strcontains(@log, '_retry') as is_retry
+                    | stats avg(duration * (1 - is_retry)) as Initial,
+                            avg(duration * is_retry) as Retry
+                            by bin(5m)
+                '''),
+                'region': 'us-east-1',
+                'stacked': False,
+                'title': 'Subgraph download time, average [s]',
+                'view': 'timeSeries'
             }
         },
         {
-            "height": 6,
-            "width": 12,
-            "y": 72,
-            "x": 12,
-            "type": "metric",
-            "properties": {
-                "metrics": [
+            'height': 6,
+            'width': 12,
+            'y': 72,
+            'x': 12,
+            'type': 'metric',
+            'properties': {
+                'metrics': [
                     [
-                        "AWS/Lambda",
-                        "Throttles",
-                        "FunctionName",
-                        "azul-indexer-prod-contribute",
+                        'AWS/Lambda',
+                        'Throttles',
+                        'FunctionName',
+                        'azul-indexer-prod-contribute',
                         {
-                            "label": "contribute"
+                            'label': 'contribute'
                         }
                     ],
                     [
-                        "...",
-                        "azul-indexer-prod-contribute_retry",
+                        '...',
+                        'azul-indexer-prod-contribute_retry',
                         {
-                            "label": "contribute_retry"
+                            'label': 'contribute_retry'
                         }
                     ],
                     [
-                        "...",
-                        "azul-indexer-prod-aggregate",
+                        '...',
+                        'azul-indexer-prod-aggregate',
                         {
-                            "label": "aggregate"
+                            'label': 'aggregate'
                         }
                     ],
                     [
-                        "...",
-                        "azul-indexer-prod-aggregate_retry",
+                        '...',
+                        'azul-indexer-prod-aggregate_retry',
                         {
-                            "label": "aggregate_retry"
+                            'label': 'aggregate_retry'
                         }
                     ]
                 ],
-                "view": "timeSeries",
-                "stacked": False,
-                "region": "us-east-1",
-                "stat": "Sum",
-                "period": 300,
-                "title": "Lambda throttles"
+                'view': 'timeSeries',
+                'stacked': False,
+                'region': 'us-east-1',
+                'stat': 'Sum',
+                'period': 300,
+                'title': 'Lambda throttles'
             }
         },
         {
-            "height": 6,
-            "width": 12,
-            "y": 60,
-            "x": 12,
-            "type": "metric",
-            "properties": {
-                "metrics": [
+            'height': 6,
+            'width': 12,
+            'y': 60,
+            'x': 12,
+            'type': 'metric',
+            'properties': {
+                'metrics': [
                     [
-                        "AWS/Lambda",
-                        "Errors",
-                        "FunctionName",
-                        "azul-indexer-prod-contribute",
+                        'AWS/Lambda',
+                        'Errors',
+                        'FunctionName',
+                        'azul-indexer-prod-contribute',
                         {
-                            "label": "contribute",
-                            "region": "us-east-1"
+                            'label': 'contribute',
+                            'region': 'us-east-1'
                         }
                     ],
                     [
-                        "AWS/Lambda",
-                        "Errors",
-                        "FunctionName",
-                        "azul-indexer-prod-contribute_retry",
+                        'AWS/Lambda',
+                        'Errors',
+                        'FunctionName',
+                        'azul-indexer-prod-contribute_retry',
                         {
-                            "label": "contribute_retry",
-                            "region": "us-east-1"
+                            'label': 'contribute_retry',
+                            'region': 'us-east-1'
                         }
                     ],
                     [
-                        "AWS/Lambda",
-                        "Errors",
-                        "FunctionName",
-                        "azul-indexer-prod-aggregate",
+                        'AWS/Lambda',
+                        'Errors',
+                        'FunctionName',
+                        'azul-indexer-prod-aggregate',
                         {
-                            "label": "aggregate",
-                            "region": "us-east-1"
+                            'label': 'aggregate',
+                            'region': 'us-east-1'
                         }
                     ],
                     [
-                        "AWS/Lambda",
-                        "Errors",
-                        "FunctionName",
-                        "azul-indexer-prod-aggregate_retry",
+                        'AWS/Lambda',
+                        'Errors',
+                        'FunctionName',
+                        'azul-indexer-prod-aggregate_retry',
                         {
-                            "label": "aggregate_retry",
-                            "region": "us-east-1"
+                            'label': 'aggregate_retry',
+                            'region': 'us-east-1'
                         }
                     ]
                 ],
-                "view": "timeSeries",
-                "stacked": False,
-                "region": "us-east-1",
-                "stat": "Sum",
-                "period": 300,
-                "title": "Lambda errors"
+                'view': 'timeSeries',
+                'stacked': False,
+                'region': 'us-east-1',
+                'stat': 'Sum',
+                'period': 300,
+                'title': 'Lambda errors'
             }
         },
         {
-            "height": 6,
-            "width": 12,
-            "y": 48,
-            "x": 12,
-            "type": "metric",
-            "properties": {
-                "metrics": [
+            'height': 6,
+            'width': 12,
+            'y': 48,
+            'x': 12,
+            'type': 'metric',
+            'properties': {
+                'metrics': [
                     [
-                        "AWS/Lambda",
-                        "Invocations",
-                        "FunctionName",
-                        "azul-indexer-prod-contribute",
+                        'AWS/Lambda',
+                        'Invocations',
+                        'FunctionName',
+                        'azul-indexer-prod-contribute',
                         {
-                            "label": "contribute"
+                            'label': 'contribute'
                         }
                     ],
                     [
-                        "...",
-                        "azul-indexer-prod-contribute_retry",
+                        '...',
+                        'azul-indexer-prod-contribute_retry',
                         {
-                            "label": "contribute_retry"
+                            'label': 'contribute_retry'
                         }
                     ],
                     [
-                        "...",
-                        "azul-indexer-prod-aggregate",
+                        '...',
+                        'azul-indexer-prod-aggregate',
                         {
-                            "label": "aggregate"
+                            'label': 'aggregate'
                         }
                     ],
                     [
-                        "...",
-                        "azul-indexer-prod-aggregate_retry",
+                        '...',
+                        'azul-indexer-prod-aggregate_retry',
                         {
-                            "label": "aggregate_retry"
+                            'label': 'aggregate_retry'
                         }
                     ]
                 ],
-                "view": "timeSeries",
-                "stacked": False,
-                "region": "us-east-1",
-                "stat": "Sum",
-                "period": 300,
-                "title": "Lambda invocations"
+                'view': 'timeSeries',
+                'stacked': False,
+                'region': 'us-east-1',
+                'stat': 'Sum',
+                'period': 300,
+                'title': 'Lambda invocations'
             }
         },
         {
-            "height": 6,
-            "width": 12,
-            "y": 54,
-            "x": 12,
-            "type": "metric",
-            "properties": {
-                "metrics": [
+            'height': 6,
+            'width': 12,
+            'y': 54,
+            'x': 12,
+            'type': 'metric',
+            'properties': {
+                'metrics': [
                     [
-                        "AWS/Lambda",
-                        "ConcurrentExecutions",
-                        "FunctionName",
-                        "azul-indexer-prod-contribute",
+                        'AWS/Lambda',
+                        'ConcurrentExecutions',
+                        'FunctionName',
+                        'azul-indexer-prod-contribute',
                         {
-                            "label": "contribute"
+                            'label': 'contribute'
                         }
                     ],
                     [
-                        "...",
-                        "azul-indexer-prod-contribute_retry",
+                        '...',
+                        'azul-indexer-prod-contribute_retry',
                         {
-                            "label": "contribute_retry"
+                            'label': 'contribute_retry'
                         }
                     ],
                     [
-                        "...",
-                        "azul-indexer-prod-aggregate",
+                        '...',
+                        'azul-indexer-prod-aggregate',
                         {
-                            "label": "aggregate"
+                            'label': 'aggregate'
                         }
                     ],
                     [
-                        "...",
-                        "azul-indexer-prod-aggregate_retry",
+                        '...',
+                        'azul-indexer-prod-aggregate_retry',
                         {
-                            "label": "aggregate_retry"
+                            'label': 'aggregate_retry'
                         }
                     ]
                 ],
-                "view": "timeSeries",
-                "stacked": False,
-                "region": "us-east-1",
-                "stat": "Maximum",
-                "period": 300,
-                "title": "Concurrent Lambda executions"
+                'view': 'timeSeries',
+                'stacked': False,
+                'region': 'us-east-1',
+                'stat': 'Maximum',
+                'period': 300,
+                'title': 'Concurrent Lambda executions'
             }
         },
         {
-            "height": 6,
-            "width": 12,
-            "y": 42,
-            "x": 12,
-            "type": "metric",
-            "properties": {
-                "metrics": [
+            'height': 6,
+            'width': 12,
+            'y': 42,
+            'x': 12,
+            'type': 'metric',
+            'properties': {
+                'metrics': [
                     [
                         {
-                            "expression": "m3 / 1000",
-                            "label": "contribute",
-                            "id": "e1",
-                            "stat": "Average",
-                            "region": "us-east-1"
+                            'expression': 'm3 / 1000',
+                            'label': 'contribute',
+                            'id': 'e1',
+                            'stat': 'Average',
+                            'region': 'us-east-1'
                         }
                     ],
                     [
                         {
-                            "expression": "m4 / 1000",
-                            "label": "contribute_retry",
-                            "id": "e2",
-                            "stat": "Average",
-                            "region": "us-east-1"
+                            'expression': 'm4 / 1000',
+                            'label': 'contribute_retry',
+                            'id': 'e2',
+                            'stat': 'Average',
+                            'region': 'us-east-1'
                         }
                     ],
                     [
                         {
-                            "expression": "m1 / 1000",
-                            "label": "aggregate",
-                            "id": "e3",
-                            "stat": "Average",
-                            "region": "us-east-1"
+                            'expression': 'm1 / 1000',
+                            'label': 'aggregate',
+                            'id': 'e3',
+                            'stat': 'Average',
+                            'region': 'us-east-1'
                         }
                     ],
                     [
                         {
-                            "expression": "m2 / 1000",
-                            "label": "aggregate_retry",
-                            "id": "e4",
-                            "stat": "Average",
-                            "region": "us-east-1"
+                            'expression': 'm2 / 1000',
+                            'label': 'aggregate_retry',
+                            'id': 'e4',
+                            'stat': 'Average',
+                            'region': 'us-east-1'
                         }
                     ],
                     [
-                        "AWS/Lambda",
-                        "Duration",
-                        "FunctionName",
-                        "azul-indexer-prod-aggregate",
+                        'AWS/Lambda',
+                        'Duration',
+                        'FunctionName',
+                        'azul-indexer-prod-aggregate',
                         {
-                            "id": "m1",
-                            "visible": False
+                            'id': 'm1',
+                            'visible': False
                         }
                     ],
                     [
-                        "...",
-                        "azul-indexer-prod-aggregate_retry",
+                        '...',
+                        'azul-indexer-prod-aggregate_retry',
                         {
-                            "id": "m2",
-                            "visible": False
+                            'id': 'm2',
+                            'visible': False
                         }
                     ],
                     [
-                        "...",
-                        "azul-indexer-prod-contribute",
+                        '...',
+                        'azul-indexer-prod-contribute',
                         {
-                            "id": "m3",
-                            "visible": False
+                            'id': 'm3',
+                            'visible': False
                         }
                     ],
                     [
-                        "...",
-                        "azul-indexer-prod-contribute_retry",
+                        '...',
+                        'azul-indexer-prod-contribute_retry',
                         {
-                            "id": "m4",
-                            "visible": False
+                            'id': 'm4',
+                            'visible': False
                         }
                     ]
                 ],
-                "view": "timeSeries",
-                "stacked": False,
-                "region": "us-east-1",
-                "stat": "Average",
-                "period": 300,
-                "title": "Lambda duration [s]",
-                "yAxis": {
-                    "left": {
-                        "showUnits": False
+                'view': 'timeSeries',
+                'stacked': False,
+                'region': 'us-east-1',
+                'stat': 'Average',
+                'period': 300,
+                'title': 'Lambda duration [s]',
+                'yAxis': {
+                    'left': {
+                        'showUnits': False
                     }
                 }
             }
         },
         {
-            "height": 6,
-            "width": 12,
-            "y": 36,
-            "x": 0,
-            "type": "log",
-            "properties": {
-                "query": "SOURCE '/aws/lambda/azul-indexer-prod-contribute' | SOURCE '/aws/lambda/azul-indexer-prod-contribute_retry' | filter @message like 'Exceeded rate limits'\n| sort @timestamp desc\n| stats count(@requestId) as trips by bin(5min)",
-                "region": "us-east-1",
-                "stacked": False,
-                "title": "BQ rate limit trips",
-                "view": "timeSeries"
+            'height': 6,
+            'width': 12,
+            'y': 36,
+            'x': 0,
+            'type': 'log',
+            'properties': {
+                'query': dedent('''\
+                    SOURCE '/aws/lambda/azul-indexer-prod-contribute'
+                    | SOURCE '/aws/lambda/azul-indexer-prod-contribute_retry'
+                    | filter @message like 'Exceeded rate limits'
+                    | sort @timestamp desc
+                    | stats count(@requestId) as trips by bin(5min)
+                '''),
+                'region': 'us-east-1',
+                'stacked': False,
+                'title': 'BQ rate limit trips',
+                'view': 'timeSeries'
             }
         },
         {
-            "height": 6,
-            "width": 12,
-            "y": 24,
-            "x": 0,
-            "type": "log",
-            "properties": {
-                "query": "SOURCE '/aws/lambda/azul-indexer-prod-contribute' | SOURCE '/aws/lambda/azul-indexer-prod-contribute_retry' | filter ispresent(stats.totalSlotMs)\n| stats sum(stats.totalSlotMs) / 1000 / 3600 * 12 as `slot hours` by bin(5min)\n",
-                "region": "us-east-1",
-                "stacked": False,
-                "title": "BQ slot-hours (pro-rated)",
-                "view": "timeSeries"
+            'height': 6,
+            'width': 12,
+            'y': 24,
+            'x': 0,
+            'type': 'log',
+            'properties': {
+                'query': dedent('''\
+                    SOURCE '/aws/lambda/azul-indexer-prod-contribute'
+                    | SOURCE '/aws/lambda/azul-indexer-prod-contribute_retry'
+                    | filter ispresent(stats.totalSlotMs)
+                    | stats sum(stats.totalSlotMs) / 1000 / 3600 * 12 as `slot hours` by bin(5min)
+                '''),
+                'region': 'us-east-1',
+                'stacked': False,
+                'title': 'BQ slot-hours (pro-rated)',
+                'view': 'timeSeries'
             }
         },
         {
-            "height": 6,
-            "width": 12,
-            "y": 42,
-            "x": 0,
-            "type": "log",
-            "properties": {
-                "query": "SOURCE '/aws/lambda/azul-indexer-prod-contribute' | SOURCE '/aws/lambda/azul-indexer-prod-contribute_retry' | filter @message like 'Exceeded rate limits'\n| parse 'BigQuery job error during attempt *. Retrying in *s.' as a, d\n| filter ispresent(d)\n| stats avg(d) as Delay by bin(5min)",
-                "region": "us-east-1",
-                "stacked": False,
-                "title": "BQ rate limit back-off, average [s]",
-                "view": "timeSeries"
+            'height': 6,
+            'width': 12,
+            'y': 42,
+            'x': 0,
+            'type': 'log',
+            'properties': {
+                'query': dedent('''\
+                    SOURCE '/aws/lambda/azul-indexer-prod-contribute'
+                    | SOURCE '/aws/lambda/azul-indexer-prod-contribute_retry'
+                    | filter @message like 'Exceeded rate limits'
+                    | parse 'BigQuery job error during attempt *. Retrying in *s.' as a, d
+                    | filter ispresent(d)
+                    | stats avg(d) as Delay by bin(5min)
+                '''),
+                'region': 'us-east-1',
+                'stacked': False,
+                'title': 'BQ rate limit back-off, average [s]',
+                'view': 'timeSeries'
             }
         },
         {
-            "height": 6,
-            "width": 12,
-            "y": 18,
-            "x": 0,
-            "type": "metric",
-            "properties": {
-                "metrics": [
+            'height': 6,
+            'width': 12,
+            'y': 18,
+            'x': 0,
+            'type': 'metric',
+            'properties': {
+                'metrics': [
                     [
                         {
-                            "expression": "DIFF(nv+ni+nd)",
-                            "label": "notifications",
-                            "id": "n",
-                            "region": "us-east-1"
+                            'expression': 'DIFF(nv+ni+nd)',
+                            'label': 'notifications',
+                            'id': 'n',
+                            'region': 'us-east-1'
                         }
                     ],
                     [
-                        "AWS/SQS",
-                        "ApproximateNumberOfMessagesVisible",
-                        "QueueName",
-                        "azul-notifications-prod",
+                        'AWS/SQS',
+                        'ApproximateNumberOfMessagesVisible',
+                        'QueueName',
+                        'azul-notifications-prod',
                         {
-                            "id": "nv",
-                            "visible": False
+                            'id': 'nv',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "ApproximateNumberOfMessagesNotVisible",
-                        ".",
-                        ".",
+                        '.',
+                        'ApproximateNumberOfMessagesNotVisible',
+                        '.',
+                        '.',
                         {
-                            "id": "ni",
-                            "visible": False
+                            'id': 'ni',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "ApproximateNumberOfMessagesDelayed",
-                        ".",
-                        ".",
+                        '.',
+                        'ApproximateNumberOfMessagesDelayed',
+                        '.',
+                        '.',
                         {
-                            "id": "nd",
-                            "visible": False
-                        }
-                    ],
-                    [
-                        {
-                            "expression": "DIFF(nrv+nri+nrd)",
-                            "label": "notifications_retry",
-                            "id": "nr",
-                            "region": "us-east-1",
-                            "color": "#ff7f0e"
-                        }
-                    ],
-                    [
-                        "AWS/SQS",
-                        "ApproximateNumberOfMessagesVisible",
-                        "QueueName",
-                        "azul-notifications_retry-prod",
-                        {
-                            "id": "nrv",
-                            "visible": False
-                        }
-                    ],
-                    [
-                        ".",
-                        "ApproximateNumberOfMessagesNotVisible",
-                        ".",
-                        ".",
-                        {
-                            "id": "nri",
-                            "visible": False
-                        }
-                    ],
-                    [
-                        ".",
-                        "ApproximateNumberOfMessagesDelayed",
-                        ".",
-                        ".",
-                        {
-                            "id": "nrd",
-                            "visible": False
+                            'id': 'nd',
+                            'visible': False
                         }
                     ],
                     [
                         {
-                            "expression": "DIFF(nfv+nfi+nfd)",
-                            "label": "notifications_fail",
-                            "id": "nf",
-                            "region": "us-east-1",
-                            "color": "#9467bd"
+                            'expression': 'DIFF(nrv+nri+nrd)',
+                            'label': 'notifications_retry',
+                            'id': 'nr',
+                            'region': 'us-east-1',
+                            'color': '#ff7f0e'
                         }
                     ],
                     [
-                        "AWS/SQS",
-                        "ApproximateNumberOfMessagesVisible",
-                        "QueueName",
-                        "azul-notifications_fail-prod",
+                        'AWS/SQS',
+                        'ApproximateNumberOfMessagesVisible',
+                        'QueueName',
+                        'azul-notifications_retry-prod',
                         {
-                            "id": "nfv",
-                            "visible": False
+                            'id': 'nrv',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "ApproximateNumberOfMessagesNotVisible",
-                        ".",
-                        ".",
+                        '.',
+                        'ApproximateNumberOfMessagesNotVisible',
+                        '.',
+                        '.',
                         {
-                            "id": "nfi",
-                            "visible": False
+                            'id': 'nri',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "ApproximateNumberOfMessagesDelayed",
-                        ".",
-                        ".",
+                        '.',
+                        'ApproximateNumberOfMessagesDelayed',
+                        '.',
+                        '.',
                         {
-                            "id": "nfd",
-                            "visible": False
-                        }
-                    ],
-                    [
-                        {
-                            "expression": "DIFF(tv+ti+td)",
-                            "label": "tallies",
-                            "id": "t",
-                            "region": "us-east-1",
-                            "color": "#2ca02c"
-                        }
-                    ],
-                    [
-                        "AWS/SQS",
-                        "ApproximateNumberOfMessagesVisible",
-                        "QueueName",
-                        "azul-tallies-prod.fifo",
-                        {
-                            "id": "tv",
-                            "visible": False
-                        }
-                    ],
-                    [
-                        ".",
-                        "ApproximateNumberOfMessagesNotVisible",
-                        ".",
-                        ".",
-                        {
-                            "id": "ti",
-                            "visible": False
-                        }
-                    ],
-                    [
-                        ".",
-                        "ApproximateNumberOfMessagesDelayed",
-                        ".",
-                        ".",
-                        {
-                            "id": "td",
-                            "visible": False
+                            'id': 'nrd',
+                            'visible': False
                         }
                     ],
                     [
                         {
-                            "expression": "DIFF(trv+tri+trd)",
-                            "label": "tallies_retry",
-                            "id": "tr",
-                            "region": "us-east-1",
-                            "color": "#d62728"
+                            'expression': 'DIFF(nfv+nfi+nfd)',
+                            'label': 'notifications_fail',
+                            'id': 'nf',
+                            'region': 'us-east-1',
+                            'color': '#9467bd'
                         }
                     ],
                     [
-                        "AWS/SQS",
-                        "ApproximateNumberOfMessagesVisible",
-                        "QueueName",
-                        "azul-tallies_retry-prod.fifo",
+                        'AWS/SQS',
+                        'ApproximateNumberOfMessagesVisible',
+                        'QueueName',
+                        'azul-notifications_fail-prod',
                         {
-                            "id": "trv",
-                            "visible": False
+                            'id': 'nfv',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "ApproximateNumberOfMessagesNotVisible",
-                        ".",
-                        ".",
+                        '.',
+                        'ApproximateNumberOfMessagesNotVisible',
+                        '.',
+                        '.',
                         {
-                            "id": "tri",
-                            "visible": False
+                            'id': 'nfi',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "ApproximateNumberOfMessagesDelayed",
-                        ".",
-                        ".",
+                        '.',
+                        'ApproximateNumberOfMessagesDelayed',
+                        '.',
+                        '.',
                         {
-                            "id": "trd",
-                            "visible": False
+                            'id': 'nfd',
+                            'visible': False
                         }
                     ],
                     [
                         {
-                            "expression": "DIFF(tfv+tfi+tfd)",
-                            "label": "tallies_fail",
-                            "id": "tf",
-                            "region": "us-east-1",
-                            "color": "#f7b6d2"
+                            'expression': 'DIFF(tv+ti+td)',
+                            'label': 'tallies',
+                            'id': 't',
+                            'region': 'us-east-1',
+                            'color': '#2ca02c'
                         }
                     ],
                     [
-                        "AWS/SQS",
-                        "ApproximateNumberOfMessagesVisible",
-                        "QueueName",
-                        "azul-tallies_fail-prod.fifo",
+                        'AWS/SQS',
+                        'ApproximateNumberOfMessagesVisible',
+                        'QueueName',
+                        'azul-tallies-prod.fifo',
                         {
-                            "id": "tfv",
-                            "visible": False
+                            'id': 'tv',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "ApproximateNumberOfMessagesNotVisible",
-                        ".",
-                        ".",
+                        '.',
+                        'ApproximateNumberOfMessagesNotVisible',
+                        '.',
+                        '.',
                         {
-                            "id": "tfi",
-                            "visible": False
+                            'id': 'ti',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "ApproximateNumberOfMessagesDelayed",
-                        ".",
-                        ".",
+                        '.',
+                        'ApproximateNumberOfMessagesDelayed',
+                        '.',
+                        '.',
                         {
-                            "id": "tfd",
-                            "visible": False
+                            'id': 'td',
+                            'visible': False
+                        }
+                    ],
+                    [
+                        {
+                            'expression': 'DIFF(trv+tri+trd)',
+                            'label': 'tallies_retry',
+                            'id': 'tr',
+                            'region': 'us-east-1',
+                            'color': '#d62728'
+                        }
+                    ],
+                    [
+                        'AWS/SQS',
+                        'ApproximateNumberOfMessagesVisible',
+                        'QueueName',
+                        'azul-tallies_retry-prod.fifo',
+                        {
+                            'id': 'trv',
+                            'visible': False
+                        }
+                    ],
+                    [
+                        '.',
+                        'ApproximateNumberOfMessagesNotVisible',
+                        '.',
+                        '.',
+                        {
+                            'id': 'tri',
+                            'visible': False
+                        }
+                    ],
+                    [
+                        '.',
+                        'ApproximateNumberOfMessagesDelayed',
+                        '.',
+                        '.',
+                        {
+                            'id': 'trd',
+                            'visible': False
+                        }
+                    ],
+                    [
+                        {
+                            'expression': 'DIFF(tfv+tfi+tfd)',
+                            'label': 'tallies_fail',
+                            'id': 'tf',
+                            'region': 'us-east-1',
+                            'color': '#f7b6d2'
+                        }
+                    ],
+                    [
+                        'AWS/SQS',
+                        'ApproximateNumberOfMessagesVisible',
+                        'QueueName',
+                        'azul-tallies_fail-prod.fifo',
+                        {
+                            'id': 'tfv',
+                            'visible': False
+                        }
+                    ],
+                    [
+                        '.',
+                        'ApproximateNumberOfMessagesNotVisible',
+                        '.',
+                        '.',
+                        {
+                            'id': 'tfi',
+                            'visible': False
+                        }
+                    ],
+                    [
+                        '.',
+                        'ApproximateNumberOfMessagesDelayed',
+                        '.',
+                        '.',
+                        {
+                            'id': 'tfd',
+                            'visible': False
                         }
                     ]
                 ],
-                "view": "timeSeries",
-                "stacked": False,
-                "region": "us-east-1",
-                "title": "Queue length Δ",
-                "period": 300,
-                "stat": "Maximum",
-                "annotations": {
-                    "horizontal": [
+                'view': 'timeSeries',
+                'stacked': False,
+                'region': 'us-east-1',
+                'title': 'Queue length Δ',
+                'period': 300,
+                'stat': 'Maximum',
+                'annotations': {
+                    'horizontal': [
                         {
-                            "color": "#aec7e8",
-                            "value": 0
+                            'color': '#aec7e8',
+                            'value': 0
                         }
                     ]
                 }
             }
         },
         {
-            "height": 6,
-            "width": 12,
-            "y": 54,
-            "x": 0,
-            "type": "metric",
-            "properties": {
-                "metrics": [
+            'height': 6,
+            'width': 12,
+            'y': 54,
+            'x': 0,
+            'type': 'metric',
+            'properties': {
+                'metrics': [
                     [
                         {
-                            "expression": "CEIL(m1 * 20 / PERIOD(m1))",
-                            "label": "notifications",
-                            "id": "e1",
-                            "region": "us-east-1"
+                            'expression': 'CEIL(m1 * 20 / PERIOD(m1))',
+                            'label': 'notifications',
+                            'id': 'e1',
+                            'region': 'us-east-1'
                         }
                     ],
                     [
                         {
-                            "expression": "CEIL(m2 * 20 / PERIOD(m2))",
-                            "label": "notifications_retry",
-                            "id": "e2",
-                            "region": "us-east-1"
+                            'expression': 'CEIL(m2 * 20 / PERIOD(m2))',
+                            'label': 'notifications_retry',
+                            'id': 'e2',
+                            'region': 'us-east-1'
                         }
                     ],
                     [
                         {
-                            "expression": "CEIL(m3 * 20 / PERIOD(m3))",
-                            "label": "tallies.fifo",
-                            "id": "e3",
-                            "region": "us-east-1"
+                            'expression': 'CEIL(m3 * 20 / PERIOD(m3))',
+                            'label': 'tallies.fifo',
+                            'id': 'e3',
+                            'region': 'us-east-1'
                         }
                     ],
                     [
                         {
-                            "expression": "CEIL(m4 * 20 / PERIOD(m4))",
-                            "label": "tallies_retry.fifo",
-                            "id": "e4",
-                            "region": "us-east-1"
+                            'expression': 'CEIL(m4 * 20 / PERIOD(m4))',
+                            'label': 'tallies_retry.fifo',
+                            'id': 'e4',
+                            'region': 'us-east-1'
                         }
                     ],
                     [
-                        "AWS/SQS",
-                        "NumberOfEmptyReceives",
-                        "QueueName",
-                        "azul-notifications-prod",
+                        'AWS/SQS',
+                        'NumberOfEmptyReceives',
+                        'QueueName',
+                        'azul-notifications-prod',
                         {
-                            "id": "m1",
-                            "visible": False,
-                            "region": "us-east-1"
+                            'id': 'm1',
+                            'visible': False,
+                            'region': 'us-east-1'
                         }
                     ],
                     [
-                        "AWS/SQS",
-                        "NumberOfEmptyReceives",
-                        "QueueName",
-                        "azul-notifications_retry-prod",
+                        'AWS/SQS',
+                        'NumberOfEmptyReceives',
+                        'QueueName',
+                        'azul-notifications_retry-prod',
                         {
-                            "id": "m2",
-                            "visible": False,
-                            "region": "us-east-1"
+                            'id': 'm2',
+                            'visible': False,
+                            'region': 'us-east-1'
                         }
                     ],
                     [
-                        "AWS/SQS",
-                        "NumberOfEmptyReceives",
-                        "QueueName",
-                        "azul-tallies-prod.fifo",
+                        'AWS/SQS',
+                        'NumberOfEmptyReceives',
+                        'QueueName',
+                        'azul-tallies-prod.fifo',
                         {
-                            "id": "m3",
-                            "visible": False,
-                            "region": "us-east-1"
+                            'id': 'm3',
+                            'visible': False,
+                            'region': 'us-east-1'
                         }
                     ],
                     [
-                        "AWS/SQS",
-                        "NumberOfEmptyReceives",
-                        "QueueName",
-                        "azul-tallies_retry-prod.fifo",
+                        'AWS/SQS',
+                        'NumberOfEmptyReceives',
+                        'QueueName',
+                        'azul-tallies_retry-prod.fifo',
                         {
-                            "id": "m4",
-                            "visible": False,
-                            "region": "us-east-1"
+                            'id': 'm4',
+                            'visible': False,
+                            'region': 'us-east-1'
                         }
                     ]
                 ],
-                "view": "timeSeries",
-                "stacked": False,
-                "region": "us-east-1",
-                "title": "Idle queue polling threads",
-                "period": 300,
-                "stat": "Sum"
+                'view': 'timeSeries',
+                'stacked': False,
+                'region': 'us-east-1',
+                'title': 'Idle queue polling threads',
+                'period': 300,
+                'stat': 'Sum'
             }
         },
         {
-            "height": 6,
-            "width": 12,
-            "y": 0,
-            "x": 12,
-            "type": "log",
-            "properties": {
-                "query": "SOURCE '/aws/lambda/azul-indexer-prod-aggregate_retry' | SOURCE '/aws/lambda/azul-indexer-prod-aggregate' | filter @message like /Attempt \\d+ of handling \\d+ contribution\\(s\\) for entity/\n       or @message like /Deferring \\d+ tallies/\n       or @message like /Successfully referred \\d+ tallies/\n| field strcontains(@message,'Attempt') and strcontains(@message,'contribution(s) for entity') as attempts\n| parse 'Deferring * tallies' as deferrals\n| parse 'Successfully referred * tallies' as successes\n| stats sum(successes) as Successes,\n        sum(attempts) - sum(successes) - sum(deferrals) as Failures,\n        sum(deferrals) as Deferrals\n        by bin(5min)\n",
-                "region": "us-east-1",
-                "stacked": True,
-                "title": "Aggregation outcomes in # of tallies",
-                "view": "timeSeries"
+            'height': 6,
+            'width': 12,
+            'y': 0,
+            'x': 12,
+            'type': 'log',
+            'properties': {
+                'query': dedent('''\
+                    SOURCE '/aws/lambda/azul-indexer-prod-aggregate_retry'
+                    | SOURCE '/aws/lambda/azul-indexer-prod-aggregate'
+                    | filter @message like /Attempt \\d+ of handling \\d+ contribution\\(s\\) for entity/
+                          or @message like /Deferring \\d+ tallies/
+                          or @message like /Successfully referred \\d+ tallies/
+                    | field strcontains(@message,'Attempt') and strcontains(@message,'contribution(s) for entity') as attempts
+                    | parse 'Deferring * tallies' as deferrals
+                    | parse 'Successfully referred * tallies' as successes
+                    | stats sum(successes) as Successes,
+                            sum(attempts) - sum(successes) - sum(deferrals) as Failures,
+                            sum(deferrals) as Deferrals
+                            by bin(5min)
+                '''),
+                'region': 'us-east-1',
+                'stacked': True,
+                'title': 'Aggregation outcomes in # of tallies',
+                'view': 'timeSeries'
             }
         },
         {
-            "height": 6,
-            "width": 12,
-            "y": 48,
-            "x": 0,
-            "type": "log",
-            "properties": {
-                "query": "SOURCE '/aws/lambda/azul-indexer-prod-contribute' | SOURCE '/aws/lambda/azul-indexer-prod-contribute_retry' | fields stats.cacheHit, strcontains(@log, 'retry') as is_retry\n| filter @message like 'Job info: '\n| sort @timestamp desc\n| stats sum(stats.cacheHit * (1 - is_retry)) / sum(1 - is_retry) * 100 as Initial, \n        sum(stats.cacheHit * is_retry ) / sum(is_retry) * 100 as Retry by bin(5min)",
-                "region": "us-east-1",
-                "stacked": False,
-                "title": "BQ cache utilization [%]",
-                "view": "timeSeries"
+            'height': 6,
+            'width': 12,
+            'y': 48,
+            'x': 0,
+            'type': 'log',
+            'properties': {
+                'query': dedent('''\
+                    SOURCE '/aws/lambda/azul-indexer-prod-contribute'
+                    | SOURCE '/aws/lambda/azul-indexer-prod-contribute_retry'
+                    | fields stats.cacheHit, strcontains(@log, 'retry') as is_retry
+                    | filter @message like 'Job info: '
+                    | sort @timestamp desc
+                    | stats sum(stats.cacheHit * (1 - is_retry)) / sum(1 - is_retry) * 100 as Initial,
+                            sum(stats.cacheHit * is_retry ) / sum(is_retry) * 100 as Retry
+                            by bin(5min)
+                '''),
+                'region': 'us-east-1',
+                'stacked': False,
+                'title': 'BQ cache utilization [%]',
+                'view': 'timeSeries'
             }
         },
         {
-            "height": 6,
-            "width": 12,
-            "y": 6,
-            "x": 0,
-            "type": "metric",
-            "properties": {
-                "metrics": [
+            'height': 6,
+            'width': 12,
+            'y': 6,
+            'x': 0,
+            'type': 'metric',
+            'properties': {
+                'metrics': [
                     [
                         {
-                            "expression": "(nv+ni+nd+nrv+nri+nrd) / IF(0<DIFF(nv+ni+nd+nrv+nri+nrd),0,-DIFF(nv+ni+nd+nrv+nri+nrd)) * DIFF_TIME(nv+ni+nd+nrv+nri+nrd) / 3600",
-                            "label": "notifications",
-                            "id": "n",
-                            "region": "us-east-1"
+                            'expression': '(nv+ni+nd+nrv+nri+nrd) / IF(0<DIFF(nv+ni+nd+nrv+nri+nrd),0,-DIFF(nv+ni+nd+nrv+nri+nrd)) * DIFF_TIME(nv+ni+nd+nrv+nri+nrd) / 3600',
+                            'label': 'notifications',
+                            'id': 'n',
+                            'region': 'us-east-1'
                         }
                     ],
                     [
-                        "AWS/SQS",
-                        "ApproximateNumberOfMessagesVisible",
-                        "QueueName",
-                        "azul-notifications-prod",
+                        'AWS/SQS',
+                        'ApproximateNumberOfMessagesVisible',
+                        'QueueName',
+                        'azul-notifications-prod',
                         {
-                            "id": "nv",
-                            "visible": False
+                            'id': 'nv',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "ApproximateNumberOfMessagesNotVisible",
-                        ".",
-                        ".",
+                        '.',
+                        'ApproximateNumberOfMessagesNotVisible',
+                        '.',
+                        '.',
                         {
-                            "id": "ni",
-                            "visible": False
+                            'id': 'ni',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "ApproximateNumberOfMessagesDelayed",
-                        ".",
-                        ".",
+                        '.',
+                        'ApproximateNumberOfMessagesDelayed',
+                        '.',
+                        '.',
                         {
-                            "id": "nd",
-                            "visible": False
+                            'id': 'nd',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "ApproximateNumberOfMessagesVisible",
-                        ".",
-                        "azul-notifications_retry-prod",
+                        '.',
+                        'ApproximateNumberOfMessagesVisible',
+                        '.',
+                        'azul-notifications_retry-prod',
                         {
-                            "id": "nrv",
-                            "visible": False
+                            'id': 'nrv',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "ApproximateNumberOfMessagesNotVisible",
-                        ".",
-                        ".",
+                        '.',
+                        'ApproximateNumberOfMessagesNotVisible',
+                        '.',
+                        '.',
                         {
-                            "id": "nri",
-                            "visible": False
+                            'id': 'nri',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "ApproximateNumberOfMessagesDelayed",
-                        ".",
-                        ".",
+                        '.',
+                        'ApproximateNumberOfMessagesDelayed',
+                        '.',
+                        '.',
                         {
-                            "id": "nrd",
-                            "visible": False
+                            'id': 'nrd',
+                            'visible': False
                         }
                     ],
                     [
                         {
-                            "expression": "(tv+ti+td+trv+tri+trd) / IF(0<DIFF(tv+ti+td+trv+tri+trd),0,-DIFF(tv+ti+td+trv+tri+trd)) * DIFF_TIME(tv+ti+td+trv+tri+trd) / 3600",
-                            "label": "tallies",
-                            "id": "t",
-                            "region": "us-east-1",
-                            "color": "#2ca02c"
+                            'expression': '(tv+ti+td+trv+tri+trd) / IF(0<DIFF(tv+ti+td+trv+tri+trd),0,-DIFF(tv+ti+td+trv+tri+trd)) * DIFF_TIME(tv+ti+td+trv+tri+trd) / 3600',
+                            'label': 'tallies',
+                            'id': 't',
+                            'region': 'us-east-1',
+                            'color': '#2ca02c'
                         }
                     ],
                     [
-                        "AWS/SQS",
-                        "ApproximateNumberOfMessagesVisible",
-                        "QueueName",
-                        "azul-tallies-prod.fifo",
+                        'AWS/SQS',
+                        'ApproximateNumberOfMessagesVisible',
+                        'QueueName',
+                        'azul-tallies-prod.fifo',
                         {
-                            "id": "tv",
-                            "visible": False
+                            'id': 'tv',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "ApproximateNumberOfMessagesNotVisible",
-                        ".",
-                        ".",
+                        '.',
+                        'ApproximateNumberOfMessagesNotVisible',
+                        '.',
+                        '.',
                         {
-                            "id": "ti",
-                            "visible": False
+                            'id': 'ti',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "ApproximateNumberOfMessagesDelayed",
-                        ".",
-                        ".",
+                        '.',
+                        'ApproximateNumberOfMessagesDelayed',
+                        '.',
+                        '.',
                         {
-                            "id": "td",
-                            "visible": False
+                            'id': 'td',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "ApproximateNumberOfMessagesVisible",
-                        ".",
-                        "azul-tallies_retry-prod.fifo",
+                        '.',
+                        'ApproximateNumberOfMessagesVisible',
+                        '.',
+                        'azul-tallies_retry-prod.fifo',
                         {
-                            "id": "trv",
-                            "visible": False
+                            'id': 'trv',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "ApproximateNumberOfMessagesNotVisible",
-                        ".",
-                        ".",
+                        '.',
+                        'ApproximateNumberOfMessagesNotVisible',
+                        '.',
+                        '.',
                         {
-                            "id": "tri",
-                            "visible": False
+                            'id': 'tri',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "ApproximateNumberOfMessagesDelayed",
-                        ".",
-                        ".",
+                        '.',
+                        'ApproximateNumberOfMessagesDelayed',
+                        '.',
+                        '.',
                         {
-                            "id": "trd",
-                            "visible": False
+                            'id': 'trd',
+                            'visible': False
                         }
                     ]
                 ],
-                "view": "timeSeries",
-                "stacked": False,
-                "region": "us-east-1",
-                "title": "ETA [h]",
-                "period": 300,
-                "stat": "Maximum"
+                'view': 'timeSeries',
+                'stacked': False,
+                'region': 'us-east-1',
+                'title': 'ETA [h]',
+                'period': 300,
+                'stat': 'Maximum'
             }
         },
         {
-            "height": 6,
-            "width": 12,
-            "y": 66,
-            "x": 12,
-            "type": "log",
-            "properties": {
-                "query": "SOURCE '/aws/lambda/azul-indexer-prod-aggregate' | SOURCE '/aws/lambda/azul-indexer-prod-aggregate_retry' | SOURCE '/aws/lambda/azul-indexer-prod-contribute' | SOURCE '/aws/lambda/azul-indexer-prod-contribute_retry' | filter @message like 'Task timed out'\n| fields strcontains(@log, 'aggregate') == 0 and strcontains(@log, 'retry') == 0 as c\n| fields strcontains(@log, 'aggregate') == 0 and strcontains(@log, 'retry') == 1 as cr\n| fields strcontains(@log, 'aggregate') == 1 and strcontains(@log, 'retry') == 0 as a\n| fields strcontains(@log, 'aggregate') == 1 and strcontains(@log, 'retry') == 1 as ar\n| stats sum(c) as contribute, \n        sum(cr) as contribute_retry,\n        sum(a) as aggregate,\n        sum(ar) as aggregate_retry\n        by bin(5min)",
-                "region": "us-east-1",
-                "stacked": False,
-                "title": "Lambda timeouts",
-                "view": "timeSeries"
+            'height': 6,
+            'width': 12,
+            'y': 66,
+            'x': 12,
+            'type': 'log',
+            'properties': {
+                'query': dedent('''\
+                    SOURCE '/aws/lambda/azul-indexer-prod-aggregate'
+                    | SOURCE '/aws/lambda/azul-indexer-prod-aggregate_retry'
+                    | SOURCE '/aws/lambda/azul-indexer-prod-contribute'
+                    | SOURCE '/aws/lambda/azul-indexer-prod-contribute_retry'
+                    | filter @message like 'Task timed out'
+                    | fields strcontains(@log, 'aggregate') == 0 and strcontains(@log, 'retry') == 0 as c
+                    | fields strcontains(@log, 'aggregate') == 0 and strcontains(@log, 'retry') == 1 as cr
+                    | fields strcontains(@log, 'aggregate') == 1 and strcontains(@log, 'retry') == 0 as a
+                    | fields strcontains(@log, 'aggregate') == 1 and strcontains(@log, 'retry') == 1 as ar
+                    | stats sum(c) as contribute,
+                            sum(cr) as contribute_retry,
+                            sum(a) as aggregate,
+                            sum(ar) as aggregate_retry
+                            by bin(5min)
+                '''),
+                'region': 'us-east-1',
+                'stacked': False,
+                'title': 'Lambda timeouts',
+                'view': 'timeSeries'
             }
         },
         {
-            "height": 6,
-            "width": 12,
-            "y": 18,
-            "x": 12,
-            "type": "metric",
-            "properties": {
-                "metrics": [
+            'height': 6,
+            'width': 12,
+            'y': 18,
+            'x': 12,
+            'type': 'metric',
+            'properties': {
+                'metrics': [
                     [
-                        "AWS/SQS",
-                        "ApproximateNumberOfMessagesNotVisible",
-                        "QueueName",
-                        "azul-notifications-prod",
+                        'AWS/SQS',
+                        'ApproximateNumberOfMessagesNotVisible',
+                        'QueueName',
+                        'azul-notifications-prod',
                         {
-                            "label": "notifications"
+                            'label': 'notifications'
                         }
                     ],
                     [
-                        "...",
-                        "azul-notifications_retry-prod",
+                        '...',
+                        'azul-notifications_retry-prod',
                         {
-                            "label": "notifications_retry"
+                            'label': 'notifications_retry'
                         }
                     ],
                     [
-                        "...",
-                        "azul-tallies-prod.fifo",
+                        '...',
+                        'azul-tallies-prod.fifo',
                         {
-                            "label": "tallies"
+                            'label': 'tallies'
                         }
                     ],
                     [
-                        "...",
-                        "azul-tallies_retry-prod.fifo",
+                        '...',
+                        'azul-tallies_retry-prod.fifo',
                         {
-                            "label": "tallies_retry"
+                            'label': 'tallies_retry'
                         }
                     ]
                 ],
-                "view": "timeSeries",
-                "stacked": False,
-                "region": "us-east-1",
-                "title": "In-flight messages",
-                "period": 300,
-                "stat": "Average"
+                'view': 'timeSeries',
+                'stacked': False,
+                'region': 'us-east-1',
+                'title': 'In-flight messages',
+                'period': 300,
+                'stat': 'Average'
             }
         },
         {
-            "height": 6,
-            "width": 12,
-            "y": 60,
-            "x": 0,
-            "type": "metric",
-            "properties": {
-                "metrics": [
+            'height': 6,
+            'width': 12,
+            'y': 60,
+            'x': 0,
+            'type': 'metric',
+            'properties': {
+                'metrics': [
                     [
                         {
-                            "expression": "m1 * 100 / m5",
-                            "label": "contribute",
-                            "id": "e1"
+                            'expression': 'm1 * 100 / m5',
+                            'label': 'contribute',
+                            'id': 'e1'
                         }
                     ],
                     [
                         {
-                            "expression": "m2 * 100 / m6",
-                            "label": "contribute_retry",
-                            "id": "e2"
+                            'expression': 'm2 * 100 / m6',
+                            'label': 'contribute_retry',
+                            'id': 'e2'
                         }
                     ],
                     [
                         {
-                            "expression": "m3 * 100 / m7",
-                            "label": "aggregate",
-                            "id": "e3"
+                            'expression': 'm3 * 100 / m7',
+                            'label': 'aggregate',
+                            'id': 'e3'
                         }
                     ],
                     [
                         {
-                            "expression": "m4 * 100 / m8",
-                            "label": "aggregate_retry",
-                            "id": "e4"
+                            'expression': 'm4 * 100 / m8',
+                            'label': 'aggregate_retry',
+                            'id': 'e4'
                         }
                     ],
                     [
-                        "AWS/Lambda",
-                        "Errors",
-                        "FunctionName",
-                        "azul-indexer-prod-contribute",
+                        'AWS/Lambda',
+                        'Errors',
+                        'FunctionName',
+                        'azul-indexer-prod-contribute',
                         {
-                            "label": "contribute",
-                            "id": "m1",
-                            "visible": False
+                            'label': 'contribute',
+                            'id': 'm1',
+                            'visible': False
                         }
                     ],
                     [
-                        "...",
-                        "azul-indexer-prod-contribute_retry",
+                        '...',
+                        'azul-indexer-prod-contribute_retry',
                         {
-                            "label": "contribute_retry",
-                            "id": "m2",
-                            "visible": False
+                            'label': 'contribute_retry',
+                            'id': 'm2',
+                            'visible': False
                         }
                     ],
                     [
-                        "...",
-                        "azul-indexer-prod-aggregate",
+                        '...',
+                        'azul-indexer-prod-aggregate',
                         {
-                            "label": "aggregate",
-                            "id": "m3",
-                            "visible": False
+                            'label': 'aggregate',
+                            'id': 'm3',
+                            'visible': False
                         }
                     ],
                     [
-                        "...",
-                        "azul-indexer-prod-aggregate_retry",
+                        '...',
+                        'azul-indexer-prod-aggregate_retry',
                         {
-                            "label": "aggregate_retry",
-                            "id": "m4",
-                            "visible": False
+                            'label': 'aggregate_retry',
+                            'id': 'm4',
+                            'visible': False
                         }
                     ],
                     [
-                        ".",
-                        "Invocations",
-                        ".",
-                        "azul-indexer-prod-contribute",
+                        '.',
+                        'Invocations',
+                        '.',
+                        'azul-indexer-prod-contribute',
                         {
-                            "id": "m5",
-                            "visible": False
+                            'id': 'm5',
+                            'visible': False
                         }
                     ],
                     [
-                        "...",
-                        "azul-indexer-prod-contribute_retry",
+                        '...',
+                        'azul-indexer-prod-contribute_retry',
                         {
-                            "id": "m6",
-                            "visible": False
+                            'id': 'm6',
+                            'visible': False
                         }
                     ],
                     [
-                        "...",
-                        "azul-indexer-prod-aggregate",
+                        '...',
+                        'azul-indexer-prod-aggregate',
                         {
-                            "id": "m7",
-                            "visible": False
+                            'id': 'm7',
+                            'visible': False
                         }
                     ],
                     [
-                        "...",
-                        "azul-indexer-prod-aggregate_retry",
+                        '...',
+                        'azul-indexer-prod-aggregate_retry',
                         {
-                            "id": "m8",
-                            "visible": False
+                            'id': 'm8',
+                            'visible': False
                         }
                     ]
                 ],
-                "view": "timeSeries",
-                "stacked": False,
-                "region": "us-east-1",
-                "stat": "Sum",
-                "period": 300,
-                "title": "Lambda error rate [%]"
+                'view': 'timeSeries',
+                'stacked': False,
+                'region': 'us-east-1',
+                'stat': 'Sum',
+                'period': 300,
+                'title': 'Lambda error rate [%]'
             }
         },
         {
-            "height": 6,
-            "width": 12,
-            "y": 66,
-            "x": 0,
-            "type": "log",
-            "properties": {
-                "query": "SOURCE '/aws/lambda/azul-indexer-prod-aggregate' | SOURCE '/aws/lambda/azul-indexer-prod-aggregate_retry' | SOURCE '/aws/lambda/azul-indexer-prod-contribute' | SOURCE '/aws/lambda/azul-indexer-prod-contribute_retry' | filter @message like 'Task timed out' or @message like 'START' \n| fields strcontains(@message, 'Task timed out') == 1 as timeout\n| fields strcontains(@message, 'START') == 1 as attempt\n| fields strcontains(@log, 'aggregate') == 0 and strcontains(@log, 'retry') == 0 as c\n| fields strcontains(@log, 'aggregate') == 0 and strcontains(@log, 'retry') == 1 as cr\n| fields strcontains(@log, 'aggregate') == 1 and strcontains(@log, 'retry') == 0 as a\n| fields strcontains(@log, 'aggregate') == 1 and strcontains(@log, 'retry') == 1 as ar\n| stats sum(c*timeout) * 100 / sum(c*attempt) as contribute, \n        sum(cr*timeout) * 100 / sum(cr*attempt) as contribute_retry,\n        sum(a*timeout) * 100 / sum(a*attempt) as aggregate,\n        sum(ar*timeout) * 100 / sum(ar*attempt) as aggregate_retry\n        by bin(5min)",
-                "region": "us-east-1",
-                "stacked": False,
-                "title": "Lambda timeout rate [%]",
-                "view": "timeSeries"
+            'height': 6,
+            'width': 12,
+            'y': 66,
+            'x': 0,
+            'type': 'log',
+            'properties': {
+                'query': dedent('''\
+                    SOURCE '/aws/lambda/azul-indexer-prod-aggregate'
+                    | SOURCE '/aws/lambda/azul-indexer-prod-aggregate_retry'
+                    | SOURCE '/aws/lambda/azul-indexer-prod-contribute'
+                    | SOURCE '/aws/lambda/azul-indexer-prod-contribute_retry'
+                    | filter @message like 'Task timed out' or @message like 'START'
+                    | fields strcontains(@message, 'Task timed out') == 1 as timeout
+                    | fields strcontains(@message, 'START') == 1 as attempt
+                    | fields strcontains(@log, 'aggregate') == 0 and strcontains(@log, 'retry') == 0 as c
+                    | fields strcontains(@log, 'aggregate') == 0 and strcontains(@log, 'retry') == 1 as cr
+                    | fields strcontains(@log, 'aggregate') == 1 and strcontains(@log, 'retry') == 0 as a
+                    | fields strcontains(@log, 'aggregate') == 1 and strcontains(@log, 'retry') == 1 as ar
+                    | stats sum(c*timeout) * 100 / sum(c*attempt) as contribute,
+                            sum(cr*timeout) * 100 / sum(cr*attempt) as contribute_retry,
+                            sum(a*timeout) * 100 / sum(a*attempt) as aggregate,
+                            sum(ar*timeout) * 100 / sum(ar*attempt) as aggregate_retry
+                            by bin(5min)
+                '''),
+                'region': 'us-east-1',
+                'stacked': False,
+                'title': 'Lambda timeout rate [%]',
+                'view': 'timeSeries'
             }
         }
     ]


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Connected issues: #6271


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make image_manifests.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `image_manifests.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved ticket to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for `dev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for `anvildev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
