### PR TITLE
Content Security Policy (CSP) Not Implemented (DataBiosphere/azul-private#6)

### DIFF
--- a/lambdas/service/app.py
+++ b/lambdas/service/app.py
@@ -490,7 +490,7 @@ def static_resource(file):
 def oauth2_redirect():
     oauth2_redirect_html = app.load_static_resource('swagger', 'oauth2-redirect.html')
     return Response(status_code=200,
-                    headers={"Content-Type": "text/html"},
+                    headers={'Content-Type': 'text/html'},
                     body=oauth2_redirect_html)
 
 

--- a/lambdas/service/app.py
+++ b/lambdas/service/app.py
@@ -12,6 +12,7 @@ from inspect import (
 )
 import json
 import logging.config
+import secrets
 from typing import (
     Any,
     Callable,
@@ -30,6 +31,7 @@ from chalice import (
     Response,
     UnauthorizedError,
 )
+import chevron
 from furl import (
     furl,
 )
@@ -488,9 +490,17 @@ def static_resource(file):
     cache_control='no-store'
 )
 def oauth2_redirect():
-    oauth2_redirect_html = app.load_static_resource('swagger', 'oauth2-redirect.html')
+    oauth2_redirect_template = app.load_static_resource('swagger',
+                                                        'oauth2-redirect.html.template.mustache')
+    nonce = secrets.token_urlsafe(32)
+    oauth2_redirect_html = chevron.render(oauth2_redirect_template, {
+        'CSP_NONCE': json.dumps(nonce)
+    })
     return Response(status_code=200,
-                    headers={'Content-Type': 'text/html'},
+                    headers={
+                        'Content-Type': 'text/html',
+                        'Content-Security-Policy': app.content_security_policy(nonce)
+                    },
                     body=oauth2_redirect_html)
 
 

--- a/src/azul/chalice.py
+++ b/src/azul/chalice.py
@@ -15,6 +15,7 @@ import logging
 import mimetypes
 import os
 import pathlib
+import secrets
 from typing import (
     Any,
     Iterator,
@@ -195,6 +196,8 @@ class AzulChaliceApp(Chalice):
         """
         response = get_response(event)
         seconds = 60 * 60 * 24 * 365
+        response.headers.setdefault('Content-Security-Policy',
+                                    self.content_security_policy())
         response.headers['Strict-Transport-Security'] = f'max-age={seconds}; includeSubDomains'
         response.headers['X-Content-Type-Options'] = 'nosniff'
         response.headers['X-Frame-Options'] = 'DENY'
@@ -468,12 +471,34 @@ class AzulChaliceApp(Chalice):
     def _controller(self, controller_cls: Type[C], **kwargs) -> C:
         return controller_cls(app=self, **kwargs)
 
+    def content_security_policy(self, nonce: Optional[str] = None) -> str:
+        def q(s: str) -> str:
+            return f"'{s}'"
+
+        def s(*args: str | None) -> str:
+            return ' '.join(filter(None, args))
+
+        self = q('self')
+        none = q('none')
+        if nonce is not None:
+            nonce = q(f'nonce-{nonce}')
+
+        return ';'.join([
+            s('default-src', self),
+            s('img-src', self, 'data:'),
+            s('script-src', self, nonce),
+            s('style-src', self, nonce),
+            s('frame-ancestors', none),
+        ])
+
     def swagger_ui(self) -> Response:
         swagger_ui_template = self.load_static_resource('swagger', 'swagger-ui.html.template.mustache')
         base_url = self.base_url
         redirect_url = furl(base_url).add(path='oauth2_redirect')
         deployment_url = furl(base_url).add(path='openapi')
+        nonce = secrets.token_urlsafe(32)
         swagger_ui_html = chevron.render(swagger_ui_template, {
+            'CSP_NONCE': json.dumps(nonce),
             'DEPLOYMENT_PATH': json.dumps(str(deployment_url.path)),
             'OAUTH2_CLIENT_ID': json.dumps(config.google_oauth2_client_id),
             'OAUTH2_REDIRECT_URL': json.dumps(str(redirect_url)),
@@ -483,7 +508,10 @@ class AzulChaliceApp(Chalice):
             ])
         })
         return Response(status_code=200,
-                        headers={'Content-Type': 'text/html'},
+                        headers={
+                            'Content-Type': 'text/html',
+                            'Content-Security-Policy': self.content_security_policy(nonce)
+                        },
                         body=swagger_ui_html)
 
     def swagger_resource(self, file) -> Response:

--- a/swagger/oauth2-redirect.html.template.mustache
+++ b/swagger/oauth2-redirect.html.template.mustache
@@ -5,7 +5,7 @@
 <body onload="run()">
 </body>
 </html>
-<script>
+<script nonce={{{CSP_NONCE}}}>
     'use strict';
     function run () {
         var oauth2 = window.opener.swaggerUIRedirectOauth2;

--- a/swagger/swagger-ui.html.template.mustache
+++ b/swagger/swagger-ui.html.template.mustache
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <title>Swagger UI</title>
     <link rel="stylesheet" href="static/swagger-ui.css" crossorigin="anonymous">
-    <style>
+    <style nonce={{{CSP_NONCE}}}>
       html
       {
         box-sizing: border-box;
@@ -30,7 +30,7 @@
     <div id="swagger-ui"></div>
     <script src="static/swagger-ui-bundle.js"></script>
     <script src="static/swagger-ui-standalone-preset.js"></script>
-    <script>
+    <script nonce={{{CSP_NONCE}}}>
     window.onload = function() {
       // Adapted from https://github.com/swagger-api/swagger-ui/issues/3725#issuecomment-334899276
       const DisableTryItOutPlugin = function() {

--- a/test/service/test_app_logging.py
+++ b/test/service/test_app_logging.py
@@ -55,6 +55,11 @@ class TestServiceAppLogging(DCP1CannedBundleTestCase, LocalAppTestCase):
                                                         'X-Amz-Date,'
                                                         'X-Amz-Security-Token,'
                                                         'X-Api-Key',
+                        'Content-Security-Policy': "default-src 'self';"
+                                                   "img-src 'self' data:;"
+                                                   "script-src 'self';"
+                                                   "style-src 'self';"
+                                                   "frame-ancestors 'none'",
                         'Strict-Transport-Security': 'max-age=31536000;'
                                                      ' includeSubDomains',
                         'X-Content-Type-Options': 'nosniff',

--- a/test/service/test_app_logging.py
+++ b/test/service/test_app_logging.py
@@ -40,7 +40,7 @@ class TestServiceAppLogging(DCP1CannedBundleTestCase, LocalAppTestCase):
                     with self.assertLogs(logger=log, level=level) as logs:
                         requests.get(str(url), headers=headers)
                     logs = [(r.levelno, r.getMessage()) for r in logs.records]
-                    headers = {
+                    request_headers = {
                         'host': url.netloc,
                         'user-agent': 'python-requests/2.32.2',
                         'accept-encoding': 'gzip, deflate, br',
@@ -48,11 +48,24 @@ class TestServiceAppLogging(DCP1CannedBundleTestCase, LocalAppTestCase):
                         'connection': 'keep-alive',
                         **headers,
                     }
+                    response_headers = {
+                        'Access-Control-Allow-Origin': '*',
+                        'Access-Control-Allow-Headers': 'Authorization,'
+                                                        'Content-Type,'
+                                                        'X-Amz-Date,'
+                                                        'X-Amz-Security-Token,'
+                                                        'X-Api-Key',
+                        'Strict-Transport-Security': 'max-age=31536000;'
+                                                     ' includeSubDomains',
+                        'X-Content-Type-Options': 'nosniff',
+                        'X-Frame-Options': 'DENY',
+                        'Cache-Control': 'no-store'
+                    }
                     self.assertEqual(logs, [
                         (
                             INFO,
                             f"Received GET request for '/health/basic', "
-                            f"with {json.dumps({'query': None, 'headers': headers})}."),
+                            f"with {json.dumps({'query': None, 'headers': request_headers})}."),
                         (
                             INFO,
                             "Authenticated request as OAuth2(access_token='foo_token')"
@@ -63,13 +76,7 @@ class TestServiceAppLogging(DCP1CannedBundleTestCase, LocalAppTestCase):
                             level,
                             'Returning 200 response. To log headers and body, set AZUL_DEBUG to 1.'
                             if level == INFO else
-                            'Returning 200 response with headers {"Access-Control-Allow-Origin": '
-                            '"*", "Access-Control-Allow-Headers": '
-                            '"Authorization,Content-Type,X-Amz-Date,X-Amz-Security-Token,X-Api-Key", '
-                            '"Strict-Transport-Security": "max-age=31536000; includeSubDomains", '
-                            '"X-Content-Type-Options": "nosniff", '
-                            '"X-Frame-Options": "DENY", '
-                            '"Cache-Control": "no-store"}. '
+                            f'Returning 200 response with headers {json.dumps(response_headers)}. '
                             'See next line for the first 1024 characters of the body.\n'
                             '{"up": true}'
                         )

--- a/test/test_app_logging.py
+++ b/test/test_app_logging.py
@@ -102,14 +102,19 @@ class TestAppLogging(AzulUnitTestCase):
                         self.assertTrue(response.startswith(traceback_header))
                         self.assertIn(magic_message, response)
                         # … and the response is logged.
+                        headers = {
+                            'Content-Type': 'text/plain',
+                            'Strict-Transport-Security': 'max-age=31536000;'
+                                                         ' includeSubDomains',
+                            'X-Content-Type-Options': 'nosniff',
+                            'X-Frame-Options': 'DENY',
+                            'Cache-Control': 'no-store'
+                        }
                         self.assertEqual(
                             azul_log.output[2],
-                            'DEBUG:azul.chalice:Returning 500 response with headers {"Content-Type": "text/plain", '
-                            '"Strict-Transport-Security": "max-age=31536000; includeSubDomains", '
-                            '"X-Content-Type-Options": "nosniff", '
-                            '"X-Frame-Options": "DENY", '
-                            '"Cache-Control": "no-store"}. '
-                            'See next line for the first 1024 characters of the body.\n' + response)
+                            f'DEBUG:azul.chalice:Returning 500 response with headers {json.dumps(headers)}. '
+                            f'See next line for the first 1024 characters of the body.\n' + response
+                        )
                     else:
                         # Otherwise, a generic error response is returned …
                         self.assertEqual(response.json(), {

--- a/test/test_app_logging.py
+++ b/test/test_app_logging.py
@@ -104,6 +104,11 @@ class TestAppLogging(AzulUnitTestCase):
                         # … and the response is logged.
                         headers = {
                             'Content-Type': 'text/plain',
+                            'Content-Security-Policy': "default-src 'self';"
+                                                       "img-src 'self' data:;"
+                                                       "script-src 'self';"
+                                                       "style-src 'self';"
+                                                       "frame-ancestors 'none'",
                             'Strict-Transport-Security': 'max-age=31536000;'
                                                          ' includeSubDomains',
                             'X-Content-Type-Options': 'nosniff',


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Connected issues: DataBiosphere/azul-private#6


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make image_manifests.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `image_manifests.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved ticket to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for `dev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for `anvildev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
