### PR TITLE
Switch to NIST 800-53 r5 standard in SecurityHub (#6203)

### DIFF
--- a/scripts/rename_resources.py
+++ b/scripts/rename_resources.py
@@ -19,9 +19,6 @@ from azul.terraform import (
 log = logging.getLogger(__name__)
 
 renamed: dict[str, Optional[str]] = {
-    # FIXME: Remove the following entry
-    #        https://github.com/DataBiosphere/azul/pull/6285
-    'opensearch_cluster_settings.index': None
 }
 
 

--- a/scripts/rename_resources.py
+++ b/scripts/rename_resources.py
@@ -18,7 +18,10 @@ from azul.terraform import (
 
 log = logging.getLogger(__name__)
 
+resource = 'aws_securityhub_standards_control'
 renamed: dict[str, Optional[str]] = {
+    f'{resource}.best_practices_macie_{num}': f'{resource}.nist_control_macie_{num}'
+    for num in [1, 2]
 }
 
 

--- a/terraform/shared/shared.tf.json.template.py
+++ b/terraform/shared/shared.tf.json.template.py
@@ -914,16 +914,16 @@ tf_config = {
         #        https://github.com/DataBiosphere/azul/issues/5890
         'aws_securityhub_standards_control': {
             **{
-                f'best_practices_macie_{num}': {
+                'nist_control_' + control.lower().replace('.', '_'): {
                     'standards_control_arn': f'arn:aws:securityhub:{aws.region_name}:{aws.account}:control'
-                                             f'/aws-foundational-security-best-practices/v/1.0.0/Macie.{num}',
+                                             f'/aws-foundational-security-best-practices/v/1.0.0/{control}',
                     'control_status': 'DISABLED',
                     'disabled_reason': 'Generates alarm noise; tracked independently as follow-up work',
                     'depends_on': [
                         'aws_securityhub_standards_subscription.best_practices'
                     ]
                 }
-                for num in [1, 2]
+                for control in ['Macie.1', 'Macie.2']
             }
         },
         'aws_iam_account_password_policy': {

--- a/terraform/shared/shared.tf.json.template.py
+++ b/terraform/shared/shared.tf.json.template.py
@@ -895,16 +895,9 @@ tf_config = {
             }
         },
         'aws_securityhub_standards_subscription': {
-            'best_practices': {
+            'nist_800_53': {
                 'standards_arn': 'arn:aws:securityhub:us-east-1::standards'
-                                 '/aws-foundational-security-best-practices/v/1.0.0',
-                'depends_on': [
-                    'aws_securityhub_account.shared'
-                ]
-            },
-            'cis': {
-                'standards_arn': 'arn:aws:securityhub:::ruleset'
-                                 '/cis-aws-foundations-benchmark/v/1.2.0',
+                                 '/nist-800-53/v/5.0.0',
                 'depends_on': [
                     'aws_securityhub_account.shared'
                 ]
@@ -916,11 +909,11 @@ tf_config = {
             **{
                 'nist_control_' + control.lower().replace('.', '_'): {
                     'standards_control_arn': f'arn:aws:securityhub:{aws.region_name}:{aws.account}:control'
-                                             f'/aws-foundational-security-best-practices/v/1.0.0/{control}',
+                                             f'/nist-800-53/v/5.0.0/{control}',
                     'control_status': 'DISABLED',
                     'disabled_reason': 'Generates alarm noise; tracked independently as follow-up work',
                     'depends_on': [
-                        'aws_securityhub_standards_subscription.best_practices'
+                        'aws_securityhub_standards_subscription.nist_800_53'
                     ]
                 }
                 for control in ['Macie.1', 'Macie.2']

--- a/terraform/shared/shared.tf.json.template.py
+++ b/terraform/shared/shared.tf.json.template.py
@@ -917,6 +917,37 @@ tf_config = {
                     ]
                 }
                 for control in ['Macie.1', 'Macie.2']
+            },
+            **{
+                'nist_control_' + control.lower().replace('.', '_'): {
+                    'standards_control_arn': f'arn:aws:securityhub:{aws.region_name}:{aws.account}:control'
+                                             f'/nist-800-53/v/5.0.0/{control}',
+                    'control_status': 'DISABLED',
+                    'disabled_reason': 'Not a moderate level control',
+                    'depends_on': [
+                        'aws_securityhub_standards_subscription.nist_800_53'
+                    ]
+                }
+                for control in [
+                    'ACM.1',
+                    'CloudFront.1',
+                    'S3.15',
+                    #
+                    # We don't disable EFS.6 since despite it being listed as a
+                    # control applicable to NIST SP 800-53 Rev. 5 …
+                    #
+                    # https://docs.aws.amazon.com/securityhub/latest/userguide/nist-standard.html
+                    #
+                    # … but it is not. Other AWS documentation backs up this
+                    # claim:
+                    #
+                    # https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-controls-reference.html
+                    #
+                    # We don't disable ElasticCache.4 to .7 since these controls
+                    # are not available in our AWS Region:
+                    #
+                    # https://docs.aws.amazon.com/securityhub/latest/userguide/regions-controls.html
+                ]
             }
         },
         'aws_iam_account_password_policy': {

--- a/terraform/shared/shared.tf.json.template.py
+++ b/terraform/shared/shared.tf.json.template.py
@@ -39,25 +39,29 @@ def conformance_pack(name: str) -> str:
     return body
 
 
-cis_alarms = [
-    # https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-3.1
+trail_alarms = [
+    # [CloudWatch.2] Ensure a log metric filter and alarm exist for unauthorized API calls
+    # https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html#cloudwatch-2
     CloudTrailAlarm(name='api_unauthorized',
                     statistic='Sum',
                     filter_pattern='{($.errorCode="*UnauthorizedOperation") || ($.errorCode="AccessDenied*")}',
                     threshold=12,
                     period=24 * 60 * 60),
-    # https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-3.2
+    # [CloudWatch.3] Ensure a log metric filter and alarm exist for Management Console sign-in without MFA
+    # https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html#cloudwatch-3
     CloudTrailAlarm(name='console_no_mfa',
                     statistic='Sum',
                     filter_pattern='{ ($.eventName = "ConsoleLogin") && ($.additionalEventData.MFAUsed != "Yes") && '
                                    '($.userIdentity.type = "IAMUser") && '
                                    '($.responseElements.ConsoleLogin = "Success") }'),
-    # https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-3.3
+    # [CloudWatch.1] A log metric filter and alarm should exist for usage of the "root" user
+    # https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html#cloudwatch-1
     CloudTrailAlarm(name='root_usage',
                     statistic='Sum',
                     filter_pattern='{$.userIdentity.type="Root" && $.userIdentity.invokedBy NOT EXISTS && $.eventType '
                                    '!="AwsServiceEvent"}'),
-    # https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-3.4
+    # [CloudWatch.4] Ensure a log metric filter and alarm exist for IAM policy changes
+    # https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html#cloudwatch-4
     CloudTrailAlarm(name='iam_policy_change',
                     statistic='Sum',
                     filter_pattern='{($.eventName=DeleteGroupPolicy) || ($.eventName=DeleteRolePolicy) || '
@@ -68,13 +72,15 @@ cis_alarms = [
                                    '($.eventName=AttachRolePolicy) || ($.eventName=DetachRolePolicy) || '
                                    '($.eventName=AttachUserPolicy) || ($.eventName=DetachUserPolicy) || '
                                    '($.eventName=AttachGroupPolicy) || ($.eventName=DetachGroupPolicy)}'),
-    # https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-3.5
+    # [CloudWatch.5] Ensure a log metric filter and alarm exist for CloudTrail AWS Configuration changes
+    # https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html#cloudwatch-5
     CloudTrailAlarm(name='cloudtrail_config_change',
                     statistic='Sum',
                     filter_pattern='{($.eventName=CreateTrail) || ($.eventName=UpdateTrail) || '
                                    '($.eventName=DeleteTrail) || ($.eventName=StartLogging) || '
                                    '($.eventName=StopLogging)}'),
-    # https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-3.8
+    # [CloudWatch.8] Ensure a log metric filter and alarm exist for S3 bucket policy changes
+    # https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html#cloudwatch-8
     CloudTrailAlarm(name='s3_policy_change',
                     statistic='Sum',
                     filter_pattern='{($.eventSource=s3.amazonaws.com) && (($.eventName=PutBucketAcl) || '
@@ -82,20 +88,23 @@ cis_alarms = [
                                    '($.eventName=PutBucketLifecycle) || ($.eventName=PutBucketReplication) || '
                                    '($.eventName=DeleteBucketPolicy) || ($.eventName=DeleteBucketCors) || '
                                    '($.eventName=DeleteBucketLifecycle) || ($.eventName=DeleteBucketReplication))}'),
-    # https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-3.12
+    # [CloudWatch.12] Ensure a log metric filter and alarm exist for changes to network gateways
+    # https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html#cloudwatch-12
     CloudTrailAlarm(name='network_gateway_change',
                     statistic='Sum',
                     filter_pattern='{($.eventName=CreateCustomerGateway) || ($.eventName=DeleteCustomerGateway) || '
                                    '($.eventName=AttachInternetGateway) || ($.eventName=CreateInternetGateway) || '
                                    '($.eventName=DeleteInternetGateway) || ($.eventName=DetachInternetGateway)}'),
-    # https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-3.13
+    # [CloudWatch.13] Ensure a log metric filter and alarm exist for route table changes
+    # https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html#cloudwatch-13
     CloudTrailAlarm(name='route_table_change',
                     statistic='Sum',
                     filter_pattern='{($.eventName=CreateRoute) || ($.eventName=CreateRouteTable) || '
                                    '($.eventName=ReplaceRoute) || ($.eventName=ReplaceRouteTableAssociation) || '
                                    '($.eventName=DeleteRouteTable) || ($.eventName=DeleteRoute) || '
                                    '($.eventName=DisassociateRouteTable)}'),
-    # https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-3.14
+    # [CloudWatch.14] Ensure a log metric filter and alarm exist for VPC changes
+    # https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html#cloudwatch-14
     CloudTrailAlarm(name='vpc_change',
                     statistic='Sum',
                     filter_pattern='{($.eventName=CreateVpc) || ($.eventName=DeleteVpc) || '
@@ -477,7 +486,7 @@ tf_config = {
                         'value': 1
                     }
                 }
-                for a in cis_alarms
+                for a in trail_alarms
             },
             'trail_logs': {
                 'name': config.qualified_resource_name('trail_logs', suffix='.filter'),
@@ -538,7 +547,7 @@ tf_config = {
                     'alarm_actions': ['${aws_sns_topic.monitoring.arn}'],
                     'ok_actions': ['${aws_sns_topic.monitoring.arn}']
                 }
-                for a in cis_alarms
+                for a in trail_alarms
             },
             'clam_fail': {
                 'alarm_name': config.qualified_resource_name('clam_fail', suffix='.alarm'),

--- a/terraform/shared/shared.tf.json.template.py
+++ b/terraform/shared/shared.tf.json.template.py
@@ -105,11 +105,6 @@ cis_alarms = [
                                    '($.eventName=RejectVpcPeeringConnection) || ($.eventName=AttachClassicLinkVpc) || '
                                    '($.eventName=DetachClassicLinkVpc) || ($.eventName=DisableVpcClassicLink) || '
                                    '($.eventName=EnableVpcClassicLink)}'),
-    # https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-1.1
-    CloudTrailAlarm(name='root_user',
-                    statistic='Sum',
-                    filter_pattern='{$.userIdentity.type="Root" && $.userIdentity.invokedBy NOT EXISTS && '
-                                   '$.eventType !="AwsServiceEvent"}')
 ]
 
 # The deployment and/or backup of the GitLab instance requires a reboot, which


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Connected issues: #6203


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make image_manifests.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `image_manifests.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved ticket to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for `dev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for `anvildev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
