### PR TITLE
Update docs & checklists about browser deployments (#6742, #6657)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/anvilprod-hotfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/anvilprod-hotfix.md
@@ -77,6 +77,8 @@ Connected issue: #0000
 - [ ] Started reindex in `anvilprod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
 - [ ] Checked for, triaged and possibly requeued messages in both fail queues in `anvilprod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
 - [ ] Emptied fail queues in `anvilprod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
+- [ ] Restarted the `trigger_child` job in the most recent Data Browser build for the [ucsc/anvil/anvilprod branch](https://gitlab.explore.anvilproject.org/ucsc/data-browser/-/pipelines?scope=branches) on GitLab in `anvilprod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
+- [ ] Restarted `deploy` job in the GitLab pipeline for this PR in `anvilprod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
 - [ ] Created backport PR and linked to it in a comment on this PR
 
 

--- a/.github/PULL_REQUEST_TEMPLATE/anvilprod-promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/anvilprod-promotion.md
@@ -91,6 +91,8 @@ Connected issue: #0000
 - [ ] Started reindex in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
 - [ ] Checked for, triaged and possibly requeued messages in both fail queues in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
 - [ ] Emptied fail queues in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
+- [ ] Restarted the `trigger_child` job in the most recent Data Browser build for the [ucsc/anvil/anvilprod branch](https://gitlab.explore.anvilproject.org/ucsc/data-browser/-/pipelines?scope=branches) on GitLab in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
+- [ ] Restarted `deploy` job in the GitLab pipeline for this PR in `anvilprod` <sub>or this PR does not require reindexing `anvilprod`</sub>
 
 
 ### Operator

--- a/.github/PULL_REQUEST_TEMPLATE/prod-hotfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/prod-hotfix.md
@@ -72,6 +72,9 @@ Connected issue: #0000
 - [ ] Started reindex in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
 - [ ] Checked for, triaged and possibly requeued messages in both fail queues in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
 - [ ] Emptied fail queues in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
+- [ ] Restarted the `trigger_child` job in the most recent Data Browser build for the [ucsc/hca/prod branch](https://gitlab.azul.data.humancellatlas.org/ucsc/data-browser/-/pipelines?scope=branches) on GitLab in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
+- [ ] Restarted the `trigger_child` job in the most recent Data Browser build for the [ucsc/lungmap/prod branch](https://gitlab.azul.data.humancellatlas.org/ucsc/data-browser/-/pipelines?scope=branches) on GitLab in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
+- [ ] Restarted `deploy` job in the GitLab pipeline for this PR in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
 - [ ] Created backport PR and linked to it in a comment on this PR
 
 

--- a/.github/PULL_REQUEST_TEMPLATE/prod-promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/prod-promotion.md
@@ -86,6 +86,9 @@ Connected issue: #0000
 - [ ] Started reindex in `prod` <sub>or this PR does not require reindexing `prod`</sub>
 - [ ] Checked for, triaged and possibly requeued messages in both fail queues in `prod` <sub>or this PR does not require reindexing `prod`</sub>
 - [ ] Emptied fail queues in `prod` <sub>or this PR does not require reindexing `prod`</sub>
+- [ ] Restarted the `trigger_child` job in the most recent Data Browser build for the [ucsc/hca/prod branch](https://gitlab.azul.data.humancellatlas.org/ucsc/data-browser/-/pipelines?scope=branches) on GitLab in `prod` <sub>or this PR does not require reindexing `prod`</sub>
+- [ ] Restarted the `trigger_child` job in the most recent Data Browser build for the [ucsc/lungmap/prod branch](https://gitlab.azul.data.humancellatlas.org/ucsc/data-browser/-/pipelines?scope=branches) on GitLab in `prod` <sub>or this PR does not require reindexing `prod`</sub>
+- [ ] Restarted `deploy` job in the GitLab pipeline for this PR in `prod` <sub>or this PR does not require reindexing `prod`</sub>
 
 
 ### Operator

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -185,6 +185,11 @@ title is `Fix: ` followed by the issue title
 - [ ] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
 - [ ] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
 - [ ] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
+- [ ] Restarted the `trigger_child` job in the most recent Data Browser build for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines?scope=branches) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
+- [ ] Restarted the `trigger_child` job in the most recent Data Browser build for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines?scope=branches) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
+- [ ] Restarted `deploy` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
+- [ ] Restarted the `trigger_child` job in the most recent Data Browser build for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines?scope=branches) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
+- [ ] Restarted `deploy` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
 
 
 ### Operator

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -5,6 +5,7 @@ from enum import (
 from itertools import (
     chain,
 )
+import json
 from pathlib import (
     Path,
 )
@@ -241,12 +242,19 @@ def main():
 
 
 @cache
-def deployment_env(deployment) -> Mapping[str, str]:
+def deployment_env(deployment: str,
+                   component: str | None = None
+                   ) -> Mapping[str, str]:
     script = load_script('export_environment')
+    deployment += '' if component is None else '.' + component
     env, warning = script.load_env(deployment)
     assert warning is None, warning
     resolved_env = script.resolve_env(env)
     return resolved_env
+
+
+def azul_domain_name(d):
+    return deployment_env(d)['AZUL_DOMAIN_NAME']
 
 
 def emit(t: T, target_branch: str):
@@ -730,7 +738,7 @@ def emit(t: T, target_branch: str):
                     {
                         'type': 'cli',
                         'content': f'Background migrations for '
-                                   f'[`{d}.gitlab`](https://gitlab.{deployment_env(d)['AZUL_DOMAIN_NAME']}'
+                                   f'[`{d}.gitlab`](https://gitlab.{azul_domain_name(d)}'
                                    f'/admin/background_migrations) are complete',
                         'alt': 'or this PR is not labeled `deploy:gitlab`'
                     }
@@ -963,6 +971,29 @@ def emit(t: T, target_branch: str):
                     ]
                     for d, s in t.target_deployments(target_branch).items()
                 ))),
+                *[
+                    {
+                        'type': 'cli',
+                        'content': f'{action} in `{d}`',
+                        'alt': (
+                            'or neither this PR nor a failed, prior promotion requires it'
+                            if t is T.hotfix else
+                            f'or this PR does not require reindexing `{d}`'
+                        )
+                    }
+                    for d, s in t.target_deployments(target_branch).items()
+                    for action in [
+                        *[
+                            'Restarted the `trigger_child` job in the most recent Data Browser build for the ['
+                            f'{browser_site['branch']} branch]'
+                            f'(https://gitlab.{azul_domain_name(d)}/ucsc/data-browser/-/pipelines?scope=branches) '
+                            f'on GitLab'
+                            for browser_site in
+                            json.loads(deployment_env(d, 'browser')['azul_browser_sites']).values()
+                        ],
+                        'Restarted `deploy` job in the GitLab pipeline for this PR'
+                    ]
+                ],
                 iif(t is T.hotfix, {
                     'type': 'cli',
                     'content': 'Created backport PR and linked to it in a comment on this PR'

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -957,7 +957,7 @@ def emit(t: T, target_branch: str):
                             for action in [
                                 'Started reindex',
                                 'Checked for, triaged and possibly requeued messages in both fail queues',
-                                'Emptied fail queues',
+                                'Emptied fail queues'
                             ]
                         ]
                     ]

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -213,6 +213,7 @@ class T(Enum):
     def needs_shared_deploy(self):
         return self not in (T.backport, T.hotfix)
 
+    # noinspection PyUnusedLocal
     def shared_deploy_is_two_phase(self, target_branch: str) -> bool:
         # All `shared` components are deployed in two-phases. The first phase,
         # prior to the merge, mirrors new images to ECR, while the second phase

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -26,6 +26,7 @@ from more_itertools import (
 )
 
 from azul import (
+    cache,
     config,
     iif,
 )
@@ -238,14 +239,12 @@ def main():
             emit(t, target_branch)
 
 
-def env_var(deployment: str, variable: str) -> str:
-    """
-    Return an environment variable value from the given deployment.
-    """
+@cache
+def deployment_env(deployment) -> Mapping[str, str]:
     script = load_script('export_environment')
     env, warning = script.load_env(deployment)
     resolved_env = script.resolve_env(env)
-    return resolved_env[variable]
+    return resolved_env
 
 
 def emit(t: T, target_branch: str):
@@ -729,7 +728,7 @@ def emit(t: T, target_branch: str):
                     {
                         'type': 'cli',
                         'content': f'Background migrations for '
-                                   f'[`{d}.gitlab`](https://gitlab.{env_var(d, 'AZUL_DOMAIN_NAME')}'
+                                   f'[`{d}.gitlab`](https://gitlab.{deployment_env(d)['AZUL_DOMAIN_NAME']}'
                                    f'/admin/background_migrations) are complete',
                         'alt': 'or this PR is not labeled `deploy:gitlab`'
                     }

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -334,7 +334,7 @@ def emit(t: T, target_branch: str):
             },
             iif(t is not T.backport, {
                 'type': 'cli',
-                'content': f"PR title references {t.issues('all', 'the')} connected {t.issues}"
+                'content': f'PR title references {t.issues('all', 'the')} connected {t.issues}'
             }),
             *(
                 [
@@ -729,7 +729,7 @@ def emit(t: T, target_branch: str):
                     {
                         'type': 'cli',
                         'content': f'Background migrations for '
-                                   f'[`{d}.gitlab`](https://gitlab.{env_var(d, "AZUL_DOMAIN_NAME")}'
+                                   f'[`{d}.gitlab`](https://gitlab.{env_var(d, 'AZUL_DOMAIN_NAME')}'
                                    f'/admin/background_migrations) are complete',
                         'alt': 'or this PR is not labeled `deploy:gitlab`'
                     }

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -243,6 +243,7 @@ def main():
 def deployment_env(deployment) -> Mapping[str, str]:
     script = load_script('export_environment')
     env, warning = script.load_env(deployment)
+    assert warning is None, warning
     resolved_env = script.resolve_env(env)
     return resolved_env
 

--- a/OPERATOR.rst
+++ b/OPERATOR.rst
@@ -629,7 +629,7 @@ backport PR first. The new PR will include the changes from the old one.
 Deploying the Data Browser
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The Data Browser is deployed two steps. The first step is building the
+The Data Browser is deployed in two steps. The first step is building the
 ``ucsc/data-browser`` project on GitLab. This is initiated by pushing a branch
 whose name matches ``ucsc/*/*`` to one of our GitLab instances. The resulting
 pipeline produces a tarball stored in the package registry on that GitLab

--- a/OPERATOR.rst
+++ b/OPERATOR.rst
@@ -1,4 +1,5 @@
 .. contents::
+.. contents::
 
 Getting started as operator
 ---------------------------
@@ -640,14 +641,16 @@ downloads the tarball from the package registry and unpacks that tarball to the
 S3 bucket backing the Data Browser's CloudFront distribution.
 
 Typically, CC requests the deployment of a Data Browser instance on Slack,
-specifying the commit they wish to be deployed. After the system administrator
-approves that request, the operator merges the specified commit into one of the
-``ucsc/{atlas}/{deployment}`` branches and then pushes that branch to the
+specifying the commit (tag or sha1) they wish to be deployed. After the
+system administrator approves that request, the operator pushes the specified tag
+(if a tag was specified) to the GitLab instance for the Azul ``{deployment}``
+that backs the Data Browser instance to be deployed. Then the specified tag (or
+commit, if no tag was specified) is merged into one of the
+``ucsc/{atlas}/{deployment}`` branches. That branch is then is pushed to the
 ``DataBiosphere/data-browser`` project on GitHub, and the ``ucsc/data-browser``
-project on the GitLab instance for the Azul ``{deployment}`` that backs the Data
-Browser instance to be deployed. For the merge commit title, SmartGit's default
-can be used, as long as the title reflects the commit (branch, tag, or sha1)
-specified by CC.
+project on GitLab (same instance as above). For the merge commit title,
+SmartGit's default can be used, as long as the title reflects the commit (tag or
+sha1) specified by CC.
 
 The ``{atlas}`` placeholder can be ``hca``, ``anvil`` or ``lungmap``. Not all
 combinations of ``{atlas}`` and ``{deployment}`` are valid. Valid combinations


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Connected issues: #6742, #6657


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved connected issues to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
