### PR TITLE
Fix: Optimistic lock contention on HCA replicas (#6648)

### DIFF
--- a/src/azul/indexer/document.py
+++ b/src/azul/indexer/document.py
@@ -1348,7 +1348,7 @@ class Document(Generic[C]):
         # For non-bulk updates, self.op_type determines which client
         # method is invoked.
         if bulk:
-            result['_op_type'] = self.op_type.name
+            result['_op_type'] = op_type.name
         if self.version_type is VersionType.none:
             pass
         elif self.version_type is VersionType.create_only:

--- a/src/azul/indexer/document.py
+++ b/src/azul/indexer/document.py
@@ -1321,12 +1321,16 @@ class Document(Generic[C]):
                  field_types: CataloguedFieldTypes
                  ) -> JSON:
         """
-        Build request parameters from the document for indexing
+        Prepare a request to write this document to the index. The return value
+        is a dictionary with keyword arguments to the ES client method selected
+        by the :meth:`op_type` property.
 
         :param catalog: An optional catalog name. If None, this document's
                         coordinates must supply it. Otherwise this document's
                         coordinates must supply the same catalog or none at all.
+
         :param field_types: A mapping of field paths to field type
+
         :return: Request parameters for indexing
         """
         op_type = self.op_type

--- a/src/azul/indexer/document.py
+++ b/src/azul/indexer/document.py
@@ -1352,11 +1352,7 @@ class Document(Generic[C]):
         if self.version_type is VersionType.none:
             pass
         elif self.version_type is VersionType.create_only:
-            if bulk:
-                if op_type is OpType.delete:
-                    result['if_seq_no'], result['if_primary_term'] = self.version
-            else:
-                assert op_type is OpType.create, op_type
+            assert op_type is OpType.create, op_type
         elif self.version_type is VersionType.internal:
             if self.version is not None:
                 # For internal versioning, self.version is None for new documents

--- a/src/azul/indexer/document.py
+++ b/src/azul/indexer/document.py
@@ -1076,20 +1076,6 @@ FieldTypes1 = Union[Mapping[str, FieldTypes2], Sequence[FieldType], FieldType]
 FieldTypes = Mapping[str, FieldTypes1]
 CataloguedFieldTypes = Mapping[CatalogName, FieldTypes]
 
-
-class VersionType(Enum):
-    # No versioning; document is created or overwritten as needed
-    none = auto()
-
-    # Writing a document fails with 409 conflict if one with the same ID already
-    # exists in the index
-    create_only = auto()
-
-    # Use the Elasticsearch "internal" versioning type
-    # https://www.elastic.co/guide/en/elasticsearch/reference/6.8/docs-index_.html#_version_types
-    internal = auto()
-
-
 InternalVersion = tuple[int, int]
 
 
@@ -1112,24 +1098,11 @@ C = TypeVar('C', bound=DocumentCoordinates)
 
 
 @attr.s(frozen=False, kw_only=True, auto_attribs=True)
-class Document(Generic[C]):
+class Document(Generic[C], metaclass=ABCMeta):
     needs_translation: ClassVar[bool] = True
 
     coordinates: C
 
-    #: By default, instances are fixed to VersionType.none. A subclass may
-    #: decide to make the version_type attribute mutable but it still needs to
-    #: declare what VersionType its instances use initially. This is so that
-    #: factories of these instances can make the necessary preparations.
-    #:
-    initial_version_type: ClassVar[VersionType] = VersionType.none
-    version_type: VersionType = attr.ib(default=initial_version_type,
-                                        on_setattr=attr.setters.frozen)
-
-    # For VersionType.internal, version is a tuple composed of the sequence
-    # number and primary term. For VersionType.none and .create_only, it is
-    # None.
-    # https://www.elastic.co/guide/en/elasticsearch/reference/7.9/docs-bulk.html#bulk-api-response-body
     version: Optional[InternalVersion]
 
     # In the index, the `contents` property is always present and never null in
@@ -1143,6 +1116,24 @@ class Document(Generic[C]):
     @property
     def entity(self) -> EntityReference:
         return self.coordinates.entity
+
+    @property
+    @abstractmethod
+    def op_type(self) -> OpType:
+        """
+        Get the ES client method to use when writing this document to the index.
+        """
+        raise NotImplementedError
+
+    @op_type.setter
+    def op_type(self, value: OpType):
+        """
+        Set the ES client method to use when writing this document to the index.
+        This setter is optional, concrete classes may not implement it. If they
+        don't, callers should gracefully handle the resulting AttributeError, as
+        that is what the Python runtime raises for the NotImplementedError.
+        """
+        raise NotImplementedError
 
     @classmethod
     def field_types(cls, field_types: FieldTypes) -> FieldTypes:
@@ -1302,14 +1293,11 @@ class Document(Generic[C]):
             document = cls.translate_fields(document,
                                             field_types[coordinates.entity.catalog],
                                             forward=False)
-        if cls.initial_version_type is VersionType.internal:
-            try:
-                version = (hit['_seq_no'], hit['_primary_term'])
-            except KeyError:
-                assert '_seq_no' not in hit
-                assert '_primary_term' not in hit
-                version = None
-        else:
+        try:
+            version = hit['_seq_no'], hit['_primary_term']
+        except KeyError:
+            assert '_seq_no' not in hit
+            assert '_primary_term' not in hit
             version = None
 
         return cls.from_json(coordinates=coordinates,
@@ -1333,30 +1321,16 @@ class Document(Generic[C]):
 
         :return: Request parameters for indexing
         """
-        op_type = self.op_type
         coordinates = self.coordinates.with_catalog(catalog)
         result = {
             'index': coordinates.index_name,
             'id': self.coordinates.document_id
         }
-        if op_type is not OpType.delete:
+        if self.op_type is not OpType.delete:
             result['body'] = self._body(field_types[coordinates.entity.catalog])
-
-        if self.version_type is VersionType.none:
-            pass
-        elif self.version_type is VersionType.create_only:
-            assert op_type is OpType.create, op_type
-        elif self.version_type is VersionType.internal:
-            if self.version is not None:
-                # For internal versioning, self.version is None for new documents
-                result['if_seq_no'], result['if_primary_term'] = self.version
-        else:
-            assert False, self.version_type
+        if self.version is not None:
+            result['if_seq_no'], result['if_primary_term'] = self.version
         return result
-
-    @property
-    def op_type(self) -> OpType:
-        raise NotImplementedError
 
     def _body(self, field_types: FieldTypes) -> JSON:
         body = self.to_json()
@@ -1377,10 +1351,17 @@ class Contribution(Document[ContributionCoordinates[E]]):
     contents: JSON
     source: DocumentSource
 
-    #: The version_type attribute will change to VersionType.none if writing
+    #: The op_type attribute will change to OpType.index if writing
     #: to Elasticsearch fails with 409
-    initial_version_type: ClassVar[VersionType] = VersionType.create_only
-    version_type: VersionType = initial_version_type
+    _op_type: OpType = OpType.create
+
+    @property
+    def op_type(self) -> OpType:
+        return self._op_type
+
+    @op_type.setter
+    def op_type(self, op_type: OpType):
+        self._op_type = op_type
 
     def __attrs_post_init__(self):
         assert self.contents is not None
@@ -1438,21 +1419,9 @@ class Contribution(Document[ContributionCoordinates[E]]):
                     bundle_version=self.coordinates.bundle.version,
                     bundle_deleted=self.coordinates.deleted)
 
-    @property
-    def op_type(self) -> OpType:
-        if self.version_type is VersionType.create_only:
-            return OpType.create
-        elif self.version_type is VersionType.none:
-            return OpType.index
-        else:
-            assert False, self.version_type
-
 
 @attr.s(frozen=False, kw_only=True, auto_attribs=True)
 class Aggregate(Document[AggregateCoordinates]):
-    initial_version_type: ClassVar[VersionType] = VersionType.internal
-    version_type: VersionType = attr.ib(default=initial_version_type,
-                                        on_setattr=attr.setters.frozen)
     sources: set[DocumentSource]
     bundles: Optional[list[BundleFQIDJSON]]
     num_contributions: int
@@ -1560,7 +1529,6 @@ class Replica(Document[ReplicaCoordinates[E]]):
 
     @property
     def op_type(self) -> OpType:
-        assert self.version_type is VersionType.none, self.version_type
         return OpType.update
 
     def _body(self, field_types: FieldTypes) -> JSON:

--- a/src/azul/indexer/document.py
+++ b/src/azul/indexer/document.py
@@ -1330,6 +1330,8 @@ class Document(Generic[C], metaclass=ABCMeta):
             result['body'] = self._body(field_types[coordinates.entity.catalog])
         if self.version is not None:
             result['if_seq_no'], result['if_primary_term'] = self.version
+        if self.op_type is OpType.update:
+            result['params'] = {'retry_on_conflict': 3}
         return result
 
     def _body(self, field_types: FieldTypes) -> JSON:

--- a/src/azul/indexer/index_service.py
+++ b/src/azul/indexer/index_service.py
@@ -609,6 +609,8 @@ class IndexService(DocumentService):
         num_contributions = sum(tallies.values())
         log.info('Reading %i expected contribution(s)', num_contributions)
 
+        is_internal_version = Contribution.initial_version_type is VersionType.internal
+
         def pages() -> Iterable[JSONs]:
             body = dict(query=query)
             while True:
@@ -617,7 +619,7 @@ class IndexService(DocumentService):
                                             body=body,
                                             size=config.contribution_page_size,
                                             track_total_hits=False,
-                                            seq_no_primary_term=Contribution.needs_seq_no_primary_term)
+                                            seq_no_primary_term=is_internal_version)
                 hits = response['hits']['hits']
                 log.debug('Read a page with %i contribution(s)', len(hits))
                 if hits:

--- a/src/azul/indexer/index_service.py
+++ b/src/azul/indexer/index_service.py
@@ -890,6 +890,7 @@ class IndexWriter:
             # optional document source.
             assert isinstance(doc, Document), doc
             action = dict(doc.to_index(self.catalog, self.field_types))
+            action.update(action.pop('params', {}))
             action['_index'] = action.pop('index')
             action['_id'] = action.pop('id')
             body = action.pop('body', None)


### PR DESCRIPTION
Connected issues: #6648


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved connected issues to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`/`partial`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for `dev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for `anvildev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
