### PR TITLE
Fix: Indexing integration test is complicated and inefficient (#6676)

### DIFF
--- a/src/azul/indexer/__init__.py
+++ b/src/azul/indexer/__init__.py
@@ -552,6 +552,9 @@ class SourceRef(SupportsLessAndGreaterThan, Generic[SOURCE_SPEC, SOURCE_REF]):
         spec_cls, ref_cls = get_generic_type_params(cls, SourceSpec, SourceRef)
         return spec_cls
 
+    def with_prefix(self, prefix: Prefix) -> Self:
+        return attrs.evolve(self, spec=attrs.evolve(self.spec, prefix=prefix))
+
 
 class SourcedBundleFQIDJSON(BundleFQIDJSON):
     source: SourceJSON

--- a/src/azul/plugins/__init__.py
+++ b/src/azul/plugins/__init__.py
@@ -640,7 +640,7 @@ class RepositoryPlugin(Plugin[BUNDLE],
                 prefix = Prefix.for_main_deployment(count)
             else:
                 prefix = Prefix.for_lesser_deployment(count)
-            source = attr.evolve(source, spec=attr.evolve(source.spec, prefix=prefix))
+            source = source.with_prefix(prefix)
         return source
 
     @abstractmethod

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -6,7 +6,6 @@ from collections.abc import (
     Iterator,
     Mapping,
     Sequence,
-    Set,
 )
 from concurrent.futures.thread import (
     ThreadPoolExecutor,
@@ -43,7 +42,6 @@ from typing import (
     Callable,
     ContextManager,
     IO,
-    Optional,
     Protocol,
     TypedDict,
     cast,
@@ -802,8 +800,8 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
                         method: str,
                         path: str,
                         *,
-                        args: Optional[Mapping[str, Any]] = None,
-                        endpoint: Optional[furl] = None,
+                        args: Mapping[str, Any] | None = None,
+                        endpoint: furl | None = None,
                         fetch: bool = False
                         ) -> bytes:
         if endpoint is None:
@@ -1207,7 +1205,7 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
 
     def _get_gs_url_content(self,
                             url: furl,
-                            size: Optional[int] = None
+                            size: int | None = None
                             ) -> BytesIO:
         self.assertEquals('gs', url.scheme)
         path = os.environ['GOOGLE_APPLICATION_CREDENTIALS']
@@ -1268,7 +1266,7 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
 
     def _get_indexed_bundles(self,
                              catalog: CatalogName,
-                             filters: Optional[JSON] = None
+                             filters: JSON | None = None
                              ) -> set[SourcedBundleFQID]:
         indexed_fqids = set()
         hits = self._get_entities(catalog, 'bundles', filters)
@@ -1286,7 +1284,7 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
 
     def _assert_catalog_complete(self,
                                  catalog: CatalogName,
-                                 bundle_fqids: Set[SourcedBundleFQID]
+                                 bundle_fqids: set[SourcedBundleFQID]
                                  ) -> None:
         with self.subTest('catalog_complete', catalog=catalog):
             expected_fqids = bundle_fqids
@@ -1345,7 +1343,7 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
     def _get_entities(self,
                       catalog: CatalogName,
                       entity_type: EntityType,
-                      filters: Optional[JSON] = None
+                      filters: JSON | None = None
                       ) -> MutableJSONs:
         entities = []
         size = 100
@@ -1377,7 +1375,7 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
 
     def _test_managed_access(self,
                              catalog: CatalogName,
-                             bundle_fqids: Set[SourcedBundleFQID]
+                             bundle_fqids: set[SourcedBundleFQID]
                              ) -> None:
         with self.subTest('managed_access', catalog=catalog):
             indexed_source_ids = {fqid.source.id for fqid in bundle_fqids}
@@ -1408,8 +1406,8 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
 
     def _test_managed_access_repository_sources(self,
                                                 catalog: CatalogName,
-                                                indexed_source_ids: Set[str],
-                                                managed_access_source_ids: Set[str]
+                                                indexed_source_ids: set[str],
+                                                managed_access_source_ids: set[str]
                                                 ) -> set[str]:
         """
         Test the managed access controls for the /repository/sources endpoint
@@ -1441,7 +1439,7 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
 
     def _test_managed_access_indices(self,
                                      catalog: CatalogName,
-                                     managed_access_source_ids: Set[str]
+                                     managed_access_source_ids: set[str]
                                      ) -> JSONs:
         """
         Test the managed-access controls for the /index/bundles and

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -3,7 +3,6 @@ from abc import (
 )
 from collections.abc import (
     Iterable,
-    Iterator,
     Mapping,
     Sequence,
 )
@@ -19,10 +18,8 @@ from io import (
     BytesIO,
     TextIOWrapper,
 )
-import itertools
 from itertools import (
     count,
-    starmap,
 )
 import json
 import os
@@ -78,6 +75,7 @@ from more_itertools import (
     first,
     grouper,
     one,
+    only,
 )
 from openapi_spec_validator import (
     validate_spec,
@@ -105,6 +103,9 @@ from azul.azulclient import (
 from azul.chalice import (
     AzulChaliceApp,
 )
+from azul.collections import (
+    alist,
+)
 from azul.drs import (
     AccessMethod,
 )
@@ -115,6 +116,7 @@ from azul.http import (
     http_client,
 )
 from azul.indexer import (
+    Prefix,
     SourceJSON,
     SourceRef,
     SourceSpec,
@@ -150,7 +152,6 @@ from azul.plugins.metadata.anvil.bundle import (
     Link,
 )
 from azul.plugins.repository.tdr_anvil import (
-    BundleType,
     TDRAnvilBundleFQID,
 )
 from azul.portal_service import (
@@ -284,73 +285,34 @@ class IntegrationTestCase(AzulTestCase, metaclass=ABCMeta):
                     managed_access_sources[catalog].add(ref)
         return managed_access_sources
 
-    def _list_partitions(self,
-                         catalog: CatalogName,
-                         *,
-                         min_bundles: int,
-                         public_1st: bool
-                         ) -> Iterator[tuple[SourceRef, str, list[SourcedBundleFQID]]]:
-        """
-        Iterate through the sources in the given catalog and yield partitions of
-        bundle FQIDs until a desired minimum number of bundles are found. For
-        each emitted source, every partition is included, even if it's empty.
-        """
-        total_bundles = 0
-        sources = sorted(config.sources(catalog))
-        self.random.shuffle(sources)
-        if public_1st:
-            managed_access_sources = frozenset(
+    def _choose_source(self,
+                       catalog: CatalogName,
+                       *,
+                       public: bool | None = None
+                       ) -> SourceRef | None:
+        plugin = self.repository_plugin(catalog)
+        sources = set(config.sources(catalog))
+        if public is not None:
+            ma_sources = {
                 str(source.spec)
+                # This would raise a KeyError during the can bundle script test
+                # due to it using a mock catalog, so we only evaluate it when
+                # it's actually needed
                 for source in self.managed_access_sources_by_catalog[catalog]
-            )
-            index = first(
-                i
-                for i, source in enumerate(sources)
-                if source not in managed_access_sources
-            )
-            sources[0], sources[index] = sources[index], sources[0]
-        plugin = self.azul_client.repository_plugin(catalog)
-        # This iteration prefers sources occurring first, so we shuffle them
-        # above to neutralize the bias.
-        for source in sources:
-            source = plugin.resolve_source(source)
-            source = plugin.partition_source(catalog, source)
-            for prefix in source.spec.prefix.partition_prefixes():
-                new_fqids = self.azul_client.list_bundles(catalog, source, prefix)
-                total_bundles += len(new_fqids)
-                yield source, prefix, new_fqids
-            # We postpone this check until after we've yielded all partitions in
-            # the current source to ensure test coverage for handling multiple
-            # partitions per source
-            if total_bundles >= min_bundles:
-                break
+            }
+            self.assertIsSubset(ma_sources, sources)
+            if public is True:
+                sources -= ma_sources
+            elif public is False:
+                sources &= ma_sources
+            else:
+                assert False, public
+        if len(sources) == 0:
+            assert public is False, 'Every catalog should contain a public source'
+            return None
         else:
-            log.warning('Checked all sources and found only %d bundles instead of the '
-                        'expected minimum %d', total_bundles, min_bundles)
-
-    def _list_managed_access_bundles(self,
-                                     catalog: CatalogName
-                                     ) -> Iterator[tuple[SourceRef, str, list[SourcedBundleFQID]]]:
-        sources = self.azul_client.catalog_sources(catalog)
-        # We need at least one managed_access bundle per IT. To index them with
-        # remote_reindex and avoid collateral bundles, we use as specific a
-        # prefix as possible.
-        for source in self.managed_access_sources_by_catalog[catalog]:
-            assert str(source.spec) in sources
-            source = self.repository_plugin(catalog).partition_source(catalog, source)
-            bundle_fqids = sorted(
-                bundle_fqid
-                for bundle_fqid in self.azul_client.list_bundles(catalog, source, prefix='')
-                if not (
-                    # DUOS bundles are too sparse to fulfill the managed access tests
-                    config.is_anvil_enabled(catalog)
-                    and cast(TDRAnvilBundleFQID, bundle_fqid).table_name is BundleType.duos
-                )
-            )
-            bundle_fqid = self.random.choice(bundle_fqids)
-            prefix = bundle_fqid.uuid[:8]
-            new_fqids = self.azul_client.list_bundles(catalog, source, prefix)
-            yield source, prefix, new_fqids
+            source = self.random.choice(sorted(sources))
+            return plugin.resolve_source(source)
 
 
 class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
@@ -426,6 +388,8 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
             name: CatalogName
             bundles: set[SourcedBundleFQID]
             notifications: list[JSON]
+            public_source: SourceRef
+            ma_source: SourceRef | None
 
         def _wait_for_indexer():
             self.azul_client.wait_for_indexer()
@@ -442,12 +406,23 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
         catalogs: list[Catalog] = []
         for catalog in config.integration_test_catalogs:
             if index:
-                notifications, fqids = self._prepare_notifications(catalog)
+                public_source = self._choose_source(catalog, public=True)
+                ma_source = self._choose_source(catalog, public=False)
+                notifications, fqids = self._prepare_notifications(catalog,
+                                                                   sources=alist(public_source, ma_source))
             else:
-                notifications, fqids = [], set()
+                with self._service_account_credentials:
+                    fqids = self._get_indexed_bundles(catalog)
+                indexed_sources = {fqid.source for fqid in fqids}
+                ma_sources = self.managed_access_sources_by_catalog[catalog]
+                public_source = one(s for s in indexed_sources if s not in ma_sources)
+                ma_source = only(s for s in indexed_sources if s in ma_sources)
+                notifications = []
             catalogs.append(Catalog(name=catalog,
                                     bundles=fqids,
-                                    notifications=notifications))
+                                    notifications=notifications,
+                                    public_source=public_source,
+                                    ma_source=ma_source))
 
         if index:
             for catalog in catalogs:
@@ -463,12 +438,9 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
             self._test_manifest_tagging_race(catalog.name)
             self._test_dos_and_drs(catalog.name)
             self._test_repository_files(catalog.name)
-            if index:
-                bundle_fqids = catalog.bundles
-            else:
-                with self._service_account_credentials:
-                    bundle_fqids = self._get_indexed_bundles(catalog.name)
-            self._test_managed_access(catalog=catalog.name, bundle_fqids=bundle_fqids)
+            self._test_managed_access(catalog=catalog.name,
+                                      public_source=catalog.public_source,
+                                      ma_source=catalog.ma_source)
 
         if index and delete:
             # FIXME: Test delete notifications
@@ -1226,33 +1198,21 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
         self.assertTrue(lines[2].startswith(b'+'))
 
     def _prepare_notifications(self,
-                               catalog: CatalogName
+                               catalog: CatalogName,
+                               sources: Iterable[SourceRef]
                                ) -> tuple[JSONs, set[SourcedBundleFQID]]:
-        bundle_fqids: set[SourcedBundleFQID] = set()
+        plugin = self.repository_plugin(catalog)
+        bundle_fqids = set()
         notifications = []
-
-        def update(source: SourceRef,
-                   prefix: str,
-                   partition_bundle_fqids: Iterable[SourcedBundleFQID]):
-            bundle_fqids.update(partition_bundle_fqids)
-            notifications.append(self.azul_client.reindex_message(catalog,
-                                                                  source,
-                                                                  prefix))
-
-        list(starmap(update, self._list_managed_access_bundles(catalog)))
-        num_bundles = max(self.min_bundles - len(bundle_fqids), 1)
-        log.info('Selected %d bundles to satisfy managed access coverage; '
-                 'selecting at least %d more', len(bundle_fqids), num_bundles)
-        # _list_partitions selects both public and managed access sources at random.
-        # If we don't index at least one public source, every request would need
-        # service account credentials and we couldn't compare the responses for
-        # public and managed access data. `public_1st` ensures that at least
-        # one of the sources will be public because sources are indexed starting
-        # with the first one yielded by the iteration.
-        list(starmap(update, self._list_partitions(catalog,
-                                                   min_bundles=num_bundles,
-                                                   public_1st=True)))
-
+        for source in sources:
+            source = plugin.partition_source(catalog, source)
+            # Some partitions may be empty, but we include them anyway to
+            # ensure test coverage for handling multiple partitions per source
+            for partition_prefix in source.spec.prefix.partition_prefixes():
+                bundle_fqids.update(self.azul_client.list_bundles(catalog, source, partition_prefix))
+                notifications.append(self.azul_client.reindex_message(catalog,
+                                                                      source,
+                                                                      partition_prefix))
         # Index some bundles again to test that we handle duplicate additions.
         # Note: random.choices() may pick the same element multiple times so
         # some notifications may end up being sent three or more times.
@@ -1375,40 +1335,34 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
 
     def _test_managed_access(self,
                              catalog: CatalogName,
-                             bundle_fqids: set[SourcedBundleFQID]
+                             public_source: SourceRef,
+                             ma_source: SourceRef | None,
                              ) -> None:
         with self.subTest('managed_access', catalog=catalog):
-            indexed_source_ids = {fqid.source.id for fqid in bundle_fqids}
-            managed_access_sources = self.managed_access_sources_by_catalog[catalog]
-            managed_access_source_ids = {source.id for source in managed_access_sources}
-            self.assertIsSubset(managed_access_source_ids, indexed_source_ids)
-
-            if not managed_access_sources:
+            if ma_source is None:
                 if config.deployment_stage in ('dev', 'sandbox'):
                     # There should always be at least one managed-access source
                     # indexed and tested on the default catalog for these deployments
                     self.assertNotEqual(catalog, config.it_catalog_for(config.default_catalog))
                 self.skipTest(f'No managed access sources found in catalog {catalog!r}')
-
             with self.subTest('managed_access_indices', catalog=catalog):
-                self._test_managed_access_indices(catalog, managed_access_source_ids)
+                self._test_managed_access_indices(catalog, public_source, ma_source)
             with self.subTest('managed_access_repository_files', catalog=catalog):
-                files = self._test_managed_access_repository_files(catalog, managed_access_source_ids)
+                files = self._test_managed_access_repository_files(catalog, ma_source)
                 with self.subTest('managed_access_summary', catalog=catalog):
                     self._test_managed_access_summary(catalog, files)
                 with self.subTest('managed_access_repository_sources', catalog=catalog):
-                    public_source_ids = self._test_managed_access_repository_sources(catalog,
-                                                                                     indexed_source_ids,
-                                                                                     managed_access_source_ids)
-                    with self.subTest('managed_access_manifest', catalog=catalog):
-                        source_id = self.random.choice(sorted(public_source_ids & indexed_source_ids))
-                        self._test_managed_access_manifest(catalog, files, source_id)
+                    self._test_managed_access_repository_sources(catalog,
+                                                                 public_source,
+                                                                 ma_source)
+                with self.subTest('managed_access_manifest', catalog=catalog):
+                    self._test_managed_access_manifest(catalog, files, public_source)
 
     def _test_managed_access_repository_sources(self,
                                                 catalog: CatalogName,
-                                                indexed_source_ids: set[str],
-                                                managed_access_source_ids: set[str]
-                                                ) -> set[str]:
+                                                public_source: SourceRef,
+                                                ma_source: SourceRef
+                                                ) -> None:
         """
         Test the managed access controls for the /repository/sources endpoint
         :return: the set of public sources
@@ -1421,11 +1375,14 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
             return {source['sourceId'] for source in cast(JSONs, response['sources'])}
 
         with self._service_account_credentials:
-            self.assertIsSubset(indexed_source_ids, list_source_ids())
+            self.assertIsSubset({public_source.id, ma_source.id}, list_source_ids())
         with self._public_service_account_credentials:
             public_source_ids = list_source_ids()
+            self.assertIn(public_source.id, public_source_ids)
+            self.assertNotIn(ma_source.id, public_source_ids)
         with self._unregistered_service_account_credentials:
             self.assertEqual(public_source_ids, list_source_ids())
+        self.assertEqual(public_source_ids, list_source_ids())
         invalid_auth = OAuth2('foo')
         with self.assertRaises(UnauthorizedError):
             TDRClient.for_registered_user(invalid_auth)
@@ -1433,13 +1390,11 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
         invalid_client = OAuth2Client(credentials_provider=invalid_provider)
         with self._authorization_context(invalid_client):
             self.assertEqual(401, self._get_url_unchecked(GET, url).status)
-        self.assertEqual(set(), list_source_ids() & managed_access_source_ids)
-        self.assertEqual(public_source_ids, list_source_ids())
-        return public_source_ids
 
     def _test_managed_access_indices(self,
                                      catalog: CatalogName,
-                                     managed_access_source_ids: set[str]
+                                     public_source: SourceRef,
+                                     ma_source: SourceRef
                                      ) -> JSONs:
         """
         Test the managed-access controls for the /index/bundles and
@@ -1449,11 +1404,6 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
         """
 
         special_fields = self.metadata_plugin(catalog).special_fields
-
-        def source_id_from_hit(hit: JSON) -> str:
-            sources: JSONs = hit['sources']
-            return one(sources)[special_fields.source_id]
-
         bundle_type = self._bundle_type(catalog)
         project_type = self._project_type(catalog)
 
@@ -1466,31 +1416,22 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
                 hits = self._get_entities(catalog, project_type, filters=filters)
                 if accessible is None:
                     unfiltered_hits = hits
-                accessible_sources, inaccessible_sources = set(), set()
                 for hit in hits:
-                    source_id = source_id_from_hit(hit)
-                    source_accessible = source_id not in managed_access_source_ids
+                    source_id = one(hit['sources'])[special_fields.source_id]
+                    source_accessible = {public_source.id: True, ma_source.id: False}[source_id]
                     hit_accessible = one(hit[project_type])[special_fields.accessible]
                     self.assertEqual(source_accessible, hit_accessible, hit['entryId'])
                     if accessible is not None:
                         self.assertEqual(accessible, hit_accessible)
-                    if source_accessible:
-                        accessible_sources.add(source_id)
-                    else:
-                        inaccessible_sources.add(source_id)
-                self.assertIsDisjoint(accessible_sources, inaccessible_sources)
-                self.assertIsDisjoint(managed_access_source_ids, accessible_sources)
-                self.assertEqual(set() if accessible else managed_access_source_ids,
-                                 inaccessible_sources)
         self.assertIsNotNone(unfiltered_hits, 'Cannot recover from subtest failure')
 
         bundle_fqids = self._get_indexed_bundles(catalog)
         hit_source_ids = {fqid.source.id for fqid in bundle_fqids}
-        self.assertEqual(set(), hit_source_ids & managed_access_source_ids)
+        self.assertEqual(hit_source_ids, {public_source.id})
 
         source_filter = {
             special_fields.source_id: {
-                'is': list(managed_access_source_ids)
+                'is': [ma_source.id]
             }
         }
         params = {
@@ -1499,18 +1440,18 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
         }
         url = config.service_endpoint.set(path=('index', bundle_type), args=params)
         response = self._get_url_unchecked(GET, url)
-        self.assertEqual(403 if managed_access_source_ids else 200, response.status)
+        self.assertEqual(403, response.status)
 
         with self._service_account_credentials:
             bundle_fqids = self._get_indexed_bundles(catalog, filters=source_filter)
         hit_source_ids = {fqid.source.id for fqid in bundle_fqids}
-        self.assertEqual(managed_access_source_ids, hit_source_ids)
+        self.assertEqual({ma_source.id}, hit_source_ids)
 
         return unfiltered_hits
 
     def _test_managed_access_repository_files(self,
                                               catalog: CatalogName,
-                                              managed_access_source_ids: set[str]
+                                              ma_source: SourceRef
                                               ) -> JSONs:
         """
         Test the managed access controls for the /repository/files endpoint
@@ -1520,7 +1461,7 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
         with self._service_account_credentials:
             files = self._get_entities(catalog, 'files', filters={
                 special_fields.source_id: {
-                    'is': list(managed_access_source_ids)
+                    'is': [ma_source.id]
                 }
             })
         managed_access_file_urls = {
@@ -1557,7 +1498,7 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
     def _test_managed_access_manifest(self,
                                       catalog: CatalogName,
                                       files: JSONs,
-                                      source_id: str
+                                      public_source: SourceRef
                                       ) -> None:
         """
         Test the managed access controls for the /manifest/files endpoint and
@@ -1579,7 +1520,7 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
             for file in files
             if len(file['sources']) == 1
         ))
-        filters = {special_fields.source_id: {'is': [source_id]}}
+        filters = {special_fields.source_id: {'is': [public_source.id]}}
         params = {'size': 1, 'catalog': catalog, 'filters': json.dumps(filters)}
         files_url = furl(url=endpoint, path='index/files', args=params)
         response = self._get_url_json(GET, files_url)
@@ -1944,13 +1885,10 @@ class CanBundleScriptIntegrationTest(IntegrationTestCase):
             self._test_catalog(mock_catalog)
 
     def bundle_fqid(self, catalog: CatalogName) -> SourcedBundleFQID:
-        # Skip through empty partitions
-        bundle_fqids = itertools.chain.from_iterable(
-            bundle_fqids
-            for _, _, bundle_fqids in self._list_partitions(catalog,
-                                                            min_bundles=1,
-                                                            public_1st=False)
-        )
+        source = self._choose_source(catalog)
+        # The plugin will raise an exception if the source lacks a prefix
+        source = source.with_prefix(Prefix.of_everything)
+        bundle_fqids = self.repository_plugin(catalog).list_bundles(source, '')
         return self.random.choice(sorted(bundle_fqids))
 
     def _can_bundle(self,


### PR DESCRIPTION
Connected issues: #6676


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved connected issues to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for `dev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for `anvildev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
