### PR TITLE
Fix: No replicas for donors in HCA (#6582)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1819,14 +1819,14 @@ the private key and can always be regenerated again later using `make config`.
 
 ### 9.1.2 Ensuring split tunnel on client
 
-It is important that you configure the client to only route VPC traffic
-through the VPN. The VPN server will not forward any other traffic, in what's
-commonly referred to as a *split tunnel*. The key indicator of a split tunnel
-is that it doesn't set up a default route on the client system. There will
-only be a route to the private 172.… subnet of the GitLab VPC but the default
-route remains in place. If you configure the VPN connection to set up a
-default route, your Internet access will be severed as soon as you establish
-the VPN connection. 
+Except on stable deployments, you should configure the client to only route VPC
+traffic through the VPN. The VPN server will not forward any other traffic, in
+what's commonly referred to as a *split tunnel*. The key indicator of a split
+tunnel is that it doesn't set up a default route on the client system. There
+will only be a route to the private 172.… subnet of the GitLab VPC but the
+default route remains in place.
+
+On stable deployments, split tunnels are prohibited.
 
 The `make config` step prints instruction on how to configure a split tunnel
 on Ubuntu. 

--- a/src/azul/indexer/transform.py
+++ b/src/azul/indexer/transform.py
@@ -34,7 +34,6 @@ from azul.json import (
 )
 from azul.types import (
     JSON,
-    MutableJSON,
 )
 
 Transform = tuple[Optional[Contribution], Optional[Replica]]
@@ -114,7 +113,7 @@ class Transformer(metaclass=ABCMeta):
         raise NotImplementedError
 
     def _contribution(self,
-                      contents: MutableJSON,
+                      contents: JSON,
                       entity: EntityReference
                       ) -> Contribution:
         coordinates = ContributionCoordinates(entity=entity,
@@ -126,7 +125,7 @@ class Transformer(metaclass=ABCMeta):
                             contents=contents)
 
     def _replica(self,
-                 contents: MutableJSON,
+                 contents: JSON,
                  entity: EntityReference,
                  hub_ids: list[EntityID]
                  ) -> Replica:

--- a/src/azul/indexer/transform.py
+++ b/src/azul/indexer/transform.py
@@ -11,6 +11,9 @@ from typing import (
 
 import attr
 
+from azul.collections import (
+    alist,
+)
 from azul.indexer import (
     Bundle,
     BundleFQID,
@@ -129,7 +132,8 @@ class Transformer(metaclass=ABCMeta):
 
     def _replica(self,
                  entity: EntityReference,
-                 hub_ids: list[EntityID]
+                 *,
+                 file_hub: EntityID | None,
                  ) -> Replica:
         replica_type, contents = self._replicate(entity)
         coordinates = ReplicaCoordinates(content_hash=json_hash(contents).hexdigest(),
@@ -138,7 +142,9 @@ class Transformer(metaclass=ABCMeta):
                        version=None,
                        replica_type=replica_type,
                        contents=contents,
-                       hub_ids=hub_ids)
+                       # The other hubs will be added when the indexer
+                       # consolidates duplicate replicas.
+                       hub_ids=alist(file_hub))
 
     @classmethod
     @abstractmethod

--- a/src/azul/plugins/metadata/anvil/__init__.py
+++ b/src/azul/plugins/metadata/anvil/__init__.py
@@ -36,7 +36,6 @@ from azul.plugins.metadata.anvil.indexer.transform import (
     BiosampleTransformer,
     BundleTransformer,
     DatasetTransformer,
-    DiagnosisTransformer,
     DonorTransformer,
     FileTransformer,
 )
@@ -96,7 +95,6 @@ class Plugin(MetadataPlugin[AnvilBundle]):
             BiosampleTransformer,
             BundleTransformer,
             DatasetTransformer,
-            DiagnosisTransformer,
             DonorTransformer,
             FileTransformer,
         )

--- a/src/azul/plugins/metadata/anvil/indexer/transform.py
+++ b/src/azul/plugins/metadata/anvil/indexer/transform.py
@@ -182,7 +182,7 @@ class BaseTransformer(Transformer, metaclass=ABCMeta):
         raise NotImplementedError
 
     def _add_replica(self,
-                     contribution: MutableJSON | None,
+                     contribution: JSON | None,
                      entity: EntityReference,
                      hub_ids: list[EntityID]
                      ) -> Transform:
@@ -335,7 +335,7 @@ class BaseTransformer(Transformer, metaclass=ABCMeta):
         }
 
     def _contribution(self,
-                      contents: MutableJSON,
+                      contents: JSON,
                       entity: EntityReference,
                       ) -> Contribution:
         # The entity type is used to determine the index name.

--- a/src/azul/plugins/metadata/anvil/indexer/transform.py
+++ b/src/azul/plugins/metadata/anvil/indexer/transform.py
@@ -97,6 +97,12 @@ class LinkedEntities:
     def __getitem__(self, item: EntityType) -> set[EntityReference]:
         return self.ancestors[item] | self.descendants[item]
 
+    def __iter__(self) -> Iterable[EntityReference]:
+        for entities in self.ancestors.values():
+            yield from entities
+        for entities in self.descendants.values():
+            yield from entities
+
     @classmethod
     def from_links(cls,
                    origin: EntityReference,
@@ -449,8 +455,8 @@ class BaseTransformer(Transformer, metaclass=ABCMeta):
 
 class SingletonTransformer(BaseTransformer, metaclass=ABCMeta):
 
-    def _contents(self) -> MutableJSON:
-        return dict(
+    def _transform(self, entity: EntityReference) -> Iterable[Contribution]:
+        contents = dict(
             activities=self._entities(self._activity, chain.from_iterable(
                 self._entities_by_type[activity_type]
                 for activity_type in self._activity_polymorphic_types
@@ -461,6 +467,7 @@ class SingletonTransformer(BaseTransformer, metaclass=ABCMeta):
             donors=self._entities(self._donor, self._entities_by_type['donor']),
             files=self._entities(self._file, self._entities_by_type['file'])
         )
+        yield self._contribution(contents, entity.entity_id)
 
     @classmethod
     def field_types(cls) -> FieldTypes:
@@ -479,8 +486,11 @@ class SingletonTransformer(BaseTransformer, metaclass=ABCMeta):
     def _duos(self, dataset: EntityReference) -> MutableJSON:
         return self._entity(dataset, self._duos_types())
 
+    def _is_duos(self, dataset: EntityReference) -> bool:
+        return 'description' in self.bundle.entities[dataset]
+
     def _dataset(self, dataset: EntityReference) -> MutableJSON:
-        if 'description' in self.bundle.entities[dataset]:
+        if self._is_duos(dataset):
             return self._duos(dataset)
         else:
             return super()._dataset(dataset)
@@ -499,23 +509,17 @@ class ActivityTransformer(BaseTransformer):
     def entity_type(cls) -> str:
         return 'activities'
 
-    def _transform(self,
-                   entity: EntityReference
-                   ) -> Iterable[Contribution | Replica]:
+    def _transform(self, entity: EntityReference) -> Iterable[Contribution]:
         linked = self._linked_entities(entity)
-        files = linked['file']
         contents = dict(
             activities=[self._activity(entity)],
             biosamples=self._entities(self._biosample, linked['biosample']),
             datasets=[self._dataset(self._only_dataset())],
             diagnoses=self._entities(self._diagnosis, linked['diagnosis']),
             donors=self._entities(self._donor, linked['donor']),
-            files=self._entities(self._file, files),
+            files=self._entities(self._file, linked['file'])
         )
         yield self._contribution(contents, entity.entity_id)
-        if config.enable_replicas:
-            hub_ids = [f.entity_id for f in files]
-            yield self._replica(entity, hub_ids)
 
 
 class BiosampleTransformer(BaseTransformer):
@@ -524,11 +528,8 @@ class BiosampleTransformer(BaseTransformer):
     def entity_type(cls) -> str:
         return 'biosamples'
 
-    def _transform(self,
-                   entity: EntityReference
-                   ) -> Iterable[Contribution | Replica]:
+    def _transform(self, entity: EntityReference) -> Iterable[Contribution]:
         linked = self._linked_entities(entity)
-        files = linked['file']
         contents = dict(
             activities=self._entities(self._activity, chain.from_iterable(
                 linked[activity_type]
@@ -538,25 +539,9 @@ class BiosampleTransformer(BaseTransformer):
             datasets=[self._dataset(self._only_dataset())],
             diagnoses=self._entities(self._diagnosis, linked['diagnosis']),
             donors=self._entities(self._donor, linked['donor']),
-            files=self._entities(self._file, files),
+            files=self._entities(self._file, linked['file']),
         )
         yield self._contribution(contents, entity.entity_id)
-        if config.enable_replicas:
-            hub_ids = [f.entity_id for f in files]
-            yield self._replica(entity, hub_ids)
-
-
-class DiagnosisTransformer(BaseTransformer):
-
-    def _transform(self, entity: EntityReference) -> Iterable[Replica]:
-        if config.enable_replicas:
-            files = self._linked_entities(entity)['file']
-            hub_ids = [f.entity_id for f in files]
-            yield self._replica(entity, hub_ids)
-
-    @classmethod
-    def entity_type(cls) -> EntityType:
-        return 'diagnoses'
 
 
 class BundleTransformer(SingletonTransformer):
@@ -568,10 +553,6 @@ class BundleTransformer(SingletonTransformer):
     def _singleton(self) -> EntityReference:
         return EntityReference(entity_type='bundle',
                                entity_id=self.bundle.uuid)
-
-    def _transform(self, entity: EntityReference) -> Iterable[Contribution]:
-        contents = self._contents()
-        yield self._contribution(contents, entity.entity_id)
 
 
 class DatasetTransformer(SingletonTransformer):
@@ -586,18 +567,9 @@ class DatasetTransformer(SingletonTransformer):
     def _transform(self,
                    entity: EntityReference
                    ) -> Iterable[Contribution | Replica]:
-        contents = self._contents()
-        yield self._contribution(contents, entity.entity_id)
-        if config.enable_replicas:
-            # Every file in a snapshot is linked to that snapshot's singular
-            # dataset, making an explicit list of hub IDs for the dataset both
-            # redundant and impractically large (we observe that for large
-            # snapshots, trying to track this many files in a single data structure
-            # causes a prohibitively high rate of conflicts during replica updates).
-            # Therefore, we leave the hub IDs field empty for datasets and rely on
-            # the tenet that every file is an implicit hub of its parent dataset.
-            hub_ids = []
-            yield self._replica(entity, hub_ids)
+        yield from super()._transform(entity)
+        if self._is_duos(entity):
+            yield self._replica(entity, file_hub=None)
 
 
 class DonorTransformer(BaseTransformer):
@@ -606,11 +578,8 @@ class DonorTransformer(BaseTransformer):
     def entity_type(cls) -> str:
         return 'donors'
 
-    def _transform(self,
-                   entity: EntityReference
-                   ) -> Iterable[Contribution | Replica]:
+    def _transform(self, entity: EntityReference) -> Iterable[Contribution]:
         linked = self._linked_entities(entity)
-        files = linked['file']
         contents = dict(
             activities=self._entities(self._activity, chain.from_iterable(
                 linked[activity_type]
@@ -620,12 +589,9 @@ class DonorTransformer(BaseTransformer):
             datasets=[self._dataset(self._only_dataset())],
             diagnoses=self._entities(self._diagnosis, linked['diagnosis']),
             donors=[self._donor(entity)],
-            files=self._entities(self._file, files),
+            files=self._entities(self._file, linked['file']),
         )
         yield self._contribution(contents, entity.entity_id)
-        if config.enable_replicas:
-            hub_ids = [f.entity_id for f in files]
-            yield self._replica(entity, hub_ids)
 
 
 class FileTransformer(BaseTransformer):
@@ -651,8 +617,14 @@ class FileTransformer(BaseTransformer):
         )
         yield self._contribution(contents, entity.entity_id)
         if config.enable_replicas:
-            # The result of the link traversal does not include the starting entity,
-            # so without this step the file itself wouldn't be included in its hubs
-            files = (entity, *linked['file'])
-            hub_ids = [f.entity_id for f in files]
-            yield self._replica(entity, hub_ids)
+            yield self._replica(entity, file_hub=entity.entity_id)
+            for linked_entity in linked:
+                yield self._replica(
+                    linked_entity,
+                    # Datasets are linked to every file in their snapshot,
+                    # making an explicit list of hub IDs for the dataset both
+                    # redundant and impractically large. Therefore, we leave the
+                    # hub IDs field empty for datasets and rely on the tenet
+                    # that every file is an implicit hub of its parent dataset.
+                    file_hub=None if linked_entity.entity_type == 'dataset' else entity.entity_id,
+                )

--- a/src/azul/plugins/metadata/hca/indexer/transform.py
+++ b/src/azul/plugins/metadata/hca/indexer/transform.py
@@ -1651,8 +1651,6 @@ class SingletonTransformer(BaseTransformer, metaclass=ABCMeta):
     def transform(self, partition: BundlePartition) -> Iterable[Transform]:
         if partition.contains(self._singleton_id):
             yield self._transform()
-        else:
-            return ()
 
     def _transform(self) -> Transform:
         # Project entities are not explicitly linked in the graph. The mere

--- a/src/azul/plugins/metadata/hca/indexer/transform.py
+++ b/src/azul/plugins/metadata/hca/indexer/transform.py
@@ -498,7 +498,7 @@ class BaseTransformer(Transformer, metaclass=ABCMeta):
             return SimpleAggregator()
 
     def _add_replica(self,
-                     contribution: MutableJSON,
+                     contribution: JSON,
                      entity: api.Entity | DatedEntity,
                      hub_ids: list[EntityID]
                      ) -> Transform:

--- a/src/azul/plugins/metadata/hca/indexer/transform.py
+++ b/src/azul/plugins/metadata/hca/indexer/transform.py
@@ -1385,7 +1385,8 @@ class TransformerVisitor(api.EntityVisitor):
             # noinspection PyDeprecation
             file_name = entity.manifest_entry.name
             is_zarr, zarr_name, sub_name = _parse_zarr_file_name(file_name)
-            # FIXME: Remove condition once https://github.com/HumanCellAtlas/metadata-schema/issues/623 is resolved
+            # zarray files no longer exist in DCP2. This condition may no longer
+            # be needed to support them, but we don't want to risk removing it.
             if not is_zarr or sub_name.endswith('.zattrs'):
                 self.files[entity.document_id] = entity
 
@@ -1433,7 +1434,8 @@ class FileTransformer(PartitionedTransformer[api.File]):
         for file in files:
             file_name = file.manifest_entry.name
             is_zarr, zarr_name, sub_name = _parse_zarr_file_name(file_name)
-            # FIXME: Remove condition once https://github.com/HumanCellAtlas/metadata-schema/issues/579 is resolved
+            # zarray files no longer exist in DCP2. This condition may no longer
+            # be needed to support them, but we don't want to risk removing it.
             if not is_zarr or sub_name.endswith('.zattrs'):
                 if is_zarr:
                     # This is the representative file, so add the related files

--- a/src/humancellatlas/data/metadata/api.py
+++ b/src/humancellatlas/data/metadata/api.py
@@ -1044,6 +1044,10 @@ class Bundle:
                 if isinstance(f, SequenceFile)
                 and any(ps.is_sequencing_process() for ps in f.from_processes.values())]
 
+    @property
+    def ref(self) -> EntityReference:
+        return EntityReference(entity_type='links', entity_id=str(self.uuid))
+
 
 entity_types = {
     # Biomaterials

--- a/src/humancellatlas/data/metadata/api.py
+++ b/src/humancellatlas/data/metadata/api.py
@@ -138,8 +138,9 @@ class Entity:
         return s if s is None else self._datetime(s)
 
     @property
-    def address(self):
-        return self.schema_name + '@' + str(self.document_id)
+    def ref(self) -> EntityReference:
+        return EntityReference(entity_type=self.schema_name,
+                               entity_id=str(self.document_id))
 
     @property
     def schema_name(self):
@@ -202,9 +203,10 @@ class LinkedEntity(Entity, metaclass=ABCMeta):
 class LinkError(RuntimeError):
 
     def __init__(self, entity: LinkedEntity, other_entity: Entity, forward: bool) -> None:
-        super().__init__(entity.address +
-                         ' cannot ' + ('reference ' if forward else 'be referenced by ') +
-                         other_entity.address)
+        super().__init__(
+            f'{entity.ref} cannot {"reference" if forward else "be referenced by"} '
+            f'{other_entity.ref}'
+        )
 
 
 L = TypeVar('L', bound=LinkedEntity)

--- a/terraform/shared/shared.tf.json.template.py
+++ b/terraform/shared/shared.tf.json.template.py
@@ -385,9 +385,8 @@ tf_config = {
             # security boundary, so vulnerabilities that are detected within
             # them do not need to be addressed with the same urgency.
             #
-            # Using CF stack because the AWS provider does not support
-            # Inspector filters and the AWSCC provider fails due to
-            # https://github.com/hashicorp/terraform-provider-awscc/issues/1364
+            # FIXME: Remove workaround for false Terraform bug
+            #        https://github.com/DataBiosphere/azul/issues/6577
             'inspector_filters': {
                 'name': config.qualified_resource_name('inspectorfilters'),
                 'template_body': json.dumps({

--- a/test/hca_metadata_api/test.py
+++ b/test/hca_metadata_api/test.py
@@ -437,7 +437,7 @@ class TestAccessorApi(AzulUnitTestCase):
         self.assertIn(DonorOrganism, root_entity_types)
         self.assertTrue({DonorOrganism, SupplementaryFile}.issuperset(root_entity_types))
         root_entity = next(iter(root_entities))
-        self.assertRegex(root_entity.address, 'donor_organism@.*')
+        self.assertEqual(root_entity.ref.entity_type, 'donor_organism')
         self.assertIsInstance(root_entity, DonorOrganism)
         self.assertEqual(root_entity.organism_age_in_seconds, age_range)
         self.assertTrue(root_entity.sex in ('female', 'male', 'unknown'))

--- a/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T11:33:44.698028Z.results.json
+++ b/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T11:33:44.698028Z.results.json
@@ -3691,5 +3691,175 @@
             "hub_ids": []
         },
         "_type": "_doc"
+    },
+    {
+        "_id": "donor_organism_7b07b9d0-cc0e-4098-9f64-f4a569f7d746_7dd78e18008a0c036bb25e84f7742c075e16873f",
+        "_index": "azul_v2_dummy_test_replica",
+        "_score": 1.0,
+        "_source": {
+            "contents": {
+                "biomaterial_core": {
+                    "biomaterial_id": "DID_scRSq06",
+                    "ncbi_taxon_id": [
+                        9606
+                    ]
+                },
+                "death": {
+                    "cause_of_death": "stroke"
+                },
+                "describedBy": "https://schema.humancellatlas.org/type/biomaterial/10.1.2/donor_organism",
+                "diseases": [
+                    {
+                        "ontology": "PATO:0000461",
+                        "ontology_label": "normal",
+                        "text": "normal"
+                    }
+                ],
+                "genus_species": [
+                    {
+                        "ontology": "NCBITaxon:9606",
+                        "ontology_label": "Australopithecus",
+                        "text": "Australopithecus"
+                    }
+                ],
+                "human_specific": {
+                    "body_mass_index": 29.5,
+                    "ethnicity": [
+                        {
+                            "ontology": "hancestro:0005",
+                            "ontology_label": "European",
+                            "text": "European"
+                        }
+                    ]
+                },
+                "is_living": "no",
+                "organism_age": "38",
+                "organism_age_unit": {
+                    "ontology": "UO:0000036",
+                    "ontology_label": "year",
+                    "text": "year"
+                },
+                "provenance": {
+                    "document_id": "7b07b9d0-cc0e-4098-9f64-f4a569f7d746",
+                    "submission_date": "2018-11-02T10:02:12.191Z",
+                    "update_date": "2018-11-02T10:07:39.622Z"
+                },
+                "schema_type": "biomaterial",
+                "sex": "female"
+            },
+            "entity_id": "7b07b9d0-cc0e-4098-9f64-f4a569f7d746",
+            "hub_ids": [
+                "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
+                "70d1af4a-82c8-478a-8960-e9028b3616ca"
+            ],
+            "replica_type": "donor_organism"
+        },
+        "_type": "_doc"
+    },
+    {
+        "_id": "library_preparation_protocol_9c32cf70-3ed7-4720-badc-5ee71e8a38af_33c8ff808fc57c3dcb4b3872d1dcbc859e45a85a",
+        "_index": "azul_v2_dummy_test_replica",
+        "_score": 1.0,
+        "_source": {
+            "contents": {
+                "describedBy": "https://schema.humancellatlas.org/type/protocol/sequencing/4.3.3/library_preparation_protocol",
+                "end_bias": "full length",
+                "input_nucleic_acid_molecule": {
+                    "ontology": "OBI:0000869",
+                    "text": "polyA RNA"
+                },
+                "library_construction_approach": {
+                    "ontology": "EFO:0008931",
+                    "ontology_label": "Smart-seq2",
+                    "text": "Smart-seq2"
+                },
+                "library_construction_kit": {
+                    "manufacturer": "Illumina",
+                    "retail_name": "Nextera XT kit"
+                },
+                "nucleic_acid_source": "single cell",
+                "primer": "poly-dT",
+                "protocol_core": {
+                    "protocol_id": "library_preparation_protocol_1"
+                },
+                "provenance": {
+                    "document_id": "9c32cf70-3ed7-4720-badc-5ee71e8a38af",
+                    "submission_date": "2018-11-02T10:05:05.547Z",
+                    "update_date": "2018-11-02T10:05:10.360Z"
+                },
+                "schema_type": "protocol",
+                "strand": "unstranded"
+            },
+            "entity_id": "9c32cf70-3ed7-4720-badc-5ee71e8a38af",
+            "hub_ids": [
+                "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
+                "70d1af4a-82c8-478a-8960-e9028b3616ca"
+            ],
+            "replica_type": "library_preparation_protocol"
+        },
+        "_type": "_doc"
+    },
+    {
+        "_id": "sequencing_protocol_61e629ed-0135-4492-ac8a-5c4ab3ccca8a_187e49da61e5d3fbf91f3a6cf626bc4ce3c2d2be",
+        "_index": "azul_v2_dummy_test_replica",
+        "_score": 1.0,
+        "_source": {
+            "contents": {
+                "describedBy": "https://schema.humancellatlas.org/type/protocol/sequencing/9.0.3/sequencing_protocol",
+                "instrument_manufacturer_model": {
+                    "ontology": "EFO:0008566",
+                    "ontology_label": "Illumina NextSeq 500",
+                    "text": "Illumina NextSeq 500"
+                },
+                "paired_end": true,
+                "protocol_core": {
+                    "protocol_id": "sequencing_protocol_1"
+                },
+                "provenance": {
+                    "document_id": "61e629ed-0135-4492-ac8a-5c4ab3ccca8a",
+                    "submission_date": "2018-11-02T10:05:05.555Z",
+                    "update_date": "2018-11-02T10:05:10.376Z"
+                },
+                "schema_type": "protocol",
+                "sequencing_approach": {
+                    "ontology": "EFO:0008896",
+                    "ontology_label": "RNA-Seq",
+                    "text": "RNA-Seq"
+                }
+            },
+            "entity_id": "61e629ed-0135-4492-ac8a-5c4ab3ccca8a",
+            "hub_ids": [
+                "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
+                "70d1af4a-82c8-478a-8960-e9028b3616ca"
+            ],
+            "replica_type": "sequencing_protocol"
+        },
+        "_type": "_doc"
+    },
+    {
+        "_id": "process_771ddaf6-3a4f-4314-97fe-6294ff8e25a4_2e08df0ed1adfe582cd63f4daef287d9a637cdf1",
+        "_index": "azul_v2_dummy_test_replica",
+        "_score": 1.0,
+        "_source": {
+            "contents": {
+                "describedBy": "https://schema.humancellatlas.org/type/process/6.0.2/process",
+                "process_core": {
+                    "process_id": "SRR3562915"
+                },
+                "provenance": {
+                    "document_id": "771ddaf6-3a4f-4314-97fe-6294ff8e25a4",
+                    "submission_date": "2018-11-02T10:06:37.087Z",
+                    "update_date": "2018-11-02T10:13:43.197Z"
+                },
+                "schema_type": "process"
+            },
+            "entity_id": "771ddaf6-3a4f-4314-97fe-6294ff8e25a4",
+            "hub_ids": [
+                "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
+                "70d1af4a-82c8-478a-8960-e9028b3616ca"
+            ],
+            "replica_type": "process"
+        },
+        "_type": "_doc"
     }
 ]

--- a/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T11:33:44.698028Z.results.json
+++ b/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T11:33:44.698028Z.results.json
@@ -1,6 +1,6 @@
 [
     {
-        "_id": "bundles_aaa96233-bf27-44c7-82df-b4dc15ad4d9d_50b88c774d130ce5cb9e680241549c2df665efca",
+        "_id": "links_aaa96233-bf27-44c7-82df-b4dc15ad4d9d_50b88c774d130ce5cb9e680241549c2df665efca",
         "_index": "azul_v2_dev_test_replica",
         "_score": 1.0,
         "_type": "_doc",
@@ -3460,7 +3460,7 @@
         }
     },
     {
-        "_id": "files_0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb_4628c80cede8a4dd39584f8b50619edacc7f62e7",
+        "_id": "sequence_file_0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb_4628c80cede8a4dd39584f8b50619edacc7f62e7",
         "_index": "azul_v2_dev_test_replica",
         "_score": 1.0,
         "_source": {
@@ -3491,7 +3491,7 @@
         "_type": "_doc"
     },
     {
-        "_id": "cell_suspensions_412898c5-5b9b-4907-b07c-e9b89666e204_f8ca7504548249c223277135af497beb5fba29df",
+        "_id": "cell_suspension_412898c5-5b9b-4907-b07c-e9b89666e204_f8ca7504548249c223277135af497beb5fba29df",
         "_index": "azul_v2_dev_test_replica",
         "_score": 1.0,
         "_source": {
@@ -3530,7 +3530,7 @@
         "_type": "_doc"
     },
     {
-        "_id": "files_70d1af4a-82c8-478a-8960-e9028b3616ca_8ee6fbddb7c933ebe39b31b977c51af21687f036",
+        "_id": "sequence_file_70d1af4a-82c8-478a-8960-e9028b3616ca_8ee6fbddb7c933ebe39b31b977c51af21687f036",
         "_index": "azul_v2_dev_test_replica",
         "_score": 1.0,
         "_source": {
@@ -3561,7 +3561,7 @@
         "_type": "_doc"
     },
     {
-        "_id": "samples_a21dc760-a500-4236-bcff-da34a0e873d2_0bb754590d94de62d6fb15bdbac5f64f54072cb0",
+        "_id": "specimen_from_organism_a21dc760-a500-4236-bcff-da34a0e873d2_0bb754590d94de62d6fb15bdbac5f64f54072cb0",
         "_index": "azul_v2_dev_test_replica",
         "_score": 1.0,
         "_source": {
@@ -3614,7 +3614,7 @@
         "_type": "_doc"
     },
     {
-        "_id": "projects_e8642221-4c2c-4fd7-b926-a68bce363c88_42d51043dcd0030b5ee9ce47fa30c85bcc92bac6",
+        "_id": "project_e8642221-4c2c-4fd7-b926-a68bce363c88_42d51043dcd0030b5ee9ce47fa30c85bcc92bac6",
         "_index": "azul_v2_dev_test_replica",
         "_score": 1.0,
         "_source": {

--- a/test/indexer/test_anvil.py
+++ b/test/indexer/test_anvil.py
@@ -204,6 +204,8 @@ class TestAnvilIndexerWithIndexesSetUp(AnvilIndexerTestCase):
         bundles = [self.primary_bundle(), self.duos_bundle()]
         for bundle_fqid in bundles:
             bundle = cast(TDRAnvilBundle, self._load_canned_bundle(bundle_fqid))
+            # To simplify the test, we drop all entities from the bundles
+            # except for the dataset
             bundle.links.clear()
             bundle.entities = {dataset_ref: bundle.entities[dataset_ref]}
             self._index_bundle(bundle, delete=False)
@@ -231,5 +233,7 @@ class TestAnvilIndexerWithIndexesSetUp(AnvilIndexerTestCase):
         self.assertDictEqual(doc_counts, {
             DocumentType.aggregate: 1,
             DocumentType.contribution: 2,
-            **({DocumentType.replica: 2} if config.enable_replicas else {})
+            # No replica is emitted for the primary dataset because we dropped
+            # the files (hubs) from its bundle above
+            **({DocumentType.replica: 1} if config.enable_replicas else {})
         })

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -396,10 +396,10 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         entity = next(e for e in tallies_1.keys() if e.entity_type != 'bundles')
         tallies_1.pop(entity)
 
-        entity_contents = one(
-            metadata
+        replica_ref, entity_contents = one(
+            (parsed_ref, metadata)
             for ref, metadata in bundle.metadata.items()
-            if EntityReference.parse(ref).entity_id == entity.entity_id
+            if (parsed_ref := EntityReference.parse(ref)).entity_id == entity.entity_id
         )
         coordinates = [
             ContributionCoordinates(
@@ -411,7 +411,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
         if config.enable_replicas:
             coordinates.append(
                 ReplicaCoordinates(
-                    entity=entity,
+                    entity=replica_ref,
                     content_hash=json_hash(entity_contents).hexdigest()
                 ).with_catalog(self.catalog)
             )

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -1521,8 +1521,6 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
                     aggregate_file_names.add(one(files)['name'])
                 else:
                     for file in files:
-                        # FIXME: need for one() is odd, file_format is a group field
-                        #        https://github.com/DataBiosphere/azul/issues/612
                         if qualifier == 'bundles':
                             if file['file_format'] == 'matrix':
                                 entities_with_matrix_files.add(hit['_source']['entity_id'])

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -1501,7 +1501,9 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
                 self.assertNotIn('!', related_file['name'])
 
     def test_indexing_with_skipped_matrix_file(self):
-        # FIXME: Remove once https://github.com/HumanCellAtlas/metadata-schema/issues/579 is resolved
+        # zarray files no longer exist in DCP2. This test covers behavior that
+        # may no longer be needed to support them, but we don't want to risk
+        # removing it.
         bundle_fqid = self.bundle_fqid(uuid='587d74b4-1075-4bbf-b96a-4d1ede0481b2',
                                        version='2018-10-10T02:23:43.182000Z')
         self._index_canned_bundle(bundle_fqid)

--- a/test/service/data/verbatim/hca/pfb_entities.json
+++ b/test/service/data/verbatim/hca/pfb_entities.json
@@ -14,7 +14,28 @@
                 },
                 {
                     "links": [],
+                    "name": "donor_organism",
+                    "ontology_reference": "",
+                    "properties": [],
+                    "values": {}
+                },
+                {
+                    "links": [],
+                    "name": "library_preparation_protocol",
+                    "ontology_reference": "",
+                    "properties": [],
+                    "values": {}
+                },
+                {
+                    "links": [],
                     "name": "links",
+                    "ontology_reference": "",
+                    "properties": [],
+                    "values": {}
+                },
+                {
+                    "links": [],
+                    "name": "process",
                     "ontology_reference": "",
                     "properties": [],
                     "values": {}
@@ -29,6 +50,13 @@
                 {
                     "links": [],
                     "name": "sequence_file",
+                    "ontology_reference": "",
+                    "properties": [],
+                    "values": {}
+                },
+                {
+                    "links": [],
+                    "name": "sequencing_protocol",
                     "ontology_reference": "",
                     "properties": [],
                     "values": {}
@@ -117,6 +145,140 @@
             },
             "schema_type": "biomaterial",
             "total_estimated_cells": 1
+        },
+        "relations": []
+    },
+    {
+        "id": "61e629ed-0135-4492-ac8a-5c4ab3ccca8a",
+        "name": "sequencing_protocol",
+        "object": {
+            "describedBy": "https://schema.humancellatlas.org/type/protocol/sequencing/9.0.3/sequencing_protocol",
+            "instrument_manufacturer_model": {
+                "ontology": "EFO:0008566",
+                "ontology_label": "Illumina NextSeq 500",
+                "text": "Illumina NextSeq 500"
+            },
+            "paired_end": true,
+            "protocol_core": {
+                "protocol_id": "sequencing_protocol_1"
+            },
+            "provenance": {
+                "document_id": "61e629ed-0135-4492-ac8a-5c4ab3ccca8a",
+                "submission_date": "2018-11-02T10:05:05.555Z",
+                "update_date": "2018-11-02T10:05:10.376Z"
+            },
+            "schema_type": "protocol",
+            "sequencing_approach": {
+                "ontology": "EFO:0008896",
+                "ontology_label": "RNA-Seq",
+                "text": "RNA-Seq"
+            }
+        },
+        "relations": []
+    },
+    {
+        "id": "771ddaf6-3a4f-4314-97fe-6294ff8e25a4",
+        "name": "process",
+        "object": {
+            "describedBy": "https://schema.humancellatlas.org/type/process/6.0.2/process",
+            "process_core": {
+                "process_id": "SRR3562915"
+            },
+            "provenance": {
+                "document_id": "771ddaf6-3a4f-4314-97fe-6294ff8e25a4",
+                "submission_date": "2018-11-02T10:06:37.087Z",
+                "update_date": "2018-11-02T10:13:43.197Z"
+            },
+            "schema_type": "process"
+        },
+        "relations": []
+    },
+    {
+        "id": "7b07b9d0-cc0e-4098-9f64-f4a569f7d746",
+        "name": "donor_organism",
+        "object": {
+            "biomaterial_core": {
+                "biomaterial_id": "DID_scRSq06",
+                "ncbi_taxon_id": [
+                    9606
+                ]
+            },
+            "death": {
+                "cause_of_death": "stroke"
+            },
+            "describedBy": "https://schema.humancellatlas.org/type/biomaterial/10.1.2/donor_organism",
+            "diseases": [
+                {
+                    "ontology": "PATO:0000461",
+                    "ontology_label": "normal",
+                    "text": "normal"
+                }
+            ],
+            "genus_species": [
+                {
+                    "ontology": "NCBITaxon:9606",
+                    "ontology_label": "Australopithecus",
+                    "text": "Australopithecus"
+                }
+            ],
+            "human_specific": {
+                "body_mass_index": 29.5,
+                "ethnicity": [
+                    {
+                        "ontology": "hancestro:0005",
+                        "ontology_label": "European",
+                        "text": "European"
+                    }
+                ]
+            },
+            "is_living": "no",
+            "organism_age": "38",
+            "organism_age_unit": {
+                "ontology": "UO:0000036",
+                "ontology_label": "year",
+                "text": "year"
+            },
+            "provenance": {
+                "document_id": "7b07b9d0-cc0e-4098-9f64-f4a569f7d746",
+                "submission_date": "2018-11-02T10:02:12.191Z",
+                "update_date": "2018-11-02T10:07:39.622Z"
+            },
+            "schema_type": "biomaterial",
+            "sex": "female"
+        },
+        "relations": []
+    },
+    {
+        "id": "9c32cf70-3ed7-4720-badc-5ee71e8a38af",
+        "name": "library_preparation_protocol",
+        "object": {
+            "describedBy": "https://schema.humancellatlas.org/type/protocol/sequencing/4.3.3/library_preparation_protocol",
+            "end_bias": "full length",
+            "input_nucleic_acid_molecule": {
+                "ontology": "OBI:0000869",
+                "text": "polyA RNA"
+            },
+            "library_construction_approach": {
+                "ontology": "EFO:0008931",
+                "ontology_label": "Smart-seq2",
+                "text": "Smart-seq2"
+            },
+            "library_construction_kit": {
+                "manufacturer": "Illumina",
+                "retail_name": "Nextera XT kit"
+            },
+            "nucleic_acid_source": "single cell",
+            "primer": "poly-dT",
+            "protocol_core": {
+                "protocol_id": "library_preparation_protocol_1"
+            },
+            "provenance": {
+                "document_id": "9c32cf70-3ed7-4720-badc-5ee71e8a38af",
+                "submission_date": "2018-11-02T10:05:05.547Z",
+                "update_date": "2018-11-02T10:05:10.360Z"
+            },
+            "schema_type": "protocol",
+            "strand": "unstranded"
         },
         "relations": []
     },

--- a/test/service/data/verbatim/hca/pfb_schema.json
+++ b/test/service/data/verbatim/hca/pfb_schema.json
@@ -225,6 +225,365 @@
                 {
                     "fields": [
                         {
+                            "name": "biomaterial_core",
+                            "namespace": "donor_organism",
+                            "type": {
+                                "fields": [
+                                    {
+                                        "name": "biomaterial_id",
+                                        "namespace": "donor_organism.biomaterial_core",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "name": "ncbi_taxon_id",
+                                        "namespace": "donor_organism.biomaterial_core",
+                                        "type": {
+                                            "items": "long",
+                                            "type": "array"
+                                        }
+                                    }
+                                ],
+                                "name": "donor_organism.biomaterial_core",
+                                "type": "record"
+                            }
+                        },
+                        {
+                            "name": "death",
+                            "namespace": "donor_organism",
+                            "type": {
+                                "fields": [
+                                    {
+                                        "name": "cause_of_death",
+                                        "namespace": "donor_organism.death",
+                                        "type": "string"
+                                    }
+                                ],
+                                "name": "donor_organism.death",
+                                "type": "record"
+                            }
+                        },
+                        {
+                            "name": "describedBy",
+                            "namespace": "donor_organism",
+                            "type": "string"
+                        },
+                        {
+                            "name": "diseases",
+                            "namespace": "donor_organism",
+                            "type": {
+                                "items": {
+                                    "fields": [
+                                        {
+                                            "name": "ontology",
+                                            "namespace": "donor_organism.diseases",
+                                            "type": "string"
+                                        },
+                                        {
+                                            "name": "ontology_label",
+                                            "namespace": "donor_organism.diseases",
+                                            "type": "string"
+                                        },
+                                        {
+                                            "name": "text",
+                                            "namespace": "donor_organism.diseases",
+                                            "type": "string"
+                                        }
+                                    ],
+                                    "name": "donor_organism.diseases",
+                                    "type": "record"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        {
+                            "name": "genus_species",
+                            "namespace": "donor_organism",
+                            "type": {
+                                "items": {
+                                    "fields": [
+                                        {
+                                            "name": "ontology",
+                                            "namespace": "donor_organism.genus_species",
+                                            "type": "string"
+                                        },
+                                        {
+                                            "name": "ontology_label",
+                                            "namespace": "donor_organism.genus_species",
+                                            "type": "string"
+                                        },
+                                        {
+                                            "name": "text",
+                                            "namespace": "donor_organism.genus_species",
+                                            "type": "string"
+                                        }
+                                    ],
+                                    "name": "donor_organism.genus_species",
+                                    "type": "record"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        {
+                            "name": "human_specific",
+                            "namespace": "donor_organism",
+                            "type": {
+                                "fields": [
+                                    {
+                                        "name": "body_mass_index",
+                                        "namespace": "donor_organism.human_specific",
+                                        "type": "double"
+                                    },
+                                    {
+                                        "name": "ethnicity",
+                                        "namespace": "donor_organism.human_specific",
+                                        "type": {
+                                            "items": {
+                                                "fields": [
+                                                    {
+                                                        "name": "ontology",
+                                                        "namespace": "donor_organism.human_specific.ethnicity",
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "name": "ontology_label",
+                                                        "namespace": "donor_organism.human_specific.ethnicity",
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "name": "text",
+                                                        "namespace": "donor_organism.human_specific.ethnicity",
+                                                        "type": "string"
+                                                    }
+                                                ],
+                                                "name": "donor_organism.human_specific.ethnicity",
+                                                "type": "record"
+                                            },
+                                            "type": "array"
+                                        }
+                                    }
+                                ],
+                                "name": "donor_organism.human_specific",
+                                "type": "record"
+                            }
+                        },
+                        {
+                            "name": "is_living",
+                            "namespace": "donor_organism",
+                            "type": "string"
+                        },
+                        {
+                            "name": "organism_age",
+                            "namespace": "donor_organism",
+                            "type": "string"
+                        },
+                        {
+                            "name": "organism_age_unit",
+                            "namespace": "donor_organism",
+                            "type": {
+                                "fields": [
+                                    {
+                                        "name": "ontology",
+                                        "namespace": "donor_organism.organism_age_unit",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "name": "ontology_label",
+                                        "namespace": "donor_organism.organism_age_unit",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "name": "text",
+                                        "namespace": "donor_organism.organism_age_unit",
+                                        "type": "string"
+                                    }
+                                ],
+                                "name": "donor_organism.organism_age_unit",
+                                "type": "record"
+                            }
+                        },
+                        {
+                            "name": "provenance",
+                            "namespace": "donor_organism",
+                            "type": {
+                                "fields": [
+                                    {
+                                        "name": "document_id",
+                                        "namespace": "donor_organism.provenance",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "name": "submission_date",
+                                        "namespace": "donor_organism.provenance",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "name": "update_date",
+                                        "namespace": "donor_organism.provenance",
+                                        "type": "string"
+                                    }
+                                ],
+                                "name": "donor_organism.provenance",
+                                "type": "record"
+                            }
+                        },
+                        {
+                            "name": "schema_type",
+                            "namespace": "donor_organism",
+                            "type": "string"
+                        },
+                        {
+                            "name": "sex",
+                            "namespace": "donor_organism",
+                            "type": "string"
+                        }
+                    ],
+                    "name": "donor_organism",
+                    "type": "record"
+                },
+                {
+                    "fields": [
+                        {
+                            "name": "describedBy",
+                            "namespace": "library_preparation_protocol",
+                            "type": "string"
+                        },
+                        {
+                            "name": "end_bias",
+                            "namespace": "library_preparation_protocol",
+                            "type": "string"
+                        },
+                        {
+                            "name": "input_nucleic_acid_molecule",
+                            "namespace": "library_preparation_protocol",
+                            "type": {
+                                "fields": [
+                                    {
+                                        "name": "ontology",
+                                        "namespace": "library_preparation_protocol.input_nucleic_acid_molecule",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "name": "text",
+                                        "namespace": "library_preparation_protocol.input_nucleic_acid_molecule",
+                                        "type": "string"
+                                    }
+                                ],
+                                "name": "library_preparation_protocol.input_nucleic_acid_molecule",
+                                "type": "record"
+                            }
+                        },
+                        {
+                            "name": "library_construction_approach",
+                            "namespace": "library_preparation_protocol",
+                            "type": {
+                                "fields": [
+                                    {
+                                        "name": "ontology",
+                                        "namespace": "library_preparation_protocol.library_construction_approach",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "name": "ontology_label",
+                                        "namespace": "library_preparation_protocol.library_construction_approach",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "name": "text",
+                                        "namespace": "library_preparation_protocol.library_construction_approach",
+                                        "type": "string"
+                                    }
+                                ],
+                                "name": "library_preparation_protocol.library_construction_approach",
+                                "type": "record"
+                            }
+                        },
+                        {
+                            "name": "library_construction_kit",
+                            "namespace": "library_preparation_protocol",
+                            "type": {
+                                "fields": [
+                                    {
+                                        "name": "manufacturer",
+                                        "namespace": "library_preparation_protocol.library_construction_kit",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "name": "retail_name",
+                                        "namespace": "library_preparation_protocol.library_construction_kit",
+                                        "type": "string"
+                                    }
+                                ],
+                                "name": "library_preparation_protocol.library_construction_kit",
+                                "type": "record"
+                            }
+                        },
+                        {
+                            "name": "nucleic_acid_source",
+                            "namespace": "library_preparation_protocol",
+                            "type": "string"
+                        },
+                        {
+                            "name": "primer",
+                            "namespace": "library_preparation_protocol",
+                            "type": "string"
+                        },
+                        {
+                            "name": "protocol_core",
+                            "namespace": "library_preparation_protocol",
+                            "type": {
+                                "fields": [
+                                    {
+                                        "name": "protocol_id",
+                                        "namespace": "library_preparation_protocol.protocol_core",
+                                        "type": "string"
+                                    }
+                                ],
+                                "name": "library_preparation_protocol.protocol_core",
+                                "type": "record"
+                            }
+                        },
+                        {
+                            "name": "provenance",
+                            "namespace": "library_preparation_protocol",
+                            "type": {
+                                "fields": [
+                                    {
+                                        "name": "document_id",
+                                        "namespace": "library_preparation_protocol.provenance",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "name": "submission_date",
+                                        "namespace": "library_preparation_protocol.provenance",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "name": "update_date",
+                                        "namespace": "library_preparation_protocol.provenance",
+                                        "type": "string"
+                                    }
+                                ],
+                                "name": "library_preparation_protocol.provenance",
+                                "type": "record"
+                            }
+                        },
+                        {
+                            "name": "schema_type",
+                            "namespace": "library_preparation_protocol",
+                            "type": "string"
+                        },
+                        {
+                            "name": "strand",
+                            "namespace": "library_preparation_protocol",
+                            "type": "string"
+                        }
+                    ],
+                    "name": "library_preparation_protocol",
+                    "type": "record"
+                },
+                {
+                    "fields": [
+                        {
                             "name": "describedBy",
                             "namespace": "links",
                             "type": "string"
@@ -308,6 +667,62 @@
                         }
                     ],
                     "name": "links",
+                    "type": "record"
+                },
+                {
+                    "fields": [
+                        {
+                            "name": "describedBy",
+                            "namespace": "process",
+                            "type": "string"
+                        },
+                        {
+                            "name": "process_core",
+                            "namespace": "process",
+                            "type": {
+                                "fields": [
+                                    {
+                                        "name": "process_id",
+                                        "namespace": "process.process_core",
+                                        "type": "string"
+                                    }
+                                ],
+                                "name": "process.process_core",
+                                "type": "record"
+                            }
+                        },
+                        {
+                            "name": "provenance",
+                            "namespace": "process",
+                            "type": {
+                                "fields": [
+                                    {
+                                        "name": "document_id",
+                                        "namespace": "process.provenance",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "name": "submission_date",
+                                        "namespace": "process.provenance",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "name": "update_date",
+                                        "namespace": "process.provenance",
+                                        "type": "string"
+                                    }
+                                ],
+                                "name": "process.provenance",
+                                "type": "record"
+                            }
+                        },
+                        {
+                            "name": "schema_type",
+                            "namespace": "process",
+                            "type": "string"
+                        }
+                    ],
+                    "name": "process",
                     "type": "record"
                 },
                 {
@@ -590,6 +1005,117 @@
                         }
                     ],
                     "name": "sequence_file",
+                    "type": "record"
+                },
+                {
+                    "fields": [
+                        {
+                            "name": "describedBy",
+                            "namespace": "sequencing_protocol",
+                            "type": "string"
+                        },
+                        {
+                            "name": "instrument_manufacturer_model",
+                            "namespace": "sequencing_protocol",
+                            "type": {
+                                "fields": [
+                                    {
+                                        "name": "ontology",
+                                        "namespace": "sequencing_protocol.instrument_manufacturer_model",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "name": "ontology_label",
+                                        "namespace": "sequencing_protocol.instrument_manufacturer_model",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "name": "text",
+                                        "namespace": "sequencing_protocol.instrument_manufacturer_model",
+                                        "type": "string"
+                                    }
+                                ],
+                                "name": "sequencing_protocol.instrument_manufacturer_model",
+                                "type": "record"
+                            }
+                        },
+                        {
+                            "name": "paired_end",
+                            "namespace": "sequencing_protocol",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "protocol_core",
+                            "namespace": "sequencing_protocol",
+                            "type": {
+                                "fields": [
+                                    {
+                                        "name": "protocol_id",
+                                        "namespace": "sequencing_protocol.protocol_core",
+                                        "type": "string"
+                                    }
+                                ],
+                                "name": "sequencing_protocol.protocol_core",
+                                "type": "record"
+                            }
+                        },
+                        {
+                            "name": "provenance",
+                            "namespace": "sequencing_protocol",
+                            "type": {
+                                "fields": [
+                                    {
+                                        "name": "document_id",
+                                        "namespace": "sequencing_protocol.provenance",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "name": "submission_date",
+                                        "namespace": "sequencing_protocol.provenance",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "name": "update_date",
+                                        "namespace": "sequencing_protocol.provenance",
+                                        "type": "string"
+                                    }
+                                ],
+                                "name": "sequencing_protocol.provenance",
+                                "type": "record"
+                            }
+                        },
+                        {
+                            "name": "schema_type",
+                            "namespace": "sequencing_protocol",
+                            "type": "string"
+                        },
+                        {
+                            "name": "sequencing_approach",
+                            "namespace": "sequencing_protocol",
+                            "type": {
+                                "fields": [
+                                    {
+                                        "name": "ontology",
+                                        "namespace": "sequencing_protocol.sequencing_approach",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "name": "ontology_label",
+                                        "namespace": "sequencing_protocol.sequencing_approach",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "name": "text",
+                                        "namespace": "sequencing_protocol.sequencing_approach",
+                                        "type": "string"
+                                    }
+                                ],
+                                "name": "sequencing_protocol.sequencing_approach",
+                                "type": "record"
+                            }
+                        }
+                    ],
+                    "name": "sequencing_protocol",
                     "type": "record"
                 },
                 {

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -1349,7 +1349,11 @@ class TestManifests(DCP1ManifestTestCase, PFBTestCase):
                 'project/e8642221-4c2c-4fd7-b926-a68bce363c88',
                 'sequence_file/70d1af4a-82c8-478a-8960-e9028b3616ca',
                 'sequence_file/0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb',
-                'specimen_from_organism/a21dc760-a500-4236-bcff-da34a0e873d2'
+                'specimen_from_organism/a21dc760-a500-4236-bcff-da34a0e873d2',
+                'donor_organism/7b07b9d0-cc0e-4098-9f64-f4a569f7d746',
+                'library_preparation_protocol/9c32cf70-3ed7-4720-badc-5ee71e8a38af',
+                'sequencing_protocol/61e629ed-0135-4492-ac8a-5c4ab3ccca8a',
+                'process/771ddaf6-3a4f-4314-97fe-6294ff8e25a4'
             ]:
                 expected.append({
                     'type': EntityReference.parse(ref).entity_type,


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Connected issues: #6582


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved connected issues to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for `dev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for `anvildev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
