### PR TITLE
Improve linkage of PR CL items for admin (#6706)

### DIFF
--- a/.github/ISSUE_TEMPLATE/upgrade.md
+++ b/.github/ISSUE_TEMPLATE/upgrade.md
@@ -13,28 +13,28 @@ _period: 14 days
   - [ ] Remove unused dependencies with high or critical CVEs
   - [ ] Push commit to GitHub (directly to `master` branch, no PR needed)
   - [ ] GH Action workflow succeeded
-  - [ ] Image is available on [DockerHub](https://hub.docker.com/repository/docker/ucscgi/azul-pycharm) 
+  - [ ] Image is available on [DockerHub](https://hub.docker.com/repository/docker/ucscgi/azul-pycharm/tags) 
 - [ ] Update [Elasticsearch image](https://github.com/DataBiosphere/azul-docker-elasticsearch)
   - [ ] Bump [base image](https://hub.docker.com/_/elasticsearch/tags) tag (only minor and patch versions), if possible
   - [ ] Bump internal version 
   - [ ] Remove unused dependencies with high or critical CVEs
   - [ ] Push commit to GitHub (directly to `main` branch, no PR needed)
   - [ ] GH Action workflow succeeded
-  - [ ] Image is available on [DockerHub](https://hub.docker.com/repository/docker/ucscgi/azul-elasticsearch) 
+  - [ ] Image is available on [DockerHub](https://hub.docker.com/repository/docker/ucscgi/azul-elasticsearch/tags) 
 - [ ] Update [BigQuery Emulator image](https://github.com/DataBiosphere/azul-bigquery-emulator)
   - [ ] Bump [base image](https://hub.docker.com/_/debian/tags?name=bookworm) tag, if possible
   - [ ] Bump internal version 
   - [ ] Push commit to GitHub (directly to `azul` branch, no PR needed)
   - [ ] GH Action workflow succeeded
-  - [ ] Image is available on [DockerHub](https://hub.docker.com/repository/docker/ucscgi/azul-bigquery-emulator) 
+  - [ ] Image is available on [DockerHub](https://hub.docker.com/repository/docker/ucscgi/azul-bigquery-emulator/tags) 
 - [ ] Create Azul PR, connected to this issue, with … 
     - [ ] … changes to `requirements*.txt` from open Dependabot PRs, one commit per PR
     - [ ] … upgrade direct Python dependencies, [reference the operator manual](https://github.com/DataBiosphere/azul/blob/develop/OPERATOR.rst#upgrade-direct-python-dependencies) for instructions <sub>or not applicable</sub>
     - [ ] … update to [Python](https://hub.docker.com/_/python/tags) (only patch versions) <sub>or no update available</sub>
     - [ ] … update to [Terraform](https://hub.docker.com/r/hashicorp/terraform/tags) (only patch versions) <sub>or no update available</sub>
-    - [ ] … new [PyCharm image](https://hub.docker.com/repository/docker/ucscgi/azul-pycharm)
-    - [ ] … new [Elasticsearch image](https://hub.docker.com/repository/docker/ucscgi/azul-elasticsearch)
-    - [ ] … new [BigQuery Emulator image](https://hub.docker.com/repository/docker/ucscgi/azul-bigquery-emulator)
+    - [ ] … new [PyCharm image](https://hub.docker.com/repository/docker/ucscgi/azul-pycharm/tags)
+    - [ ] … new [Elasticsearch image](https://hub.docker.com/repository/docker/ucscgi/azul-elasticsearch/tags)
+    - [ ] … new [BigQuery Emulator image](https://hub.docker.com/repository/docker/ucscgi/azul-bigquery-emulator/tags))
     - [ ] … update to [Docker images](https://hub.docker.com/_/docker/tags) (only minor and patch versions) <sub>or no update available</sub>
     - [ ] … update to [GitLab](https://hub.docker.com/r/gitlab/gitlab-ce/tags) & [GitLab runner images](https://hub.docker.com/r/gitlab/gitlab-runner/tags) <sub>or no update available</sub>
     - [ ] … update to [ClamAV image](https://hub.docker.com/r/clamav/clamav/tags) <sub>or no update available</sub>

--- a/.github/PULL_REQUEST_TEMPLATE/anvilprod-promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/anvilprod-promotion.md
@@ -53,7 +53,7 @@ Connected issue: #0000
 
 ### System administrator
 
-- [ ] Background migrations for `anvilprod.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
+- [ ] Background migrations for [`anvilprod.gitlab`](https://gitlab.explore.anvilproject.org/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
 - [ ] PR is assigned to only the operator
 
 

--- a/.github/PULL_REQUEST_TEMPLATE/anvilprod-promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/anvilprod-promotion.md
@@ -100,9 +100,9 @@ Connected issue: #0000
 
 ### System administrator
 
-- [ ] Removed unused image tags from [pycharm image on DockerHub](https://hub.docker.com/repository/docker/ucscgi/azul-pycharm) <sub>or this promotion does not alter references to that image</sub>
-- [ ] Removed unused image tags from [elasticsearch image on DockerHub](https://hub.docker.com/repository/docker/ucscgi/azul-elasticsearch) <sub>or this promotion does not alter references to that image</sub>
-- [ ] Removed unused image tags from [bigquery_emulator image on DockerHub](https://hub.docker.com/repository/docker/ucscgi/azul-bigquery-emulator) <sub>or this promotion does not alter references to that image</sub>
+- [ ] Removed unused image tags from [pycharm image on DockerHub](https://hub.docker.com/repository/docker/ucscgi/azul-pycharm/tags) <sub>or this promotion does not alter references to that image</sub>
+- [ ] Removed unused image tags from [elasticsearch image on DockerHub](https://hub.docker.com/repository/docker/ucscgi/azul-elasticsearch/tags) <sub>or this promotion does not alter references to that image</sub>
+- [ ] Removed unused image tags from [bigquery_emulator image on DockerHub](https://hub.docker.com/repository/docker/ucscgi/azul-bigquery-emulator/tags) <sub>or this promotion does not alter references to that image</sub>
 - [ ] PR is assigned to no one
 
 

--- a/.github/PULL_REQUEST_TEMPLATE/prod-promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/prod-promotion.md
@@ -53,7 +53,7 @@ Connected issue: #0000
 
 ### System administrator
 
-- [ ] Background migrations for `prod.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
+- [ ] Background migrations for [`prod.gitlab`](https://gitlab.azul.data.humancellatlas.org/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
 - [ ] PR is assigned to only the operator
 
 

--- a/.github/PULL_REQUEST_TEMPLATE/prod-promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/prod-promotion.md
@@ -95,9 +95,9 @@ Connected issue: #0000
 
 ### System administrator
 
-- [ ] Removed unused image tags from [pycharm image on DockerHub](https://hub.docker.com/repository/docker/ucscgi/azul-pycharm) <sub>or this promotion does not alter references to that image</sub>
-- [ ] Removed unused image tags from [elasticsearch image on DockerHub](https://hub.docker.com/repository/docker/ucscgi/azul-elasticsearch) <sub>or this promotion does not alter references to that image</sub>
-- [ ] Removed unused image tags from [bigquery_emulator image on DockerHub](https://hub.docker.com/repository/docker/ucscgi/azul-bigquery-emulator) <sub>or this promotion does not alter references to that image</sub>
+- [ ] Removed unused image tags from [pycharm image on DockerHub](https://hub.docker.com/repository/docker/ucscgi/azul-pycharm/tags) <sub>or this promotion does not alter references to that image</sub>
+- [ ] Removed unused image tags from [elasticsearch image on DockerHub](https://hub.docker.com/repository/docker/ucscgi/azul-elasticsearch/tags) <sub>or this promotion does not alter references to that image</sub>
+- [ ] Removed unused image tags from [bigquery_emulator image on DockerHub](https://hub.docker.com/repository/docker/ucscgi/azul-bigquery-emulator/tags) <sub>or this promotion does not alter references to that image</sub>
 - [ ] PR is assigned to no one
 
 

--- a/.github/PULL_REQUEST_TEMPLATE/upgrade.md
+++ b/.github/PULL_REQUEST_TEMPLATE/upgrade.md
@@ -65,8 +65,8 @@ Connected issue: #0000
 
 ### System administrator
 
-- [ ] Background migrations for `dev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
-- [ ] Background migrations for `anvildev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
+- [ ] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
+- [ ] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
 - [ ] PR is assigned to only the operator
 
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -118,8 +118,8 @@ title is `Fix: ` followed by the issue title
 
 ### System administrator
 
-- [ ] Background migrations for `dev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
-- [ ] Background migrations for `anvildev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
+- [ ] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
+- [ ] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
 - [ ] PR is assigned to only the operator
 
 

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -32,6 +32,9 @@ from azul import (
 from azul.collections import (
     OrderedSet,
 )
+from azul.modules import (
+    load_script,
+)
 from azul.strings import (
     back_quote as bq,
     join_grammatically,
@@ -233,6 +236,16 @@ def main():
             pass
         else:
             emit(t, target_branch)
+
+
+def env_var(deployment: str, variable: str) -> str:
+    """
+    Return an environment variable value from the given deployment.
+    """
+    script = load_script('export_environment')
+    env, warning = script.load_env(deployment)
+    resolved_env = script.resolve_env(env)
+    return resolved_env[variable]
 
 
 def emit(t: T, target_branch: str):
@@ -715,7 +728,9 @@ def emit(t: T, target_branch: str):
                 *[
                     {
                         'type': 'cli',
-                        'content': f'Background migrations for `{d}.gitlab` are complete',
+                        'content': f'Background migrations for '
+                                   f'[`{d}.gitlab`](https://gitlab.{env_var(d, "AZUL_DOMAIN_NAME")}'
+                                   f'/admin/background_migrations) are complete',
                         'alt': 'or this PR is not labeled `deploy:gitlab`'
                     }
                     for d in t.target_deployments(target_branch)

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -1027,7 +1027,7 @@ def emit(t: T, target_branch: str):
                 *[
                     {
                         'type': 'cli',
-                        'content': f'Removed unused image tags from [{name} image on DockerHub]({url})',
+                        'content': f'Removed unused image tags from [{name} image on DockerHub]({url}/tags)',
                         'alt': 'or this promotion does not alter references to that image'
                     }
                     for name, url in custom_images.items()

--- a/scripts/export_environment.py
+++ b/scripts/export_environment.py
@@ -73,6 +73,14 @@ class EnvironmentModule(metaclass=ABCMeta):
         }
 
 
+class InvalidDeployment(RuntimeError):
+
+    def __init__(self, dir_: Path) -> None:
+        super().__init__(
+            f"{dir_} does not exist or is not a symbolic link to a directory."
+        )
+
+
 class InvalidActiveDeployment(RuntimeError):
 
     def __init__(self, dir_: Path) -> None:
@@ -91,45 +99,55 @@ class BadParentDeployment(RuntimeError):
         )
 
 
-def load_env() -> Tuple[Environment, Optional[str]]:
+def load_env(deployment: Optional[str] = None
+             ) -> Tuple[Environment, Optional[str]]:
     """
     Load environment.py and environment.local.py modules from the project
-    root and the current active deployment directory, call their env()
-    function to obtain the environment dictionary and merge the dictionaries.
-    The entries from an environment.local.py take precedence over those from
-    a corresponding environment.py in the same directory. The modules from
-    the deployment directory take precedence over ones in the project root.
+    root and either the specified deployment or the current active deployment
+    directory, call their env() function to obtain the environment dictionary
+    and merge the dictionaries. The entries from an environment.local.py take
+    precedence over those from a corresponding environment.py in the same
+    directory. The modules from the deployment directory take precedence over
+    ones in the project root.
     """
 
     deployments_dir = root_dir / 'deployments'
     active_deployment_dir = deployments_dir / '.active'
-    if active_deployment_dir.exists():
-        if not active_deployment_dir.is_dir() or not active_deployment_dir.is_symlink():
-            raise InvalidActiveDeployment(active_deployment_dir)
 
-        # If active deployment is a component of another one, also load the parent
-        # deployments (like dev.gitlab).
-        active_deployment_dir = Path(os.readlink(str(active_deployment_dir)))
-        if not active_deployment_dir.is_absolute():
-            active_deployment_dir = deployments_dir / active_deployment_dir
-        if not active_deployment_dir.is_dir():
-            raise InvalidActiveDeployment(active_deployment_dir)
-        relative_active_deployment_dir = active_deployment_dir.relative_to(deployments_dir)
-        prefix, _, suffix = str(relative_active_deployment_dir).partition('.')
-        if suffix and suffix != 'local':
-            parent_deployment_dir = deployments_dir / prefix
-            if not parent_deployment_dir.exists():
-                raise BadParentDeployment(parent_deployment_dir, active_deployment_dir)
-        else:
-            parent_deployment_dir = None
+    if deployment is not None:
+        deployment_dir = deployments_dir / deployment
+        if not deployment_dir.is_dir():
+            raise InvalidDeployment(deployments_dir)
         warning = None
+    elif active_deployment_dir.is_dir() and active_deployment_dir.is_symlink():
+        deployment_dir = Path(os.readlink(str(active_deployment_dir)))
+        if not deployment_dir.is_absolute():
+            deployment_dir = deployments_dir / deployment_dir
+        if not deployment_dir.is_dir():
+            raise InvalidActiveDeployment(deployment_dir)
+        warning = None
+    elif active_deployment_dir.exists():
+        raise InvalidActiveDeployment(active_deployment_dir)
     else:
         warning = (
             f'No active deployment (missing {str(active_deployment_dir)!r}). '
             f'Loaded global defaults only.'
         )
-        active_deployment_dir = None
+        deployment_dir = None
+
+    if deployment_dir is None:
         parent_deployment_dir = None
+    else:
+        # If the deployment is a component of another one (e.g. `dev.gitlab`),
+        # also get the parent deployment's directory.
+        relative_deployment_dir = deployment_dir.relative_to(deployments_dir)
+        prefix, _, suffix = str(relative_deployment_dir).partition('.')
+        if suffix and suffix != 'local':
+            parent_deployment_dir = deployments_dir / prefix
+            if not parent_deployment_dir.exists():
+                raise BadParentDeployment(parent_deployment_dir, deployment_dir)
+        else:
+            parent_deployment_dir = None
 
     def _load(dir_path: Path, local: bool = False) -> Optional[EnvironmentModule]:
         """
@@ -153,10 +171,10 @@ def load_env() -> Tuple[Environment, Optional[str]]:
             return None
 
     modules = [
-        active_deployment_dir and _load(active_deployment_dir, local=True),
+        deployment_dir and _load(deployment_dir, local=True),
         parent_deployment_dir and _load(parent_deployment_dir, local=True),
         _load(root_dir, local=True),
-        active_deployment_dir and _load(active_deployment_dir),
+        deployment_dir and _load(deployment_dir),
         parent_deployment_dir and _load(parent_deployment_dir),
         _load(root_dir)
     ]


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Connected issues: #6706


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved connected issues to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for `dev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for `anvildev.gitlab` are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
