### PR TITLE
Clean-up and generalize TDR source specs (#6426)

### DIFF
--- a/OPERATOR.rst
+++ b/OPERATOR.rst
@@ -278,7 +278,7 @@ To specify a catalog to be reindexed, set ``Key`` to ``azul_current_catalog``
 and ``Value`` to the name of the catalog, for example, ``dcp3``. To specify the
 sources to be reindexed, set ``Key`` to ``azul_current_sources`` and
 ``Value`` to a space-separated list of sources globs, e.g.
-``*:snapshot/hca_dev_* *:snapshot/lungmap_dev_*``. Check the inputs you just
+``*:hca_dev_* *:lungmap_dev_*``. Check the inputs you just
 made. Start the ``reindex`` job by clicking on ``Run job``. Wait until the job
 has completed.
 

--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -20,6 +20,16 @@ reverted. This is all fairly informal and loosely defined. Hopefully we won't
 have too many entries in this file.
 
 
+#6426 Clean-up and generalize TDR source specs
+==============================================
+
+The "snapshot/" string has been removed from TDR source specs.
+
+Update the ``mksrc`` function in ``environment.py`` for each of your personal
+deployments. As always, use the sandbox deployment's ``environment.py`` as a
+model when upgrading personal deployments.
+
+
 #6432 Upgrade dependencies 2024-07-22
 =====================================
 

--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -23,7 +23,8 @@ have too many entries in this file.
 #6426 Clean-up and generalize TDR source specs
 ==============================================
 
-The "snapshot/" string has been removed from TDR source specs.
+The "snapshot/" string has been removed from TDR source specs, and the ``type``
+and ``domain`` fields have been added.
 
 Update the ``mksrc`` function in ``environment.py`` for each of your personal
 deployments. As always, use the sandbox deployment's ``environment.py`` as a

--- a/deployments/anvilbox/environment.py
+++ b/deployments/anvilbox/environment.py
@@ -40,6 +40,8 @@ def mksrc(google_project,
         prefix = common_prefix(subgraphs)
     source = None if flags & pop else ':'.join([
         'tdr',
+        'bigquery',
+        'gcp',
         google_project,
         snapshot,
         prefix + '/0'

--- a/deployments/anvilbox/environment.py
+++ b/deployments/anvilbox/environment.py
@@ -41,7 +41,7 @@ def mksrc(google_project,
     source = None if flags & pop else ':'.join([
         'tdr',
         google_project,
-        'snapshot/' + snapshot,
+        snapshot,
         prefix + '/0'
     ])
     return project, source

--- a/deployments/anvildev/environment.py
+++ b/deployments/anvildev/environment.py
@@ -28,7 +28,7 @@ def mksrc(google_project, snapshot, subgraphs, flags: int = 0) -> tuple[str, str
     source = None if flags & pop else ':'.join([
         'tdr',
         google_project,
-        'snapshot/' + snapshot,
+        snapshot,
         '/' + str(partition_prefix_length(subgraphs))
     ])
     return project, source

--- a/deployments/anvildev/environment.py
+++ b/deployments/anvildev/environment.py
@@ -27,6 +27,8 @@ def mksrc(google_project, snapshot, subgraphs, flags: int = 0) -> tuple[str, str
     assert flags <= ma | pop
     source = None if flags & pop else ':'.join([
         'tdr',
+        'bigquery',
+        'gcp',
         google_project,
         snapshot,
         '/' + str(partition_prefix_length(subgraphs))

--- a/deployments/anvilprod/environment.py
+++ b/deployments/anvilprod/environment.py
@@ -28,7 +28,7 @@ def mksrc(google_project, snapshot, subgraphs, flags: int = 0) -> tuple[str, str
     source = None if flags & pop else ':'.join([
         'tdr',
         google_project,
-        'snapshot/' + snapshot,
+        snapshot,
         '/' + str(partition_prefix_length(subgraphs))
     ])
     return project, source

--- a/deployments/anvilprod/environment.py
+++ b/deployments/anvilprod/environment.py
@@ -27,6 +27,8 @@ def mksrc(google_project, snapshot, subgraphs, flags: int = 0) -> tuple[str, str
     assert flags <= ma | pop
     source = None if flags & pop else ':'.join([
         'tdr',
+        'bigquery',
+        'gcp',
         google_project,
         snapshot,
         '/' + str(partition_prefix_length(subgraphs))

--- a/deployments/dev/environment.py
+++ b/deployments/dev/environment.py
@@ -28,7 +28,7 @@ def mksrc(google_project, snapshot, subgraphs, flags: int = 0) -> tuple[str, str
     source = None if flags & pop else ':'.join([
         'tdr',
         google_project,
-        'snapshot/' + snapshot,
+        snapshot,
         '/' + str(partition_prefix_length(subgraphs))
     ])
     return project, source

--- a/deployments/dev/environment.py
+++ b/deployments/dev/environment.py
@@ -27,6 +27,8 @@ def mksrc(google_project, snapshot, subgraphs, flags: int = 0) -> tuple[str, str
     assert flags <= ma | pop
     source = None if flags & pop else ':'.join([
         'tdr',
+        'bigquery',
+        'gcp',
         google_project,
         snapshot,
         '/' + str(partition_prefix_length(subgraphs))

--- a/deployments/hammerbox/environment.py
+++ b/deployments/hammerbox/environment.py
@@ -40,6 +40,8 @@ def mksrc(google_project,
         prefix = common_prefix(subgraphs)
     source = None if flags & pop else ':'.join([
         'tdr',
+        'bigquery',
+        'gcp',
         google_project,
         snapshot,
         prefix + '/0'

--- a/deployments/hammerbox/environment.py
+++ b/deployments/hammerbox/environment.py
@@ -41,7 +41,7 @@ def mksrc(google_project,
     source = None if flags & pop else ':'.join([
         'tdr',
         google_project,
-        'snapshot/' + snapshot,
+        snapshot,
         prefix + '/0'
     ])
     return project, source

--- a/deployments/prod/environment.py
+++ b/deployments/prod/environment.py
@@ -30,7 +30,7 @@ def mksrc(google_project, snapshot, subgraphs, flags: int = 0) -> tuple[str, str
     source = None if flags & pop else ':'.join([
         'tdr',
         google_project,
-        'snapshot/' + snapshot,
+        snapshot,
         '/' + str(partition_prefix_length(subgraphs))
     ])
     return project, source

--- a/deployments/prod/environment.py
+++ b/deployments/prod/environment.py
@@ -29,6 +29,8 @@ def mksrc(google_project, snapshot, subgraphs, flags: int = 0) -> tuple[str, str
     assert flags <= ma | pop
     source = None if flags & pop else ':'.join([
         'tdr',
+        'bigquery',
+        'gcp',
         google_project,
         snapshot,
         '/' + str(partition_prefix_length(subgraphs))

--- a/deployments/sandbox/environment.py
+++ b/deployments/sandbox/environment.py
@@ -40,6 +40,8 @@ def mksrc(google_project,
         prefix = common_prefix(subgraphs)
     source = None if flags & pop else ':'.join([
         'tdr',
+        'bigquery',
+        'gcp',
         google_project,
         snapshot,
         prefix + '/0'

--- a/deployments/sandbox/environment.py
+++ b/deployments/sandbox/environment.py
@@ -41,7 +41,7 @@ def mksrc(google_project,
     source = None if flags & pop else ':'.join([
         'tdr',
         google_project,
-        'snapshot/' + snapshot,
+        snapshot,
         prefix + '/0'
     ])
     return project, source

--- a/deployments/tempdev/environment.py
+++ b/deployments/tempdev/environment.py
@@ -28,7 +28,7 @@ def mksrc(google_project, snapshot, subgraphs, flags: int = 0) -> tuple[str, str
     source = None if flags & pop else ':'.join([
         'tdr',
         google_project,
-        'snapshot/' + snapshot,
+        snapshot,
         '/' + str(partition_prefix_length(subgraphs))
     ])
     return project, source

--- a/deployments/tempdev/environment.py
+++ b/deployments/tempdev/environment.py
@@ -27,6 +27,8 @@ def mksrc(google_project, snapshot, subgraphs, flags: int = 0) -> tuple[str, str
     assert flags <= ma | pop
     source = None if flags & pop else ':'.join([
         'tdr',
+        'bigquery',
+        'gcp',
         google_project,
         snapshot,
         '/' + str(partition_prefix_length(subgraphs))

--- a/environment.py
+++ b/environment.py
@@ -70,15 +70,13 @@ def env() -> Mapping[str, Optional[str]]:
         #
         # The first catalog listed is the default catalog.
         #
-        # A source represents a TDR dataset, TDR snapshot, or canned staging
-        # area to index. Each source is a string matching the following EBNF
-        # grammar:
+        # A source represents a TDR snapshot or canned staging area to index.
+        # Each source is a string matching the following EBNF grammar:
         #
         # source = TDR source | canned source ;
         #
         # TDR source = 'tdr:', Google Cloud project name,
-        #              ':', ( 'dataset' | 'snapshot' ),
-        #              '/', TDR dataset or snapshot name,
+        #              ':', TDR dataset or snapshot name,
         #              ':', [ prefix ],
         #              '/', partition prefix length ;
         #
@@ -116,8 +114,7 @@ def env() -> Mapping[str, Optional[str]]:
         #
         # Examples:
         #
-        # tdr:broad-jade-dev-data:snapshot/hca_mvp:/1
-        # tdr:broad-jade-dev-data:dataset/hca_mvp:2/1
+        # tdr:broad-jade-dev-data:hca_mvp:/1
         # https://github.com/HumanCellAtlas/schema-test-data/tree/de355ca/tests:2
         #
         # This variable tends to be large. If you get `Argument list too long`

--- a/scripts/post_deploy_tdr.py
+++ b/scripts/post_deploy_tdr.py
@@ -93,9 +93,9 @@ class TerraValidator:
                       ) -> None:
         source = self.tdr.lookup_source(source_spec)
         log.info('TDR client is authorized for API access to %s.', source_spec)
-        require(source.project == source_spec.project,
+        require(source.project == source_spec.subdomain,
                 'Actual Google project of TDR source differs from configured one',
-                source.project, source_spec.project)
+                source.project, source_spec.subdomain)
         # Uppercase is standard for multi-regions in the documentation but TDR
         # returns 'us' in lowercase
         require(source.location.lower() == config.tdr_source_location.lower(),

--- a/scripts/recan_bundle_tdr.py
+++ b/scripts/recan_bundle_tdr.py
@@ -400,7 +400,7 @@ def main(argv):
 
     tdr_source = TDRSourceRef(id=args.source_id,
                               spec=TDRSourceSpec(prefix=Prefix.of_everything,
-                                                 project='test_project',
+                                                 subdomain='test_project',
                                                  name='test_name',
                                                  is_snapshot=True))
     tdr_bundle = dss_bundle_to_tdr(dss_bundle, tdr_source)

--- a/scripts/recan_bundle_tdr.py
+++ b/scripts/recan_bundle_tdr.py
@@ -240,7 +240,6 @@ class File(Entity):
         assert self.concrete_type.endswith('_file')
         self.file_manifest_entry = one(e for e in bundle.manifest
                                        if e['name'] == self.metadata['file_core']['file_name'])
-        assert bundle.fqid.source.spec.is_snapshot
         assert self.file_manifest_entry['drs_path'] is not None
 
     def to_json_row(self) -> JSON:
@@ -368,7 +367,7 @@ def main(argv):
                         help='The UUID of the existing DCP/1 canned bundle.')
     parser.add_argument('--source-id', '-s',
                         default=TestTDRHCAPlugin.source.id,
-                        help='The UUID of the snapshot/dataset to contain the canned DCP/2 bundle.')
+                        help='The UUID of the snapshot to contain the canned DCP/2 bundle.')
     parser.add_argument('--version', '-v',
                         default=TestTDRHCAPlugin.bundle_fqid.version,
                         help='The version for any mock entities synthesized by the script.')
@@ -401,8 +400,7 @@ def main(argv):
     tdr_source = TDRSourceRef(id=args.source_id,
                               spec=TDRSourceSpec(prefix=Prefix.of_everything,
                                                  subdomain='test_project',
-                                                 name='test_name',
-                                                 is_snapshot=True))
+                                                 name='test_name'))
     tdr_bundle = dss_bundle_to_tdr(dss_bundle, tdr_source)
 
     add_supp_files(tdr_bundle,

--- a/scripts/update_subgraph_counts.py
+++ b/scripts/update_subgraph_counts.py
@@ -105,12 +105,12 @@ class SubgraphCounter:
 @attr.s(auto_attribs=True, frozen=True, kw_only=True)
 class SourceSpecArgs:
     project: str
-    snapshot: str
+    name: str
     subgraph_count: int
     explicit_prefix: Optional[str]
 
     def __str__(self) -> str:
-        params = f'{self.project!r}, {self.snapshot!r}, {self.subgraph_count!r}'
+        params = f'{self.project!r}, {self.name!r}, {self.subgraph_count!r}'
         if self.explicit_prefix is not None:
             params += f', prefix={self.explicit_prefix!r}'
         return f'mksrc({params})'
@@ -141,7 +141,7 @@ def generate_sources(catalog: CatalogName,
             if default_prefix not in prefixed_counter.partition_sizes:
                 explicit_prefix = prefixed_counter.ideal_common_prefix()
         return SourceSpecArgs(project=source.spec.project,
-                              snapshot=source.spec.name,
+                              name=source.spec.name,
                               subgraph_count=counter.count,
                               explicit_prefix=explicit_prefix)
 

--- a/scripts/update_subgraph_counts.py
+++ b/scripts/update_subgraph_counts.py
@@ -104,13 +104,13 @@ class SubgraphCounter:
 
 @attr.s(auto_attribs=True, frozen=True, kw_only=True)
 class SourceSpecArgs:
-    project: str
+    subdomain: str
     name: str
     subgraph_count: int
     explicit_prefix: Optional[str]
 
     def __str__(self) -> str:
-        params = f'{self.project!r}, {self.name!r}, {self.subgraph_count!r}'
+        params = f'{self.subdomain!r}, {self.name!r}, {self.subgraph_count!r}'
         if self.explicit_prefix is not None:
             params += f', prefix={self.explicit_prefix!r}'
         return f'mksrc({params})'
@@ -140,7 +140,7 @@ def generate_sources(catalog: CatalogName,
             prefixed_counter = SubgraphCounter.for_source(plugin, source, counter_prefix)
             if default_prefix not in prefixed_counter.partition_sizes:
                 explicit_prefix = prefixed_counter.ideal_common_prefix()
-        return SourceSpecArgs(project=source.spec.project,
+        return SourceSpecArgs(subdomain=source.spec.subdomain,
                               name=source.spec.name,
                               subgraph_count=counter.count,
                               explicit_prefix=explicit_prefix)

--- a/test/azul_test_case.py
+++ b/test/azul_test_case.py
@@ -510,7 +510,7 @@ class TDRTestCase(CatalogTestCase, metaclass=ABCMeta):
 
 class DCP2TestCase(TDRTestCase):
     source = TDRSourceRef(id='d8c20944-739f-4e7d-9161-b720953432ce',
-                          spec=TDRSourceSpec.parse('tdr:test_hca_project:snapshot/hca_snapshot:/2'))
+                          spec=TDRSourceSpec.parse('tdr:test_hca_project:hca_snapshot:/2'))
 
     @classmethod
     def catalog_config(cls) -> dict[CatalogName, config.Catalog]:
@@ -526,7 +526,7 @@ class DCP2TestCase(TDRTestCase):
 
 class AnvilTestCase(TDRTestCase):
     source = TDRSourceRef(id='6c87f0e1-509d-46a4-b845-7584df39263b',
-                          spec=TDRSourceSpec.parse('tdr:test_anvil_project:snapshot/anvil_snapshot:/2'))
+                          spec=TDRSourceSpec.parse('tdr:test_anvil_project:anvil_snapshot:/2'))
 
     @classmethod
     def catalog_config(cls) -> dict[CatalogName, config.Catalog]:

--- a/test/azul_test_case.py
+++ b/test/azul_test_case.py
@@ -510,7 +510,7 @@ class TDRTestCase(CatalogTestCase, metaclass=ABCMeta):
 
 class DCP2TestCase(TDRTestCase):
     source = TDRSourceRef(id='d8c20944-739f-4e7d-9161-b720953432ce',
-                          spec=TDRSourceSpec.parse('tdr:test_hca_project:hca_snapshot:/2'))
+                          spec=TDRSourceSpec.parse('tdr:bigquery:gcp:test_hca_project:hca_snapshot:/2'))
 
     @classmethod
     def catalog_config(cls) -> dict[CatalogName, config.Catalog]:
@@ -526,7 +526,7 @@ class DCP2TestCase(TDRTestCase):
 
 class AnvilTestCase(TDRTestCase):
     source = TDRSourceRef(id='6c87f0e1-509d-46a4-b845-7584df39263b',
-                          spec=TDRSourceSpec.parse('tdr:test_anvil_project:anvil_snapshot:/2'))
+                          spec=TDRSourceSpec.parse('tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2'))
 
     @classmethod
     def catalog_config(cls) -> dict[CatalogName, config.Catalog]:

--- a/test/indexer/data/826dea02-e274-affe-aabc-eb3db63ad068.results.json
+++ b/test/indexer/data/826dea02-e274-affe-aabc-eb3db63ad068.results.json
@@ -230,7 +230,7 @@
             "sources": [
                 {
                     "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                    "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
+                    "spec": "tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2"
                 }
             ],
             "bundles": [
@@ -421,7 +421,7 @@
             "document_id": "1509ef40-d1ba-440d-b298-16b7c173dcd4_826dea02-e274-affe-aabc-eb3db63ad068_2022-06-01T00:00:00.000000Z_exists",
             "source": {
                 "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
+                "spec": "tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2"
             },
             "bundle_uuid": "826dea02-e274-affe-aabc-eb3db63ad068",
             "bundle_version": "2022-06-01T00:00:00.000000Z",
@@ -664,7 +664,7 @@
             "sources": [
                 {
                     "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                    "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
+                    "spec": "tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2"
                 }
             ],
             "bundles": [
@@ -855,7 +855,7 @@
             "document_id": "15b76f9c-6b46-433f-851d-34e89f1b9ba6_826dea02-e274-affe-aabc-eb3db63ad068_2022-06-01T00:00:00.000000Z_exists",
             "source": {
                 "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
+                "spec": "tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2"
             },
             "bundle_uuid": "826dea02-e274-affe-aabc-eb3db63ad068",
             "bundle_version": "2022-06-01T00:00:00.000000Z",
@@ -1226,7 +1226,7 @@
             "sources": [
                 {
                     "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                    "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
+                    "spec": "tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2"
                 }
             ],
             "bundles": [
@@ -1462,7 +1462,7 @@
             "document_id": "2370f948-2783-4eb6-afea-e022897f4dcf_826dea02-e274-affe-aabc-eb3db63ad068_2022-06-01T00:00:00.000000Z_exists",
             "source": {
                 "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
+                "spec": "tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2"
             },
             "bundle_uuid": "826dea02-e274-affe-aabc-eb3db63ad068",
             "bundle_version": "2022-06-01T00:00:00.000000Z",
@@ -1709,7 +1709,7 @@
             "sources": [
                 {
                     "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                    "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
+                    "spec": "tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2"
                 }
             ],
             "bundles": [
@@ -1932,7 +1932,7 @@
             "document_id": "3b17377b-16b1-431c-9967-e5d01fc5923f_826dea02-e274-affe-aabc-eb3db63ad068_2022-06-01T00:00:00.000000Z_exists",
             "source": {
                 "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
+                "spec": "tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2"
             },
             "bundle_uuid": "826dea02-e274-affe-aabc-eb3db63ad068",
             "bundle_version": "2022-06-01T00:00:00.000000Z",
@@ -2170,7 +2170,7 @@
             "sources": [
                 {
                     "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                    "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
+                    "spec": "tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2"
                 }
             ],
             "bundles": [
@@ -2391,7 +2391,7 @@
             "document_id": "816e364e-1193-4e5b-a91a-14e4b009157c_826dea02-e274-affe-aabc-eb3db63ad068_2022-06-01T00:00:00.000000Z_exists",
             "source": {
                 "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
+                "spec": "tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2"
             },
             "bundle_uuid": "826dea02-e274-affe-aabc-eb3db63ad068",
             "bundle_version": "2022-06-01T00:00:00.000000Z",
@@ -2686,7 +2686,7 @@
             "sources": [
                 {
                     "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                    "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
+                    "spec": "tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2"
                 }
             ],
             "bundles": [
@@ -2922,7 +2922,7 @@
             "document_id": "826dea02-e274-4ffe-aabc-eb3db63ad068_826dea02-e274-affe-aabc-eb3db63ad068_2022-06-01T00:00:00.000000Z_exists",
             "source": {
                 "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
+                "spec": "tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2"
             },
             "bundle_uuid": "826dea02-e274-affe-aabc-eb3db63ad068",
             "bundle_version": "2022-06-01T00:00:00.000000Z",
@@ -3266,7 +3266,7 @@
             "sources": [
                 {
                     "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                    "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
+                    "spec": "tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2"
                 }
             ],
             "bundles": [
@@ -3502,7 +3502,7 @@
             "document_id": "826dea02-e274-affe-aabc-eb3db63ad068_826dea02-e274-affe-aabc-eb3db63ad068_2022-06-01T00:00:00.000000Z_exists",
             "source": {
                 "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
+                "spec": "tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2"
             },
             "bundle_uuid": "826dea02-e274-affe-aabc-eb3db63ad068",
             "bundle_version": "2022-06-01T00:00:00.000000Z",
@@ -3839,7 +3839,7 @@
             "sources": [
                 {
                     "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                    "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
+                    "spec": "tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2"
                 }
             ],
             "bundles": [
@@ -4075,7 +4075,7 @@
             "document_id": "bfd991f2-2797-4083-972a-da7c6d7f1b2e_826dea02-e274-affe-aabc-eb3db63ad068_2022-06-01T00:00:00.000000Z_exists",
             "source": {
                 "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
+                "spec": "tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2"
             },
             "bundle_uuid": "826dea02-e274-affe-aabc-eb3db63ad068",
             "bundle_version": "2022-06-01T00:00:00.000000Z",

--- a/test/indexer/data/826dea02-e274-affe-aabc-eb3db63ad068.results.json
+++ b/test/indexer/data/826dea02-e274-affe-aabc-eb3db63ad068.results.json
@@ -230,7 +230,7 @@
             "sources": [
                 {
                     "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                    "spec": "tdr:test_anvil_project:snapshot/anvil_snapshot:/2"
+                    "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
                 }
             ],
             "bundles": [
@@ -421,7 +421,7 @@
             "document_id": "1509ef40-d1ba-440d-b298-16b7c173dcd4_826dea02-e274-affe-aabc-eb3db63ad068_2022-06-01T00:00:00.000000Z_exists",
             "source": {
                 "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                "spec": "tdr:test_anvil_project:snapshot/anvil_snapshot:/2"
+                "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
             },
             "bundle_uuid": "826dea02-e274-affe-aabc-eb3db63ad068",
             "bundle_version": "2022-06-01T00:00:00.000000Z",
@@ -664,7 +664,7 @@
             "sources": [
                 {
                     "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                    "spec": "tdr:test_anvil_project:snapshot/anvil_snapshot:/2"
+                    "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
                 }
             ],
             "bundles": [
@@ -855,7 +855,7 @@
             "document_id": "15b76f9c-6b46-433f-851d-34e89f1b9ba6_826dea02-e274-affe-aabc-eb3db63ad068_2022-06-01T00:00:00.000000Z_exists",
             "source": {
                 "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                "spec": "tdr:test_anvil_project:snapshot/anvil_snapshot:/2"
+                "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
             },
             "bundle_uuid": "826dea02-e274-affe-aabc-eb3db63ad068",
             "bundle_version": "2022-06-01T00:00:00.000000Z",
@@ -1226,7 +1226,7 @@
             "sources": [
                 {
                     "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                    "spec": "tdr:test_anvil_project:snapshot/anvil_snapshot:/2"
+                    "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
                 }
             ],
             "bundles": [
@@ -1462,7 +1462,7 @@
             "document_id": "2370f948-2783-4eb6-afea-e022897f4dcf_826dea02-e274-affe-aabc-eb3db63ad068_2022-06-01T00:00:00.000000Z_exists",
             "source": {
                 "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                "spec": "tdr:test_anvil_project:snapshot/anvil_snapshot:/2"
+                "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
             },
             "bundle_uuid": "826dea02-e274-affe-aabc-eb3db63ad068",
             "bundle_version": "2022-06-01T00:00:00.000000Z",
@@ -1709,7 +1709,7 @@
             "sources": [
                 {
                     "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                    "spec": "tdr:test_anvil_project:snapshot/anvil_snapshot:/2"
+                    "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
                 }
             ],
             "bundles": [
@@ -1932,7 +1932,7 @@
             "document_id": "3b17377b-16b1-431c-9967-e5d01fc5923f_826dea02-e274-affe-aabc-eb3db63ad068_2022-06-01T00:00:00.000000Z_exists",
             "source": {
                 "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                "spec": "tdr:test_anvil_project:snapshot/anvil_snapshot:/2"
+                "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
             },
             "bundle_uuid": "826dea02-e274-affe-aabc-eb3db63ad068",
             "bundle_version": "2022-06-01T00:00:00.000000Z",
@@ -2170,7 +2170,7 @@
             "sources": [
                 {
                     "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                    "spec": "tdr:test_anvil_project:snapshot/anvil_snapshot:/2"
+                    "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
                 }
             ],
             "bundles": [
@@ -2391,7 +2391,7 @@
             "document_id": "816e364e-1193-4e5b-a91a-14e4b009157c_826dea02-e274-affe-aabc-eb3db63ad068_2022-06-01T00:00:00.000000Z_exists",
             "source": {
                 "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                "spec": "tdr:test_anvil_project:snapshot/anvil_snapshot:/2"
+                "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
             },
             "bundle_uuid": "826dea02-e274-affe-aabc-eb3db63ad068",
             "bundle_version": "2022-06-01T00:00:00.000000Z",
@@ -2686,7 +2686,7 @@
             "sources": [
                 {
                     "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                    "spec": "tdr:test_anvil_project:snapshot/anvil_snapshot:/2"
+                    "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
                 }
             ],
             "bundles": [
@@ -2922,7 +2922,7 @@
             "document_id": "826dea02-e274-4ffe-aabc-eb3db63ad068_826dea02-e274-affe-aabc-eb3db63ad068_2022-06-01T00:00:00.000000Z_exists",
             "source": {
                 "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                "spec": "tdr:test_anvil_project:snapshot/anvil_snapshot:/2"
+                "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
             },
             "bundle_uuid": "826dea02-e274-affe-aabc-eb3db63ad068",
             "bundle_version": "2022-06-01T00:00:00.000000Z",
@@ -3266,7 +3266,7 @@
             "sources": [
                 {
                     "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                    "spec": "tdr:test_anvil_project:snapshot/anvil_snapshot:/2"
+                    "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
                 }
             ],
             "bundles": [
@@ -3502,7 +3502,7 @@
             "document_id": "826dea02-e274-affe-aabc-eb3db63ad068_826dea02-e274-affe-aabc-eb3db63ad068_2022-06-01T00:00:00.000000Z_exists",
             "source": {
                 "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                "spec": "tdr:test_anvil_project:snapshot/anvil_snapshot:/2"
+                "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
             },
             "bundle_uuid": "826dea02-e274-affe-aabc-eb3db63ad068",
             "bundle_version": "2022-06-01T00:00:00.000000Z",
@@ -3839,7 +3839,7 @@
             "sources": [
                 {
                     "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                    "spec": "tdr:test_anvil_project:snapshot/anvil_snapshot:/2"
+                    "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
                 }
             ],
             "bundles": [
@@ -4075,7 +4075,7 @@
             "document_id": "bfd991f2-2797-4083-972a-da7c6d7f1b2e_826dea02-e274-affe-aabc-eb3db63ad068_2022-06-01T00:00:00.000000Z_exists",
             "source": {
                 "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
-                "spec": "tdr:test_anvil_project:snapshot/anvil_snapshot:/2"
+                "spec": "tdr:test_anvil_project:anvil_snapshot:/2"
             },
             "bundle_uuid": "826dea02-e274-affe-aabc-eb3db63ad068",
             "bundle_version": "2022-06-01T00:00:00.000000Z",

--- a/test/indexer/test_tdr.py
+++ b/test/indexer/test_tdr.py
@@ -177,7 +177,7 @@ class TDRPluginTestCase(TDRTestCase,
         # noinspection PyAbstractClass
         class Plugin(MockPlugin, self._plugin_cls()):
             netloc = self.netloc
-            project_id = self.source.spec.project
+            project_id = self.source.spec.subdomain
 
         return Plugin(sources={source_spec})
 
@@ -193,7 +193,7 @@ class TDRPluginTestCase(TDRTestCase,
                                            command=[
                                                '--log-level=debug',
                                                '--port=9050',
-                                               '--project=' + cls.source.spec.project,
+                                               '--project=' + cls.source.spec.subdomain,
                                                '--dataset=' + cls.source.spec.bq_name
                                            ])
 
@@ -228,7 +228,7 @@ class TDRPluginTestCase(TDRTestCase,
             }
 
         plugin = self.plugin_for_source_spec(source)
-        bq = plugin.tdr._bigquery(source.project)
+        bq = plugin.tdr._bigquery(source.subdomain)
         table_name = plugin._full_table_name(source, table_name)
         # https://youtrack.jetbrains.com/issue/PY-50178
         # noinspection PyTypeChecker

--- a/test/indexer/test_tdr.py
+++ b/test/indexer/test_tdr.py
@@ -194,7 +194,7 @@ class TDRPluginTestCase(TDRTestCase,
                                                '--log-level=debug',
                                                '--port=9050',
                                                '--project=' + cls.source.spec.subdomain,
-                                               '--dataset=' + cls.source.spec.bq_name
+                                               '--dataset=' + cls.source.spec.name
                                            ])
 
     def _make_mock_tdr_tables(self,

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -1720,9 +1720,9 @@ class TestAnvilManifests(AnvilManifestTestCase):
             ),
             (
                 'source_spec',
-                'tdr:test_anvil_project:anvil_snapshot:/2',
-                'tdr:test_anvil_project:anvil_snapshot:/2',
-                'tdr:test_anvil_project:anvil_snapshot:/2'
+                'tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2',
+                'tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2',
+                'tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2'
             ),
             (
                 'datasets.document_id',

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -1720,9 +1720,9 @@ class TestAnvilManifests(AnvilManifestTestCase):
             ),
             (
                 'source_spec',
-                'tdr:test_anvil_project:snapshot/anvil_snapshot:/2',
-                'tdr:test_anvil_project:snapshot/anvil_snapshot:/2',
-                'tdr:test_anvil_project:snapshot/anvil_snapshot:/2'
+                'tdr:test_anvil_project:anvil_snapshot:/2',
+                'tdr:test_anvil_project:anvil_snapshot:/2',
+                'tdr:test_anvil_project:anvil_snapshot:/2'
             ),
             (
                 'datasets.document_id',

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -176,7 +176,7 @@ class TestRepositoryFilesWithTDR(DCP2TestCase, RepositoryFilesTestCase):
             self.assertEqual(response.status, 404)
 
     mock_source_names = ['mock_snapshot_1', 'mock_snapshot_2']
-    make_mock_source_spec = 'tdr:mock:snapshot/{}:/2'.format
+    make_mock_source_spec = 'tdr:mock:{}:/2'.format
 
     @classmethod
     def _sources(cls):

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -176,7 +176,7 @@ class TestRepositoryFilesWithTDR(DCP2TestCase, RepositoryFilesTestCase):
             self.assertEqual(response.status, 404)
 
     mock_source_names = ['mock_snapshot_1', 'mock_snapshot_2']
-    make_mock_source_spec = 'tdr:mock:{}:/2'.format
+    make_mock_source_spec = 'tdr:bigquery:gcp:mock:{}:/2'.format
 
     @classmethod
     def _sources(cls):

--- a/test/service/test_response_anvil.py
+++ b/test/service/test_response_anvil.py
@@ -48,7 +48,7 @@ class TestAnvilResponse(AnvilIndexerTestCase, WebServiceTestCase):
                         'entryId': '1509ef40-d1ba-440d-b298-16b7c173dcd4',
                         'sources': [
                             {
-                                'source_spec': 'tdr:test_anvil_project:snapshot/anvil_snapshot:/2',
+                                'source_spec': 'tdr:test_anvil_project:anvil_snapshot:/2',
                                 'source_id': '6c87f0e1-509d-46a4-b845-7584df39263b'
                             }
                         ],
@@ -169,7 +169,7 @@ class TestAnvilResponse(AnvilIndexerTestCase, WebServiceTestCase):
                         'entryId': '816e364e-1193-4e5b-a91a-14e4b009157c',
                         'sources': [
                             {
-                                'source_spec': 'tdr:test_anvil_project:snapshot/anvil_snapshot:/2',
+                                'source_spec': 'tdr:test_anvil_project:anvil_snapshot:/2',
                                 'source_id': '6c87f0e1-509d-46a4-b845-7584df39263b'
                             }
                         ],
@@ -524,7 +524,7 @@ class TestAnvilResponse(AnvilIndexerTestCase, WebServiceTestCase):
                         'entryId': '826dea02-e274-4ffe-aabc-eb3db63ad068',
                         'sources': [
                             {
-                                'source_spec': 'tdr:test_anvil_project:snapshot/anvil_snapshot:/2',
+                                'source_spec': 'tdr:test_anvil_project:anvil_snapshot:/2',
                                 'source_id': '6c87f0e1-509d-46a4-b845-7584df39263b'
                             }
                         ],
@@ -953,7 +953,7 @@ class TestAnvilResponse(AnvilIndexerTestCase, WebServiceTestCase):
                         'sources': [
                             {
                                 'source_id': '6c87f0e1-509d-46a4-b845-7584df39263b',
-                                'source_spec': 'tdr:test_anvil_project:snapshot/anvil_snapshot:/2'
+                                'source_spec': 'tdr:test_anvil_project:anvil_snapshot:/2'
                             }
                         ]
                     }
@@ -1088,7 +1088,7 @@ class TestAnvilResponse(AnvilIndexerTestCase, WebServiceTestCase):
                         'entryId': '2370f948-2783-4eb6-afea-e022897f4dcf',
                         'sources': [
                             {
-                                'source_spec': 'tdr:test_anvil_project:snapshot/anvil_snapshot:/2',
+                                'source_spec': 'tdr:test_anvil_project:anvil_snapshot:/2',
                                 'source_id': '6c87f0e1-509d-46a4-b845-7584df39263b'
                             }
                         ],
@@ -1469,7 +1469,7 @@ class TestAnvilResponse(AnvilIndexerTestCase, WebServiceTestCase):
                         'entryId': 'bfd991f2-2797-4083-972a-da7c6d7f1b2e',
                         'sources': [
                             {
-                                'source_spec': 'tdr:test_anvil_project:snapshot/anvil_snapshot:/2',
+                                'source_spec': 'tdr:test_anvil_project:anvil_snapshot:/2',
                                 'source_id': '6c87f0e1-509d-46a4-b845-7584df39263b'
                             }
                         ],
@@ -1845,7 +1845,7 @@ class TestAnvilResponse(AnvilIndexerTestCase, WebServiceTestCase):
                         'entryId': '15b76f9c-6b46-433f-851d-34e89f1b9ba6',
                         'sources': [
                             {
-                                'source_spec': 'tdr:test_anvil_project:snapshot/anvil_snapshot:/2',
+                                'source_spec': 'tdr:test_anvil_project:anvil_snapshot:/2',
                                 'source_id': '6c87f0e1-509d-46a4-b845-7584df39263b'
                             }
                         ],
@@ -1974,7 +1974,7 @@ class TestAnvilResponse(AnvilIndexerTestCase, WebServiceTestCase):
                         'entryId': '3b17377b-16b1-431c-9967-e5d01fc5923f',
                         'sources': [
                             {
-                                'source_spec': 'tdr:test_anvil_project:snapshot/anvil_snapshot:/2',
+                                'source_spec': 'tdr:test_anvil_project:anvil_snapshot:/2',
                                 'source_id': '6c87f0e1-509d-46a4-b845-7584df39263b'
                             }
                         ],

--- a/test/service/test_response_anvil.py
+++ b/test/service/test_response_anvil.py
@@ -48,7 +48,7 @@ class TestAnvilResponse(AnvilIndexerTestCase, WebServiceTestCase):
                         'entryId': '1509ef40-d1ba-440d-b298-16b7c173dcd4',
                         'sources': [
                             {
-                                'source_spec': 'tdr:test_anvil_project:anvil_snapshot:/2',
+                                'source_spec': 'tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2',
                                 'source_id': '6c87f0e1-509d-46a4-b845-7584df39263b'
                             }
                         ],
@@ -169,7 +169,7 @@ class TestAnvilResponse(AnvilIndexerTestCase, WebServiceTestCase):
                         'entryId': '816e364e-1193-4e5b-a91a-14e4b009157c',
                         'sources': [
                             {
-                                'source_spec': 'tdr:test_anvil_project:anvil_snapshot:/2',
+                                'source_spec': 'tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2',
                                 'source_id': '6c87f0e1-509d-46a4-b845-7584df39263b'
                             }
                         ],
@@ -524,7 +524,7 @@ class TestAnvilResponse(AnvilIndexerTestCase, WebServiceTestCase):
                         'entryId': '826dea02-e274-4ffe-aabc-eb3db63ad068',
                         'sources': [
                             {
-                                'source_spec': 'tdr:test_anvil_project:anvil_snapshot:/2',
+                                'source_spec': 'tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2',
                                 'source_id': '6c87f0e1-509d-46a4-b845-7584df39263b'
                             }
                         ],
@@ -953,7 +953,7 @@ class TestAnvilResponse(AnvilIndexerTestCase, WebServiceTestCase):
                         'sources': [
                             {
                                 'source_id': '6c87f0e1-509d-46a4-b845-7584df39263b',
-                                'source_spec': 'tdr:test_anvil_project:anvil_snapshot:/2'
+                                'source_spec': 'tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2'
                             }
                         ]
                     }
@@ -1088,7 +1088,7 @@ class TestAnvilResponse(AnvilIndexerTestCase, WebServiceTestCase):
                         'entryId': '2370f948-2783-4eb6-afea-e022897f4dcf',
                         'sources': [
                             {
-                                'source_spec': 'tdr:test_anvil_project:anvil_snapshot:/2',
+                                'source_spec': 'tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2',
                                 'source_id': '6c87f0e1-509d-46a4-b845-7584df39263b'
                             }
                         ],
@@ -1469,7 +1469,7 @@ class TestAnvilResponse(AnvilIndexerTestCase, WebServiceTestCase):
                         'entryId': 'bfd991f2-2797-4083-972a-da7c6d7f1b2e',
                         'sources': [
                             {
-                                'source_spec': 'tdr:test_anvil_project:anvil_snapshot:/2',
+                                'source_spec': 'tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2',
                                 'source_id': '6c87f0e1-509d-46a4-b845-7584df39263b'
                             }
                         ],
@@ -1845,7 +1845,7 @@ class TestAnvilResponse(AnvilIndexerTestCase, WebServiceTestCase):
                         'entryId': '15b76f9c-6b46-433f-851d-34e89f1b9ba6',
                         'sources': [
                             {
-                                'source_spec': 'tdr:test_anvil_project:anvil_snapshot:/2',
+                                'source_spec': 'tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2',
                                 'source_id': '6c87f0e1-509d-46a4-b845-7584df39263b'
                             }
                         ],
@@ -1974,7 +1974,7 @@ class TestAnvilResponse(AnvilIndexerTestCase, WebServiceTestCase):
                         'entryId': '3b17377b-16b1-431c-9967-e5d01fc5923f',
                         'sources': [
                             {
-                                'source_spec': 'tdr:test_anvil_project:anvil_snapshot:/2',
+                                'source_spec': 'tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2',
                                 'source_id': '6c87f0e1-509d-46a4-b845-7584df39263b'
                             }
                         ],


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Connected issues: #6426


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make image_manifests.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `image_manifests.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [ ] ~~Actually approved the PR~~
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved ticket to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for `dev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for `anvildev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
