### PR TITLE
Promotion 2024-07-16 anvilprod (#6413)

### DIFF
--- a/deployments/anvilprod/environment.py
+++ b/deployments/anvilprod/environment.py
@@ -694,6 +694,19 @@ anvil6_sources = mkdict(anvil5_sources, 250, mkdelta([
     # @formatter:on
 ]))
 
+anvil7_sources = mkdict(anvil6_sources, 259, mkdelta([
+    mksrc('datarepo-b09013d2', 'ANVIL_ALSCompute_Collection_GRU_20231016_ANV5_202406261937', 14593),
+    mksrc('datarepo-c9e438dc', 'ANVIL_CCDG_Broad_NP_Epilepsy_GBRUCL_DS_EARET_MDS_WES_20221026_ANV5_202406261957', 686),
+    mksrc('datarepo-90a1d452', 'ANVIL_GREGoR_R01_GRU_20240208_ANV5_202407011515', 2473),
+    mksrc('datarepo-c27c13db', 'ANVIL_GREGoR_R01_HMB_20240208_ANV5_202407011529', 222),
+    mksrc('datarepo-3594cc06', 'ANVIL_HPRC_20240401_ANV5_202406261913', 63201),
+    mksrc('datarepo-93e6891e', 'ANVIL_MAS_ISO_seq_20240113_ANV5_202406262021', 205),
+    mksrc('datarepo-49f55ff6', 'ANVIL_NIMH_Broad_WGSPD1_McCarroll_Light_DS_WGS_20240625_ANV5_202406262032', 60),
+    mksrc('datarepo-54040f7f', 'ANVIL_T2T_CHRY_20240301_ANV5_202406271432', 309979),
+    mksrc('datarepo-5048eadd', 'ANVIL_ccdg_broad_ai_ibd_daly_brant_burnstein_utsw_wes_20240627_ANV5_202406271535', 66),
+    mksrc('datarepo-5d003f44', 'ANVIL_ccdg_broad_daly_igsr_1kg_twist_wes_20240625_ANV5_202406261904', 670)
+]))
+
 
 def env() -> Mapping[str, Optional[str]]:
     """
@@ -736,6 +749,7 @@ def env() -> Mapping[str, Optional[str]]:
                                        sources=list(filter(None, sources.values())))
             for atlas, catalog, sources in [
                 ('anvil', 'anvil6', anvil6_sources),
+                ('anvil', 'anvil7', anvil7_sources),
             ]
             for suffix, internal in [
                 ('', False),

--- a/deployments/anvilprod/environment.py
+++ b/deployments/anvilprod/environment.py
@@ -694,8 +694,7 @@ anvil6_sources = mkdict(anvil5_sources, 250, mkdelta([
     # @formatter:on
 ]))
 
-anvil7_sources = mkdict(anvil6_sources, 259, mkdelta([
-    mksrc('datarepo-b09013d2', 'ANVIL_ALSCompute_Collection_GRU_20231016_ANV5_202406261937', 14593),
+anvil7_sources = mkdict(anvil6_sources, 258, mkdelta([
     mksrc('datarepo-c9e438dc', 'ANVIL_CCDG_Broad_NP_Epilepsy_GBRUCL_DS_EARET_MDS_WES_20221026_ANV5_202406261957', 686),
     mksrc('datarepo-90a1d452', 'ANVIL_GREGoR_R01_GRU_20240208_ANV5_202407011515', 2473),
     mksrc('datarepo-c27c13db', 'ANVIL_GREGoR_R01_HMB_20240208_ANV5_202407011529', 222),

--- a/deployments/hammerbox/environment.py
+++ b/deployments/hammerbox/environment.py
@@ -707,6 +707,19 @@ anvil6_sources = mkdict(anvil5_sources, 250, mkdelta([
     # @formatter:on
 ]))
 
+anvil7_sources = mkdict(anvil6_sources, 259, mkdelta([
+    mksrc('datarepo-b09013d2', 'ANVIL_ALSCompute_Collection_GRU_20231016_ANV5_202406261937', 14593),
+    mksrc('datarepo-c9e438dc', 'ANVIL_CCDG_Broad_NP_Epilepsy_GBRUCL_DS_EARET_MDS_WES_20221026_ANV5_202406261957', 686),
+    mksrc('datarepo-90a1d452', 'ANVIL_GREGoR_R01_GRU_20240208_ANV5_202407011515', 2473),
+    mksrc('datarepo-c27c13db', 'ANVIL_GREGoR_R01_HMB_20240208_ANV5_202407011529', 222),
+    mksrc('datarepo-3594cc06', 'ANVIL_HPRC_20240401_ANV5_202406261913', 63201),
+    mksrc('datarepo-93e6891e', 'ANVIL_MAS_ISO_seq_20240113_ANV5_202406262021', 205),
+    mksrc('datarepo-49f55ff6', 'ANVIL_NIMH_Broad_WGSPD1_McCarroll_Light_DS_WGS_20240625_ANV5_202406262032', 60),
+    mksrc('datarepo-54040f7f', 'ANVIL_T2T_CHRY_20240301_ANV5_202406271432', 309979),
+    mksrc('datarepo-5048eadd', 'ANVIL_ccdg_broad_ai_ibd_daly_brant_burnstein_utsw_wes_20240627_ANV5_202406271535', 66),
+    mksrc('datarepo-5d003f44', 'ANVIL_ccdg_broad_daly_igsr_1kg_twist_wes_20240625_ANV5_202406261904', 670)
+]))
+
 
 def env() -> Mapping[str, Optional[str]]:
     """
@@ -761,6 +774,7 @@ def env() -> Mapping[str, Optional[str]]:
                                        sources=list(filter(None, sources.values())))
             for atlas, catalog, sources in [
                 ('anvil', 'anvil6', anvil6_sources),
+                ('anvil', 'anvil7', anvil7_sources),
             ]
             for suffix, internal in [
                 ('', False),

--- a/deployments/hammerbox/environment.py
+++ b/deployments/hammerbox/environment.py
@@ -707,8 +707,7 @@ anvil6_sources = mkdict(anvil5_sources, 250, mkdelta([
     # @formatter:on
 ]))
 
-anvil7_sources = mkdict(anvil6_sources, 259, mkdelta([
-    mksrc('datarepo-b09013d2', 'ANVIL_ALSCompute_Collection_GRU_20231016_ANV5_202406261937', 14593),
+anvil7_sources = mkdict(anvil6_sources, 258, mkdelta([
     mksrc('datarepo-c9e438dc', 'ANVIL_CCDG_Broad_NP_Epilepsy_GBRUCL_DS_EARET_MDS_WES_20221026_ANV5_202406261957', 686),
     mksrc('datarepo-90a1d452', 'ANVIL_GREGoR_R01_GRU_20240208_ANV5_202407011515', 2473),
     mksrc('datarepo-c27c13db', 'ANVIL_GREGoR_R01_HMB_20240208_ANV5_202407011529', 222),

--- a/deployments/prod/environment.py
+++ b/deployments/prod/environment.py
@@ -1138,7 +1138,6 @@ def env() -> Mapping[str, Optional[str]]:
             for atlas, catalog, sources in [
                 ('hca', 'dcp39', dcp39_sources),
                 ('hca', 'pilot1', pilot1_sources),
-                ('lungmap', 'lm6', lm6_sources),
                 ('lungmap', 'lm7', lm7_sources)
             ] for suffix, internal in [
                 ('', False),

--- a/deployments/prod/environment.py
+++ b/deployments/prod/environment.py
@@ -1047,6 +1047,7 @@ dcp38_sources = mkdict(dcp37_sources, 455, mkdelta([
 ]))
 dcp39_sources = mkdict(dcp38_sources, 456, mkdelta([
     mksrc('datarepo-31abbcbe', 'hca_prod_4a95101c9ffc4f30a809f04518a23803__20220113_dcp2_20240603_dcp39', 38),
+    mksrc('datarepo-664a24cb', 'hca_prod_7c75f07c608d4c4aa1b7b13d11c0ad31__20220117_dcp2_20230314_dcp25', 67, pop),
     mksrc('datarepo-cd6f5afa', 'hca_prod_838d46603d624b08b32ddc5cbd93919d__20240531_dcp2_20240603_dcp39', 8),
     mksrc('datarepo-f6c258a6', 'hca_prod_9483c664d5464b309ba3efbdbf9290b4__20240301_dcp2_20240604_dcp39', 13),
     mksrc('datarepo-cf29bb39', 'hca_prod_f2078d5f2e7d48448552f7c41a231e52__20230201_dcp2_20240603_dcp39', 78)

--- a/deployments/prod/environment.py
+++ b/deployments/prod/environment.py
@@ -1045,8 +1045,7 @@ dcp38_sources = mkdict(dcp37_sources, 455, mkdelta([
     mksrc('datarepo-37460143', 'hca_prod_d5c91e922e7f473d8cf3ab03bbae21c2__20240503_dcp2_20240508_dcp38', 41),
     mksrc('datarepo-39884574', 'hca_prod_daef3fda262045aea3f71613814a35bf__20240503_dcp2_20240508_dcp38', 47)
 ]))
-dcp39_sources = mkdict(dcp38_sources, 457, mkdelta([
-    mksrc('datarepo-ed01025c', 'hca_prod_0cc58d0b17344e1d9113b32e52f75e36__20240531_dcp2_20240604_dcp39', 990),
+dcp39_sources = mkdict(dcp38_sources, 456, mkdelta([
     mksrc('datarepo-31abbcbe', 'hca_prod_4a95101c9ffc4f30a809f04518a23803__20220113_dcp2_20240603_dcp39', 38),
     mksrc('datarepo-cd6f5afa', 'hca_prod_838d46603d624b08b32ddc5cbd93919d__20240531_dcp2_20240603_dcp39', 8),
     mksrc('datarepo-f6c258a6', 'hca_prod_9483c664d5464b309ba3efbdbf9290b4__20240301_dcp2_20240604_dcp39', 13),

--- a/deployments/prod/environment.py
+++ b/deployments/prod/environment.py
@@ -1053,6 +1053,44 @@ dcp39_sources = mkdict(dcp38_sources, 456, mkdelta([
 
 ]))
 
+dcp40_sources = mkdict(dcp39_sources, 459, mkdelta([
+    mksrc('datarepo-7ff6ae27', 'hca_prod_005d611a14d54fbf846e571a1f874f70__20220111_dcp2_20240711_dcp40', 884),
+    mksrc('datarepo-083a593d', 'hca_prod_027c51c60719469fa7f5640fe57cbece__20220110_dcp2_20240711_dcp40', 8),
+    mksrc('datarepo-6e878a15', 'hca_prod_065e6c13ad6b46a38075c3137eb03068__20220213_dcp2_20240711_dcp40', 121),
+    mksrc('datarepo-d001eadd', 'hca_prod_102018327c7340339b653ef13d81656a__20220213_dcp2_20240711_dcp40', 2),
+    mksrc('datarepo-56a4f662', 'hca_prod_135f7f5c4a854bcf9f7c4f035ff1e428__20220729_dcp2_20240711_dcp40', 116),
+    mksrc('datarepo-b081c1a1', 'hca_prod_1538d572bcb7426b8d2c84f3a7f87bb0__20220630_dcp2_20240711_dcp40', 12),
+    mksrc('datarepo-0c56d5cc', 'hca_prod_16dc40f92c1342e38cdf251e95bfc043__20240708_dcp2_20240711_dcp40', 3),
+    mksrc('datarepo-2f17d9dd', 'hca_prod_16ed4ad8731946b288596fe1c1d73a82__20220111_dcp2_20240711_dcp40', 29),
+    mksrc('datarepo-98b77527', 'hca_prod_1c6a960d52ac44eab728a59c7ab9dc8e__20220110_dcp2_20240711_dcp40', 11),
+    mksrc('datarepo-8c31fd19', 'hca_prod_2d4d89f2ebeb467cae60a3efc5e8d4ba__20230206_dcp2_20240711_dcp40', 2),
+    mksrc('datarepo-f9579ac6', 'hca_prod_2ef3655a973d4d699b4121fa4041eed7__20220111_dcp2_20240711_dcp40', 11),
+    mksrc('datarepo-5feaa5ad', 'hca_prod_31887183a72c43089eacc6140313f39c__20220111_dcp2_20240711_dcp40', 7),
+    mksrc('datarepo-c094bcbc', 'hca_prod_40272c3b46974bd4ba3f82fa96b9bf71__20220303_dcp2_20240711_dcp40', 7),
+    mksrc('datarepo-d72f8298', 'hca_prod_425c2759db664c93a358a562c069b1f1__20220519_dcp2_20240711_dcp40', 326),
+    mksrc('datarepo-496892e7', 'hca_prod_4a95101c9ffc4f30a809f04518a23803__20220113_dcp2_20240711_dcp40', 38),
+    mksrc('datarepo-1f66dc6c', 'hca_prod_4bec484dca7a47b48d488830e06ad6db__20220113_dcp2_20240711_dcp40', 105),
+    mksrc('datarepo-3b468668', 'hca_prod_4d6f6c962a8343d88fe10f53bffd4674__20220113_dcp2_20240712_dcp40', 12),
+    mksrc('datarepo-03fca13b', 'hca_prod_50151324f3ed435898afec352a940a61__20220113_dcp2_20240711_dcp40', 117),
+    mksrc('datarepo-bfba7263', 'hca_prod_51f02950ee254f4b8d0759aa99bb3498__20220117_dcp2_20240711_dcp40', 12),
+    mksrc('datarepo-af6e91dc', 'hca_prod_577c946d6de54b55a854cd3fde40bff2__20220117_dcp2_20240711_dcp40', 21),
+    mksrc('datarepo-1a5200cb', 'hca_prod_86fd2521c5014e41841c06d79277bb7c__20240708_dcp2_20240711_dcp40', 53),
+    mksrc('datarepo-436c5a47', 'hca_prod_99101928d9b14aafb759e97958ac7403__20220118_dcp2_20240711_dcp40', 1192),
+    mksrc('datarepo-e10ecf5f', 'hca_prod_a83b7f45bfb14c6a97e98e3370065cc1__20240708_dcp2_20240711_dcp40', 15),
+    mksrc('datarepo-028b06ac', 'hca_prod_ad04c8e79b7d4cceb8e901e31da10b94__20220118_dcp2_20240711_dcp40', 50),
+    mksrc('datarepo-7c60076d', 'hca_prod_ae71be1dddd84feb9bed24c3ddb6e1ad__20220118_dcp2_20240711_dcp40', 3516),
+    mksrc('datarepo-27cbfba4', 'hca_prod_b963bd4b4bc14404842569d74bc636b8__20220118_dcp2_20240711_dcp40', 3),
+    mksrc('datarepo-7345f02d', 'hca_prod_c16a754f5da346ed8c1e6426af2ef625__20220519_dcp2_20240711_dcp40', 220),
+    mksrc('datarepo-ed0b32a2', 'hca_prod_c1a9a93dd9de4e659619a9cec1052eaa__20220118_dcp2_20240711_dcp40', 47),
+    mksrc('datarepo-9e3eace2', 'hca_prod_c211fd49d9804ba18c6ac24254a3cb52__20220303_dcp2_20240711_dcp40', 121),
+    mksrc('datarepo-4db5785d', 'hca_prod_c4077b3c5c984d26a614246d12c2e5d7__20220118_dcp2_20240711_dcp40', 366),
+    mksrc('datarepo-325d0681', 'hca_prod_c5ca43aa3b2b42168eb3f57adcbc99a1__20220118_dcp2_20240711_dcp40', 195),
+    mksrc('datarepo-2e8307b5', 'hca_prod_c6ad8f9bd26a4811b2ba93d487978446__20220118_dcp2_20240711_dcp40', 640),
+    mksrc('datarepo-812cbdeb', 'hca_prod_cddab57b68684be4806f395ed9dd635a__20220118_dcp2_20240711_dcp40', 2546),
+    mksrc('datarepo-d8cb1e24', 'hca_prod_d3446f0c30f34a12b7c36af877c7bb2d__20220119_dcp2_20240711_dcp40', 41),
+    mksrc('datarepo-bde87024', 'hca_prod_dc0b65b0771346f0a3390b03ea786046__20230427_dcp2_20240711_dcp40', 5)
+]))
+
 pilot1_sources = mkdict({}, 4, mkdelta([
     mksrc('datarepo-11e4dc06', 'hca_prod_59b3bfd9cf454d538c8ee240273cba71__20240410_dcp2_20240410_dcpPilot', 3),
     mksrc('datarepo-9ebf5be4', 'hca_prod_5bbd9f925bf447cb91999a9750d3fbcd__20240410_dcp2_20240410_dcpPilot', 3),
@@ -1136,6 +1174,7 @@ def env() -> Mapping[str, Optional[str]]:
                                        sources=mklist(sources))
             for atlas, catalog, sources in [
                 ('hca', 'dcp39', dcp39_sources),
+                ('hca', 'dcp40', dcp40_sources),
                 ('hca', 'pilot1', pilot1_sources),
                 ('lungmap', 'lm7', lm7_sources)
             ] for suffix, internal in [

--- a/terraform/gitlab/gitlab.tf.json.template.py
+++ b/terraform/gitlab/gitlab.tf.json.template.py
@@ -229,13 +229,6 @@ operator_keys = [
     )
 ]
 
-other_public_keys = {
-    'dev': operator_keys,
-    'anvildev': operator_keys,
-    'anvilprod': operator_keys,
-    'prod': []
-}
-
 # FIXME: Launch GitLab, DinD & runner images using image ID
 #        https://github.com/DataBiosphere/azul/issues/5960
 
@@ -1639,7 +1632,7 @@ emit_tf({} if config.terraform_component != 'gitlab' else {
                         'amazon-ecr-credential-helper',
                         'dracut-fips'
                     ],
-                    'ssh_authorized_keys': other_public_keys.get(config.deployment_stage, []),
+                    'ssh_authorized_keys': [] if config.deployment.is_stable else operator_keys,
                     'bootcmd': [
                         [
                             'cloud-init-per',


### PR DESCRIPTION
Connected issue: #6413

## Notes
- Perform a [targeted reindex](https://github.com/DataBiosphere/azul/blob/develop/OPERATOR.rst#reindexing-a-specific-catalog-or-sources-in-gitlab) of the `anvil7` catalog in hammerbox and anvilprod
- [x] Update [spreadsheet](https://docs.google.com/spreadsheets/d/1yYiB3TrX0wvLCHvtWY1GTZZcAf5MmMREgn52OKCHsqs/edit#gid=1813930149) to indicate the removal of `ALSCompute_Collection_GRU` in anvil7


## Checklist


### Author

- [x] Target branch is `anvilprod`
- [x] Name of PR branch matches `promotions/yyyy-mm-dd-anvilprod`
- [x] On ZenHub, PR is connected to the promotion issue it resolves
- [x] PR description links to connected issue
- [x] Title of connected issue matches `Promotion yyyy-mm-dd`
- [x] PR title starts with title of connected issue followed by ` anvilprod`
- [x] PR title references the connected issue


### Author (reindex, API changes)

- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `anvilprod` <sub>or requires a full reindex or is not labeled`reindex:anvilprod`</sub>


### Author (upgrading deployments)

- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `image_manifests.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Decided if PR can be labeled `no sandbox`
- [x] Moved ticket to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Pushed PR branch to GitHub
- [x] Ran `_select anvilprod.shared && CI_COMMIT_REF_NAME=anvilprod make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Made a backup of the GitLab data volume in `anvilprod` (see [operator manual](../blob/develop/OPERATOR.rst#backup-gitlab-volumes) for details) <sub>or this PR is not labeled `backup:gitlab`</sub>
- [x] Ran `_select anvilprod.gitlab && CI_COMMIT_REF_NAME=anvilprod make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for `anvilprod.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select anvilprod.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but excluded any `p` tags</sub>
- [x] Pushed merge commit to GitHub


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `anvilprod`
- [x] Build passes on GitLab `anvilprod`
- [x] Reviewed build logs for anomalies on GitLab `anvilprod`
- [x] Ran `_select anvilprod.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `anvilprod`
- [x] Moved connected issue to *Merged stable* column on ZenHub
- [x] Moved promoted issues from *Merged lower* to *Merged stable* column on ZenHub
- [x] Moved promoted issues from *Lower* to *Stable* column on ZenHub


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `anvilprod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvilprod`</sub>
- [x] Deindexed specific sources in `anvilprod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvilprod`</sub>
- [x] Indexed specific sources in `anvilprod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvilprod`</sub>
- [x] Started reindex in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
- [x] Emptied fail queues in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>


### Operator

- [x] PR is assigned to only the system administrator


### System administrator

- [x] Removed unused image tags from [pycharm image on DockerHub](https://hub.docker.com/repository/docker/ucscgi/azul-pycharm) <sub>or this promotion does not alter references to that image</sub>
- [x] Removed unused image tags from [elasticsearch image on DockerHub](https://hub.docker.com/repository/docker/ucscgi/azul-elasticsearch) <sub>or this promotion does not alter references to that image</sub>
- [x] Removed unused image tags from [bigquery_emulator image on DockerHub](https://hub.docker.com/repository/docker/ucscgi/azul-bigquery-emulator) <sub>or this promotion does not alter references to that image</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
