### PR TITLE
Fix: Verbatim JSONL manifest issues (#6453)

### DIFF
--- a/src/azul/plugins/metadata/hca/indexer/transform.py
+++ b/src/azul/plugins/metadata/hca/indexer/transform.py
@@ -462,8 +462,8 @@ class BaseTransformer(Transformer, metaclass=ABCMeta):
     api_bundle: api.Bundle
 
     def replica_type(self, entity: EntityReference) -> str:
-        assert entity.entity_type == self.entity_type(), entity
-        return entity.entity_type.removesuffix('s')
+        api_entity = self.api_bundle.entities[UUID(entity.entity_id)]
+        return api_entity.schema_name
 
     @classmethod
     def aggregator(cls, entity_type: EntityType) -> Optional[EntityAggregator]:

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -2081,7 +2081,7 @@ class JSONLVerbatimManifestGenerator(VerbatimManifestGenerator):
         with open(path, 'w') as f:
             for replica in self._all_replicas():
                 entry = {
-                    'contents': replica['contents'],
+                    'value': replica['contents'],
                     'type': replica['replica_type']
                 }
                 json.dump(entry, f)

--- a/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T11:33:44.698028Z.results.json
+++ b/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T11:33:44.698028Z.results.json
@@ -3471,7 +3471,7 @@
                 }
             },
             "entity_id": "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
-            "replica_type": "file",
+            "replica_type": "sequence_file",
             "hub_ids": [
                 "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb"
             ]
@@ -3541,7 +3541,7 @@
                 }
             },
             "entity_id": "70d1af4a-82c8-478a-8960-e9028b3616ca",
-            "replica_type": "file",
+            "replica_type": "sequence_file",
             "hub_ids": [
                 "70d1af4a-82c8-478a-8960-e9028b3616ca"
             ]
@@ -3593,7 +3593,7 @@
                 }
             },
             "entity_id": "a21dc760-a500-4236-bcff-da34a0e873d2",
-            "replica_type": "sample",
+            "replica_type": "specimen_from_organism",
             "hub_ids": [
                 "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
                 "70d1af4a-82c8-478a-8960-e9028b3616ca"

--- a/test/service/data/verbatim/hca/pfb_entities.json
+++ b/test/service/data/verbatim/hca/pfb_entities.json
@@ -14,13 +14,6 @@
                 },
                 {
                     "links": [],
-                    "name": "file",
-                    "ontology_reference": "",
-                    "properties": [],
-                    "values": {}
-                },
-                {
-                    "links": [],
                     "name": "links",
                     "ontology_reference": "",
                     "properties": [],
@@ -35,7 +28,14 @@
                 },
                 {
                     "links": [],
-                    "name": "sample",
+                    "name": "sequence_file",
+                    "ontology_reference": "",
+                    "properties": [],
+                    "values": {}
+                },
+                {
+                    "links": [],
+                    "name": "specimen_from_organism",
                     "ontology_reference": "",
                     "properties": [],
                     "values": {}
@@ -46,7 +46,7 @@
     },
     {
         "id": "70d1af4a-82c8-478a-8960-e9028b3616ca",
-        "name": "file",
+        "name": "sequence_file",
         "object": {
             "describedBy": "https://schema.humancellatlas.org/type/file/6.5.2/sequence_file",
             "file_core": {
@@ -69,7 +69,7 @@
     },
     {
         "id": "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
-        "name": "file",
+        "name": "sequence_file",
         "object": {
             "describedBy": "https://schema.humancellatlas.org/type/file/6.5.2/sequence_file",
             "file_core": {
@@ -122,7 +122,7 @@
     },
     {
         "id": "a21dc760-a500-4236-bcff-da34a0e873d2",
-        "name": "sample",
+        "name": "specimen_from_organism",
         "object": {
             "biomaterial_core": {
                 "biomaterial_id": "DID_scRSq06_pancreas",

--- a/test/service/data/verbatim/hca/pfb_schema.json
+++ b/test/service/data/verbatim/hca/pfb_schema.json
@@ -226,85 +226,6 @@
                     "fields": [
                         {
                             "name": "describedBy",
-                            "namespace": "file",
-                            "type": "string"
-                        },
-                        {
-                            "name": "file_core",
-                            "namespace": "file",
-                            "type": {
-                                "fields": [
-                                    {
-                                        "name": "file_format",
-                                        "namespace": "file.file_core",
-                                        "type": "string"
-                                    },
-                                    {
-                                        "name": "file_name",
-                                        "namespace": "file.file_core",
-                                        "type": "string"
-                                    }
-                                ],
-                                "name": "file.file_core",
-                                "type": "record"
-                            }
-                        },
-                        {
-                            "name": "insdc_run",
-                            "namespace": "file",
-                            "type": {
-                                "items": "string",
-                                "type": "array"
-                            }
-                        },
-                        {
-                            "name": "provenance",
-                            "namespace": "file",
-                            "type": {
-                                "fields": [
-                                    {
-                                        "name": "document_id",
-                                        "namespace": "file.provenance",
-                                        "type": "string"
-                                    },
-                                    {
-                                        "name": "submission_date",
-                                        "namespace": "file.provenance",
-                                        "type": "string"
-                                    },
-                                    {
-                                        "name": "update_date",
-                                        "namespace": "file.provenance",
-                                        "type": "string"
-                                    }
-                                ],
-                                "name": "file.provenance",
-                                "type": "record"
-                            }
-                        },
-                        {
-                            "name": "read_index",
-                            "namespace": "file",
-                            "type": "string"
-                        },
-                        {
-                            "name": "read_length",
-                            "namespace": "file",
-                            "type": "long"
-                        },
-                        {
-                            "name": "schema_type",
-                            "namespace": "file",
-                            "type": "string"
-                        }
-                    ],
-                    "name": "file",
-                    "type": "record"
-                },
-                {
-                    "fields": [
-                        {
-                            "name": "describedBy",
                             "namespace": "links",
                             "type": "string"
                         },
@@ -595,56 +516,135 @@
                 {
                     "fields": [
                         {
+                            "name": "describedBy",
+                            "namespace": "sequence_file",
+                            "type": "string"
+                        },
+                        {
+                            "name": "file_core",
+                            "namespace": "sequence_file",
+                            "type": {
+                                "fields": [
+                                    {
+                                        "name": "file_format",
+                                        "namespace": "sequence_file.file_core",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "name": "file_name",
+                                        "namespace": "sequence_file.file_core",
+                                        "type": "string"
+                                    }
+                                ],
+                                "name": "sequence_file.file_core",
+                                "type": "record"
+                            }
+                        },
+                        {
+                            "name": "insdc_run",
+                            "namespace": "sequence_file",
+                            "type": {
+                                "items": "string",
+                                "type": "array"
+                            }
+                        },
+                        {
+                            "name": "provenance",
+                            "namespace": "sequence_file",
+                            "type": {
+                                "fields": [
+                                    {
+                                        "name": "document_id",
+                                        "namespace": "sequence_file.provenance",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "name": "submission_date",
+                                        "namespace": "sequence_file.provenance",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "name": "update_date",
+                                        "namespace": "sequence_file.provenance",
+                                        "type": "string"
+                                    }
+                                ],
+                                "name": "sequence_file.provenance",
+                                "type": "record"
+                            }
+                        },
+                        {
+                            "name": "read_index",
+                            "namespace": "sequence_file",
+                            "type": "string"
+                        },
+                        {
+                            "name": "read_length",
+                            "namespace": "sequence_file",
+                            "type": "long"
+                        },
+                        {
+                            "name": "schema_type",
+                            "namespace": "sequence_file",
+                            "type": "string"
+                        }
+                    ],
+                    "name": "sequence_file",
+                    "type": "record"
+                },
+                {
+                    "fields": [
+                        {
                             "name": "biomaterial_core",
-                            "namespace": "sample",
+                            "namespace": "specimen_from_organism",
                             "type": {
                                 "fields": [
                                     {
                                         "name": "biomaterial_id",
-                                        "namespace": "sample.biomaterial_core",
+                                        "namespace": "specimen_from_organism.biomaterial_core",
                                         "type": "string"
                                     },
                                     {
                                         "name": "ncbi_taxon_id",
-                                        "namespace": "sample.biomaterial_core",
+                                        "namespace": "specimen_from_organism.biomaterial_core",
                                         "type": {
                                             "items": "long",
                                             "type": "array"
                                         }
                                     }
                                 ],
-                                "name": "sample.biomaterial_core",
+                                "name": "specimen_from_organism.biomaterial_core",
                                 "type": "record"
                             }
                         },
                         {
                             "name": "describedBy",
-                            "namespace": "sample",
+                            "namespace": "specimen_from_organism",
                             "type": "string"
                         },
                         {
                             "name": "diseases",
-                            "namespace": "sample",
+                            "namespace": "specimen_from_organism",
                             "type": {
                                 "items": {
                                     "fields": [
                                         {
                                             "name": "ontology",
-                                            "namespace": "sample.diseases",
+                                            "namespace": "specimen_from_organism.diseases",
                                             "type": "string"
                                         },
                                         {
                                             "name": "ontology_label",
-                                            "namespace": "sample.diseases",
+                                            "namespace": "specimen_from_organism.diseases",
                                             "type": "string"
                                         },
                                         {
                                             "name": "text",
-                                            "namespace": "sample.diseases",
+                                            "namespace": "specimen_from_organism.diseases",
                                             "type": "string"
                                         }
                                     ],
-                                    "name": "sample.diseases",
+                                    "name": "specimen_from_organism.diseases",
                                     "type": "record"
                                 },
                                 "type": "array"
@@ -652,27 +652,27 @@
                         },
                         {
                             "name": "genus_species",
-                            "namespace": "sample",
+                            "namespace": "specimen_from_organism",
                             "type": {
                                 "items": {
                                     "fields": [
                                         {
                                             "name": "ontology",
-                                            "namespace": "sample.genus_species",
+                                            "namespace": "specimen_from_organism.genus_species",
                                             "type": "string"
                                         },
                                         {
                                             "name": "ontology_label",
-                                            "namespace": "sample.genus_species",
+                                            "namespace": "specimen_from_organism.genus_species",
                                             "type": "string"
                                         },
                                         {
                                             "name": "text",
-                                            "namespace": "sample.genus_species",
+                                            "namespace": "specimen_from_organism.genus_species",
                                             "type": "string"
                                         }
                                     ],
-                                    "name": "sample.genus_species",
+                                    "name": "specimen_from_organism.genus_species",
                                     "type": "record"
                                 },
                                 "type": "array"
@@ -680,86 +680,86 @@
                         },
                         {
                             "name": "organ",
-                            "namespace": "sample",
+                            "namespace": "specimen_from_organism",
                             "type": {
                                 "fields": [
                                     {
                                         "name": "ontology",
-                                        "namespace": "sample.organ",
+                                        "namespace": "specimen_from_organism.organ",
                                         "type": "string"
                                     },
                                     {
                                         "name": "ontology_label",
-                                        "namespace": "sample.organ",
+                                        "namespace": "specimen_from_organism.organ",
                                         "type": "string"
                                     },
                                     {
                                         "name": "text",
-                                        "namespace": "sample.organ",
+                                        "namespace": "specimen_from_organism.organ",
                                         "type": "string"
                                     }
                                 ],
-                                "name": "sample.organ",
+                                "name": "specimen_from_organism.organ",
                                 "type": "record"
                             }
                         },
                         {
                             "name": "organ_part",
-                            "namespace": "sample",
+                            "namespace": "specimen_from_organism",
                             "type": {
                                 "fields": [
                                     {
                                         "name": "ontology",
-                                        "namespace": "sample.organ_part",
+                                        "namespace": "specimen_from_organism.organ_part",
                                         "type": "string"
                                     },
                                     {
                                         "name": "ontology_label",
-                                        "namespace": "sample.organ_part",
+                                        "namespace": "specimen_from_organism.organ_part",
                                         "type": "string"
                                     },
                                     {
                                         "name": "text",
-                                        "namespace": "sample.organ_part",
+                                        "namespace": "specimen_from_organism.organ_part",
                                         "type": "string"
                                     }
                                 ],
-                                "name": "sample.organ_part",
+                                "name": "specimen_from_organism.organ_part",
                                 "type": "record"
                             }
                         },
                         {
                             "name": "provenance",
-                            "namespace": "sample",
+                            "namespace": "specimen_from_organism",
                             "type": {
                                 "fields": [
                                     {
                                         "name": "document_id",
-                                        "namespace": "sample.provenance",
+                                        "namespace": "specimen_from_organism.provenance",
                                         "type": "string"
                                     },
                                     {
                                         "name": "submission_date",
-                                        "namespace": "sample.provenance",
+                                        "namespace": "specimen_from_organism.provenance",
                                         "type": "string"
                                     },
                                     {
                                         "name": "update_date",
-                                        "namespace": "sample.provenance",
+                                        "namespace": "specimen_from_organism.provenance",
                                         "type": "string"
                                     }
                                 ],
-                                "name": "sample.provenance",
+                                "name": "specimen_from_organism.provenance",
                                 "type": "record"
                             }
                         },
                         {
                             "name": "schema_type",
-                            "namespace": "sample",
+                            "namespace": "specimen_from_organism",
                             "type": "string"
                         }
                     ],
-                    "name": "sample",
+                    "name": "specimen_from_organism",
                     "type": "record"
                 }
             ]

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -1333,7 +1333,7 @@ class TestManifests(DCP1ManifestTestCase, PFBTestCase):
         expected = [
             {
                 'type': replica_type,
-                'contents': bundle.metadata_files[key],
+                'value': bundle.metadata_files[key],
             }
             for bundle in map(self._load_canned_bundle, self.bundles())
             for replica_type, key in [
@@ -2082,7 +2082,7 @@ class TestAnvilManifests(AnvilManifestTestCase):
             # Consolidate entities with the same replica (i.e. datasets)
             json_hash(entity).digest(): {
                 'type': 'anvil_' + entity_ref.entity_type,
-                'contents': entity,
+                'value': entity,
             }
             for bundle in self.bundles()
             for entity_ref, entity in self._load_canned_bundle(bundle).entities.items()

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -1340,9 +1340,9 @@ class TestManifests(DCP1ManifestTestCase, PFBTestCase):
                 ('links', 'links.json'),
                 ('cell_suspension', 'cell_suspension_0.json'),
                 ('project', 'project_0.json'),
-                ('file', 'sequence_file_0.json'),
-                ('file', 'sequence_file_1.json'),
-                ('sample', 'specimen_from_organism_0.json')
+                ('sequence_file', 'sequence_file_0.json'),
+                ('sequence_file', 'sequence_file_1.json'),
+                ('specimen_from_organism', 'specimen_from_organism_0.json')
             ]
         ]
         response = self._get_manifest(ManifestFormat.verbatim_jsonl, {})


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Connected issues: #6453


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make image_manifests.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `image_manifests.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved ticket to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for `dev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for `anvildev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
