### PR TITLE
Fix: 404 from S3 when re-requesting manifest after it expired (#6441)

### DIFF
--- a/environment.py
+++ b/environment.py
@@ -912,5 +912,21 @@ def env() -> Mapping[str, Optional[str]]:
         # in the Azul VPC. This subnet can't overlap the VPC CIDR and the subnet
         # mask must be less than 22 bits.
         #
-        'azul_vpn_subnet': None
+        'azul_vpn_subnet': None,
+
+        # This variable contains a space-separated list of keywords, also known
+        # as *flags*, that control certain aspects of the integration test (IT).
+        #
+        # The presence of the `no_index` flag prevents the IT from indexing and
+        # causes it to reuse the indices created by a previous run. The
+        # `no_delete` flag prevents the IT from performing any deletions,
+        # allowing subsequent runs to reuse the indices.
+        #
+        # For faster modify-deploy-test cycles, set this to 'no_delete' and run
+        # the IT. Then set it to 'no_index no_delete'. Subsequent IT runs will
+        # reuse the index from a prior run, and be significantly faster, albeit
+        # not covering any changes to the indexer, since indexing will be
+        # skipped.
+        #
+        'azul_it_flags': None
     }

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -1600,6 +1600,10 @@ class Config:
     def vpn_subnet(self) -> str:
         return self.environ['azul_vpn_subnet']
 
+    @property
+    def it_flags(self) -> set[str]:
+        return set(self.environ.get('azul_it_flags', '').split())
+
 
 config: Config = Config()  # yes, the type hint does help PyCharm
 

--- a/src/azul/service/async_manifest_service.py
+++ b/src/azul/service/async_manifest_service.py
@@ -37,13 +37,13 @@ class Token:
     """
     Represents an ongoing manifest generation
     """
-    execution_id: UUID = strict_auto()
+    generation_id: UUID = strict_auto()
     request_index: int = strict_auto()
     retry_after: int = strict_auto()
 
     def pack(self) -> bytes:
         return msgpack.packb([
-            self.execution_id.bytes,
+            self.generation_id.bytes,
             self.request_index,
             self.retry_after
         ])
@@ -51,7 +51,7 @@ class Token:
     @classmethod
     def unpack(cls, pack: bytes) -> Self:
         i = iter(msgpack.unpackb(pack))
-        return cls(execution_id=UUID(bytes=next(i)),
+        return cls(generation_id=UUID(bytes=next(i)),
                    request_index=next(i),
                    retry_after=next(i))
 
@@ -66,8 +66,8 @@ class Token:
             raise InvalidTokenError(token) from e
 
     @classmethod
-    def first(cls, execution_id: UUID) -> Self:
-        return cls(execution_id=execution_id,
+    def first(cls, generation_id: UUID) -> Self:
+        return cls(generation_id=generation_id,
                    request_index=0,
                    retry_after=cls._next_retry_after(0))
 
@@ -112,14 +112,14 @@ class AsyncManifestService:
     def machine_name(self):
         return config.qualified_resource_name(config.manifest_sfn)
 
-    def start_generation(self, execution_id: UUID, input: JSON) -> Token:
-        execution_name = self.execution_name(execution_id)
+    def start_generation(self, generation_id: UUID, input: JSON) -> Token:
+        execution_name = self.execution_name(generation_id)
         execution_arn = self.execution_arn(execution_name)
         # The input contains the verbatim manifest key as JSON while the ARN
         # contains the encoded hash of the key so this log line is useful for
         # associating the hash with the key for diagnostic purposes.
         log.info('Starting execution %r for input %r', execution_arn, input)
-        token = Token.first(execution_id)
+        token = Token.first(generation_id)
         try:
             # If there already is an execution of the given name, and if that
             # execution is still ongoing and was given the same input as what we
@@ -154,7 +154,7 @@ class AsyncManifestService:
             return token
 
     def inspect_generation(self, token: Token) -> Token | JSON:
-        execution_name = self.execution_name(token.execution_id)
+        execution_name = self.execution_name(token.generation_id)
         execution_arn = self.execution_arn(execution_name)
         try:
             execution = self._sfn.describe_execution(executionArn=execution_arn)
@@ -186,10 +186,10 @@ class AsyncManifestService:
     def execution_arn(self, execution_name):
         return self.arn(f'execution:{self.machine_name}:{execution_name}')
 
-    def execution_name(self, execution_id: UUID) -> str:
-        assert isinstance(execution_id, UUID), execution_id
-        execution_name = str(execution_id)
-        assert 0 < len(execution_name) <= 80, (execution_id, execution_name)
+    def execution_name(self, generation_id: UUID) -> str:
+        assert isinstance(generation_id, UUID), generation_id
+        execution_name = str(generation_id)
+        assert 0 < len(execution_name) <= 80, (generation_id, execution_name)
         return execution_name
 
     @property

--- a/src/azul/service/async_manifest_service.py
+++ b/src/azul/service/async_manifest_service.py
@@ -6,19 +6,18 @@ from typing import (
     Self,
     Union,
 )
+from uuid import (
+    UUID,
+)
 
 import attrs
 import msgpack
 
 from azul import (
     config,
-    require,
 )
 from azul.attrs import (
     strict_auto,
-)
-from azul.bytes import (
-    azul_urlsafe_b64encode,
 )
 from azul.deployment import (
     aws,
@@ -40,13 +39,13 @@ class Token:
     """
     Represents an ongoing manifest generation
     """
-    execution_id: bytes = strict_auto()
+    execution_id: UUID = strict_auto()
     request_index: int = strict_auto()
     retry_after: int = strict_auto()
 
     def pack(self) -> bytes:
         return msgpack.packb([
-            self.execution_id,
+            self.execution_id.bytes,
             self.request_index,
             self.retry_after
         ])
@@ -54,7 +53,7 @@ class Token:
     @classmethod
     def unpack(cls, pack: bytes) -> Self:
         i = iter(msgpack.unpackb(pack))
-        return cls(execution_id=next(i),
+        return cls(execution_id=UUID(bytes=next(i)),
                    request_index=next(i),
                    retry_after=next(i))
 
@@ -69,7 +68,7 @@ class Token:
             raise InvalidTokenError(token) from e
 
     @classmethod
-    def first(cls, execution_id: bytes) -> Self:
+    def first(cls, execution_id: UUID) -> Self:
         return cls(execution_id=execution_id,
                    request_index=0,
                    retry_after=cls._next_retry_after(0))
@@ -115,7 +114,7 @@ class AsyncManifestService:
     def machine_name(self):
         return config.qualified_resource_name(config.manifest_sfn)
 
-    def start_generation(self, execution_id: bytes, input: JSON) -> Token:
+    def start_generation(self, execution_id: UUID, input: JSON) -> Token:
         execution_name = self.execution_name(execution_id)
         execution_arn = self.execution_arn(execution_name)
         # The input contains the verbatim manifest key as JSON while the ARN
@@ -189,10 +188,9 @@ class AsyncManifestService:
     def execution_arn(self, execution_name):
         return self.arn(f'execution:{self.machine_name}:{execution_name}')
 
-    def execution_name(self, execution_id: bytes) -> str:
-        require(0 < len(execution_id) <= 60,
-                'Execution ID is too short or too long', execution_id)
-        execution_name = azul_urlsafe_b64encode(execution_id)
+    def execution_name(self, execution_id: UUID) -> str:
+        assert isinstance(execution_id, UUID), execution_id
+        execution_name = str(execution_id)
         assert 0 < len(execution_name) <= 80, (execution_id, execution_name)
         return execution_name
 

--- a/src/azul/service/async_manifest_service.py
+++ b/src/azul/service/async_manifest_service.py
@@ -3,6 +3,7 @@ import json
 import logging
 from typing import (
     Self,
+    TypedDict,
 )
 from uuid import (
     UUID,
@@ -35,15 +36,30 @@ class InvalidTokenError(Exception):
 @attrs.frozen(kw_only=True)
 class Token:
     """
-    Represents an ongoing manifest generation
+    Represents a Step Function execution to generate a manifest
     """
+    #: A hash of the inputs
     generation_id: UUID = strict_auto()
+
+    #: Number of prior executions for the generation represented by this token
+    iteration: int = strict_auto()
+
+    #: The number of times the service received a request to inspect the
+    #: status of the execution represented by this token
     request_index: int = strict_auto()
+
+    #: How long clients should wait before requesting a status update about the
+    #: execution represented by the token
     retry_after: int = strict_auto()
+
+    @property
+    def execution_id(self) -> tuple[UUID, int]:
+        return self.generation_id, self.iteration
 
     def pack(self) -> bytes:
         return msgpack.packb([
             self.generation_id.bytes,
+            self.iteration,
             self.request_index,
             self.retry_after
         ])
@@ -52,6 +68,7 @@ class Token:
     def unpack(cls, pack: bytes) -> Self:
         i = iter(msgpack.unpackb(pack))
         return cls(generation_id=UUID(bytes=next(i)),
+                   iteration=next(i),
                    request_index=next(i),
                    retry_after=next(i))
 
@@ -66,8 +83,9 @@ class Token:
             raise InvalidTokenError(token) from e
 
     @classmethod
-    def first(cls, generation_id: UUID) -> Self:
+    def first(cls, generation_id: UUID, iteration: int) -> Self:
         return cls(generation_id=generation_id,
+                   iteration=iteration,
                    request_index=0,
                    retry_after=cls._next_retry_after(0))
 
@@ -87,8 +105,18 @@ class Token:
             return delays[-1]
 
 
+class ExecutionResult(TypedDict):
+    input: JSON
+    output: JSON
+
+
 @attrs.frozen
 class NoSuchGeneration(Exception):
+    token: Token = strict_auto()
+
+
+@attrs.frozen
+class GenerationFinished(Exception):
     token: Token = strict_auto()
 
 
@@ -112,14 +140,18 @@ class AsyncManifestService:
     def machine_name(self):
         return config.qualified_resource_name(config.manifest_sfn)
 
-    def start_generation(self, generation_id: UUID, input: JSON) -> Token:
-        execution_name = self.execution_name(generation_id)
+    def start_generation(self,
+                         generation_id: UUID,
+                         input: JSON,
+                         iteration: int
+                         ) -> Token:
+        execution_name = self.execution_name(generation_id, iteration)
         execution_arn = self.execution_arn(execution_name)
         # The input contains the verbatim manifest key as JSON while the ARN
         # contains the encoded hash of the key so this log line is useful for
         # associating the hash with the key for diagnostic purposes.
         log.info('Starting execution %r for input %r', execution_arn, input)
-        token = Token.first(generation_id)
+        token = Token.first(generation_id, iteration)
         try:
             # If there already is an execution of the given name, and if that
             # execution is still ongoing and was given the same input as what we
@@ -145,16 +177,16 @@ class AsyncManifestService:
             execution = self._sfn.describe_execution(executionArn=execution_arn)
             if input == json.loads(execution['input']):
                 log.info('A completed execution %r already exists', execution_arn)
-                return token
+                raise GenerationFinished(token)
             else:
                 raise InvalidGeneration(token)
         else:
-            assert execution_arn == execution['executionArn'], execution
+            assert execution_arn == execution['executionArn'], (execution_arn, execution)
             log.info('Started execution %r or it was already running', execution_arn)
             return token
 
-    def inspect_generation(self, token: Token) -> Token | JSON:
-        execution_name = self.execution_name(token.generation_id)
+    def inspect_generation(self, token: Token) -> Token | ExecutionResult:
+        execution_name = self.execution_name(token.generation_id, token.iteration)
         execution_arn = self.execution_arn(execution_name)
         try:
             execution = self._sfn.describe_execution(executionArn=execution_arn)
@@ -169,7 +201,7 @@ class AsyncManifestService:
                     return token.next(retry_after=1)
                 else:
                     log.info('Execution %r succeeded with output %r', execution_arn, output)
-                    return json.loads(output)
+                    return {k: json.loads(execution[k]) for k in ['input', 'output']}
             elif status == 'RUNNING':
                 log.info('Execution %r is still running', execution_arn)
                 return token.next()
@@ -186,10 +218,11 @@ class AsyncManifestService:
     def execution_arn(self, execution_name):
         return self.arn(f'execution:{self.machine_name}:{execution_name}')
 
-    def execution_name(self, generation_id: UUID) -> str:
+    def execution_name(self, generation_id: UUID, iteration: int) -> str:
         assert isinstance(generation_id, UUID), generation_id
-        execution_name = str(generation_id)
-        assert 0 < len(execution_name) <= 80, (generation_id, execution_name)
+        assert isinstance(iteration, int), iteration
+        execution_name = f'{generation_id}_{iteration}'
+        assert 0 < len(execution_name) <= 80, execution_name
         return execution_name
 
     @property

--- a/src/azul/service/async_manifest_service.py
+++ b/src/azul/service/async_manifest_service.py
@@ -2,9 +2,7 @@ import base64
 import json
 import logging
 from typing import (
-    Optional,
     Self,
-    Union,
 )
 from uuid import (
     UUID,
@@ -73,7 +71,7 @@ class Token:
                    request_index=0,
                    retry_after=cls._next_retry_after(0))
 
-    def next(self, *, retry_after: Optional[int] = None) -> Self:
+    def next(self, *, retry_after: int | None = None) -> Self:
         if retry_after is None:
             retry_after = self._next_retry_after(self.request_index)
         return attrs.evolve(self,
@@ -97,7 +95,7 @@ class NoSuchGeneration(Exception):
 @attrs.frozen(kw_only=True)
 class GenerationFailed(Exception):
     status: str = strict_auto()
-    output: Optional[str] = strict_auto()
+    output: str | None = strict_auto()
 
 
 @attrs.frozen
@@ -155,7 +153,7 @@ class AsyncManifestService:
             log.info('Started execution %r or it was already running', execution_arn)
             return token
 
-    def inspect_generation(self, token: Token) -> Union[Token, JSON]:
+    def inspect_generation(self, token: Token) -> Token | JSON:
         execution_name = self.execution_name(token.execution_id)
         execution_arn = self.execution_arn(execution_name)
         try:

--- a/src/azul/service/manifest_controller.py
+++ b/src/azul/service/manifest_controller.py
@@ -37,6 +37,7 @@ from azul.service import (
 from azul.service.async_manifest_service import (
     AsyncManifestService,
     GenerationFailed,
+    GenerationFinished,
     InvalidTokenError,
     NoSuchGeneration,
     Token,
@@ -127,6 +128,33 @@ class ManifestController(SourceController):
                     # The OpenAPI spec doesn't distinguish key and token
                     raise BadRequestError('Invalid token')
 
+    def _start_execution(self,
+                         filters: Filters,
+                         manifest_key: ManifestKey,
+                         previous_token: Token | None = None,
+                         ) -> Token:
+        partition = ManifestPartition.first()
+        state: ManifestGenerationState = {
+            'filters': filters.to_json(),
+            'manifest_key': manifest_key.to_json(),
+            'partition': partition.to_json()
+        }
+        # Manifest keys for catalogs with long names would be too long to be
+        # used directly as state machine execution names.
+        generation_id = manifest_key.uuid
+        # ManifestGenerationState is also JSON but there is no way to express
+        # that since TypedDict rejects a co-parent class.
+        input = cast(JSON, state)
+        next_iteration = 0 if previous_token is None else previous_token.iteration + 1
+        for i in range(10):
+            try:
+                return self.async_service.start_generation(generation_id,
+                                                           input,
+                                                           iteration=next_iteration + i)
+            except GenerationFinished:
+                pass
+        raise ChaliceViewError('Too many executions of this manifest generation')
+
     def get_manifest_async(self,
                            *,
                            token_or_key: str,
@@ -152,19 +180,8 @@ class ManifestController(SourceController):
                     # A cache miss, but the exception tells us the cache key
                     manifest, manifest_key = None, e.manifest_key
                     # Prepare the execution that will generate the manifest
-                    partition = ManifestPartition.first()
-                    state: ManifestGenerationState = {
-                        'filters': filters.to_json(),
-                        'manifest_key': manifest_key.to_json(),
-                        'partition': partition.to_json()
-                    }
-                    # Manifest keys for catalogs with long names would be too
-                    # long to be used directly in state machine execution names.
-                    generation_id = manifest_key.uuid
-                    # ManifestGenerationState is also JSON but there is no way
-                    # to express that since TypedDict rejects a co-parent class.
-                    input = cast(JSON, state)
-                    token = self.async_service.start_generation(generation_id, input)
+                    token = self._start_execution(filters=filters,
+                                                  manifest_key=manifest_key)
                 else:
                     # A cache hit
                     manifest_key = manifest.manifest_key
@@ -180,31 +197,48 @@ class ManifestController(SourceController):
                     manifest_key = self.service.verify_manifest_key(manifest_key)
                     manifest = self.service.get_cached_manifest_with_key(manifest_key)
                 except CachedManifestNotFound:
-                    # We can't restart the execution to regenerate the manifest
-                    # because we don't know the parameters that were used to
-                    # create it. So the client will have to do it.
-                    raise GoneError('The requested manifest has expired, please request a new one')
+                    # We could start another execution but that would require
+                    # the client to follow more redirects. We've already sent
+                    # the final 302 so we shouldn't that.
+                    raise GoneError('The manifest has expired, please request a new one')
                 except InvalidManifestKeySignature:
                     raise BadRequestError('Invalid token')
         else:
             # A token for an ongoing execution was given
             assert manifest_key is None, manifest_key
             try:
-                token_or_state = self.async_service.inspect_generation(token)
+                token_or_result = self.async_service.inspect_generation(token)
             except NoSuchGeneration:
                 raise BadRequestError('Invalid token')
             except GenerationFailed as e:
                 raise ChaliceViewError('Failed to generate manifest', e.status, e.output)
-            if isinstance(token_or_state, Token):
+            if isinstance(token_or_result, Token):
                 # Execution is still ongoing, we got an updated token
-                token, manifest, manifest_key = token_or_state, None, None
-            elif isinstance(token_or_state, dict):
-                # Eecution is done, a cached manifest should be ready
-                state = token_or_state
-                manifest = Manifest.from_json(state['manifest'])
+                token, manifest, manifest_key = token_or_result, None, None
+            elif isinstance(token_or_result, dict):
+                # The execution is done, the resulting manifest should be ready
+                result = token_or_result
+                manifest = Manifest.from_json(result['output']['manifest'])
                 manifest_key = manifest.manifest_key
+                try:
+                    manifest = self.service.get_cached_manifest_with_key(manifest_key)
+                except CachedManifestNotFound as e:
+                    assert manifest_key == e.manifest_key
+                    # There are two possible causes for the missing manifest: it
+                    # may have expired, in which case the supplied token must be
+                    # really stale, or the manifest was deleted immediately
+                    # after it was created. We haven't sent a 302 redirect yet,
+                    # so we'll just restart the generation by starting another
+                    # execution for it.
+                    manifest = None
+                    filters = Filters.from_json(result['input']['filters'])
+                    token = self._start_execution(filters=filters,
+                                                  manifest_key=manifest_key,
+                                                  previous_token=token)
+                else:
+                    assert manifest_key == manifest.manifest_key
             else:
-                assert False, token_or_state
+                assert False, token_or_result
 
         body: dict[str, int | str | FlatJSON]
 

--- a/src/azul/service/manifest_controller.py
+++ b/src/azul/service/manifest_controller.py
@@ -160,7 +160,7 @@ class ManifestController(SourceController):
                     }
                     # Manifest keys for catalogs with long names would be too
                     # long to be used directly as state machine execution names.
-                    execution_id = manifest_key.hash
+                    execution_id = manifest_key.uuid
                     # ManifestGenerationState is also JSON but there is no way
                     # to express that since TypedDict rejects a co-parent class.
                     input = cast(JSON, state)

--- a/src/azul/service/manifest_controller.py
+++ b/src/azul/service/manifest_controller.py
@@ -209,6 +209,7 @@ class ManifestController(SourceController):
         body: dict[str, int | str | FlatJSON]
 
         if manifest is None:
+            assert token is not None
             url = self.manifest_url_func(fetch=fetch, token_or_key=token.encode())
             body = {
                 'Status': 301,

--- a/src/azul/service/manifest_controller.py
+++ b/src/azul/service/manifest_controller.py
@@ -138,6 +138,9 @@ class ManifestController(SourceController):
 
         if token is None:
             if manifest_key is None:
+                # Neither a token representing an ongoing execution was given,
+                # nor the key of an already cached manifest. There could still
+                # be a cached manifest, so we'll need to look it up.
                 format = ManifestFormat(query_params['format'])
                 catalog = query_params.get('catalog', config.default_catalog)
                 filters = self.get_filters(catalog, authentication, query_params.get('filters'))
@@ -146,7 +149,9 @@ class ManifestController(SourceController):
                                                                 catalog=catalog,
                                                                 filters=filters)
                 except CachedManifestNotFound as e:
+                    # A cache miss, but the exception tells us the cache key
                     manifest, manifest_key = None, e.manifest_key
+                    # Prepare the execution that will generate the manifest
                     partition = ManifestPartition.first()
                     state: ManifestGenerationState = {
                         'filters': filters.to_json(),
@@ -161,8 +166,12 @@ class ManifestController(SourceController):
                     input: JSON = cast(JSON, state)
                     token = self.async_service.start_generation(execution_id, input)
                 else:
+                    # A cache hit
                     manifest_key = manifest.manifest_key
             else:
+                # The client passed the key of a cached manifest, originating
+                # from the final 302 response to a fetch request for a curl
+                # manifest (see below).
                 if fetch:
                     raise BadRequestError('The fetch endpoint does not support a manifest key')
                 if authentication is not None:
@@ -171,10 +180,14 @@ class ManifestController(SourceController):
                     manifest_key = self.service.verify_manifest_key(manifest_key)
                     manifest = self.service.get_cached_manifest_with_key(manifest_key)
                 except CachedManifestNotFound:
+                    # We can't restart the execution to regenerate the manifest
+                    # because we don't know the parameters that were used to
+                    # create it. So the client will have to do it.
                     raise GoneError('The requested manifest has expired, please request a new one')
                 except InvalidManifestKeySignature:
                     raise BadRequestError('Invalid token')
         else:
+            # A token for an ongoing execution was given
             assert manifest_key is None, manifest_key
             try:
                 token_or_state = self.async_service.inspect_generation(token)
@@ -183,8 +196,10 @@ class ManifestController(SourceController):
             except GenerationFailed as e:
                 raise ChaliceViewError('Failed to generate manifest', e.status, e.output)
             if isinstance(token_or_state, Token):
+                # Execution is still ongoing, we got an updated token
                 token, manifest, manifest_key = token_or_state, None, None
             elif isinstance(token_or_state, dict):
+                # Eecution is done, a cached manifest should be ready
                 state = token_or_state
                 manifest = Manifest.from_json(state['manifest'])
                 manifest_key = manifest.manifest_key

--- a/src/azul/service/manifest_controller.py
+++ b/src/azul/service/manifest_controller.py
@@ -112,23 +112,29 @@ class ManifestController(SourceController):
         else:
             assert False, type(result)
 
+    def _unpack_token_or_key(self,
+                             token_or_key: str
+                             ) -> tuple[Token | None, SignedManifestKey | None]:
+        if token_or_key is None:
+            return None, None
+        else:
+            try:
+                return Token.decode(token_or_key), None
+            except InvalidTokenError:
+                try:
+                    return None, SignedManifestKey.decode(token_or_key)
+                except InvalidManifestKey:
+                    # The OpenAPI spec doesn't distinguish key and token
+                    raise BadRequestError('Invalid token')
+
     def get_manifest_async(self,
                            *,
                            token_or_key: str,
                            query_params: Mapping[str, str],
                            fetch: bool,
                            authentication: Optional[Authentication]):
-        if token_or_key is None:
-            token, manifest_key = None, None
-        else:
-            try:
-                token, manifest_key = Token.decode(token_or_key), None
-            except InvalidTokenError:
-                try:
-                    token, manifest_key = None, SignedManifestKey.decode(token_or_key)
-                except InvalidManifestKey:
-                    # The OpenAPI spec doesn't distinguish key and token
-                    raise BadRequestError('Invalid token')
+
+        token, manifest_key = self._unpack_token_or_key(token_or_key)
 
         if token is None:
             if manifest_key is None:
@@ -169,6 +175,7 @@ class ManifestController(SourceController):
                 except InvalidManifestKeySignature:
                     raise BadRequestError('Invalid token')
         else:
+            assert manifest_key is None, manifest_key
             try:
                 token_or_state = self.async_service.inspect_generation(token)
             except NoSuchGeneration:

--- a/src/azul/service/manifest_controller.py
+++ b/src/azul/service/manifest_controller.py
@@ -218,7 +218,7 @@ class ManifestController(SourceController):
                 manifest_key = self.service.sign_manifest_key(manifest_key)
                 url = self.manifest_url_func(fetch=False, token_or_key=manifest_key.encode())
             else:
-                url = furl(manifest.location)
+                url = furl(self.service.get_manifest_url(manifest))
             body = {
                 'Status': 302,
                 'Location': str(url),

--- a/src/azul/service/manifest_controller.py
+++ b/src/azul/service/manifest_controller.py
@@ -163,7 +163,7 @@ class ManifestController(SourceController):
                     execution_id = manifest_key.hash
                     # ManifestGenerationState is also JSON but there is no way
                     # to express that since TypedDict rejects a co-parent class.
-                    input: JSON = cast(JSON, state)
+                    input = cast(JSON, state)
                     token = self.async_service.start_generation(execution_id, input)
                 else:
                     # A cache hit

--- a/src/azul/service/manifest_controller.py
+++ b/src/azul/service/manifest_controller.py
@@ -159,12 +159,12 @@ class ManifestController(SourceController):
                         'partition': partition.to_json()
                     }
                     # Manifest keys for catalogs with long names would be too
-                    # long to be used directly as state machine execution names.
-                    execution_id = manifest_key.uuid
+                    # long to be used directly in state machine execution names.
+                    generation_id = manifest_key.uuid
                     # ManifestGenerationState is also JSON but there is no way
                     # to express that since TypedDict rejects a co-parent class.
                     input = cast(JSON, state)
-                    token = self.async_service.start_generation(execution_id, input)
+                    token = self.async_service.start_generation(generation_id, input)
                 else:
                     # A cache hit
                     manifest_key = manifest.manifest_key

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -405,8 +405,9 @@ class Manifest:
     """
     Contains the details of a prepared manifest.
     """
-    #: The URL of the manifest file.
-    location: str
+    #: The S3 object key under which the manifest is stored in the storage
+    #: bucket
+    object_key: str
 
     #: True if an existing manifest was reused or False if a new manifest was
     #: generated.
@@ -415,7 +416,7 @@ class Manifest:
     #: The format of the manifest
     format: ManifestFormat
 
-    #: The key under which the manifest is stored
+    #: Uniquely identifies this manifest
     manifest_key: ManifestKey
 
     #: The proposed file name of the manifest when downloading it to a user's
@@ -424,7 +425,7 @@ class Manifest:
 
     def to_json(self) -> JSON:
         return {
-            'location': self.location,
+            'object_key': self.object_key,
             'was_cached': self.was_cached,
             'format': self.format.value,
             'manifest_key': self.manifest_key.to_json(),
@@ -433,7 +434,7 @@ class Manifest:
 
     @classmethod
     def from_json(cls, json: JSON) -> 'Manifest':
-        return cls(location=json['location'],
+        return cls(object_key=json['object_key'],
                    was_cached=json['was_cached'],
                    format=ManifestFormat(json['format']),
                    manifest_key=ManifestKey.from_json(json['manifest_key']),
@@ -637,10 +638,10 @@ class ManifestService(ElasticsearchService):
                            ) -> Manifest | ManifestPartition:
         partition = generator.write(manifest_key, partition)
         if partition.is_last:
-            return self._presign_manifest(generator_cls=type(generator),
-                                          manifest_key=manifest_key,
-                                          file_name=partition.file_name,
-                                          was_cached=False)
+            return self._make_manifest(generator_cls=type(generator),
+                                       manifest_key=manifest_key,
+                                       file_name=partition.file_name,
+                                       was_cached=False)
         else:
             return partition
 
@@ -695,26 +696,29 @@ class ManifestService(ElasticsearchService):
         if file_name is None:
             raise CachedManifestNotFound(manifest_key)
         else:
-            return self._presign_manifest(generator_cls=generator_cls,
-                                          manifest_key=manifest_key,
-                                          file_name=file_name,
-                                          was_cached=True)
+            return self._make_manifest(generator_cls=generator_cls,
+                                       manifest_key=manifest_key,
+                                       file_name=file_name,
+                                       was_cached=True)
 
-    def _presign_manifest(self,
-                          generator_cls: Type['ManifestGenerator'],
-                          manifest_key: ManifestKey,
-                          file_name: Optional[str],
-                          was_cached: bool
-                          ) -> Manifest:
+    def _make_manifest(self,
+                       generator_cls: Type['ManifestGenerator'],
+                       manifest_key: ManifestKey,
+                       file_name: Optional[str],
+                       was_cached: bool
+                       ) -> Manifest:
         if not generator_cls.use_content_disposition_file_name:
             file_name = None
         object_key = generator_cls.s3_object_key(manifest_key)
-        presigned_url = self.storage_service.get_presigned_url(object_key, file_name)
-        return Manifest(location=presigned_url,
+        return Manifest(object_key=object_key,
                         was_cached=was_cached,
                         format=generator_cls.format(),
                         manifest_key=manifest_key,
                         file_name=file_name)
+
+    def get_manifest_url(self, manifest: Manifest) -> str:
+        return self.storage_service.get_presigned_url(key=manifest.object_key,
+                                                      file_name=manifest.file_name)
 
     file_name_tag = 'azul_file_name'
 

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -17,9 +17,6 @@ import csv
 from datetime import (
     datetime,
 )
-from hashlib import (
-    sha256,
-)
 from inspect import (
     isabstract,
 )
@@ -48,6 +45,7 @@ from tempfile import (
 )
 import time
 from typing import (
+    ClassVar,
     IO,
     Optional,
     Protocol,
@@ -149,6 +147,9 @@ from azul.types import (
     JSON,
     JSONs,
     MutableJSON,
+)
+from azul.uuids import (
+    uuid5_for_bytes,
 )
 from azul.vendored.frozendict import (
     frozendict,
@@ -390,9 +391,11 @@ class ManifestKey(BareManifestKey):
                    manifest_hash=UUID(json['manifest_hash']),
                    source_hash=UUID(json['source_hash']))
 
+    _uuid_namespace: ClassVar[UUID] = UUID('c5a0cd95-44f7-4216-972f-623f00f8fd22')
+
     @property
-    def hash(self) -> bytes:
-        return sha256(self.pack()).digest()
+    def uuid(self) -> UUID:
+        return uuid5_for_bytes(self._uuid_namespace, self.pack())
 
 
 @attrs.frozen

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -173,18 +173,25 @@ class StorageService:
         """
         Return a pre-signed URL to the given key.
 
-        :param key: the key of the S3 object whose content a request to the signed URL will return
+        :param key: The key of the S3 object whose content a request to the
+                    signed URL will return
 
-        :param file_name: the file name to be returned as part of a Content-Disposition header in the response to a
-                          request to the signed URL. If None, no such header will be present in the response.
+        :param file_name: the file name to be returned as part of a
+                          Content-Disposition header in the response to a
+                          request to the signed URL. If None, no such header
+                          will be present in the response.
         """
-        assert file_name is None or '"' not in file_name
+        assert file_name is None or '"' not in file_name, file_name
         return self._s3.generate_presigned_url(
             ClientMethod=self._s3.get_object.__name__,
             Params={
                 'Bucket': self.bucket_name,
                 'Key': key,
-                **({} if file_name is None else {'ResponseContentDisposition': f'attachment;filename="{file_name}"'})
+                **(
+                    {}
+                    if file_name is None else
+                    {'ResponseContentDisposition': f'attachment;filename="{file_name}"'}
+                )
             })
 
     def put_object_tagging(self, object_key: str, tagging: Tagging = None):

--- a/src/azul/uuids.py
+++ b/src/azul/uuids.py
@@ -1,3 +1,6 @@
+from hashlib import (
+    sha1,
+)
 import math
 from typing import (
     ClassVar,
@@ -254,3 +257,13 @@ class UUIDPartition(Generic[UUID_PARTITION]):
 
 
 UUIDPartition.init_cls()
+
+
+def uuid5_for_bytes(namespace: UUID, name: bytes) -> UUID:
+    """
+    Generate a UUID from the SHA-1 hash of a namespace UUID and a name. Same as
+    uuid.uuid5 but takes `bytes` not `str`, and thereby avoids assuming an
+    encoding (uuid.uuid5 assumes UTF-8).
+    """
+    hash = sha1(namespace.bytes + name).digest()
+    return UUID(bytes=hash[:16], version=5)

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -660,7 +660,7 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
         else:
             urls = [furl(r.headers['Location']) for r in responses if r.status == 301]
         tokens = {Token.decode(url.path.segments[-1]) for url in urls}
-        execution_ids = {token.execution_id for token in tokens}
+        execution_ids = {token.generation_id for token in tokens}
         return execution_ids
 
     def _get_one_inner_file(self, catalog: CatalogName) -> tuple[JSON, FileInnerEntity]:

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -109,6 +109,9 @@ from azul.collections import (
 from azul.csp import (
     CSP,
 )
+from azul.deployment import (
+    aws,
+)
 from azul.drs import (
     AccessMethod,
 )
@@ -532,9 +535,10 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
         assert supported_formats
         for format in [None, *supported_formats]:
             filters = self._manifest_filters(catalog)
-            first_fetch = bool(self.random.getrandbits(1))
-            for fetch in [first_fetch, not first_fetch]:
-                with self.subTest('manifest', catalog=catalog, format=format, fetch=fetch):
+            execution_ids = set()
+            coin_flip = bool(self.random.getrandbits(1))
+            for i, fetch in enumerate([coin_flip, coin_flip, not coin_flip]):
+                with self.subTest('manifest', catalog=catalog, format=format, i=i, fetch=fetch):
                     args = dict(catalog=catalog, filters=json.dumps(filters))
                     if format is None:
                         format = first(supported_formats)
@@ -565,13 +569,22 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
                             results = list(tpe.map(worker, range(num_workers)))
 
                     self.assertEqual([None] * num_workers, results)
-                    execution_ids = self._manifest_execution_ids(responses, fetch=fetch)
-                    # The second iteration of the inner-most loop re-requests
-                    # the manifest with only `fetch` being different. In that
-                    # case, the manifest will already be cached and no step
-                    # function execution is expected to have been started.
-                    expect_execution = fetch == first_fetch
-                    self.assertEqual(1 if expect_execution else 0, len(execution_ids))
+
+                    execution_ids.update(self._manifest_execution_ids(responses))
+                    bucket, key = one(self._manifest_objects(responses))
+                    if i == 0:
+                        aws.s3.delete_object(Bucket=bucket, Key=key)
+                        # One execution to generate the manifest
+                        self.assertEqual(1, len(execution_ids))
+                    elif i == 1:
+                        # One more execution to re-generate the manifest
+                        self.assertEqual(2, len(execution_ids))
+                    elif i == 2:
+                        # Only fetch mode changed, cached manifest will be used,
+                        # and no additional executions are expectect
+                        self.assertEqual(2, len(execution_ids))
+                    else:
+                        assert False
 
     def _manifest_filters(self, catalog: CatalogName) -> JSON:
         # IT catalogs with just one public source are always indexed completely
@@ -642,27 +655,42 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
                             self._manifest_validators[format](catalog, response.data)
                             break
 
-                execution_ids = self._manifest_execution_ids(responses, fetch=False)
+                execution_ids = self._manifest_execution_ids(responses)
                 self.assertEqual(1, len(execution_ids))
 
     def _manifest_execution_ids(self,
-                                responses: list[urllib3.HTTPResponse],
-                                *,
-                                fetch: bool
-                                ) -> set[uuid.UUID]:
-        urls: list[furl]
-        if fetch:
-            responses = [
-                json.loads(r.data)
-                for r in responses
-                if r.status == 200 and r.headers['Content-Type'] == 'application/json'
-            ]
-            urls = [furl(r['Location']) for r in responses if r['Status'] == 301]
-        else:
-            urls = [furl(r.headers['Location']) for r in responses if r.status == 301]
+                                responses: list[urllib3.HTTPResponse]
+                                ) -> set[tuple[uuid.UUID, int]]:
+        urls = self._manifest_urls(responses, status=301)
         tokens = {Token.decode(url.path.segments[-1]) for url in urls}
-        execution_ids = {token.generation_id for token in tokens}
+        execution_ids = {token.execution_id for token in tokens}
         return execution_ids
+
+    def _manifest_objects(self,
+                          responses: list[urllib3.HTTPResponse]
+                          ) -> set[tuple[str, str]]:
+        urls = self._manifest_urls(responses, status=302)
+        return {
+            (url.path.segments[0], '/'.join(url.path.segments[1:]))
+            for url in urls
+            if url.netloc == 's3.amazonaws.com' and url.scheme == 'https'
+        }
+
+    def _manifest_urls(self,
+                       responses: list[urllib3.HTTPResponse],
+                       *,
+                       status: int
+                       ) -> list[furl]:
+        urls: list[furl] = []
+        for response in responses:
+            if response.status == 200:
+                if response.headers['Content-Type'] == 'application/json':
+                    body = json.loads(response.data)
+                    if body['Status'] == status:
+                        urls.append(furl(body['Location']))
+            elif response.status == status:
+                urls.append(furl(response.headers['Location']))
+        return urls
 
     def _get_one_inner_file(self, catalog: CatalogName) -> tuple[JSON, FileInnerEntity]:
         outer_file = self._get_one_outer_file(catalog)
@@ -1065,8 +1093,8 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
         num_files = 0
         for url, output in grouper(lines, 2):
             num_files += 1
-            self.assertTrue(url.startswith('url='))
-            self.assertTrue(output.startswith('output='))
+            self.assertTrue(url.startswith('url='), url)
+            self.assertTrue(output.startswith('output='), output)
         log.info(f'Manifest contains {num_files} files.')
         self.assertGreater(num_files, 0)
 

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -647,7 +647,7 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
                                 responses: list[urllib3.HTTPResponse],
                                 *,
                                 fetch: bool
-                                ) -> set[bytes]:
+                                ) -> set[uuid.UUID]:
         urls: list[furl]
         if fetch:
             responses = [

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -1196,7 +1196,7 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
                             url: furl,
                             size: int | None = None
                             ) -> BytesIO:
-        self.assertEquals('gs', url.scheme)
+        self.assertEqual('gs', url.scheme)
         path = os.environ['GOOGLE_APPLICATION_CREDENTIALS']
         credentials = service_account.Credentials.from_service_account_file(path)
         storage_client = storage.Client(credentials=credentials)

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -411,14 +411,13 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
         def _wait_for_indexer():
             self.azul_client.wait_for_indexer()
 
-        # For faster modify-deploy-test cycles, set `delete` to False and run
-        # test once. Then also set `index` to False. Subsequent runs will use
-        # catalogs from first run. Don't commit changes to these two lines.
-        index = True
-        delete = True
+        flags = config.it_flags
+        index, delete = ['no_' + flag not in flags for flag in ['index', 'delete']]
 
         if index:
             self._reset_indexer()
+        else:
+            log.warning('Will skip indexing due to overriding IT flag.')
 
         catalogs: list[Catalog] = []
         for catalog in config.integration_test_catalogs:
@@ -467,6 +466,8 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
                 with self._service_account_credentials:
                     for catalog in catalogs:
                         self._assert_catalog_empty(catalog.name)
+        else:
+            log.warning('Will skip deletions due to overriding IT flag')
 
         self._test_other_endpoints()
 

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -178,6 +178,7 @@ from azul.terra import (
 from azul.types import (
     JSON,
     JSONs,
+    MutableJSON,
     MutableJSONs,
 )
 from azul_test_case import (
@@ -980,7 +981,7 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
         # The schema is also an Avro object, specifically a Avro record which
         # FastAVRO exposes to us as a JSON object, i.e., a `dict` with string
         # keys
-        record_schema = reader.writer_schema
+        record_schema: MutableJSON = reader.writer_schema
         # Each object in a PFB is also of type 'record'
         self.assertEqual('record', record_schema['type'])
         # PFB calls the records *entities*. Unfortunately, the PFB standard is

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -225,11 +225,11 @@ class ManifestTestCase(WebServiceTestCase,
                       ) -> Response:
         manifest, num_partitions = self._get_manifest_object(format, filters)
         self.assertEqual(1, num_partitions)
-        response = requests.get(manifest.location, stream=stream)
+        url = furl(self._service.get_manifest_url(manifest))
+        response = requests.get(str(url), stream=stream)
         # Moto doesn't support signed S3 URLs with Content-Disposition baked in,
         # so we'll retroactively inject it into the response header.
-        location = furl(manifest.location)
-        content_disposition = location.args.get('response-content-disposition')
+        content_disposition = url.args.get('response-content-disposition')
         if content_disposition is not None:
             response.headers['content-disposition'] = content_disposition
         return response
@@ -1373,9 +1373,9 @@ class TestManifests(DCP1ManifestTestCase):
                         manifest, num_partitions = self._get_manifest_object(format, filters)
                         self.assertFalse(manifest.was_cached)
                         self.assertEqual(1, num_partitions)
-                        query = furl(manifest.location).query
+                        url = furl(self._service.get_manifest_url(manifest))
                         expected_cd = f'attachment;filename="{expected_name}.tsv"'
-                        actual_cd = query.params['response-content-disposition']
+                        actual_cd = url.args['response-content-disposition']
                         self.assertEqual(expected_cd, actual_cd)
 
     def test_verbatim_jsonl_manifest(self):
@@ -1591,11 +1591,11 @@ class TestManifestCache(DCP1ManifestTestCase):
         # seconds, the signed URL is going to have a different expiration.
         manifest = attrs.evolve(manifest,
                                 was_cached=True,
-                                location=cached_manifest_1.location)
+                                object_key=cached_manifest_1.object_key)
         self.assertEqual(manifest, cached_manifest_1)
         cached_manifest_2 = self._service.get_cached_manifest_with_key(manifest_key)
         cached_manifest_1 = attrs.evolve(cached_manifest_1,
-                                         location=cached_manifest_2.location)
+                                         object_key=cached_manifest_2.object_key)
         self.assertEqual(cached_manifest_1, cached_manifest_2)
         _time_until_object_expires.assert_called_once()
         _time_until_object_expires.reset_mock()
@@ -1623,7 +1623,9 @@ class TestManifestResponse(DCP1ManifestTestCase):
     @patch.object(ManifestService, 'get_cached_manifest_with_key')
     @patch.object(ManifestService, 'sign_manifest_key')
     @patch.object(ManifestService, 'verify_manifest_key')
+    @patch.object(ManifestService, 'get_manifest_url')
     def test_manifest(self,
+                      get_manifest_url,
                       verify_manifest_key,
                       sign_manifest_key,
                       get_cached_manifest_with_key,
@@ -1642,13 +1644,14 @@ class TestManifestResponse(DCP1ManifestTestCase):
             signed_manifest_key = SignedManifestKey(value=manifest_key, signature=b'123')
             sign_manifest_key.return_value = signed_manifest_key
             verify_manifest_key.return_value = manifest_key
-            manifest = Manifest(location=str(object_url),
+            manifest = Manifest(object_key='key/of/manifest',
                                 was_cached=False,
                                 format=format,
                                 manifest_key=manifest_key,
                                 file_name=default_file_name)
             get_cached_manifest.return_value = manifest
             get_cached_manifest_with_key.return_value = manifest
+            get_manifest_url.return_value = object_url
             args = dict(catalog=self.catalog,
                         format=format.value,
                         filters='{}')
@@ -1726,7 +1729,8 @@ class TestManifestPartitioning(DCP1ManifestTestCase, DocumentCloningTestCase):
         with patch.object(PagedManifestGenerator, 'part_size', part_size):
             manifest, num_partitions = self._get_manifest_object(ManifestFormat.compact,
                                                                  filters={})
-        content = requests.get(manifest.location).content
+        url = self._service.get_manifest_url(manifest)
+        content = requests.get(url).content
         self.assertGreater(num_partitions, 1)
         self.assertGreater(len(content), (num_partitions - 1) * part_size)
 

--- a/test/service/test_manifest_async.py
+++ b/test/service/test_manifest_async.py
@@ -186,7 +186,6 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                                                format=format,
                                                manifest_hash=UUID('d2b0ce3c-46f0-57fe-b9d4-2e38d8934fd4'),
                                                source_hash=UUID('77936747-5968-588e-809f-af842d6be9e0'))
-                    get_cached_manifest.side_effect = CachedManifestNotFound(manifest_key)
                     signed_manifest_key = SignedManifestKey(value=manifest_key,
                                                             signature=b'123')
 
@@ -251,9 +250,14 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                             self.assertGreaterEqual(int(headers['Retry-After']), 0)
                         return furl(headers['Location'])
 
-                    url = initial_url
-
-                    url = request('PUT', url, expect=301)
+                    # Request the manifest. The cached manifest does not exist
+                    # so we expect a StepFunction execution to be started and a
+                    # 301 redirect to the manifest endpoint with a token
+                    # embedded in the URL.
+                    #
+                    get_cached_manifest.side_effect = CachedManifestNotFound(manifest_key)
+                    url = request('PUT', initial_url, expect=301)
+                    token_url = url
                     state: ManifestGenerationState = input
                     _sfn.start_execution.assert_called_once_with(
                         stateMachineArn=machine_arn,
@@ -262,9 +266,12 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     )
                     _sfn.describe_execution.assert_not_called()
                     _sfn.reset_mock()
-                    _sfn.describe_execution.return_value = {'status': 'RUNNING'}
-                    token_url = url
 
+                    # Follow the redirect. We expect a call to determine the
+                    # status of the execution, which we mock to be still
+                    # running, and another 301 redirect.
+                    #
+                    _sfn.describe_execution.return_value = {'status': 'RUNNING'}
                     url = request('GET', url, expect=301)
                     get_manifest.return_value = partitions[1]
                     state = self.app_module.generate_manifest(state, None)
@@ -277,12 +284,18 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                         partition=partitions[0],
                         manifest_key=ManifestKey.from_json(state['manifest_key'])
                     )
-
                     get_manifest.reset_mock()
                     _sfn.start_execution.assert_not_called()
                     _sfn.describe_execution.assert_called_once()
                     _sfn.reset_mock()
-                    # simulate absence of output due eventual consistency
+
+                    # Follow the redirect. The StepFunction has finished but the
+                    # output is not yet available due to eventual consistency.
+                    # We observed this behaviour a few years ago, but it
+                    # probably doesn't happen anymore. The output is most likely
+                    # stored on S3 under the hood which strongly consistent a
+                    # while back.
+                    #
                     _sfn.describe_execution.return_value = {'status': 'SUCCEEDED'}
                     url = request('GET', url, expect=301)
                     get_manifest.return_value = manifest
@@ -291,6 +304,12 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     _sfn.describe_execution.assert_called_once()
                     _sfn.reset_mock()
 
+                    # The StepFunction has finished and the output is available.
+                    # We expect a 302 redirect to either the signed URL of the
+                    # manifest object in S3, or, when fetching a curl manifest,
+                    # a 302 redirect to the non-fetch endpoint with the key of
+                    # the manifest in the URL.
+                    #
                     _sfn.describe_execution.return_value = {
                         'status': 'SUCCEEDED',
                         'input': json.dumps(input),
@@ -307,7 +326,6 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                         manifest_key=ManifestKey.from_json(state['manifest_key'])
                     )
                     get_manifest.reset_mock()
-
                     _sfn.start_execution.assert_not_called()
                     _sfn.describe_execution.assert_called_once()
                     expect_redirect = fetch and format is ManifestFormat.curl
@@ -315,24 +333,27 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     self.assertEqual(expected_url, str(url))
                     _sfn.reset_mock()
 
-                    # Repeat the initial request while continuing to mock the
-                    # absence of the manifest. The SFN execution is complete so
-                    # this simulates an expired manifest. To satisfy the
-                    # request, a new generation has to be started, and the
-                    # response should be 301 redirect for the new generation.
+                    # Re-request the manifest at the initial URL. The manifest
+                    # is cached so we expect no intermediate 301 redirects.
+                    #
+                    get_cached_manifest.side_effect = None
+                    get_cached_manifest.return_value = manifest
+                    url = request('PUT', initial_url, expect=302)
+                    self.assertEqual(expected_url, str(url))
+
+                    # Expire the cached manifest and repeat the initial request
+                    # but with an insignificant difference to the filters
+                    # parameter. The repeated request should be considered valid
+                    # and matching the completed step function execution.
+                    #
+                    get_cached_manifest.side_effect = CachedManifestNotFound(manifest_key)
                     exception = self._mock_sfn_exception(_sfn,
                                                          operation_name='StartExecution',
                                                          error_code='ExecutionAlreadyExists')
                     _sfn.start_execution.side_effect = exception
-
-                    # Introduce an insignificant difference in the SFN input by
-                    # reordering the `filters` dictionary entries. The repeated
-                    # request should be considered valid and matching the completed
-                    # step function execution.
                     url = initial_url.copy()
                     filters = json.loads(url.args['filters'])
                     url.args['filters'] = json.dumps(dict(reversed(filters.items())))
-
                     response = requests.put(url=str(url), allow_redirects=False)
                     _sfn.reset_mock(side_effect=True)
                     if fetch:

--- a/test/service/test_manifest_async.py
+++ b/test/service/test_manifest_async.py
@@ -354,17 +354,14 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     url = initial_url.copy()
                     filters = json.loads(url.args['filters'])
                     url.args['filters'] = json.dumps(dict(reversed(filters.items())))
-                    response = requests.put(url=str(url), allow_redirects=False)
+                    url = request('PUT', url, expect=301)
                     _sfn.reset_mock(side_effect=True)
-                    if fetch:
-                        self.assertEqual(200, response.status_code)
-                        self.assertEqual(301, response.json()['Status'])
-                    else:
-                        self.assertEqual(301, response.status_code)
                     # FIXME: 404 from S3 when re-requesting manifest after it expired
                     #        https://github.com/DataBiosphere/azul/issues/6441
-                    if False:
-                        self.assertNotEqual(token_url, response.json()['Location'])
+                    if True:
+                        self.assertEqual(token_url, url)
+                    else:
+                        self.assertNotEqual(token_url, url)
 
             assert signed_manifest_key.encode() == manifest_url.path.segments[-1]
             assert not verify_manifest_key.called

--- a/test/service/test_manifest_async.py
+++ b/test/service/test_manifest_async.py
@@ -236,29 +236,13 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                         'startDate': 123
                     }
 
-                    def request(method: str, url: furl, *, expect: int) -> furl:
-                        response = requests.request(method=method,
-                                                    url=str(url),
-                                                    allow_redirects=False)
-                        if url.path.segments[0] == 'fetch':
-                            self.assertEqual(200, response.status_code)
-                            response = response.json()
-                            self.assertEqual(expect, response.pop('Status'))
-                            headers = response
-                        else:
-                            self.assertEqual(expect, response.status_code)
-                            headers = response.headers
-                        if expect == 301:
-                            self.assertGreaterEqual(int(headers['Retry-After']), 0)
-                        return furl(headers['Location'])
-
                     # Request the manifest. The cached manifest does not exist
                     # so we expect a StepFunction execution to be started and a
                     # 301 redirect to the manifest endpoint with a token
                     # embedded in the URL.
                     #
                     get_cached_manifest.side_effect = CachedManifestNotFound(manifest_key)
-                    url = request('PUT', initial_url, expect=301)
+                    url = self._request('PUT', initial_url, expect=301)
                     token_url = url
                     state: ManifestGenerationState = input
                     _sfn.start_execution.assert_called_once_with(
@@ -274,7 +258,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     # running, and another 301 redirect.
                     #
                     _sfn.describe_execution.return_value = {'status': 'RUNNING'}
-                    url = request('GET', url, expect=301)
+                    url = self._request('GET', url, expect=301)
                     get_manifest.return_value = partitions[1]
                     state = self.app_module.generate_manifest(state, None)
                     self.assertEqual(partitions[1],
@@ -299,7 +283,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     # while back.
                     #
                     _sfn.describe_execution.return_value = {'status': 'SUCCEEDED'}
-                    url = request('GET', url, expect=301)
+                    url = self._request('GET', url, expect=301)
                     get_manifest.return_value = manifest
                     get_manifest_url.return_value = str(object_url)
                     _sfn.start_execution.assert_not_called()
@@ -326,7 +310,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     else:
                         key_url = None
                         expected_url = object_url
-                    url = request('GET', url, expect=302)
+                    url = self._request('GET', url, expect=302)
                     self.assertEqual(expected_url, url)
                     get_manifest.assert_called_once_with(
                         format=format,
@@ -346,7 +330,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     get_cached_manifest.reset_mock()
                     get_cached_manifest.side_effect = None
                     get_cached_manifest.return_value = manifest
-                    url = request('PUT', initial_url, expect=302)
+                    url = self._request('PUT', initial_url, expect=302)
                     get_cached_manifest.assert_called_once_with(
                         format=format,
                         catalog=self.catalog,
@@ -367,7 +351,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     equivalent_filters = dict(reversed(equivalent_filters.items()))
                     equivalent_url.args['filters'] = json.dumps(equivalent_filters)
                     get_cached_manifest.reset_mock()
-                    url = request('PUT', equivalent_url, expect=302)
+                    url = self._request('PUT', equivalent_url, expect=302)
                     self.assertEqual(expected_url, url)
                     get_cached_manifest.assert_called_once_with(
                         format=format,
@@ -385,7 +369,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                                                          operation_name='StartExecution',
                                                          error_code='ExecutionAlreadyExists')
                     _sfn.start_execution.side_effect = exception
-                    url = request('PUT', equivalent_url, expect=301)
+                    url = self._request('PUT', equivalent_url, expect=301)
                     _sfn.reset_mock(side_effect=True)
                     # FIXME: 404 from S3 when re-requesting manifest after it expired
                     #        https://github.com/DataBiosphere/azul/issues/6441
@@ -405,7 +389,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                         assert not get_cached_manifest_with_key.called
                         get_cached_manifest_with_key.side_effect = None
                         get_cached_manifest_with_key.return_value = manifest
-                        url = request('GET', key_url, expect=302)
+                        url = self._request('GET', key_url, expect=302)
                         self.assertEqual(object_url, url)
                         get_cached_manifest_with_key.side_effect = CachedManifestNotFound(manifest_key)
                         response = requests.get(str(key_url), allow_redirects=False)
@@ -415,6 +399,22 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                             'Message': 'The requested manifest has expired, please request a new one'
                         }
                         self.assertEqual(expected_response, response.json())
+
+    def _request(self, method: str, url: furl, *, expect: int) -> furl:
+        response = requests.request(method=method,
+                                    url=str(url),
+                                    allow_redirects=False)
+        if url.path.segments[0] == 'fetch':
+            self.assertEqual(200, response.status_code)
+            response = response.json()
+            self.assertEqual(expect, response.pop('Status'))
+            headers = response
+        else:
+            self.assertEqual(expect, response.status_code)
+            headers = response.headers
+        if expect == 301:
+            self.assertGreaterEqual(int(headers['Retry-After']), 0)
+        return furl(headers['Location'])
 
     token = Token.first(execution_id).encode()
 

--- a/test/service/test_manifest_async.py
+++ b/test/service/test_manifest_async.py
@@ -73,14 +73,14 @@ def setUpModule():
 
 @patch.object(AsyncManifestService, '_sfn')
 class TestAsyncManifestService(AzulUnitTestCase):
-    execution_id = UUID('1ea94a54-a64d-54f1-8b41-15455fb958db')
+    generation_id = UUID('1ea94a54-a64d-54f1-8b41-15455fb958db')
 
     def test_token_encoding(self, _sfn):
-        token = Token(execution_id=self.execution_id, request_index=42, retry_after=123)
+        token = Token(generation_id=self.generation_id, request_index=42, retry_after=123)
         self.assertEqual(token, Token.decode(token.encode()))
 
     def test_token_validation(self, _sfn):
-        token = Token(execution_id=self.execution_id, request_index=42, retry_after=123)
+        token = Token(generation_id=self.generation_id, request_index=42, retry_after=123)
         self.assertRaises(InvalidTokenError, token.decode, token.encode()[:-1])
 
     def test_status_success(self, _sfn):
@@ -89,7 +89,7 @@ class TestAsyncManifestService(AzulUnitTestCase):
         manifest
         """
         service = AsyncManifestService()
-        execution_name = service.execution_name(self.execution_id)
+        execution_name = service.execution_name(self.generation_id)
         output = {'foo': 'bar'}
         _sfn.describe_execution.return_value = {
             'executionArn': service.execution_arn(execution_name),
@@ -101,7 +101,7 @@ class TestAsyncManifestService(AzulUnitTestCase):
             'input': '{"filters": {}}',
             'output': json.dumps(output)
         }
-        token = Token(execution_id=self.execution_id, request_index=0, retry_after=0)
+        token = Token(generation_id=self.generation_id, request_index=0, retry_after=0)
         actual_output = service.inspect_generation(token)
         self.assertEqual(output, actual_output)
 
@@ -111,7 +111,7 @@ class TestAsyncManifestService(AzulUnitTestCase):
         checking the job status
         """
         service = AsyncManifestService()
-        execution_name = service.execution_name(self.execution_id)
+        execution_name = service.execution_name(self.generation_id)
         _sfn.describe_execution.return_value = {
             'executionArn': service.execution_arn(execution_name),
             'stateMachineArn': service.machine_arn,
@@ -120,9 +120,9 @@ class TestAsyncManifestService(AzulUnitTestCase):
             'startDate': datetime.datetime(2018, 11, 15, 18, 30, 44, 896000),
             'input': '{"filters": {}}'
         }
-        token = Token(execution_id=self.execution_id, request_index=0, retry_after=0)
+        token = Token(generation_id=self.generation_id, request_index=0, retry_after=0)
         token = service.inspect_generation(token)
-        expected = Token(execution_id=self.execution_id, request_index=1, retry_after=1)
+        expected = Token(generation_id=self.generation_id, request_index=1, retry_after=1)
         self.assertEqual(expected, token)
 
     def test_status_failed(self, _sfn):
@@ -130,7 +130,7 @@ class TestAsyncManifestService(AzulUnitTestCase):
         A failed manifest job should raise a GenerationFailed
         """
         service = AsyncManifestService()
-        execution_name = service.execution_name(self.execution_id)
+        execution_name = service.execution_name(self.generation_id)
         _sfn.describe_execution.return_value = {
             'executionArn': service.execution_arn(execution_name),
             'stateMachineArn': service.machine_arn,
@@ -140,7 +140,7 @@ class TestAsyncManifestService(AzulUnitTestCase):
             'stopDate': datetime.datetime(2018, 11, 14, 16, 6, 55, 860000),
             'input': '{"filters": {"organ": {"is": ["lymph node"]}}}',
         }
-        token = Token(execution_id=self.execution_id, request_index=0, retry_after=0)
+        token = Token(generation_id=self.generation_id, request_index=0, retry_after=0)
         with self.assertRaises(GenerationFailed):
             service.inspect_generation(token)
 
@@ -151,7 +151,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
     def lambda_name(cls) -> str:
         return 'service'
 
-    execution_id = UUID('1ea94a54-a64d-54f1-8b41-15455fb958db')
+    generation_id = UUID('1ea94a54-a64d-54f1-8b41-15455fb958db')
 
     @mock_aws
     @mock.patch.object(AsyncManifestService, '_sfn')
@@ -231,8 +231,8 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                              partition=partitions[0].to_json())
                 service: AsyncManifestService
                 service = self.app_module.app.manifest_controller.async_service
-                execution_id = manifest_key.uuid
-                execution_name = service.execution_name(execution_id)
+                generation_id = manifest_key.uuid
+                execution_name = service.execution_name(generation_id)
                 machine_arn = service.machine_arn
                 execution_arn = service.execution_arn(execution_name)
                 _sfn.start_execution.return_value = {
@@ -422,7 +422,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
             self.assertGreaterEqual(int(headers['Retry-After']), 0)
         return furl(headers['Location'])
 
-    token = Token.first(execution_id).encode()
+    token = Token.first(generation_id).encode()
 
     def _test(self, *, expected_status, token=token):
         url = self.base_url.set(path=['fetch', 'manifest', 'files', token])

--- a/test/service/test_manifest_async.py
+++ b/test/service/test_manifest_async.py
@@ -156,7 +156,9 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
     @mock.patch.object(ManifestService, 'get_cached_manifest')
     @mock.patch.object(ManifestService, 'verify_manifest_key')
     @mock.patch.object(ManifestService, 'get_cached_manifest_with_key')
+    @mock.patch.object(ManifestService, 'get_manifest_url')
     def test(self,
+             get_manifest_url,
              get_cached_manifest_with_key,
              verify_manifest_key,
              get_cached_manifest,
@@ -193,7 +195,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
 
                     object_url = 'https://url.to.manifest?foo=bar'
                     file_name = 'some_file_name'
-                    manifest = Manifest(location=object_url,
+                    manifest = Manifest(object_key='key/of/manifest',
                                         was_cached=False,
                                         format=format,
                                         manifest_key=manifest_key,
@@ -279,6 +281,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                             _sfn.describe_execution.return_value = {'status': 'SUCCEEDED'}
                         elif i == 2:
                             get_manifest.return_value = manifest
+                            get_manifest_url.return_value = object_url
                             _sfn.start_execution.assert_not_called()
                             _sfn.describe_execution.assert_called_once()
                             _sfn.reset_mock()

--- a/test/service/test_manifest_async.py
+++ b/test/service/test_manifest_async.py
@@ -176,7 +176,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                         'format': format.value,
                         'filters': json.dumps(filters.explicit)
                     }
-                    path = '/manifest/files'
+                    path = ['manifest', 'files']
 
                     initial_url = self.base_url.set(path=path, args=params)
                     if fetch:
@@ -189,10 +189,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     signed_manifest_key = SignedManifestKey(value=manifest_key,
                                                             signature=b'123')
 
-                    manifest_url = self.base_url.set(path=path)
-                    manifest_url.path.segments.append(signed_manifest_key.encode())
-
-                    object_url = 'https://url.to.manifest?foo=bar'
+                    object_url = furl('https://url.to.manifest?foo=bar')
                     file_name = 'some_file_name'
                     manifest = Manifest(object_key='key/of/manifest',
                                         was_cached=False,
@@ -299,7 +296,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     _sfn.describe_execution.return_value = {'status': 'SUCCEEDED'}
                     url = request('GET', url, expect=301)
                     get_manifest.return_value = manifest
-                    get_manifest_url.return_value = object_url
+                    get_manifest_url.return_value = str(object_url)
                     _sfn.start_execution.assert_not_called()
                     _sfn.describe_execution.assert_called_once()
                     _sfn.reset_mock()
@@ -328,9 +325,13 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     get_manifest.reset_mock()
                     _sfn.start_execution.assert_not_called()
                     _sfn.describe_execution.assert_called_once()
-                    expect_redirect = fetch and format is ManifestFormat.curl
-                    expected_url = str(manifest_url) if expect_redirect else object_url
-                    self.assertEqual(expected_url, str(url))
+                    if fetch and format is ManifestFormat.curl:
+                        key_url = self.base_url.set(path=[*path, signed_manifest_key.encode()])
+                        expected_url = key_url
+                    else:
+                        key_url = None
+                        expected_url = object_url
+                    self.assertEqual(expected_url, url)
                     _sfn.reset_mock()
 
                     # Re-request the manifest at the initial URL. The manifest
@@ -345,7 +346,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                         catalog=self.catalog,
                         filters=filters
                     )
-                    self.assertEqual(expected_url, str(url))
+                    self.assertEqual(expected_url, url)
 
                     # Re-request the manifest at a URL with an insignificant
                     # change to the filters parameter. The cached manifest
@@ -361,7 +362,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     equivalent_url.args['filters'] = json.dumps(equivalent_filters)
                     get_cached_manifest.reset_mock()
                     url = request('PUT', equivalent_url, expect=302)
-                    self.assertEqual(expected_url, str(url))
+                    self.assertEqual(expected_url, url)
                     get_cached_manifest.assert_called_once_with(
                         format=format,
                         catalog=self.catalog,
@@ -387,22 +388,27 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     else:
                         self.assertNotEqual(token_url, url)
 
-            assert signed_manifest_key.encode() == manifest_url.path.segments[-1]
-            assert not verify_manifest_key.called
-            verify_manifest_key.return_value = manifest_key
-            assert not get_cached_manifest_with_key.called
-            get_cached_manifest_with_key.return_value = manifest
-            response = requests.get(str(manifest_url), allow_redirects=False)
-            self.assertEqual(302, response.status_code)
-            self.assertEqual(object_url, response.headers['Location'])
-            get_cached_manifest_with_key.side_effect = CachedManifestNotFound(manifest_key)
-            response = requests.get(str(manifest_url), allow_redirects=False)
-            self.assertEqual(410, response.status_code)
-            expected_response = {
-                'Code': 'GoneError',
-                'Message': 'The requested manifest has expired, please request a new one'
-            }
-            self.assertEqual(expected_response, response.json())
+                    # Request the manifest by its key if a URL with that key
+                    # that was the result of the final 302 redirect above. Then
+                    # expire the manifest and request it again.
+                    #
+                    if key_url is not None:
+                        assert signed_manifest_key.encode() == key_url.path.segments[-1]
+                        assert not verify_manifest_key.called
+                        verify_manifest_key.return_value = manifest_key
+                        assert get_cached_manifest_with_key.not_called
+                        get_cached_manifest_with_key.side_effect = None
+                        get_cached_manifest_with_key.return_value = manifest
+                        url = request('GET', key_url, expect=302)
+                        self.assertEqual(object_url, url)
+                        get_cached_manifest_with_key.side_effect = CachedManifestNotFound(manifest_key)
+                        response = requests.get(str(key_url), allow_redirects=False)
+                        self.assertEqual(410, response.status_code)
+                        expected_response = {
+                            'Code': 'GoneError',
+                            'Message': 'The requested manifest has expired, please request a new one'
+                        }
+                        self.assertEqual(expected_response, response.json())
 
     token = Token.first(execution_id).encode()
 

--- a/test/service/test_manifest_async.py
+++ b/test/service/test_manifest_async.py
@@ -336,25 +336,49 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     # Re-request the manifest at the initial URL. The manifest
                     # is cached so we expect no intermediate 301 redirects.
                     #
+                    get_cached_manifest.reset_mock()
                     get_cached_manifest.side_effect = None
                     get_cached_manifest.return_value = manifest
                     url = request('PUT', initial_url, expect=302)
+                    get_cached_manifest.assert_called_once_with(
+                        format=format,
+                        catalog=self.catalog,
+                        filters=filters
+                    )
                     self.assertEqual(expected_url, str(url))
 
+                    # Re-request the manifest at a URL with an insignificant
+                    # change to the filters parameter. The cached manifest
+                    # should be reused. Note that this does not cover the
+                    # insensitivity of the manifest key derivation to such
+                    # insignificant differences because we mock the manifest
+                    # service method where that is done. However, this test is
+                    # not supposed to cover the service, only the controller.
+                    #
+                    equivalent_url = initial_url.copy()
+                    equivalent_filters = json.loads(equivalent_url.args['filters'])
+                    equivalent_filters = dict(reversed(equivalent_filters.items()))
+                    equivalent_url.args['filters'] = json.dumps(equivalent_filters)
+                    get_cached_manifest.reset_mock()
+                    url = request('PUT', equivalent_url, expect=302)
+                    self.assertEqual(expected_url, str(url))
+                    get_cached_manifest.assert_called_once_with(
+                        format=format,
+                        catalog=self.catalog,
+                        filters=filters.update(equivalent_filters)
+                    )
+
                     # Expire the cached manifest and repeat the initial request
-                    # but with an insignificant difference to the filters
-                    # parameter. The repeated request should be considered valid
-                    # and matching the completed step function execution.
+                    # with the insignificant difference. The repeated request
+                    # should be considered valid and matching the completed step
+                    # function execution.
                     #
                     get_cached_manifest.side_effect = CachedManifestNotFound(manifest_key)
                     exception = self._mock_sfn_exception(_sfn,
                                                          operation_name='StartExecution',
                                                          error_code='ExecutionAlreadyExists')
                     _sfn.start_execution.side_effect = exception
-                    url = initial_url.copy()
-                    filters = json.loads(url.args['filters'])
-                    url.args['filters'] = json.dumps(dict(reversed(filters.items())))
-                    url = request('PUT', url, expect=301)
+                    url = request('PUT', equivalent_url, expect=301)
                     _sfn.reset_mock(side_effect=True)
                     # FIXME: 404 from S3 when re-requesting manifest after it expired
                     #        https://github.com/DataBiosphere/azul/issues/6441

--- a/test/service/test_manifest_async.py
+++ b/test/service/test_manifest_async.py
@@ -234,73 +234,80 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                         'executionArn': execution_arn,
                         'startDate': 123
                     }
-                    url = initial_url
-                    for i, expected_status in enumerate(3 * [301] + [302]):
-                        response = requests.request(method='PUT' if i == 0 else 'GET',
+
+                    def request(method: str, url: furl, *, expect: int) -> furl:
+                        response = requests.request(method=method,
                                                     url=str(url),
                                                     allow_redirects=False)
                         if fetch:
                             self.assertEqual(200, response.status_code)
                             response = response.json()
-                            self.assertEqual(expected_status, response.pop('Status'))
+                            self.assertEqual(expect, response.pop('Status'))
                             headers = response
                         else:
-                            self.assertEqual(expected_status, response.status_code)
+                            self.assertEqual(expect, response.status_code)
                             headers = response.headers
-                        if expected_status == 301:
+                        if expect == 301:
                             self.assertGreaterEqual(int(headers['Retry-After']), 0)
-                        url = furl(headers['Location'])
-                        if i == 0:
-                            state: ManifestGenerationState = input
-                            _sfn.start_execution.assert_called_once_with(
-                                stateMachineArn=machine_arn,
-                                name=execution_name,
-                                input=json.dumps(input)
-                            )
-                            _sfn.describe_execution.assert_not_called()
-                            _sfn.reset_mock()
-                            _sfn.describe_execution.return_value = {'status': 'RUNNING'}
-                            token_url = url
-                        elif i == 1:
-                            get_manifest.return_value = partitions[1]
-                            state = self.app_module.generate_manifest(state, None)
-                            self.assertEqual(partitions[1],
-                                             ManifestPartition.from_json(state['partition']))
-                            get_manifest.assert_called_once_with(
-                                format=format,
-                                catalog=self.catalog,
-                                filters=Filters.from_json(state['filters']),
-                                partition=partitions[0],
-                                manifest_key=ManifestKey.from_json(state['manifest_key'])
-                            )
-                            get_manifest.reset_mock()
-                            _sfn.start_execution.assert_not_called()
-                            _sfn.describe_execution.assert_called_once()
-                            _sfn.reset_mock()
-                            # simulate absence of output due eventual consistency
-                            _sfn.describe_execution.return_value = {'status': 'SUCCEEDED'}
-                        elif i == 2:
-                            get_manifest.return_value = manifest
-                            get_manifest_url.return_value = object_url
-                            _sfn.start_execution.assert_not_called()
-                            _sfn.describe_execution.assert_called_once()
-                            _sfn.reset_mock()
-                            _sfn.describe_execution.return_value = {
-                                'status': 'SUCCEEDED',
-                                'input': json.dumps(input),
-                                'output': json.dumps(
-                                    self.app_module.generate_manifest(state, None)
-                                )
-                            }
-                        elif i == 3:
-                            get_manifest.assert_called_once_with(
-                                format=format,
-                                catalog=self.catalog,
-                                filters=Filters.from_json(state['filters']),
-                                partition=partitions[1],
-                                manifest_key=ManifestKey.from_json(state['manifest_key'])
-                            )
-                            get_manifest.reset_mock()
+                        return furl(headers['Location'])
+
+                    url = initial_url
+
+                    url = request('PUT', url, expect=301)
+                    state: ManifestGenerationState = input
+                    _sfn.start_execution.assert_called_once_with(
+                        stateMachineArn=machine_arn,
+                        name=execution_name,
+                        input=json.dumps(input)
+                    )
+                    _sfn.describe_execution.assert_not_called()
+                    _sfn.reset_mock()
+                    _sfn.describe_execution.return_value = {'status': 'RUNNING'}
+                    token_url = url
+
+                    url = request('GET', url, expect=301)
+                    get_manifest.return_value = partitions[1]
+                    state = self.app_module.generate_manifest(state, None)
+                    self.assertEqual(partitions[1],
+                                     ManifestPartition.from_json(state['partition']))
+                    get_manifest.assert_called_once_with(
+                        format=format,
+                        catalog=self.catalog,
+                        filters=Filters.from_json(state['filters']),
+                        partition=partitions[0],
+                        manifest_key=ManifestKey.from_json(state['manifest_key'])
+                    )
+
+                    get_manifest.reset_mock()
+                    _sfn.start_execution.assert_not_called()
+                    _sfn.describe_execution.assert_called_once()
+                    _sfn.reset_mock()
+                    # simulate absence of output due eventual consistency
+                    _sfn.describe_execution.return_value = {'status': 'SUCCEEDED'}
+                    url = request('GET', url, expect=301)
+                    get_manifest.return_value = manifest
+                    get_manifest_url.return_value = object_url
+                    _sfn.start_execution.assert_not_called()
+                    _sfn.describe_execution.assert_called_once()
+                    _sfn.reset_mock()
+
+                    _sfn.describe_execution.return_value = {
+                        'status': 'SUCCEEDED',
+                        'input': json.dumps(input),
+                        'output': json.dumps(
+                            self.app_module.generate_manifest(state, None)
+                        )
+                    }
+                    url = request('GET', url, expect=302)
+                    get_manifest.assert_called_once_with(
+                        format=format,
+                        catalog=self.catalog,
+                        filters=Filters.from_json(state['filters']),
+                        partition=partitions[1],
+                        manifest_key=ManifestKey.from_json(state['manifest_key'])
+                    )
+                    get_manifest.reset_mock()
+
                     _sfn.start_execution.assert_not_called()
                     _sfn.describe_execution.assert_called_once()
                     expect_redirect = fetch and format is ManifestFormat.curl

--- a/test/service/test_manifest_async.py
+++ b/test/service/test_manifest_async.py
@@ -29,7 +29,6 @@ from moto import (
     mock_aws,
 )
 import requests
-import responses
 
 from app_test_case import (
     LocalAppTestCase,
@@ -169,236 +168,234 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
              get_cached_manifest,
              get_manifest,
              _sfn):
-        with responses.RequestsMock() as helper:
-            helper.add_passthru(str(self.base_url))
-            for format, fetch in product([ManifestFormat.compact, ManifestFormat.curl],
-                                         [True, False]):
-                with self.subTest(format=format, fetch=fetch):
-                    filters = {'organ': {'is': ['lymph node']}, 'fileFormat': {'is': ['txt']}}
-                    filters = Filters(explicit=filters, source_ids={self.source.id})
-                    params = {
-                        'catalog': self.catalog,
-                        'format': format.value,
-                        'filters': json.dumps(filters.explicit)
+        for format, fetch in product([ManifestFormat.compact, ManifestFormat.curl],
+                                     [True, False]):
+            with self.subTest(format=format, fetch=fetch):
+                filters = {'organ': {'is': ['lymph node']}, 'fileFormat': {'is': ['txt']}}
+                filters = Filters(explicit=filters, source_ids={self.source.id})
+                params = {
+                    'catalog': self.catalog,
+                    'format': format.value,
+                    'filters': json.dumps(filters.explicit)
+                }
+                path = ['manifest', 'files']
+
+                initial_url = self.base_url.set(path=path.copy(), args=params)
+                if fetch:
+                    initial_url.path.segments.insert(0, 'fetch')
+
+                manifest_key = ManifestKey(catalog=self.catalog,
+                                           format=format,
+                                           manifest_hash=UUID('d2b0ce3c-46f0-57fe-b9d4-2e38d8934fd4'),
+                                           source_hash=UUID('77936747-5968-588e-809f-af842d6be9e0'))
+                signed_manifest_key = SignedManifestKey(value=manifest_key,
+                                                        signature=b'123')
+
+                object_url = furl('https://url.to.manifest?foo=bar')
+                file_name = 'some_file_name'
+                manifest = Manifest(object_key='key/of/manifest',
+                                    was_cached=False,
+                                    format=format,
+                                    manifest_key=manifest_key,
+                                    file_name=file_name)
+
+                partitions = (
+                    ManifestPartition(index=0,
+                                      is_last=False,
+                                      file_name=None,
+                                      config=None,
+                                      multipart_upload_id=None,
+                                      part_etags=None,
+                                      page_index=None,
+                                      is_last_page=None,
+                                      search_after=None),
+                    ManifestPartition(index=1,
+                                      is_last=False,
+                                      file_name=file_name,
+                                      config=[[['foo', 'bar'], {'baz': 'blah'}]],
+                                      multipart_upload_id='some_upload_id',
+                                      part_etags=('some_etag',),
+                                      page_index=512,
+                                      is_last_page=False,
+                                      search_after=('foo', 'doc#bar'))
+                )
+                input: ManifestGenerationState = dict(filters=filters.to_json(),
+                                                      manifest_key=manifest_key.to_json(),
+                                                      partition=partitions[0].to_json())
+                service: AsyncManifestService
+                service = self.app_module.app.manifest_controller.async_service
+                execution_id = manifest_key.uuid
+                execution_name = service.execution_name(execution_id)
+                machine_arn = service.machine_arn
+                execution_arn = service.execution_arn(execution_name)
+                _sfn.start_execution.return_value = {
+                    'executionArn': execution_arn,
+                    'startDate': 123
+                }
+
+                # Request the manifest. The cached manifest does not exist
+                # so we expect a StepFunction execution to be started and a
+                # 301 redirect to the manifest endpoint with a token
+                # embedded in the URL.
+                #
+                get_cached_manifest.side_effect = CachedManifestNotFound(manifest_key)
+                url = self._request('PUT', initial_url, expect=301)
+                token_url = url
+                state: ManifestGenerationState = input
+                _sfn.start_execution.assert_called_once_with(
+                    stateMachineArn=machine_arn,
+                    name=execution_name,
+                    input=json.dumps(input)
+                )
+                _sfn.describe_execution.assert_not_called()
+                _sfn.reset_mock()
+
+                # Follow the redirect. We expect a call to determine the
+                # status of the execution, which we mock to be still
+                # running, and another 301 redirect.
+                #
+                _sfn.describe_execution.return_value = {'status': 'RUNNING'}
+                url = self._request('GET', url, expect=301)
+                get_manifest.return_value = partitions[1]
+                state = self.app_module.generate_manifest(state, None)
+                self.assertEqual(partitions[1],
+                                 ManifestPartition.from_json(state['partition']))
+                get_manifest.assert_called_once_with(
+                    format=format,
+                    catalog=self.catalog,
+                    filters=Filters.from_json(state['filters']),
+                    partition=partitions[0],
+                    manifest_key=ManifestKey.from_json(state['manifest_key'])
+                )
+                get_manifest.reset_mock()
+                _sfn.start_execution.assert_not_called()
+                _sfn.describe_execution.assert_called_once()
+                _sfn.reset_mock()
+
+                # Follow the redirect. The StepFunction has finished but the
+                # output is not yet available due to eventual consistency.
+                # We observed this behaviour a few years ago, but it
+                # probably doesn't happen anymore. The output is most likely
+                # stored on S3 under the hood which strongly consistent a
+                # while back.
+                #
+                _sfn.describe_execution.return_value = {'status': 'SUCCEEDED'}
+                url = self._request('GET', url, expect=301)
+                get_manifest.return_value = manifest
+                get_manifest_url.return_value = str(object_url)
+                _sfn.start_execution.assert_not_called()
+                _sfn.describe_execution.assert_called_once()
+                _sfn.reset_mock()
+
+                # The StepFunction has finished and the output is available.
+                # We expect a 302 redirect to either the signed URL of the
+                # manifest object in S3, or, when fetching a curl manifest,
+                # a 302 redirect to the non-fetch endpoint with the key of
+                # the manifest in the URL.
+                #
+                _sfn.describe_execution.return_value = {
+                    'status': 'SUCCEEDED',
+                    'input': json.dumps(input),
+                    'output': json.dumps(
+                        self.app_module.generate_manifest(state, None)
+                    )
+                }
+                if fetch and format is ManifestFormat.curl:
+                    key_url = self.base_url.set(path=[*path, signed_manifest_key.encode()])
+                    expected_url = key_url
+                    sign_manifest_key.return_value = signed_manifest_key
+                else:
+                    key_url = None
+                    expected_url = object_url
+                url = self._request('GET', url, expect=302)
+                self.assertEqual(expected_url, url)
+                get_manifest.assert_called_once_with(
+                    format=format,
+                    catalog=self.catalog,
+                    filters=Filters.from_json(state['filters']),
+                    partition=partitions[1],
+                    manifest_key=ManifestKey.from_json(state['manifest_key'])
+                )
+                get_manifest.reset_mock()
+                _sfn.start_execution.assert_not_called()
+                _sfn.describe_execution.assert_called_once()
+                _sfn.reset_mock()
+
+                # Re-request the manifest at the initial URL. The manifest
+                # is cached so we expect no intermediate 301 redirects.
+                #
+                get_cached_manifest.reset_mock()
+                get_cached_manifest.side_effect = None
+                get_cached_manifest.return_value = manifest
+                url = self._request('PUT', initial_url, expect=302)
+                get_cached_manifest.assert_called_once_with(
+                    format=format,
+                    catalog=self.catalog,
+                    filters=filters
+                )
+                self.assertEqual(expected_url, url)
+
+                # Re-request the manifest at a URL with an insignificant
+                # change to the filters parameter. The cached manifest
+                # should be reused. Note that this does not cover the
+                # insensitivity of the manifest key derivation to such
+                # insignificant differences because we mock the manifest
+                # service method where that is done. However, this test is
+                # not supposed to cover the service, only the controller.
+                #
+                equivalent_url = initial_url.copy()
+                equivalent_filters = json.loads(equivalent_url.args['filters'])
+                equivalent_filters = dict(reversed(equivalent_filters.items()))
+                equivalent_url.args['filters'] = json.dumps(equivalent_filters)
+                get_cached_manifest.reset_mock()
+                url = self._request('PUT', equivalent_url, expect=302)
+                self.assertEqual(expected_url, url)
+                get_cached_manifest.assert_called_once_with(
+                    format=format,
+                    catalog=self.catalog,
+                    filters=filters.update(equivalent_filters)
+                )
+
+                # Expire the cached manifest and repeat the initial request
+                # with the insignificant difference. The repeated request
+                # should be considered valid and matching the completed step
+                # function execution.
+                #
+                get_cached_manifest.side_effect = CachedManifestNotFound(manifest_key)
+                exception = self._mock_sfn_exception(_sfn,
+                                                     operation_name='StartExecution',
+                                                     error_code='ExecutionAlreadyExists')
+                _sfn.start_execution.side_effect = exception
+                url = self._request('PUT', equivalent_url, expect=301)
+                _sfn.reset_mock(side_effect=True)
+                # FIXME: 404 from S3 when re-requesting manifest after it expired
+                #        https://github.com/DataBiosphere/azul/issues/6441
+                if True:
+                    self.assertEqual(token_url, url)
+                else:
+                    self.assertNotEqual(token_url, url)
+
+                # Request the manifest by its key if a URL with that key
+                # that was the result of the final 302 redirect above. Then
+                # expire the manifest and request it again.
+                #
+                if key_url is not None:
+                    assert signed_manifest_key.encode() == key_url.path.segments[-1]
+                    assert not verify_manifest_key.called
+                    verify_manifest_key.return_value = manifest_key
+                    assert not get_cached_manifest_with_key.called
+                    get_cached_manifest_with_key.side_effect = None
+                    get_cached_manifest_with_key.return_value = manifest
+                    url = self._request('GET', key_url, expect=302)
+                    self.assertEqual(object_url, url)
+                    get_cached_manifest_with_key.side_effect = CachedManifestNotFound(manifest_key)
+                    response = requests.get(str(key_url), allow_redirects=False)
+                    self.assertEqual(410, response.status_code)
+                    expected_response = {
+                        'Code': 'GoneError',
+                        'Message': 'The requested manifest has expired, please request a new one'
                     }
-                    path = ['manifest', 'files']
-
-                    initial_url = self.base_url.set(path=path.copy(), args=params)
-                    if fetch:
-                        initial_url.path.segments.insert(0, 'fetch')
-
-                    manifest_key = ManifestKey(catalog=self.catalog,
-                                               format=format,
-                                               manifest_hash=UUID('d2b0ce3c-46f0-57fe-b9d4-2e38d8934fd4'),
-                                               source_hash=UUID('77936747-5968-588e-809f-af842d6be9e0'))
-                    signed_manifest_key = SignedManifestKey(value=manifest_key,
-                                                            signature=b'123')
-
-                    object_url = furl('https://url.to.manifest?foo=bar')
-                    file_name = 'some_file_name'
-                    manifest = Manifest(object_key='key/of/manifest',
-                                        was_cached=False,
-                                        format=format,
-                                        manifest_key=manifest_key,
-                                        file_name=file_name)
-
-                    partitions = (
-                        ManifestPartition(index=0,
-                                          is_last=False,
-                                          file_name=None,
-                                          config=None,
-                                          multipart_upload_id=None,
-                                          part_etags=None,
-                                          page_index=None,
-                                          is_last_page=None,
-                                          search_after=None),
-                        ManifestPartition(index=1,
-                                          is_last=False,
-                                          file_name=file_name,
-                                          config=[[['foo', 'bar'], {'baz': 'blah'}]],
-                                          multipart_upload_id='some_upload_id',
-                                          part_etags=('some_etag',),
-                                          page_index=512,
-                                          is_last_page=False,
-                                          search_after=('foo', 'doc#bar'))
-                    )
-                    input: ManifestGenerationState = dict(filters=filters.to_json(),
-                                                          manifest_key=manifest_key.to_json(),
-                                                          partition=partitions[0].to_json())
-                    service: AsyncManifestService
-                    service = self.app_module.app.manifest_controller.async_service
-                    execution_id = manifest_key.uuid
-                    execution_name = service.execution_name(execution_id)
-                    machine_arn = service.machine_arn
-                    execution_arn = service.execution_arn(execution_name)
-                    _sfn.start_execution.return_value = {
-                        'executionArn': execution_arn,
-                        'startDate': 123
-                    }
-
-                    # Request the manifest. The cached manifest does not exist
-                    # so we expect a StepFunction execution to be started and a
-                    # 301 redirect to the manifest endpoint with a token
-                    # embedded in the URL.
-                    #
-                    get_cached_manifest.side_effect = CachedManifestNotFound(manifest_key)
-                    url = self._request('PUT', initial_url, expect=301)
-                    token_url = url
-                    state: ManifestGenerationState = input
-                    _sfn.start_execution.assert_called_once_with(
-                        stateMachineArn=machine_arn,
-                        name=execution_name,
-                        input=json.dumps(input)
-                    )
-                    _sfn.describe_execution.assert_not_called()
-                    _sfn.reset_mock()
-
-                    # Follow the redirect. We expect a call to determine the
-                    # status of the execution, which we mock to be still
-                    # running, and another 301 redirect.
-                    #
-                    _sfn.describe_execution.return_value = {'status': 'RUNNING'}
-                    url = self._request('GET', url, expect=301)
-                    get_manifest.return_value = partitions[1]
-                    state = self.app_module.generate_manifest(state, None)
-                    self.assertEqual(partitions[1],
-                                     ManifestPartition.from_json(state['partition']))
-                    get_manifest.assert_called_once_with(
-                        format=format,
-                        catalog=self.catalog,
-                        filters=Filters.from_json(state['filters']),
-                        partition=partitions[0],
-                        manifest_key=ManifestKey.from_json(state['manifest_key'])
-                    )
-                    get_manifest.reset_mock()
-                    _sfn.start_execution.assert_not_called()
-                    _sfn.describe_execution.assert_called_once()
-                    _sfn.reset_mock()
-
-                    # Follow the redirect. The StepFunction has finished but the
-                    # output is not yet available due to eventual consistency.
-                    # We observed this behaviour a few years ago, but it
-                    # probably doesn't happen anymore. The output is most likely
-                    # stored on S3 under the hood which strongly consistent a
-                    # while back.
-                    #
-                    _sfn.describe_execution.return_value = {'status': 'SUCCEEDED'}
-                    url = self._request('GET', url, expect=301)
-                    get_manifest.return_value = manifest
-                    get_manifest_url.return_value = str(object_url)
-                    _sfn.start_execution.assert_not_called()
-                    _sfn.describe_execution.assert_called_once()
-                    _sfn.reset_mock()
-
-                    # The StepFunction has finished and the output is available.
-                    # We expect a 302 redirect to either the signed URL of the
-                    # manifest object in S3, or, when fetching a curl manifest,
-                    # a 302 redirect to the non-fetch endpoint with the key of
-                    # the manifest in the URL.
-                    #
-                    _sfn.describe_execution.return_value = {
-                        'status': 'SUCCEEDED',
-                        'input': json.dumps(input),
-                        'output': json.dumps(
-                            self.app_module.generate_manifest(state, None)
-                        )
-                    }
-                    if fetch and format is ManifestFormat.curl:
-                        key_url = self.base_url.set(path=[*path, signed_manifest_key.encode()])
-                        expected_url = key_url
-                        sign_manifest_key.return_value = signed_manifest_key
-                    else:
-                        key_url = None
-                        expected_url = object_url
-                    url = self._request('GET', url, expect=302)
-                    self.assertEqual(expected_url, url)
-                    get_manifest.assert_called_once_with(
-                        format=format,
-                        catalog=self.catalog,
-                        filters=Filters.from_json(state['filters']),
-                        partition=partitions[1],
-                        manifest_key=ManifestKey.from_json(state['manifest_key'])
-                    )
-                    get_manifest.reset_mock()
-                    _sfn.start_execution.assert_not_called()
-                    _sfn.describe_execution.assert_called_once()
-                    _sfn.reset_mock()
-
-                    # Re-request the manifest at the initial URL. The manifest
-                    # is cached so we expect no intermediate 301 redirects.
-                    #
-                    get_cached_manifest.reset_mock()
-                    get_cached_manifest.side_effect = None
-                    get_cached_manifest.return_value = manifest
-                    url = self._request('PUT', initial_url, expect=302)
-                    get_cached_manifest.assert_called_once_with(
-                        format=format,
-                        catalog=self.catalog,
-                        filters=filters
-                    )
-                    self.assertEqual(expected_url, url)
-
-                    # Re-request the manifest at a URL with an insignificant
-                    # change to the filters parameter. The cached manifest
-                    # should be reused. Note that this does not cover the
-                    # insensitivity of the manifest key derivation to such
-                    # insignificant differences because we mock the manifest
-                    # service method where that is done. However, this test is
-                    # not supposed to cover the service, only the controller.
-                    #
-                    equivalent_url = initial_url.copy()
-                    equivalent_filters = json.loads(equivalent_url.args['filters'])
-                    equivalent_filters = dict(reversed(equivalent_filters.items()))
-                    equivalent_url.args['filters'] = json.dumps(equivalent_filters)
-                    get_cached_manifest.reset_mock()
-                    url = self._request('PUT', equivalent_url, expect=302)
-                    self.assertEqual(expected_url, url)
-                    get_cached_manifest.assert_called_once_with(
-                        format=format,
-                        catalog=self.catalog,
-                        filters=filters.update(equivalent_filters)
-                    )
-
-                    # Expire the cached manifest and repeat the initial request
-                    # with the insignificant difference. The repeated request
-                    # should be considered valid and matching the completed step
-                    # function execution.
-                    #
-                    get_cached_manifest.side_effect = CachedManifestNotFound(manifest_key)
-                    exception = self._mock_sfn_exception(_sfn,
-                                                         operation_name='StartExecution',
-                                                         error_code='ExecutionAlreadyExists')
-                    _sfn.start_execution.side_effect = exception
-                    url = self._request('PUT', equivalent_url, expect=301)
-                    _sfn.reset_mock(side_effect=True)
-                    # FIXME: 404 from S3 when re-requesting manifest after it expired
-                    #        https://github.com/DataBiosphere/azul/issues/6441
-                    if True:
-                        self.assertEqual(token_url, url)
-                    else:
-                        self.assertNotEqual(token_url, url)
-
-                    # Request the manifest by its key if a URL with that key
-                    # that was the result of the final 302 redirect above. Then
-                    # expire the manifest and request it again.
-                    #
-                    if key_url is not None:
-                        assert signed_manifest_key.encode() == key_url.path.segments[-1]
-                        assert not verify_manifest_key.called
-                        verify_manifest_key.return_value = manifest_key
-                        assert not get_cached_manifest_with_key.called
-                        get_cached_manifest_with_key.side_effect = None
-                        get_cached_manifest_with_key.return_value = manifest
-                        url = self._request('GET', key_url, expect=302)
-                        self.assertEqual(object_url, url)
-                        get_cached_manifest_with_key.side_effect = CachedManifestNotFound(manifest_key)
-                        response = requests.get(str(key_url), allow_redirects=False)
-                        self.assertEqual(410, response.status_code)
-                        expected_response = {
-                            'Code': 'GoneError',
-                            'Message': 'The requested manifest has expired, please request a new one'
-                        }
-                        self.assertEqual(expected_response, response.json())
+                    self.assertEqual(expected_response, response.json())
 
     def _request(self, method: str, url: furl, *, expect: int) -> furl:
         response = requests.request(method=method,

--- a/test/service/test_manifest_async.py
+++ b/test/service/test_manifest_async.py
@@ -52,6 +52,7 @@ from azul.service.manifest_controller import (
     ManifestGenerationState,
 )
 from azul.service.manifest_service import (
+    BareManifestKey,
     CachedManifestNotFound,
     Manifest,
     ManifestKey,
@@ -191,8 +192,10 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                                            format=format,
                                            manifest_hash=UUID('d2b0ce3c-46f0-57fe-b9d4-2e38d8934fd4'),
                                            source_hash=UUID('77936747-5968-588e-809f-af842d6be9e0'))
-                signed_manifest_key = SignedManifestKey(value=manifest_key,
-                                                        signature=b'123')
+                signed_manifest_key = SignedManifestKey(
+                    value=BareManifestKey.unpack(manifest_key.pack()),
+                    signature=b'123'
+                )
 
                 object_url = furl('https://url.to.manifest?foo=bar')
                 file_name = 'some_file_name'
@@ -384,11 +387,13 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     verify_manifest_key.assert_not_called()
                     verify_manifest_key.return_value = manifest_key
                     get_cached_manifest_with_key.assert_not_called()
-                    get_cached_manifest_with_key.side_effect = None
                     get_cached_manifest_with_key.return_value = manifest
                     url = self._request('GET', key_url, expect=302)
                     self.assertEqual(object_url, url)
+                    verify_manifest_key.assert_called_once_with(signed_manifest_key)
                     get_cached_manifest.assert_not_called()
+                    get_cached_manifest_with_key.assert_called_once_with(manifest_key)
+                    get_cached_manifest_with_key.reset_mock(return_value=True)
                     get_cached_manifest_with_key.side_effect = CachedManifestNotFound(manifest_key)
                     response = requests.get(str(key_url), allow_redirects=False)
                     self.assertEqual(410, response.status_code)
@@ -398,6 +403,8 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     }
                     self.assertEqual(expected_response, response.json())
                     get_cached_manifest.assert_not_called()
+                    get_cached_manifest_with_key.assert_called_once_with(manifest_key)
+                    get_cached_manifest_with_key.reset_mock()
 
     def _request(self, method: str, url: furl, *, expect: int) -> furl:
         response = requests.request(method=method,

--- a/test/service/test_manifest_async.py
+++ b/test/service/test_manifest_async.py
@@ -233,6 +233,24 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     'startDate': 123
                 }
 
+                def assert_get_cached_manifest(filters=filters):
+                    get_cached_manifest.assert_called_once_with(
+                        format=format,
+                        catalog=self.catalog,
+                        filters=filters
+                    )
+                    get_cached_manifest.reset_mock()
+
+                def assert_get_manifest(partition):
+                    get_manifest.assert_called_once_with(
+                        format=format,
+                        catalog=self.catalog,
+                        filters=Filters.from_json(state['filters']),
+                        partition=partitions[partition],
+                        manifest_key=ManifestKey.from_json(state['manifest_key'])
+                    )
+                    get_manifest.reset_mock()
+
                 # Request the manifest. The cached manifest does not exist
                 # so we expect a StepFunction execution to be started and a
                 # 301 redirect to the manifest endpoint with a token
@@ -240,6 +258,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 #
                 get_cached_manifest.side_effect = CachedManifestNotFound(manifest_key)
                 url = self._request('PUT', initial_url, expect=301)
+                assert_get_cached_manifest()
                 token_url = url
                 state: ManifestGenerationState = input
                 _sfn.start_execution.assert_called_once_with(
@@ -260,14 +279,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 state = self.app_module.generate_manifest(state, None)
                 self.assertEqual(partitions[1],
                                  ManifestPartition.from_json(state['partition']))
-                get_manifest.assert_called_once_with(
-                    format=format,
-                    catalog=self.catalog,
-                    filters=Filters.from_json(state['filters']),
-                    partition=partitions[0],
-                    manifest_key=ManifestKey.from_json(state['manifest_key'])
-                )
-                get_manifest.reset_mock()
+                assert_get_manifest(partition=0)
                 _sfn.start_execution.assert_not_called()
                 _sfn.describe_execution.assert_called_once()
                 _sfn.reset_mock()
@@ -309,13 +321,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     expected_url = object_url
                 url = self._request('GET', url, expect=302)
                 self.assertEqual(expected_url, url)
-                get_manifest.assert_called_once_with(
-                    format=format,
-                    catalog=self.catalog,
-                    filters=Filters.from_json(state['filters']),
-                    partition=partitions[1],
-                    manifest_key=ManifestKey.from_json(state['manifest_key'])
-                )
+                assert_get_manifest(partition=1)
                 get_manifest.reset_mock()
                 _sfn.start_execution.assert_not_called()
                 _sfn.describe_execution.assert_called_once()
@@ -324,15 +330,10 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 # Re-request the manifest at the initial URL. The manifest
                 # is cached so we expect no intermediate 301 redirects.
                 #
-                get_cached_manifest.reset_mock()
                 get_cached_manifest.side_effect = None
                 get_cached_manifest.return_value = manifest
                 url = self._request('PUT', initial_url, expect=302)
-                get_cached_manifest.assert_called_once_with(
-                    format=format,
-                    catalog=self.catalog,
-                    filters=filters
-                )
+                assert_get_cached_manifest()
                 self.assertEqual(expected_url, url)
 
                 # Re-request the manifest at a URL with an insignificant
@@ -347,14 +348,9 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 equivalent_filters = json.loads(equivalent_url.args['filters'])
                 equivalent_filters = dict(reversed(equivalent_filters.items()))
                 equivalent_url.args['filters'] = json.dumps(equivalent_filters)
-                get_cached_manifest.reset_mock()
                 url = self._request('PUT', equivalent_url, expect=302)
                 self.assertEqual(expected_url, url)
-                get_cached_manifest.assert_called_once_with(
-                    format=format,
-                    catalog=self.catalog,
-                    filters=filters.update(equivalent_filters)
-                )
+                assert_get_cached_manifest(filters.update(equivalent_filters))
 
                 # Expire the cached manifest and repeat the initial request
                 # with the insignificant difference. The repeated request
@@ -368,6 +364,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 _sfn.start_execution.side_effect = exception
                 url = self._request('PUT', equivalent_url, expect=301)
                 _sfn.reset_mock(side_effect=True)
+                assert_get_cached_manifest()
                 # FIXME: 404 from S3 when re-requesting manifest after it expired
                 #        https://github.com/DataBiosphere/azul/issues/6441
                 if True:
@@ -388,6 +385,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     get_cached_manifest_with_key.return_value = manifest
                     url = self._request('GET', key_url, expect=302)
                     self.assertEqual(object_url, url)
+                    get_cached_manifest.assert_not_called()
                     get_cached_manifest_with_key.side_effect = CachedManifestNotFound(manifest_key)
                     response = requests.get(str(key_url), allow_redirects=False)
                     self.assertEqual(410, response.status_code)
@@ -396,6 +394,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                         'Message': 'The requested manifest has expired, please request a new one'
                     }
                     self.assertEqual(expected_response, response.json())
+                    get_cached_manifest.assert_not_called()
 
     def _request(self, method: str, url: furl, *, expect: int) -> furl:
         response = requests.request(method=method,

--- a/test/service/test_manifest_async.py
+++ b/test/service/test_manifest_async.py
@@ -199,7 +199,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                                     manifest_key=manifest_key,
                                     file_name=file_name)
 
-                partitions = (
+                partitions = [
                     ManifestPartition(index=0,
                                       is_last=False,
                                       file_name=None,
@@ -218,7 +218,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                                       page_index=512,
                                       is_last_page=False,
                                       search_after=('foo', 'doc#bar'))
-                )
+                ]
                 input: ManifestGenerationState = dict(filters=filters.to_json(),
                                                       manifest_key=manifest_key.to_json(),
                                                       partition=partitions[0].to_json())

--- a/test/service/test_manifest_async.py
+++ b/test/service/test_manifest_async.py
@@ -36,6 +36,12 @@ import requests
 from app_test_case import (
     LocalAppTestCase,
 )
+from azul import (
+    JSON,
+)
+from azul.collections import (
+    deep_dict_merge,
+)
 from azul.logging import (
     configure_test_logging,
 )
@@ -44,6 +50,7 @@ from azul.plugins import (
 )
 from azul.service import (
     Filters,
+    FiltersJSON,
 )
 from azul.service.async_manifest_service import (
     AsyncManifestService,
@@ -79,11 +86,17 @@ class TestAsyncManifestService(AzulUnitTestCase):
     generation_id = UUID('1ea94a54-a64d-54f1-8b41-15455fb958db')
 
     def test_token_encoding(self, _sfn):
-        token = Token(generation_id=self.generation_id, request_index=42, retry_after=123)
+        token = Token(generation_id=self.generation_id,
+                      iteration=3,
+                      request_index=42,
+                      retry_after=123)
         self.assertEqual(token, Token.decode(token.encode()))
 
     def test_token_validation(self, _sfn):
-        token = Token(generation_id=self.generation_id, request_index=42, retry_after=123)
+        token = Token(generation_id=self.generation_id,
+                      iteration=3,
+                      request_index=42,
+                      retry_after=123)
         self.assertRaises(InvalidTokenError, token.decode, token.encode()[:-1])
 
     def test_status_success(self, _sfn):
@@ -92,8 +105,8 @@ class TestAsyncManifestService(AzulUnitTestCase):
         manifest
         """
         service = AsyncManifestService()
-        execution_name = service.execution_name(self.generation_id)
-        output = {'foo': 'bar'}
+        execution_name = service.execution_name(self.generation_id, iteration=0)
+        input, output = {'filters': {}}, {'foo': 'bar'}
         _sfn.describe_execution.return_value = {
             'executionArn': service.execution_arn(execution_name),
             'stateMachineArn': service.machine_arn,
@@ -101,12 +114,15 @@ class TestAsyncManifestService(AzulUnitTestCase):
             'status': 'SUCCEEDED',
             'startDate': datetime.datetime(2018, 11, 15, 18, 30, 44, 896000),
             'stopDate': datetime.datetime(2018, 11, 15, 18, 30, 59, 295000),
-            'input': '{"filters": {}}',
+            'input': json.dumps(input),
             'output': json.dumps(output)
         }
-        token = Token(generation_id=self.generation_id, request_index=0, retry_after=0)
-        actual_output = service.inspect_generation(token)
-        self.assertEqual(output, actual_output)
+        token = Token(generation_id=self.generation_id,
+                      iteration=0,
+                      request_index=0,
+                      retry_after=0)
+        actual_result = service.inspect_generation(token)
+        self.assertEqual({'input': input, 'output': output}, actual_result)
 
     def test_status_running(self, _sfn):
         """
@@ -114,7 +130,7 @@ class TestAsyncManifestService(AzulUnitTestCase):
         checking the job status
         """
         service = AsyncManifestService()
-        execution_name = service.execution_name(self.generation_id)
+        execution_name = service.execution_name(self.generation_id, iteration=0)
         _sfn.describe_execution.return_value = {
             'executionArn': service.execution_arn(execution_name),
             'stateMachineArn': service.machine_arn,
@@ -123,9 +139,15 @@ class TestAsyncManifestService(AzulUnitTestCase):
             'startDate': datetime.datetime(2018, 11, 15, 18, 30, 44, 896000),
             'input': '{"filters": {}}'
         }
-        token = Token(generation_id=self.generation_id, request_index=0, retry_after=0)
+        token = Token(generation_id=self.generation_id,
+                      iteration=0,
+                      request_index=0,
+                      retry_after=0)
         token = service.inspect_generation(token)
-        expected = Token(generation_id=self.generation_id, request_index=1, retry_after=1)
+        expected = Token(generation_id=self.generation_id,
+                         iteration=0,
+                         request_index=1,
+                         retry_after=1)
         self.assertEqual(expected, token)
 
     def test_status_failed(self, _sfn):
@@ -133,7 +155,7 @@ class TestAsyncManifestService(AzulUnitTestCase):
         A failed manifest job should raise a GenerationFailed
         """
         service = AsyncManifestService()
-        execution_name = service.execution_name(self.generation_id)
+        execution_name = service.execution_name(self.generation_id, iteration=0)
         _sfn.describe_execution.return_value = {
             'executionArn': service.execution_arn(execution_name),
             'stateMachineArn': service.machine_arn,
@@ -143,7 +165,10 @@ class TestAsyncManifestService(AzulUnitTestCase):
             'stopDate': datetime.datetime(2018, 11, 14, 16, 6, 55, 860000),
             'input': '{"filters": {"organ": {"is": ["lymph node"]}}}',
         }
-        token = Token(generation_id=self.generation_id, request_index=0, retry_after=0)
+        token = Token(generation_id=self.generation_id,
+                      iteration=0,
+                      request_index=0,
+                      retry_after=0)
         with self.assertRaises(GenerationFailed):
             service.inspect_generation(token)
 
@@ -246,9 +271,19 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 service: AsyncManifestService
                 service = self.app_module.app.manifest_controller.async_service
                 generation_id = manifest_key.uuid
-                execution_name = service.execution_name(generation_id)
+                execution_names = [
+                    service.execution_name(generation_id, iteration=i)
+                    for i in range(3)
+                ]
                 machine_arn = service.machine_arn
-                execution_arn = service.execution_arn(execution_name)
+                execution_arns = list(map(service.execution_arn, execution_names))
+
+                not_found = CachedManifestNotFound(manifest_key)
+                execution_exists = self._mock_sfn_exception(
+                    _sfn,
+                    operation_name='StartExecution',
+                    error_code='ExecutionAlreadyExists'
+                )
 
                 not_found = CachedManifestNotFound(manifest_key)
                 execution_exists = self._mock_sfn_exception(_sfn,
@@ -277,6 +312,45 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 key_url: furl
                 final_url: furl
                 equivalent_url: furl
+                equivalent_filters: FiltersJSON
+                equivalent_input: ManifestGenerationState
+
+                iterations: list[JSON] = []
+
+                def mock_start_generation(*, start: int = 0, describe: int = 0):
+                    *rest, last = range(start, len(iterations))
+                    _sfn.start_execution.side_effect = [
+                        *(execution_exists for _ in rest),
+                        {
+                            'executionArn': execution_arns[last],
+                            'startDate': 1234
+                        }
+                    ]
+                    *rest, last = range(describe, len(iterations))
+                    _sfn.describe_execution.side_effect = [
+                        {
+                            'status': 'SUCCEEDED',
+                            'input': json.dumps(iterations[i]),
+                            'output': json.dumps(state)
+                        }
+                        for i in rest
+                    ]
+
+                def assert_start_generation(*, start: int = 0, describe: int = 0):
+                    indices = range(start, len(iterations))
+                    expected_calls = [
+                        mock.call(stateMachineArn=machine_arn,
+                                  name=execution_names[i],
+                                  input=json.dumps(iterations[-1]))
+                        for i in indices
+                    ]
+                    self.assertEqual(expected_calls, _sfn.start_execution.mock_calls)
+                    indices = range(describe, len(iterations))
+                    expected_calls = [
+                        mock.call(executionArn=execution_arns[i])
+                        for i in indices[:-1]
+                    ]
+                    self.assertEqual(expected_calls, _sfn.describe_execution.mock_calls)
 
                 # Request the manifest. The cached manifest does not exist
                 # so we expect a StepFunction execution to be started and a
@@ -287,19 +361,13 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 def put():
                     nonlocal url, state, token_url
                     get_cached_manifest.side_effect = not_found
-                    _sfn.start_execution.return_value = {
-                        'executionArn': execution_arn,
-                        'startDate': 123
-                    }
+                    iterations.append(input)
+                    mock_start_generation()
                     url = self._request('PUT', initial_url, expect=301)
                     assert_get_cached_manifest()
+                    assert_start_generation()
                     state = input
                     token_url = url
-                    _sfn.start_execution.assert_called_once_with(
-                        stateMachineArn=machine_arn,
-                        name=execution_name,
-                        input=json.dumps(input)
-                    )
 
                 put()
 
@@ -361,10 +429,12 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                         key_url = None
                         final_url = object_url
                         get_manifest_url.return_value = str(object_url)
+                    get_cached_manifest_with_key.return_value = manifest
                     url = self._request('GET', url, expect=302)
                     self.assertEqual(final_url, url)
                     assert_get_manifest(partition=1)
                     _sfn.describe_execution.assert_called_once()
+                    get_cached_manifest_with_key.assert_called_once_with(manifest_key)
 
                 get_token_when_done()
 
@@ -394,7 +464,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 #
                 @reset
                 def modified_put():
-                    nonlocal url, equivalent_url
+                    nonlocal url, equivalent_url, equivalent_filters
                     get_cached_manifest.return_value = manifest
                     get_manifest_url.return_value = str(object_url)
                     if key_url is not None:
@@ -412,28 +482,58 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 # Expire the cached manifest and repeat the initial request
                 # with the insignificant difference. The repeated request
                 # should be considered valid and matching the completed step
-                # function execution.
+                # function execution. However, because the manifest is missing,
+                # the generation should be restarted with a new execution.
                 #
                 @reset
                 def modified_put_after_expiration():
-                    nonlocal url
+                    nonlocal url, state, token_url, equivalent_input
                     get_cached_manifest.side_effect = not_found
-                    _sfn.start_execution.side_effect = execution_exists
-                    _sfn.describe_execution.return_value = {
-                        'status': 'SUCCEEDED',
-                        'input': json.dumps(input),
-                        'output': json.dumps(state)
-                    }
+                    equivalent_input = deep_dict_merge(
+                        {'filters': {'explicit': equivalent_filters}},
+                        input
+                    )
+                    iterations.append(equivalent_input)
+                    mock_start_generation()
                     url = self._request('PUT', equivalent_url, expect=301)
-                    # FIXME: 404 from S3 when re-requesting manifest after it expired
-                    #        https://github.com/DataBiosphere/azul/issues/6441
-                    if True:
-                        self.assertEqual(token_url, url)
-                    else:
-                        self.assertNotEqual(token_url, url)
                     assert_get_cached_manifest()
+                    self.assertNotEqual(token_url, url)
+                    assert_get_cached_manifest()
+                    assert_start_generation()
+                    token_url = url
+                    state = equivalent_input
 
                 modified_put_after_expiration()
+                get_token_while_running()
+                get_token_when_almost_done()
+
+                # The StepFunction has finished but the output is has expired
+                # or was deleted. We expect yet another execution to restart
+                # the generation.
+                #
+                @reset
+                def get_stale_token_when_done():
+                    nonlocal url, state, key_url, token_url
+                    get_manifest.return_value = manifest
+                    state = self.app_module.generate_manifest(state, None)
+                    get_cached_manifest_with_key.side_effect = not_found
+                    previous_iteration = len(iterations)
+                    iterations.append(equivalent_input)
+                    mock_start_generation(start=previous_iteration,
+                                          describe=previous_iteration - 1)
+                    url = self._request('GET', url, expect=301)
+                    self.assertNotEqual(token_url, url)
+                    assert_get_manifest(partition=1)
+                    get_cached_manifest_with_key.assert_called_once_with(manifest_key)
+                    assert_start_generation(start=previous_iteration,
+                                            describe=previous_iteration - 1)
+                    token_url = url
+                    state = equivalent_input
+
+                get_stale_token_when_done()
+                get_token_while_running()
+                get_token_when_almost_done()
+                get_token_when_done()
 
                 # Request the manifest by its key if a URL with that key
                 # was the result of the final 302 redirect above.
@@ -467,7 +567,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     self.assertEqual(410, response.status_code)
                     expected_response = {
                         'Code': 'GoneError',
-                        'Message': 'The requested manifest has expired, please request a new one'
+                        'Message': 'The manifest has expired, please request a new one'
                     }
                     self.assertEqual(expected_response, response.json())
                     get_cached_manifest_with_key.assert_called_once_with(manifest_key)
@@ -491,7 +591,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
             self.assertGreaterEqual(int(headers['Retry-After']), 0)
         return furl(headers['Location'])
 
-    token = Token.first(generation_id).encode()
+    token = Token.first(generation_id, iteration=0).encode()
 
     def _test(self, *, expected_status, token=token):
         url = self.base_url.set(path=['fetch', 'manifest', 'files', token])

--- a/test/service/test_manifest_async.py
+++ b/test/service/test_manifest_async.py
@@ -258,38 +258,53 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     )
                     get_manifest.reset_mock()
 
+                url: furl
+                state: ManifestGenerationState
+                token_url: furl
+                key_url: furl
+                expected_url: furl
+                equivalent_url: furl
+
                 # Request the manifest. The cached manifest does not exist
                 # so we expect a StepFunction execution to be started and a
                 # 301 redirect to the manifest endpoint with a token
                 # embedded in the URL.
                 #
-                get_cached_manifest.side_effect = CachedManifestNotFound(manifest_key)
-                url = self._request('PUT', initial_url, expect=301)
-                assert_get_cached_manifest()
-                token_url = url
-                state: ManifestGenerationState = input
-                _sfn.start_execution.assert_called_once_with(
-                    stateMachineArn=machine_arn,
-                    name=execution_name,
-                    input=json.dumps(input)
-                )
-                _sfn.describe_execution.assert_not_called()
-                _sfn.reset_mock()
+                def put():
+                    nonlocal url, state, token_url
+                    get_cached_manifest.side_effect = CachedManifestNotFound(manifest_key)
+                    url = self._request('PUT', initial_url, expect=301)
+                    assert_get_cached_manifest()
+                    state = input
+                    token_url = url
+                    _sfn.start_execution.assert_called_once_with(
+                        stateMachineArn=machine_arn,
+                        name=execution_name,
+                        input=json.dumps(input)
+                    )
+                    _sfn.describe_execution.assert_not_called()
+                    _sfn.reset_mock()
+
+                put()
 
                 # Follow the redirect. We expect a call to determine the
                 # status of the execution, which we mock to be still
                 # running, and another 301 redirect.
                 #
-                _sfn.describe_execution.return_value = {'status': 'RUNNING'}
-                url = self._request('GET', url, expect=301)
-                get_manifest.return_value = partitions[1]
-                state = self.app_module.generate_manifest(state, None)
-                self.assertEqual(partitions[1],
-                                 ManifestPartition.from_json(state['partition']))
-                assert_get_manifest(partition=0)
-                _sfn.start_execution.assert_not_called()
-                _sfn.describe_execution.assert_called_once()
-                _sfn.reset_mock()
+                def get_token_while_running():
+                    nonlocal url, state
+                    _sfn.describe_execution.return_value = {'status': 'RUNNING'}
+                    url = self._request('GET', url, expect=301)
+                    get_manifest.return_value = partitions[1]
+                    state = self.app_module.generate_manifest(state, None)
+                    self.assertEqual(partitions[1],
+                                     ManifestPartition.from_json(state['partition']))
+                    assert_get_manifest(partition=0)
+                    _sfn.start_execution.assert_not_called()
+                    _sfn.describe_execution.assert_called_once()
+                    _sfn.reset_mock()
+
+                get_token_while_running()
 
                 # Follow the redirect. The StepFunction has finished but the
                 # output is not yet available due to eventual consistency.
@@ -298,13 +313,17 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 # stored on S3 under the hood which strongly consistent a
                 # while back.
                 #
-                _sfn.describe_execution.return_value = {'status': 'SUCCEEDED'}
-                url = self._request('GET', url, expect=301)
-                get_manifest.return_value = manifest
-                get_manifest_url.return_value = str(object_url)
-                _sfn.start_execution.assert_not_called()
-                _sfn.describe_execution.assert_called_once()
-                _sfn.reset_mock()
+                def get_token_when_almost_done():
+                    nonlocal url
+                    _sfn.describe_execution.return_value = {'status': 'SUCCEEDED'}
+                    url = self._request('GET', url, expect=301)
+                    get_manifest.return_value = manifest
+                    get_manifest_url.return_value = str(object_url)
+                    _sfn.start_execution.assert_not_called()
+                    _sfn.describe_execution.assert_called_once()
+                    _sfn.reset_mock()
+
+                get_token_when_almost_done()
 
                 # The StepFunction has finished and the output is available.
                 # We expect a 302 redirect to either the signed URL of the
@@ -312,35 +331,43 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 # a 302 redirect to the non-fetch endpoint with the key of
                 # the manifest in the URL.
                 #
-                state = self.app_module.generate_manifest(state, None)
-                _sfn.describe_execution.return_value = {
-                    'status': 'SUCCEEDED',
-                    'input': json.dumps(input),
-                    'output': json.dumps(state)
-                }
-                if fetch and format is ManifestFormat.curl:
-                    key_url = self.base_url.set(path=[*path, signed_manifest_key.encode()])
-                    expected_url = key_url
-                    sign_manifest_key.return_value = signed_manifest_key
-                else:
-                    key_url = None
-                    expected_url = object_url
-                url = self._request('GET', url, expect=302)
-                self.assertEqual(expected_url, url)
-                assert_get_manifest(partition=1)
-                get_manifest.reset_mock()
-                _sfn.start_execution.assert_not_called()
-                _sfn.describe_execution.assert_called_once()
-                _sfn.reset_mock()
+                def get_token_when_done():
+                    nonlocal url, state, key_url, expected_url
+                    state = self.app_module.generate_manifest(state, None)
+                    _sfn.describe_execution.return_value = {
+                        'status': 'SUCCEEDED',
+                        'input': json.dumps(input),
+                        'output': json.dumps(state)
+                    }
+                    if fetch and format is ManifestFormat.curl:
+                        key_url = self.base_url.set(path=[*path, signed_manifest_key.encode()])
+                        expected_url = key_url
+                        sign_manifest_key.return_value = signed_manifest_key
+                    else:
+                        key_url = None
+                        expected_url = object_url
+                    url = self._request('GET', url, expect=302)
+                    self.assertEqual(expected_url, url)
+                    assert_get_manifest(partition=1)
+                    get_manifest.reset_mock()
+                    _sfn.start_execution.assert_not_called()
+                    _sfn.describe_execution.assert_called_once()
+                    _sfn.reset_mock()
+
+                get_token_when_done()
 
                 # Re-request the manifest at the initial URL. The manifest
                 # is cached so we expect no intermediate 301 redirects.
                 #
-                get_cached_manifest.side_effect = None
-                get_cached_manifest.return_value = manifest
-                url = self._request('PUT', initial_url, expect=302)
-                assert_get_cached_manifest()
-                self.assertEqual(expected_url, url)
+                def repeat_put():
+                    nonlocal url
+                    get_cached_manifest.side_effect = None
+                    get_cached_manifest.return_value = manifest
+                    url = self._request('PUT', initial_url, expect=302)
+                    assert_get_cached_manifest()
+                    self.assertEqual(expected_url, url)
+
+                repeat_put()
 
                 # Re-request the manifest at a URL with an insignificant
                 # change to the filters parameter. The cached manifest
@@ -350,39 +377,47 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 # service method where that is done. However, this test is
                 # not supposed to cover the service, only the controller.
                 #
-                equivalent_url = initial_url.copy()
-                equivalent_filters = json.loads(equivalent_url.args['filters'])
-                equivalent_filters = dict(reversed(equivalent_filters.items()))
-                equivalent_url.args['filters'] = json.dumps(equivalent_filters)
-                url = self._request('PUT', equivalent_url, expect=302)
-                self.assertEqual(expected_url, url)
-                assert_get_cached_manifest(filters.update(equivalent_filters))
+                def modified_put():
+                    nonlocal url, equivalent_url
+                    equivalent_url = initial_url.copy()
+                    equivalent_filters = json.loads(equivalent_url.args['filters'])
+                    equivalent_filters = dict(reversed(equivalent_filters.items()))
+                    equivalent_url.args['filters'] = json.dumps(equivalent_filters)
+                    url = self._request('PUT', equivalent_url, expect=302)
+                    self.assertEqual(expected_url, url)
+                    assert_get_cached_manifest(filters.update(equivalent_filters))
+
+                modified_put()
 
                 # Expire the cached manifest and repeat the initial request
                 # with the insignificant difference. The repeated request
                 # should be considered valid and matching the completed step
                 # function execution.
                 #
-                get_cached_manifest.side_effect = CachedManifestNotFound(manifest_key)
-                exception = self._mock_sfn_exception(_sfn,
-                                                     operation_name='StartExecution',
-                                                     error_code='ExecutionAlreadyExists')
-                _sfn.start_execution.side_effect = exception
-                url = self._request('PUT', equivalent_url, expect=301)
-                _sfn.reset_mock(side_effect=True)
-                assert_get_cached_manifest()
-                # FIXME: 404 from S3 when re-requesting manifest after it expired
-                #        https://github.com/DataBiosphere/azul/issues/6441
-                if True:
-                    self.assertEqual(token_url, url)
-                else:
-                    self.assertNotEqual(token_url, url)
+                def modified_put_after_expiration():
+                    nonlocal url
+                    get_cached_manifest.side_effect = CachedManifestNotFound(manifest_key)
+                    exception = self._mock_sfn_exception(_sfn,
+                                                         operation_name='StartExecution',
+                                                         error_code='ExecutionAlreadyExists')
+                    _sfn.start_execution.side_effect = exception
+                    url = self._request('PUT', equivalent_url, expect=301)
+                    _sfn.reset_mock(side_effect=True)
+                    assert_get_cached_manifest()
+                    # FIXME: 404 from S3 when re-requesting manifest after it expired
+                    #        https://github.com/DataBiosphere/azul/issues/6441
+                    if True:
+                        self.assertEqual(token_url, url)
+                    else:
+                        self.assertNotEqual(token_url, url)
+
+                modified_put_after_expiration()
 
                 # Request the manifest by its key if a URL with that key
-                # that was the result of the final 302 redirect above. Then
-                # expire the manifest and request it again.
+                # was the result of the final 302 redirect above.
                 #
-                if key_url is not None:
+                def get_key():
+                    nonlocal url
                     assert signed_manifest_key.encode() == key_url.path.segments[-1]
                     verify_manifest_key.assert_not_called()
                     verify_manifest_key.return_value = manifest_key
@@ -394,6 +429,15 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     get_cached_manifest.assert_not_called()
                     get_cached_manifest_with_key.assert_called_once_with(manifest_key)
                     get_cached_manifest_with_key.reset_mock(return_value=True)
+
+                if key_url is not None:
+                    get_key()
+
+                # Expire the manifest and request the manifest by its key if a
+                # URL with that key was the result of the final 302 redirect
+                # above.
+                #
+                def get_key_after_expiration():
                     get_cached_manifest_with_key.side_effect = CachedManifestNotFound(manifest_key)
                     response = requests.get(str(key_url), allow_redirects=False)
                     self.assertEqual(410, response.status_code)
@@ -405,6 +449,9 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     get_cached_manifest.assert_not_called()
                     get_cached_manifest_with_key.assert_called_once_with(manifest_key)
                     get_cached_manifest_with_key.reset_mock()
+
+                if key_url is not None:
+                    get_key_after_expiration()
 
     def _request(self, method: str, url: furl, *, expect: int) -> furl:
         response = requests.request(method=method,

--- a/test/service/test_manifest_async.py
+++ b/test/service/test_manifest_async.py
@@ -170,6 +170,9 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
              _sfn):
         for format, fetch in product([ManifestFormat.compact, ManifestFormat.curl],
                                      [True, False]):
+            for v in locals().values():
+                if isinstance(v, mock.Mock):
+                    v.reset_mock(return_value=True, side_effect=True)
             with self.subTest(format=format, fetch=fetch):
                 filters = {'organ': {'is': ['lymph node']}, 'fileFormat': {'is': ['txt']}}
                 filters = Filters(explicit=filters, source_ids={self.source.id})

--- a/test/service/test_manifest_async.py
+++ b/test/service/test_manifest_async.py
@@ -2,6 +2,9 @@ from contextlib import (
     contextmanager,
 )
 import datetime
+from itertools import (
+    product,
+)
 import json
 from typing import (
     ContextManager,
@@ -157,7 +160,9 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
     @mock.patch.object(ManifestService, 'verify_manifest_key')
     @mock.patch.object(ManifestService, 'get_cached_manifest_with_key')
     @mock.patch.object(ManifestService, 'get_manifest_url')
+    @mock.patch.object(ManifestService, 'sign_manifest_key')
     def test(self,
+             sign_manifest_key,
              get_manifest_url,
              get_cached_manifest_with_key,
              verify_manifest_key,
@@ -166,9 +171,9 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
              _sfn):
         with responses.RequestsMock() as helper:
             helper.add_passthru(str(self.base_url))
-            for fetch in (True, False):
-                with self.subTest(fetch=fetch):
-                    format = ManifestFormat.compact
+            for format, fetch in product([ManifestFormat.compact, ManifestFormat.curl],
+                                         [True, False]):
+                with self.subTest(format=format, fetch=fetch):
                     filters = {'organ': {'is': ['lymph node']}, 'fileFormat': {'is': ['txt']}}
                     filters = Filters(explicit=filters, source_ids={self.source.id})
                     params = {
@@ -178,7 +183,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     }
                     path = ['manifest', 'files']
 
-                    initial_url = self.base_url.set(path=path, args=params)
+                    initial_url = self.base_url.set(path=path.copy(), args=params)
                     if fetch:
                         initial_url.path.segments.insert(0, 'fetch')
 
@@ -235,7 +240,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                         response = requests.request(method=method,
                                                     url=str(url),
                                                     allow_redirects=False)
-                        if fetch:
+                        if url.path.segments[0] == 'fetch':
                             self.assertEqual(200, response.status_code)
                             response = response.json()
                             self.assertEqual(expect, response.pop('Status'))
@@ -314,7 +319,15 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                             self.app_module.generate_manifest(state, None)
                         )
                     }
+                    if fetch and format is ManifestFormat.curl:
+                        key_url = self.base_url.set(path=[*path, signed_manifest_key.encode()])
+                        expected_url = key_url
+                        sign_manifest_key.return_value = signed_manifest_key
+                    else:
+                        key_url = None
+                        expected_url = object_url
                     url = request('GET', url, expect=302)
+                    self.assertEqual(expected_url, url)
                     get_manifest.assert_called_once_with(
                         format=format,
                         catalog=self.catalog,
@@ -325,13 +338,6 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     get_manifest.reset_mock()
                     _sfn.start_execution.assert_not_called()
                     _sfn.describe_execution.assert_called_once()
-                    if fetch and format is ManifestFormat.curl:
-                        key_url = self.base_url.set(path=[*path, signed_manifest_key.encode()])
-                        expected_url = key_url
-                    else:
-                        key_url = None
-                        expected_url = object_url
-                    self.assertEqual(expected_url, url)
                     _sfn.reset_mock()
 
                     # Re-request the manifest at the initial URL. The manifest
@@ -396,7 +402,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                         assert signed_manifest_key.encode() == key_url.path.segments[-1]
                         assert not verify_manifest_key.called
                         verify_manifest_key.return_value = manifest_key
-                        assert get_cached_manifest_with_key.not_called
+                        assert not get_cached_manifest_with_key.called
                         get_cached_manifest_with_key.side_effect = None
                         get_cached_manifest_with_key.return_value = manifest
                         url = request('GET', key_url, expect=302)

--- a/test/service/test_manifest_async.py
+++ b/test/service/test_manifest_async.py
@@ -70,7 +70,7 @@ def setUpModule():
 
 @patch.object(AsyncManifestService, '_sfn')
 class TestAsyncManifestService(AzulUnitTestCase):
-    execution_id = b'42'
+    execution_id = UUID('1ea94a54-a64d-54f1-8b41-15455fb958db')
 
     def test_token_encoding(self, _sfn):
         token = Token(execution_id=self.execution_id, request_index=42, retry_after=123)
@@ -148,7 +148,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
     def lambda_name(cls) -> str:
         return 'service'
 
-    execution_id = b'42'
+    execution_id = UUID('1ea94a54-a64d-54f1-8b41-15455fb958db')
 
     @mock_aws
     @mock.patch.object(AsyncManifestService, '_sfn')
@@ -226,7 +226,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                                                           partition=partitions[0].to_json())
                     service: AsyncManifestService
                     service = self.app_module.app.manifest_controller.async_service
-                    execution_id = manifest_key.hash
+                    execution_id = manifest_key.uuid
                     execution_name = service.execution_name(execution_id)
                     machine_arn = service.machine_arn
                     execution_arn = service.execution_arn(execution_name)

--- a/test/service/test_manifest_async.py
+++ b/test/service/test_manifest_async.py
@@ -381,9 +381,9 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 #
                 if key_url is not None:
                     assert signed_manifest_key.encode() == key_url.path.segments[-1]
-                    assert not verify_manifest_key.called
+                    verify_manifest_key.assert_not_called()
                     verify_manifest_key.return_value = manifest_key
-                    assert not get_cached_manifest_with_key.called
+                    get_cached_manifest_with_key.assert_not_called()
                     get_cached_manifest_with_key.side_effect = None
                     get_cached_manifest_with_key.return_value = manifest
                     url = self._request('GET', key_url, expect=302)

--- a/test/service/test_manifest_async.py
+++ b/test/service/test_manifest_async.py
@@ -2,6 +2,9 @@ from contextlib import (
     contextmanager,
 )
 import datetime
+from functools import (
+    wraps,
+)
 from itertools import (
     product,
 )
@@ -169,11 +172,22 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
              get_cached_manifest,
              get_manifest,
              _sfn):
+
+        mocks = [v for v in locals().values() if isinstance(v, mock.Mock)]
+
+        def reset(f):
+            @wraps(f)
+            def wrapper(*args, **kwargs):
+                try:
+                    return f(*args, **kwargs)
+                finally:
+                    for m in mocks:
+                        m.reset_mock(return_value=True, side_effect=True)
+
+            return wrapper
+
         for format, fetch in product([ManifestFormat.compact, ManifestFormat.curl],
                                      [True, False]):
-            for v in locals().values():
-                if isinstance(v, mock.Mock):
-                    v.reset_mock(return_value=True, side_effect=True)
             with self.subTest(format=format, fetch=fetch):
                 filters = {'organ': {'is': ['lymph node']}, 'fileFormat': {'is': ['txt']}}
                 filters = Filters(explicit=filters, source_ids={self.source.id})
@@ -235,10 +249,6 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 execution_name = service.execution_name(generation_id)
                 machine_arn = service.machine_arn
                 execution_arn = service.execution_arn(execution_name)
-                _sfn.start_execution.return_value = {
-                    'executionArn': execution_arn,
-                    'startDate': 123
-                }
 
                 def assert_get_cached_manifest(filters=filters):
                     get_cached_manifest.assert_called_once_with(
@@ -246,7 +256,6 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                         catalog=self.catalog,
                         filters=filters
                     )
-                    get_cached_manifest.reset_mock()
 
                 def assert_get_manifest(partition):
                     get_manifest.assert_called_once_with(
@@ -256,7 +265,6 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                         partition=partitions[partition],
                         manifest_key=manifest_key
                     )
-                    get_manifest.reset_mock()
 
                 url: furl
                 state: ManifestGenerationState
@@ -270,9 +278,14 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 # 301 redirect to the manifest endpoint with a token
                 # embedded in the URL.
                 #
+                @reset
                 def put():
                     nonlocal url, state, token_url
                     get_cached_manifest.side_effect = CachedManifestNotFound(manifest_key)
+                    _sfn.start_execution.return_value = {
+                        'executionArn': execution_arn,
+                        'startDate': 123
+                    }
                     url = self._request('PUT', initial_url, expect=301)
                     assert_get_cached_manifest()
                     state = input
@@ -282,8 +295,6 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                         name=execution_name,
                         input=json.dumps(input)
                     )
-                    _sfn.describe_execution.assert_not_called()
-                    _sfn.reset_mock()
 
                 put()
 
@@ -291,6 +302,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 # status of the execution, which we mock to be still
                 # running, and another 301 redirect.
                 #
+                @reset
                 def get_token_while_running():
                     nonlocal url, state
                     _sfn.describe_execution.return_value = {'status': 'RUNNING'}
@@ -300,9 +312,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     self.assertEqual(partitions[1],
                                      ManifestPartition.from_json(state['partition']))
                     assert_get_manifest(partition=0)
-                    _sfn.start_execution.assert_not_called()
                     _sfn.describe_execution.assert_called_once()
-                    _sfn.reset_mock()
 
                 get_token_while_running()
 
@@ -313,15 +323,12 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 # stored on S3 under the hood which strongly consistent a
                 # while back.
                 #
+                @reset
                 def get_token_when_almost_done():
                     nonlocal url
                     _sfn.describe_execution.return_value = {'status': 'SUCCEEDED'}
                     url = self._request('GET', url, expect=301)
-                    get_manifest.return_value = manifest
-                    get_manifest_url.return_value = str(object_url)
-                    _sfn.start_execution.assert_not_called()
                     _sfn.describe_execution.assert_called_once()
-                    _sfn.reset_mock()
 
                 get_token_when_almost_done()
 
@@ -331,8 +338,10 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 # a 302 redirect to the non-fetch endpoint with the key of
                 # the manifest in the URL.
                 #
+                @reset
                 def get_token_when_done():
                     nonlocal url, state, key_url, expected_url
+                    get_manifest.return_value = manifest
                     state = self.app_module.generate_manifest(state, None)
                     _sfn.describe_execution.return_value = {
                         'status': 'SUCCEEDED',
@@ -346,23 +355,24 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     else:
                         key_url = None
                         expected_url = object_url
+                        get_manifest_url.return_value = str(object_url)
                     url = self._request('GET', url, expect=302)
                     self.assertEqual(expected_url, url)
                     assert_get_manifest(partition=1)
-                    get_manifest.reset_mock()
-                    _sfn.start_execution.assert_not_called()
                     _sfn.describe_execution.assert_called_once()
-                    _sfn.reset_mock()
 
                 get_token_when_done()
 
                 # Re-request the manifest at the initial URL. The manifest
                 # is cached so we expect no intermediate 301 redirects.
                 #
+                @reset
                 def repeat_put():
                     nonlocal url
-                    get_cached_manifest.side_effect = None
                     get_cached_manifest.return_value = manifest
+                    get_manifest_url.return_value = str(object_url)
+                    if fetch and format is ManifestFormat.curl:
+                        sign_manifest_key.return_value = signed_manifest_key
                     url = self._request('PUT', initial_url, expect=302)
                     assert_get_cached_manifest()
                     self.assertEqual(expected_url, url)
@@ -377,8 +387,13 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 # service method where that is done. However, this test is
                 # not supposed to cover the service, only the controller.
                 #
+                @reset
                 def modified_put():
                     nonlocal url, equivalent_url
+                    get_cached_manifest.return_value = manifest
+                    get_manifest_url.return_value = str(object_url)
+                    if key_url is not None:
+                        sign_manifest_key.return_value = signed_manifest_key
                     equivalent_url = initial_url.copy()
                     equivalent_filters = json.loads(equivalent_url.args['filters'])
                     equivalent_filters = dict(reversed(equivalent_filters.items()))
@@ -394,6 +409,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 # should be considered valid and matching the completed step
                 # function execution.
                 #
+                @reset
                 def modified_put_after_expiration():
                     nonlocal url
                     get_cached_manifest.side_effect = CachedManifestNotFound(manifest_key)
@@ -401,34 +417,38 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                                                          operation_name='StartExecution',
                                                          error_code='ExecutionAlreadyExists')
                     _sfn.start_execution.side_effect = exception
+                    _sfn.describe_execution.return_value = {
+                        'status': 'SUCCEEDED',
+                        'input': json.dumps(input),
+                        'output': json.dumps(state)
+                    }
                     url = self._request('PUT', equivalent_url, expect=301)
-                    _sfn.reset_mock(side_effect=True)
-                    assert_get_cached_manifest()
                     # FIXME: 404 from S3 when re-requesting manifest after it expired
                     #        https://github.com/DataBiosphere/azul/issues/6441
                     if True:
                         self.assertEqual(token_url, url)
                     else:
                         self.assertNotEqual(token_url, url)
+                    assert_get_cached_manifest()
 
                 modified_put_after_expiration()
 
                 # Request the manifest by its key if a URL with that key
                 # was the result of the final 302 redirect above.
                 #
+                @reset
                 def get_key():
                     nonlocal url
                     assert signed_manifest_key.encode() == key_url.path.segments[-1]
-                    verify_manifest_key.assert_not_called()
                     verify_manifest_key.return_value = manifest_key
-                    get_cached_manifest_with_key.assert_not_called()
                     get_cached_manifest_with_key.return_value = manifest
+                    if key_url is not None:
+                        sign_manifest_key.return_value = signed_manifest_key
+                    get_manifest_url.return_value = str(object_url)
                     url = self._request('GET', key_url, expect=302)
                     self.assertEqual(object_url, url)
                     verify_manifest_key.assert_called_once_with(signed_manifest_key)
-                    get_cached_manifest.assert_not_called()
                     get_cached_manifest_with_key.assert_called_once_with(manifest_key)
-                    get_cached_manifest_with_key.reset_mock(return_value=True)
 
                 if key_url is not None:
                     get_key()
@@ -437,7 +457,9 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 # URL with that key was the result of the final 302 redirect
                 # above.
                 #
+                @reset
                 def get_key_after_expiration():
+                    verify_manifest_key.return_value = manifest_key
                     get_cached_manifest_with_key.side_effect = CachedManifestNotFound(manifest_key)
                     response = requests.get(str(key_url), allow_redirects=False)
                     self.assertEqual(410, response.status_code)
@@ -446,9 +468,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                         'Message': 'The requested manifest has expired, please request a new one'
                     }
                     self.assertEqual(expected_response, response.json())
-                    get_cached_manifest.assert_not_called()
                     get_cached_manifest_with_key.assert_called_once_with(manifest_key)
-                    get_cached_manifest_with_key.reset_mock()
 
                 if key_url is not None:
                     get_key_after_expiration()

--- a/test/service/test_manifest_async.py
+++ b/test/service/test_manifest_async.py
@@ -225,9 +225,10 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                                       is_last_page=False,
                                       search_after=('foo', 'doc#bar'))
                 ]
-                input: ManifestGenerationState = dict(filters=filters.to_json(),
-                                                      manifest_key=manifest_key.to_json(),
-                                                      partition=partitions[0].to_json())
+                input: ManifestGenerationState
+                input = dict(filters=filters.to_json(),
+                             manifest_key=manifest_key.to_json(),
+                             partition=partitions[0].to_json())
                 service: AsyncManifestService
                 service = self.app_module.app.manifest_controller.async_service
                 execution_id = manifest_key.uuid
@@ -251,9 +252,9 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     get_manifest.assert_called_once_with(
                         format=format,
                         catalog=self.catalog,
-                        filters=Filters.from_json(state['filters']),
+                        filters=filters,
                         partition=partitions[partition],
-                        manifest_key=ManifestKey.from_json(state['manifest_key'])
+                        manifest_key=manifest_key
                     )
                     get_manifest.reset_mock()
 
@@ -311,12 +312,11 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 # a 302 redirect to the non-fetch endpoint with the key of
                 # the manifest in the URL.
                 #
+                state = self.app_module.generate_manifest(state, None)
                 _sfn.describe_execution.return_value = {
                     'status': 'SUCCEEDED',
                     'input': json.dumps(input),
-                    'output': json.dumps(
-                        self.app_module.generate_manifest(state, None)
-                    )
+                    'output': json.dumps(state)
                 }
                 if fetch and format is ManifestFormat.curl:
                     key_url = self.base_url.set(path=[*path, signed_manifest_key.encode()])

--- a/test/service/test_manifest_async.py
+++ b/test/service/test_manifest_async.py
@@ -270,7 +270,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 state: ManifestGenerationState
                 token_url: furl
                 key_url: furl
-                expected_url: furl
+                final_url: furl
                 equivalent_url: furl
 
                 # Request the manifest. The cached manifest does not exist
@@ -340,7 +340,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 #
                 @reset
                 def get_token_when_done():
-                    nonlocal url, state, key_url, expected_url
+                    nonlocal url, state, key_url, final_url
                     get_manifest.return_value = manifest
                     state = self.app_module.generate_manifest(state, None)
                     _sfn.describe_execution.return_value = {
@@ -350,14 +350,14 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     }
                     if fetch and format is ManifestFormat.curl:
                         key_url = self.base_url.set(path=[*path, signed_manifest_key.encode()])
-                        expected_url = key_url
+                        final_url = key_url
                         sign_manifest_key.return_value = signed_manifest_key
                     else:
                         key_url = None
-                        expected_url = object_url
+                        final_url = object_url
                         get_manifest_url.return_value = str(object_url)
                     url = self._request('GET', url, expect=302)
-                    self.assertEqual(expected_url, url)
+                    self.assertEqual(final_url, url)
                     assert_get_manifest(partition=1)
                     _sfn.describe_execution.assert_called_once()
 
@@ -375,7 +375,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                         sign_manifest_key.return_value = signed_manifest_key
                     url = self._request('PUT', initial_url, expect=302)
                     assert_get_cached_manifest()
-                    self.assertEqual(expected_url, url)
+                    self.assertEqual(final_url, url)
 
                 repeat_put()
 
@@ -399,7 +399,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     equivalent_filters = dict(reversed(equivalent_filters.items()))
                     equivalent_url.args['filters'] = json.dumps(equivalent_filters)
                     url = self._request('PUT', equivalent_url, expect=302)
-                    self.assertEqual(expected_url, url)
+                    self.assertEqual(final_url, url)
                     assert_get_cached_manifest(filters.update(equivalent_filters))
 
                 modified_put()

--- a/test/service/test_manifest_async.py
+++ b/test/service/test_manifest_async.py
@@ -250,6 +250,11 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 machine_arn = service.machine_arn
                 execution_arn = service.execution_arn(execution_name)
 
+                not_found = CachedManifestNotFound(manifest_key)
+                execution_exists = self._mock_sfn_exception(_sfn,
+                                                            operation_name='StartExecution',
+                                                            error_code='ExecutionAlreadyExists')
+
                 def assert_get_cached_manifest(filters=filters):
                     get_cached_manifest.assert_called_once_with(
                         format=format,
@@ -281,7 +286,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 @reset
                 def put():
                     nonlocal url, state, token_url
-                    get_cached_manifest.side_effect = CachedManifestNotFound(manifest_key)
+                    get_cached_manifest.side_effect = not_found
                     _sfn.start_execution.return_value = {
                         'executionArn': execution_arn,
                         'startDate': 123
@@ -412,11 +417,8 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 @reset
                 def modified_put_after_expiration():
                     nonlocal url
-                    get_cached_manifest.side_effect = CachedManifestNotFound(manifest_key)
-                    exception = self._mock_sfn_exception(_sfn,
-                                                         operation_name='StartExecution',
-                                                         error_code='ExecutionAlreadyExists')
-                    _sfn.start_execution.side_effect = exception
+                    get_cached_manifest.side_effect = not_found
+                    _sfn.start_execution.side_effect = execution_exists
                     _sfn.describe_execution.return_value = {
                         'status': 'SUCCEEDED',
                         'input': json.dumps(input),
@@ -460,7 +462,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 @reset
                 def get_key_after_expiration():
                     verify_manifest_key.return_value = manifest_key
-                    get_cached_manifest_with_key.side_effect = CachedManifestNotFound(manifest_key)
+                    get_cached_manifest_with_key.side_effect = not_found
                     response = requests.get(str(key_url), allow_redirects=False)
                     self.assertEqual(410, response.status_code)
                     expected_response = {


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Connected issues: #6441


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved connected issues to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
