### PR TITLE
 Refactor handing of AnVIL links (#6612)

### DIFF
--- a/src/azul/collections.py
+++ b/src/azul/collections.py
@@ -270,6 +270,10 @@ def adict(seq: Union[Mapping[K, V], Iterable[tuple[K, V]]] = None,
     return kwargs if seq is None else dict(seq, **kwargs)
 
 
+def _athing(cls: type, *args):
+    return cls(arg for arg in args if arg is not None)
+
+
 def atuple(*args: V) -> tuple[V, ...]:
     """
     >>> atuple()
@@ -281,7 +285,7 @@ def atuple(*args: V) -> tuple[V, ...]:
     >>> atuple(0, None)
     (0,)
     """
-    return tuple(arg for arg in args if arg is not None)
+    return _athing(tuple, *args)
 
 
 def alist(*args: V) -> list[V]:
@@ -295,7 +299,7 @@ def alist(*args: V) -> list[V]:
     >>> alist(0, None)
     [0]
     """
-    return list(arg for arg in args if arg is not None)
+    return _athing(list, *args)
 
 
 class NestedDict(defaultdict):

--- a/src/azul/collections.py
+++ b/src/azul/collections.py
@@ -131,6 +131,17 @@ def explode_dict(d: Mapping[K, Union[V, list[V], set[V], tuple[V]]]
         yield dict(zip(d.keys(), t))
 
 
+def none_safe_apply(f: Callable[[K], V], o: K | None) -> V | None:
+    """
+    >>> none_safe_apply(str, 123)
+    '123'
+
+    >>> none_safe_apply(str, None) is None
+    True
+    """
+    return None if o is None else f(o)
+
+
 def none_safe_key(none_last: bool = False) -> Callable[[Any], Any]:
     """
     Returns a sort key that handles None values.
@@ -300,6 +311,20 @@ def alist(*args: V) -> list[V]:
     [0]
     """
     return _athing(list, *args)
+
+
+def aset(*args: V) -> set[V]:
+    """
+    >>> aset()
+    set()
+
+    >>> aset(None)
+    set()
+
+    >>> aset(0, None)
+    {0}
+    """
+    return _athing(set, *args)
 
 
 class NestedDict(defaultdict):

--- a/src/azul/plugins/metadata/anvil/bundle.py
+++ b/src/azul/plugins/metadata/anvil/bundle.py
@@ -88,10 +88,18 @@ class Link(Generic[REF]):
         return min(self.inputs) < min(other.inputs)
 
 
+class EntityLink(Link[EntityReference]):
+    pass
+
+
+class KeyLink(Link[KeyReference]):
+    pass
+
+
 @attrs.define(kw_only=True)
 class AnvilBundle(Bundle[BUNDLE_FQID], ABC):
     entities: dict[EntityReference, MutableJSON] = attrs.field(factory=dict)
-    links: set[Link[EntityReference]] = attrs.field(factory=set)
+    links: set[EntityLink] = attrs.field(factory=set)
 
     def reject_joiner(self, catalog: CatalogName):
         # FIXME: Optimize joiner rejection and re-enable it for AnVIL
@@ -115,5 +123,5 @@ class AnvilBundle(Bundle[BUNDLE_FQID], ABC):
                 EntityReference.parse(entity_ref): entity
                 for entity_ref, entity in json_['entities'].items()
             },
-            links=set(map(Link.from_json, json_['links']))
+            links=set(map(EntityLink.from_json, json_['links']))
         )

--- a/src/azul/plugins/metadata/anvil/bundle.py
+++ b/src/azul/plugins/metadata/anvil/bundle.py
@@ -48,21 +48,21 @@ class KeyReference:
     entity_type: EntityType
 
 
-ENTITY_REF = TypeVar('ENTITY_REF', bound=EntityReference | KeyReference)
+REF = TypeVar('REF', bound=EntityReference | KeyReference)
 
 
 @attrs.frozen(kw_only=True, order=False)
-class Link(Generic[ENTITY_REF]):
-    inputs: AbstractSet[ENTITY_REF] = attrs.field(factory=frozenset,
-                                                  converter=frozenset)
+class Link(Generic[REF]):
+    inputs: AbstractSet[REF] = attrs.field(factory=frozenset,
+                                           converter=frozenset)
 
-    activity: ENTITY_REF | None = attrs.field(default=None)
+    activity: REF | None = attrs.field(default=None)
 
-    outputs: AbstractSet[ENTITY_REF] = attrs.field(factory=frozenset,
-                                                   converter=frozenset)
+    outputs: AbstractSet[REF] = attrs.field(factory=frozenset,
+                                            converter=frozenset)
 
     @property
-    def all_entities(self) -> AbstractSet[ENTITY_REF]:
+    def all_entities(self) -> AbstractSet[REF]:
         return self.inputs | self.outputs | aset(self.activity)
 
     @classmethod

--- a/src/azul/plugins/metadata/anvil/bundle.py
+++ b/src/azul/plugins/metadata/anvil/bundle.py
@@ -104,7 +104,14 @@ class EntityLink(Link[EntityReference]):
 
 
 class KeyLink(Link[KeyReference]):
-    pass
+
+    def to_entity_link(self,
+                       entities_by_key: Mapping[KeyReference, EntityReference]
+                       ) -> EntityLink:
+        lookup = entities_by_key.__getitem__
+        return EntityLink(inputs=set(map(lookup, self.inputs)),
+                          activity=none_safe_apply(lookup, self.activity),
+                          outputs=set(map(lookup, self.outputs)))
 
 
 @attrs.define(kw_only=True)

--- a/src/azul/plugins/metadata/anvil/bundle.py
+++ b/src/azul/plugins/metadata/anvil/bundle.py
@@ -17,6 +17,10 @@ from more_itertools import (
 from azul import (
     CatalogName,
 )
+from azul.collections import (
+    aset,
+    none_safe_apply,
+)
 from azul.indexer import (
     BUNDLE_FQID,
     Bundle,
@@ -59,18 +63,18 @@ class Link(Generic[ENTITY_REF]):
 
     @property
     def all_entities(self) -> AbstractSet[ENTITY_REF]:
-        return self.inputs | self.outputs | (set() if self.activity is None else {self.activity})
+        return self.inputs | self.outputs | aset(self.activity)
 
     @classmethod
     def from_json(cls, link: JSON) -> Self:
         return cls(inputs=set(map(EntityReference.parse, link['inputs'])),
-                   activity=None if link['activity'] is None else EntityReference.parse(link['activity']),
+                   activity=none_safe_apply(EntityReference.parse, link['activity']),
                    outputs=set(map(EntityReference.parse, link['outputs'])))
 
     def to_json(self) -> MutableJSON:
         return {
             'inputs': sorted(map(str, self.inputs)),
-            'activity': None if self.activity is None else str(self.activity),
+            'activity': none_safe_apply(str, self.activity),
             'outputs': sorted(map(str, self.outputs))
         }
 

--- a/src/azul/plugins/metadata/anvil/bundle.py
+++ b/src/azul/plugins/metadata/anvil/bundle.py
@@ -5,6 +5,7 @@ from typing import (
     AbstractSet,
     Generic,
     Iterable,
+    Self,
     TypeVar,
 )
 
@@ -61,7 +62,7 @@ class Link(Generic[ENTITY_REF]):
         return self.inputs | self.outputs | (set() if self.activity is None else {self.activity})
 
     @classmethod
-    def from_json(cls, link: JSON) -> 'Link':
+    def from_json(cls, link: JSON) -> Self:
         return cls(inputs=set(map(EntityReference.parse, link['inputs'])),
                    activity=None if link['activity'] is None else EntityReference.parse(link['activity']),
                    outputs=set(map(EntityReference.parse, link['outputs'])))
@@ -74,12 +75,12 @@ class Link(Generic[ENTITY_REF]):
         }
 
     @classmethod
-    def merge(cls, links: Iterable['Link']) -> 'Link':
+    def merge(cls, links: Iterable[Self]) -> Self:
         return cls(inputs=frozenset.union(*[link.inputs for link in links]),
                    activity=one({link.activity for link in links}),
                    outputs=frozenset.union(*[link.outputs for link in links]))
 
-    def __lt__(self, other: 'Link') -> bool:
+    def __lt__(self, other: Self) -> bool:
         return min(self.inputs) < min(other.inputs)
 
 
@@ -103,7 +104,7 @@ class AnvilBundle(Bundle[BUNDLE_FQID], ABC):
         }
 
     @classmethod
-    def from_json(cls, fqid: BUNDLE_FQID, json_: JSON) -> 'AnvilBundle':
+    def from_json(cls, fqid: BUNDLE_FQID, json_: JSON) -> Self:
         return cls(
             fqid=fqid,
             entities={

--- a/src/azul/plugins/metadata/anvil/indexer/transform.py
+++ b/src/azul/plugins/metadata/anvil/indexer/transform.py
@@ -22,6 +22,7 @@ from typing import (
     Callable,
     Collection,
     Iterable,
+    Self,
 )
 from uuid import (
     UUID,
@@ -107,7 +108,7 @@ class LinkedEntities:
     def from_links(cls,
                    origin: EntityReference,
                    links: Collection[Link[EntityReference]]
-                   ) -> 'LinkedEntities':
+                   ) -> Self:
         return cls(origin=origin,
                    ancestors=cls._search(origin, links, from_='outputs', to='inputs'),
                    descendants=cls._search(origin, links, from_='inputs', to='outputs'))

--- a/src/azul/plugins/metadata/anvil/indexer/transform.py
+++ b/src/azul/plugins/metadata/anvil/indexer/transform.py
@@ -66,7 +66,7 @@ from azul.indexer.transform import (
 )
 from azul.plugins.metadata.anvil.bundle import (
     AnvilBundle,
-    Link,
+    EntityLink,
 )
 from azul.plugins.metadata.anvil.indexer.aggregate import (
     ActivityAggregator,
@@ -107,7 +107,7 @@ class LinkedEntities:
     @classmethod
     def from_links(cls,
                    origin: EntityReference,
-                   links: Collection[Link[EntityReference]]
+                   links: Collection[EntityLink]
                    ) -> Self:
         return cls(origin=origin,
                    ancestors=cls._search(origin, links, from_='outputs', to='inputs'),
@@ -116,7 +116,7 @@ class LinkedEntities:
     @classmethod
     def _search(cls,
                 entity_ref: EntityReference,
-                links: Collection[Link[EntityReference]],
+                links: Collection[EntityLink],
                 entities: EntityRefsByType | None = None,
                 *,
                 from_: str,

--- a/src/azul/plugins/repository/tdr_anvil/__init__.py
+++ b/src/azul/plugins/repository/tdr_anvil/__init__.py
@@ -29,6 +29,9 @@ from azul import (
 from azul.bigquery import (
     backtick,
 )
+from azul.collections import (
+    none_safe_apply,
+)
 from azul.drs import (
     DRSURI,
 )
@@ -156,16 +159,11 @@ class TDRAnvilBundle(AnvilBundle[TDRAnvilBundleFQID], TDRBundle):
     def add_links(self,
                   links: KeyLinks,
                   entities_by_key: Mapping[KeyReference, EntityReference]) -> None:
-        def key_ref_to_entity_ref(key_ref: KeyReference) -> EntityReference:
-            return entities_by_key[key_ref]
-
-        def optional_key_ref_to_entity_ref(key_ref: KeyReference | None) -> EntityReference | None:
-            return None if key_ref is None else key_ref_to_entity_ref(key_ref)
-
+        lookup = entities_by_key.__getitem__
         self.links.update(
-            Link(inputs=set(map(key_ref_to_entity_ref, link.inputs)),
-                 activity=optional_key_ref_to_entity_ref(link.activity),
-                 outputs=set(map(key_ref_to_entity_ref, link.outputs)))
+            Link(inputs=set(map(lookup, link.inputs)),
+                 activity=none_safe_apply(lookup, link.activity),
+                 outputs=set(map(lookup, link.outputs)))
             for link in links
         )
 


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Connected issues: #6612


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved connected issues to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for `dev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for `anvildev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
