### PR TITLE
Fix: Optimistic lock contention on HCA replicas (#6648)

### DIFF
--- a/deployments/prod/environment.py
+++ b/deployments/prod/environment.py
@@ -1432,7 +1432,7 @@ def env() -> Mapping[str, Optional[str]]:
             'channel_id': 'C04JWDFCPFZ'  # #team-boardwalk-prod
         }),
 
-        'AZUL_ENABLE_REPLICAS': '0',
+        'AZUL_ENABLE_REPLICAS': '1',
 
         # HCA allocates a daily budget for file downloads. To avoid exceeding
         # that budget, we limit the download rate as follows:

--- a/src/azul/collections.py
+++ b/src/azul/collections.py
@@ -20,6 +20,7 @@ from operator import (
 from typing import (
     Any,
     Callable,
+    Protocol,
     TypeVar,
     Union,
 )
@@ -361,6 +362,68 @@ class NestedDict(defaultdict):
             k: v.to_dict() if isinstance(v, NestedDict) else v
             for k, v in self.items()
         }
+
+
+# FIXME: Remove once upstream issue is closed
+#        https://github.com/python/typeshed/issues/11822
+
+_KT_contra = TypeVar("_KT_contra", contravariant=True)
+_VT_co = TypeVar("_VT_co", covariant=True)
+
+
+class SupportsGetItem(Protocol[_KT_contra, _VT_co]):
+
+    def __getitem__(self, key: _KT_contra, /) -> _VT_co: ...
+
+
+def getitem(d: SupportsGetItem[_KT_contra, _VT_co],
+            k: _KT_contra,
+            /,
+            default: _VT_co | None = None) -> _VT_co:
+    """
+    For mappings that implement ``.__getitem__()`` but forego the recommended
+    implementation of ``.get()``:
+
+    https://docs.python.org/3/reference/datamodel.html#emulating-container-types
+
+    >  It is also recommended that mappings provide the methods keys(),
+    >  values(), items(), get() …
+
+    :param d: the mapping of keys to values
+
+    :param k: a key
+
+    :param default: the value to return when the key is absent
+
+    :return: the value at the given key or the default if the key is absent
+             from the mapping
+
+    >>> class M:
+    ...     def __getitem__(self, k):
+    ...         return {42:7}[k]
+
+    >>> m = M()
+
+    >>> getitem(m, 42)
+    7
+
+    >>> getitem(m, 42, 2)
+    7
+
+    >>> m[1]
+    Traceback (most recent call last):
+    ...
+    KeyError: 1
+
+    >>> getitem(m, 1)
+
+    >>> getitem(m, 1, default=2)
+    2
+    """
+    try:
+        return d.__getitem__(k)
+    except KeyError:
+        return default
 
 
 class OrderedSet(MutableSet[K]):

--- a/src/azul/indexer/aggregate.py
+++ b/src/azul/indexer/aggregate.py
@@ -112,6 +112,28 @@ class SetAccumulator(Accumulator):
     def accumulate(self, value) -> bool:
         """
         :return: True, if the given value was incorporated into the set
+
+        >>> acc = SetAccumulator(max_size=3)
+        >>> acc.accumulate(1)
+        True
+
+        >>> acc.accumulate(1)
+        False
+
+        >>> acc.accumulate(2)
+        True
+
+        >>> acc.accumulate([1, 2, 3])
+        True
+
+        >>> acc.accumulate([2, 3])
+        False
+
+        >>> acc.accumulate(4)
+        False
+
+        >>> acc.get()
+        [1, 2, 3]
         """
         if self.max_size is None or len(self.value) < self.max_size:
             before = len(self.value)
@@ -147,6 +169,20 @@ class ListAccumulator(Accumulator):
         self.max_size = max_size
 
     def accumulate(self, value):
+        """
+        >>> acc = ListAccumulator(max_size=3)
+        >>> acc.accumulate(1)
+        >>> acc.get()
+        [1]
+
+        >>> acc.accumulate([3, 2])
+        >>> acc.get()
+        [1, 2, 3]
+
+        >>> acc.accumulate([4])
+        >>> acc.get()
+        [1, 2, 3]
+        """
         if self.max_size is None or len(self.value) < self.max_size:
             if isinstance(value, (list, set)):
                 self.value.extend(value)
@@ -217,6 +253,30 @@ class DictAccumulator(Accumulator):
         self.value = {}
 
     def accumulate(self, value):
+        """
+        >>> acc = DictAccumulator(max_size=3, key=lambda s: s.lower())
+        >>> acc.accumulate('foo')
+        >>> acc.get()
+        ['foo']
+
+        >>> acc.accumulate('foo')
+        >>> acc.get()
+        ['foo']
+
+        >>> acc.accumulate('Foo')
+        Traceback (most recent call last):
+        ...
+        azul.RequirementError: ('foo', 'Foo')
+
+        >>> acc.accumulate('Bar')
+        >>> acc.accumulate('BAZ')
+        >>> acc.get()
+        ['Bar', 'BAZ', 'foo']
+
+        >>> acc.accumulate('spam')
+        >>> acc.get()
+        ['Bar', 'BAZ', 'foo']
+        """
         if self.max_size is None or len(self.value) < self.max_size:
             key = self.key(value)
             try:

--- a/src/azul/indexer/aggregate.py
+++ b/src/azul/indexer/aggregate.py
@@ -235,15 +235,15 @@ class FrequencySetAccumulator(Accumulator):
     An accumulator that accepts any number of values and returns a list with
     length max_size or smaller containing the most frequent values accumulated.
 
-    >>> a = FrequencySetAccumulator(2)
-    >>> a.accumulate('x')
-    >>> a.accumulate(['x','y'])
-    >>> a.accumulate({'x','y','z'})
-    >>> a.get()
+    >>> acc = FrequencySetAccumulator(2)
+    >>> acc.accumulate('x')
+    >>> acc.accumulate(['x','y'])
+    >>> acc.accumulate({'x','y','z'})
+    >>> acc.get()
     ['x', 'y']
-    >>> a = FrequencySetAccumulator(0)
-    >>> a.accumulate('x')
-    >>> a.get()
+    >>> acc = FrequencySetAccumulator(0)
+    >>> acc.accumulate('x')
+    >>> acc.get()
     []
     """
 
@@ -365,22 +365,22 @@ class DistinctAccumulator(Accumulator):
     the value from the first pair will be accumulated. The actual values will be
     accumulated in another accumulator instance specified at construction.
 
-        >>> a = DistinctAccumulator(SumAccumulator(initially=0), max_size=3)
+        >>> acc = DistinctAccumulator(SumAccumulator(initially=0), max_size=3)
 
     Keys can be tuples, too.
 
-        >>> a.accumulate((('x', 'y'), 3))
+        >>> acc.accumulate((('x', 'y'), 3))
 
     Values associated with a recurring key will not be accumulated.
 
-        >>> a.accumulate((('x', 'y'), 4))
-        >>> a.accumulate(('a', 20))
-        >>> a.accumulate(('b', 100))
+        >>> acc.accumulate((('x', 'y'), 4))
+        >>> acc.accumulate(('a', 20))
+        >>> acc.accumulate(('b', 100))
 
     Accumulation stops at max_size distinct keys.
 
-        >>> a.accumulate(('c', 1000))
-        >>> a.get()
+        >>> acc.accumulate(('c', 1000))
+        >>> acc.get()
         123
     """
 

--- a/src/azul/indexer/aggregate.py
+++ b/src/azul/indexer/aggregate.py
@@ -10,7 +10,6 @@ import logging
 from typing import (
     Any,
     Callable,
-    Optional,
 )
 
 from azul import (
@@ -202,7 +201,7 @@ class DictAccumulator(Accumulator):
     a SetAccumulator by using the identity function (``lambda _: _``) for the key.
     """
 
-    def __init__(self, max_size: Optional[int], key: Callable):
+    def __init__(self, max_size: int | None, key: Callable):
         """
         :param max_size: The maximum number of elements to retain. A value of
                          None can be used to specify no maximum.
@@ -420,14 +419,14 @@ class EntityAggregator(metaclass=ABCMeta):
     def _transform_entity(self, entity: JSON) -> JSON:
         return entity
 
-    def _accumulator(self, field: str) -> Optional[Accumulator]:
+    def _accumulator(self, field: str) -> Accumulator | None:
         """
         Return the Accumulator instance to be used for the given field or None
         if the field should not be accumulated.
         """
         return self._default_accumulator()
 
-    def _default_accumulator(self) -> Optional[Accumulator]:
+    def _default_accumulator(self) -> Accumulator | None:
         return SetAccumulator(max_size=100)
 
     @abstractmethod
@@ -450,7 +449,7 @@ class SimpleAggregator(EntityAggregator):
         ] if aggregate else []
 
     def _accumulate(self,
-                    aggregate: dict[str, Optional[Accumulator]],
+                    aggregate: dict[str, Accumulator | None],
                     entity: JSON
                     ):
         entity = self._transform_entity(entity)
@@ -467,7 +466,7 @@ class SimpleAggregator(EntityAggregator):
 class GroupingAggregator(SimpleAggregator):
 
     def aggregate(self, entities: Entities) -> Entities:
-        aggregates: dict[Any, dict[str, Optional[Accumulator]]] = defaultdict(dict)
+        aggregates: dict[Any, dict[str, Accumulator | None]] = defaultdict(dict)
         for entity in entities:
             group_keys = self._group_keys(entity)
             aggregate = aggregates[group_keys]

--- a/src/azul/indexer/aggregate.py
+++ b/src/azul/indexer/aggregate.py
@@ -429,13 +429,14 @@ class SimpleAggregator(EntityAggregator):
         aggregate = {}
         for entity in entities:
             self._accumulate(aggregate, entity)
-        return [
-            {
-                k: accumulator.get()
-                for k, accumulator in aggregate.items()
-                if accumulator is not None
-            }
-        ] if aggregate else []
+        return [self._aggregate(aggregate)] if aggregate else []
+
+    def _aggregate(self, aggregate: dict[str, Accumulator]) -> JSON:
+        result = {}
+        for k, accumulator in aggregate.items():
+            if accumulator is not None:
+                result[k] = accumulator.get()
+        return result
 
     def _accumulate(self,
                     aggregate: dict[str, Accumulator | None],
@@ -461,11 +462,7 @@ class GroupingAggregator(SimpleAggregator):
             aggregate = aggregates[group_keys]
             self._accumulate(aggregate, entity)
         return [
-            {
-                field: accumulator.get()
-                for field, accumulator in aggregate.items()
-                if accumulator is not None
-            }
+            self._aggregate(aggregate)
             for aggregate in aggregates.values()
         ]
 

--- a/src/azul/indexer/aggregate.py
+++ b/src/azul/indexer/aggregate.py
@@ -41,10 +41,15 @@ class Accumulator(metaclass=ABCMeta):
     type.
     """
 
+    def __init__(self):
+        self.dropped = 0
+
     @abstractmethod
     def accumulate(self, value):
         """
-        Incorporate the given value into this accumulator.
+        Incorporate the given value into this accumulator. If the value is not
+        incorporated (due to e.g. a maximum size constraint), implementations
+        should increment :py:attr:`dropped`.
         """
         raise NotImplementedError
 
@@ -114,23 +119,23 @@ class SetAccumulator(Accumulator):
         :return: True, if the given value was incorporated into the set
 
         >>> acc = SetAccumulator(max_size=3)
-        >>> acc.accumulate(1)
-        True
+        >>> acc.accumulate(1), acc.dropped
+        (True, 0)
 
-        >>> acc.accumulate(1)
-        False
+        >>> acc.accumulate(1), acc.dropped
+        (False, 0)
 
-        >>> acc.accumulate(2)
-        True
+        >>> (acc.accumulate(2), acc.dropped)
+        (True, 0)
 
-        >>> acc.accumulate([1, 2, 3])
-        True
+        >>> acc.accumulate([1, 2, 3]), acc.dropped
+        (True, 0)
 
-        >>> acc.accumulate([2, 3])
-        False
+        >>> acc.accumulate([2, 3]), acc.dropped
+        (False, 0)
 
-        >>> acc.accumulate(4)
-        False
+        >>> acc.accumulate(4), acc.dropped
+        (False, 1)
 
         >>> acc.get()
         [1, 2, 3]
@@ -151,6 +156,11 @@ class SetAccumulator(Accumulator):
             else:
                 assert False
         else:
+            if isinstance(value, (list, set)):
+                if not self.value.issuperset(value):
+                    self.dropped += 1
+            elif value not in self.value:
+                self.dropped += 1
             return False
 
     def get(self) -> list[Any]:
@@ -172,22 +182,24 @@ class ListAccumulator(Accumulator):
         """
         >>> acc = ListAccumulator(max_size=3)
         >>> acc.accumulate(1)
-        >>> acc.get()
-        [1]
+        >>> acc.get(), acc.dropped
+        ([1], 0)
 
         >>> acc.accumulate([3, 2])
-        >>> acc.get()
-        [1, 2, 3]
+        >>> acc.get(), acc.dropped
+        ([1, 2, 3], 0)
 
         >>> acc.accumulate([4])
-        >>> acc.get()
-        [1, 2, 3]
+        >>> acc.get(), acc.dropped
+        ([1, 2, 3], 1)
         """
         if self.max_size is None or len(self.value) < self.max_size:
             if isinstance(value, (list, set)):
                 self.value.extend(value)
             else:
                 self.value.append(value)
+        else:
+            self.dropped += 1
 
     def get(self) -> list[Any]:
         return sorted(self.value)
@@ -248,6 +260,7 @@ class DictAccumulator(Accumulator):
         :param key: A function returning the key to be used both for storing the
                     accumulated value and sorting the accumulated set of values.
         """
+        super().__init__()
         self.max_size = max_size
         self.key = key
         self.value = {}
@@ -256,12 +269,12 @@ class DictAccumulator(Accumulator):
         """
         >>> acc = DictAccumulator(max_size=3, key=lambda s: s.lower())
         >>> acc.accumulate('foo')
-        >>> acc.get()
-        ['foo']
+        >>> acc.get(), acc.dropped
+        (['foo'], 0)
 
         >>> acc.accumulate('foo')
-        >>> acc.get()
-        ['foo']
+        >>> acc.get(), acc.dropped
+        (['foo'], 0)
 
         >>> acc.accumulate('Foo')
         Traceback (most recent call last):
@@ -270,21 +283,23 @@ class DictAccumulator(Accumulator):
 
         >>> acc.accumulate('Bar')
         >>> acc.accumulate('BAZ')
-        >>> acc.get()
-        ['Bar', 'BAZ', 'foo']
+        >>> acc.get(), acc.dropped
+        (['Bar', 'BAZ', 'foo'], 0)
 
         >>> acc.accumulate('spam')
-        >>> acc.get()
-        ['Bar', 'BAZ', 'foo']
+        >>> acc.get(), acc.dropped
+        (['Bar', 'BAZ', 'foo'], 1)
         """
+        key = self.key(value)
         if self.max_size is None or len(self.value) < self.max_size:
-            key = self.key(value)
             try:
                 old_value = self.value[key]
             except KeyError:
                 self.value[key] = value
             else:
                 require(old_value == value, old_value, value)
+        elif key not in self.value:
+            self.dropped += 1
 
     def get(self):
         return sorted(self.value.values(), key=self.key)
@@ -319,6 +334,7 @@ class FrequencySetAccumulator(Accumulator):
             self.value[value] += 1
 
     def get(self) -> list[Any]:
+        self.dropped = max(0, len(self.value) - self.max_size)
         return [item for item, count in self.value.most_common(self.max_size)]
 
 
@@ -445,6 +461,7 @@ class DistinctAccumulator(Accumulator):
     """
 
     def __init__(self, inner: Accumulator, max_size: int = None) -> None:
+        super().__init__()
         self.value = inner
         self.keys = SetAccumulator(max_size=max_size)
 
@@ -502,6 +519,9 @@ class SimpleAggregator(EntityAggregator):
         for k, accumulator in aggregate.items():
             if accumulator is not None:
                 result[k] = accumulator.get()
+                if accumulator.dropped > 0:
+                    log.warning('Values were dropped %d times while aggregating %s.%s',
+                                accumulator.dropped, self.entity_type, k)
         return result
 
     def _accumulate(self,

--- a/src/azul/indexer/aggregate.py
+++ b/src/azul/indexer/aggregate.py
@@ -18,6 +18,9 @@ from azul import (
 from azul.collections import (
     none_safe_key,
 )
+from azul.indexer.document import (
+    EntityType,
+)
 from azul.json_freeze import (
     freeze,
     thaw,
@@ -404,6 +407,9 @@ class UniqueValueCountAccumulator(SetAccumulator):
 
 
 class EntityAggregator(metaclass=ABCMeta):
+
+    def __init__(self, entity_type: EntityType):
+        self.entity_type = entity_type
 
     def _transform_entity(self, entity: JSON) -> JSON:
         return entity

--- a/src/azul/indexer/aggregate.py
+++ b/src/azul/indexer/aggregate.py
@@ -394,24 +394,13 @@ class DistinctAccumulator(Accumulator):
         return self.value.get()
 
 
-class UniqueValueCountAccumulator(Accumulator):
+class UniqueValueCountAccumulator(SetAccumulator):
     """
     Count the number of unique values
     """
 
-    def __init__(self):
-        super().__init__()
-        self.value = SetAccumulator()
-
-    def accumulate(self, value) -> bool:
-        """
-        :return: True, if the given value increased the count of unique values
-        """
-        return self.value.accumulate(value)
-
     def get(self) -> int:
-        unique_items = self.value.get()
-        return len(unique_items)
+        return len(super().get())
 
 
 class EntityAggregator(metaclass=ABCMeta):

--- a/src/azul/indexer/transform.py
+++ b/src/azul/indexer/transform.py
@@ -184,3 +184,16 @@ class Transformer(metaclass=ABCMeta):
                  passed as the ``this`` argument.
         """
         raise NotImplementedError
+
+
+class ReplicaTransformer(Transformer, metaclass=ABCMeta):
+
+    @classmethod
+    @abstractmethod
+    def hot_entity_types(cls) -> dict[EntityType, EntityType]:
+        """
+        The types of entities that do not explicitly track their hubs in
+        replica documents. Keys describe untransformed entities in a bundle;
+        values describe transformed inner entities in the index.
+        """
+        raise NotImplementedError

--- a/src/azul/plugins/__init__.py
+++ b/src/azul/plugins/__init__.py
@@ -22,6 +22,9 @@ from typing import (
 )
 
 import attr
+from more_itertools import (
+    one,
+)
 
 from azul import (
     CatalogName,
@@ -56,6 +59,7 @@ from azul.indexer.document import (
     IndexName,
 )
 from azul.indexer.transform import (
+    ReplicaTransformer,
     Transformer,
 )
 from azul.types import (
@@ -144,7 +148,7 @@ class SpecialFields:
     source_spec: FieldName
     bundle_uuid: FieldName
     bundle_version: FieldName
-    implicit_hub_id: FieldName
+    root_entity_id: FieldName
 
 
 class ManifestFormat(Enum):
@@ -428,16 +432,34 @@ class MetadataPlugin(Plugin[BUNDLE]):
         raise NotImplementedError
 
     @property
-    @abstractmethod
-    def implicit_hub_type(self) -> str:
+    def root_entity_type(self) -> str:
         """
-        The type of entities that do not explicitly track their hubs in replica
-        documents in order to avoid a large list of hub references in the
-        replica document, and to avoid contention when updating that list during
-        indexing. Note that this is not a type of hub entities, but rather the
-        type of replica entities that have implicit hubs.
+        The type of entity that sits at the root of the entity graph, and that
+        all other entities are directly or indirectly associated with.
+        Typically, entities of other types are thought of as *belonging to* the
+        root entity and this relationship is implied rather than made explicit
+        via a foreign key or some other manifestation of a graph connection. The
+        mere presence of a `project` entity in a TDR snapshot for HCA, for
+        example, implies that all other entities in that snapshot *belong* to
+        that project.
         """
         raise NotImplementedError
+
+    @property
+    def hot_entity_types(self) -> Iterable[str]:
+        """
+        The types of inner entities that do not explicitly track their hubs in
+        replica documents in order to avoid a large list of hub references in
+        the replica document, and to avoid contention when updating that list
+        during indexing. This will always include the root type.
+        """
+        replica_transformer_type = one(
+            t for t in self.transformer_types()
+            if issubclass(t, ReplicaTransformer)
+        )
+        hot_entity_types = replica_transformer_type.hot_entity_types().values()
+        assert self.root_entity_type in hot_entity_types
+        return hot_entity_types
 
     @property
     def facets(self) -> Sequence[str]:

--- a/src/azul/plugins/metadata/anvil/__init__.py
+++ b/src/azul/plugins/metadata/anvil/__init__.py
@@ -244,10 +244,10 @@ class Plugin(MetadataPlugin[AnvilBundle]):
                              source_spec='source_spec',
                              bundle_uuid='bundle_uuid',
                              bundle_version='bundle_version',
-                             implicit_hub_id='datasets.dataset_id')
+                             root_entity_id='datasets.dataset_id')
 
     @property
-    def implicit_hub_type(self) -> str:
+    def root_entity_type(self) -> str:
         return 'datasets'
 
     @property

--- a/src/azul/plugins/metadata/anvil/indexer/transform.py
+++ b/src/azul/plugins/metadata/anvil/indexer/transform.py
@@ -155,19 +155,20 @@ class BaseTransformer(Transformer, metaclass=ABCMeta):
     @classmethod
     def aggregator(cls, entity_type) -> EntityAggregator:
         if entity_type == 'activities':
-            return ActivityAggregator()
+            agg_cls = ActivityAggregator
         elif entity_type == 'biosamples':
-            return BiosampleAggregator()
+            agg_cls = BiosampleAggregator
         elif entity_type == 'datasets':
-            return DatasetAggregator()
+            agg_cls = DatasetAggregator
         elif entity_type == 'diagnoses':
-            return DiagnosisAggregator()
+            agg_cls = DiagnosisAggregator
         elif entity_type == 'donors':
-            return DonorAggregator()
+            agg_cls = DonorAggregator
         elif entity_type == 'files':
-            return FileAggregator()
+            agg_cls = FileAggregator
         else:
             assert False, entity_type
+        return agg_cls(entity_type)
 
     def estimate(self, partition: BundlePartition) -> int:
         # Orphans are not considered when deciding whether to partition the

--- a/src/azul/plugins/metadata/anvil/indexer/transform.py
+++ b/src/azul/plugins/metadata/anvil/indexer/transform.py
@@ -62,6 +62,7 @@ from azul.indexer.document import (
     pass_thru_json,
 )
 from azul.indexer.transform import (
+    ReplicaTransformer,
     Transformer,
 )
 from azul.plugins.metadata.anvil.bundle import (
@@ -623,11 +624,17 @@ class DonorTransformer(BaseTransformer):
         yield self._contribution(contents, entity.entity_id)
 
 
-class FileTransformer(BaseTransformer):
+class FileTransformer(BaseTransformer, ReplicaTransformer):
 
     @classmethod
     def entity_type(cls) -> str:
         return 'files'
+
+    @classmethod
+    def hot_entity_types(cls) -> dict[EntityType, EntityType]:
+        return {
+            'anvil_dataset': 'datasets',
+        }
 
     def _transform(self,
                    entity: EntityReference
@@ -645,17 +652,14 @@ class FileTransformer(BaseTransformer):
             donors=self._entities(self._donor, linked['anvil_donor']),
             files=[self._file(entity)],
         )
-        yield self._contribution(contents, entity.entity_id)
+        file_id = entity.entity_id
+        yield self._contribution(contents, file_id)
         if config.enable_replicas:
-            yield self._replica(entity, file_hub=entity.entity_id, root_hub=dataset.entity_id)
+            dataset_id = dataset.entity_id
+            yield self._replica(entity, file_hub=file_id, root_hub=dataset_id)
             for linked_entity in linked:
                 yield self._replica(
                     linked_entity,
-                    # Datasets are linked to every file in their snapshot,
-                    # making an explicit list of hub IDs for the dataset both
-                    # redundant and impractically large. Therefore, we leave the
-                    # hub IDs field empty for datasets and rely on the tenet
-                    # that every file is an implicit hub of its parent dataset.
-                    file_hub=None if linked_entity.entity_type == 'anvil_dataset' else entity.entity_id,
-                    root_hub=dataset.entity_id
+                    file_hub=None if linked_entity.entity_type in self.hot_entity_types() else file_id,
+                    root_hub=dataset_id
                 )

--- a/src/azul/plugins/metadata/hca/__init__.py
+++ b/src/azul/plugins/metadata/hca/__init__.py
@@ -283,10 +283,10 @@ class Plugin(MetadataPlugin[HCABundle]):
                              source_spec='sourceSpec',
                              bundle_uuid='bundleUuid',
                              bundle_version='bundleVersion',
-                             implicit_hub_id='projectId')
+                             root_entity_id='projectId')
 
     @property
-    def implicit_hub_type(self) -> str:
+    def root_entity_type(self) -> str:
         return 'projects'
 
     @property

--- a/src/azul/plugins/metadata/hca/indexer/aggregate.py
+++ b/src/azul/plugins/metadata/hca/indexer/aggregate.py
@@ -166,6 +166,9 @@ class DonorOrganismAggregator(SimpleAggregator):
             # be omitted during the verbatim handover. Donors are a "hot" entity
             # type, and we can't track their hubs in replica documents, so we
             # rely on the inner entity IDs instead.
+            #
+            # FIXME: Enforce that hot entity types are completely aggregated
+            #        https://github.com/DataBiosphere/azul/issues/6793
             return SetAccumulator(max_size=100)
         else:
             return super()._accumulator(field)
@@ -207,6 +210,9 @@ class ProtocolAggregator(SimpleAggregator):
             # protocols may be omitted during the verbatim handover. Some
             # protocols are "hot" entity types, and we can't track their hubs in
             # replicas, so we rely on the inner entity IDs instead.
+            #
+            # FIXME: Enforce that hot entity types are completely aggregated
+            #        https://github.com/DataBiosphere/azul/issues/6793
             return SetAccumulator(max_size=100)
         else:
             return super()._accumulator(field)

--- a/src/azul/plugins/metadata/hca/indexer/aggregate.py
+++ b/src/azul/plugins/metadata/hca/indexer/aggregate.py
@@ -161,6 +161,12 @@ class DonorOrganismAggregator(SimpleAggregator):
                                                          none_safe_itemgetter('value', 'unit')))
         elif field == 'donor_count':
             return UniqueValueCountAccumulator()
+        elif field == 'document_id':
+            # If any donor IDs are missing from the aggregate, those donors will
+            # be omitted during the verbatim handover. Donors are a "hot" entity
+            # type, and we can't track their hubs in replica documents, so we
+            # rely on the inner entity IDs instead.
+            return SetAccumulator(max_size=100)
         else:
             return super()._accumulator(field)
 
@@ -196,6 +202,12 @@ class ProtocolAggregator(SimpleAggregator):
     def _accumulator(self, field) -> Accumulator | None:
         if field == 'assay_type':
             return FrequencySetAccumulator(max_size=100)
+        elif field == 'document_id':
+            # If any protocol IDs are missing from the aggregate, those
+            # protocols may be omitted during the verbatim handover. Some
+            # protocols are "hot" entity types, and we can't track their hubs in
+            # replicas, so we rely on the inner entity IDs instead.
+            return SetAccumulator(max_size=100)
         else:
             return super()._accumulator(field)
 

--- a/src/azul/plugins/metadata/hca/indexer/transform.py
+++ b/src/azul/plugins/metadata/hca/indexer/transform.py
@@ -12,6 +12,9 @@ from datetime import (
 from enum import (
     Enum,
 )
+from itertools import (
+    chain,
+)
 import logging
 import re
 from typing import (
@@ -79,6 +82,7 @@ from azul.indexer.document import (
     pass_thru_json,
 )
 from azul.indexer.transform import (
+    ReplicaTransformer,
     Transformer,
 )
 from azul.iterators import (
@@ -1418,11 +1422,17 @@ class PartitionedTransformer(BaseTransformer, Generic[ENTITY]):
         return self._transform(generable(self._entities_in, partition))
 
 
-class FileTransformer(PartitionedTransformer[api.File]):
+class FileTransformer(PartitionedTransformer[api.File], ReplicaTransformer):
 
     @classmethod
     def entity_type(cls) -> str:
         return 'files'
+
+    @classmethod
+    def hot_entity_types(cls) -> dict[EntityType, EntityType]:
+        return {
+            'project': 'projects'
+        }
 
     def _entities(self) -> Iterable[api.File]:
         return self.api_bundle.not_stitched(self.api_bundle.files)
@@ -1470,19 +1480,13 @@ class FileTransformer(PartitionedTransformer[api.File]):
                         for entity_type, values in additional_contents.items():
                             contents[entity_type].extend(values)
                 file_id = file.ref.entity_id
-                project_ref = self._api_project.ref
-                project_id = project_ref.entity_id
                 yield self._contribution(contents, file_id)
                 if config.enable_replicas:
-                    yield self._replica(self.api_bundle.ref, file_hub=file_id, root_hub=project_id)
-                    # Projects are linked to every file in their snapshot,
-                    # making an explicit list of hub IDs for the project both
-                    # redundant and impractically large. Therefore, we leave the
-                    # hub IDs field empty for projects and rely on the tenet
-                    # that every file is an implicit hub of its parent project.
-                    yield self._replica(project_ref, file_hub=None, root_hub=project_id)
-                    for linked_entity in visitor.entities:
-                        yield self._replica(linked_entity, file_hub=file_id, root_hub=project_id)
+                    project_ref = self._api_project.ref
+                    project_id = project_ref.entity_id
+                    for ref in chain([project_ref, self.api_bundle.ref], visitor.entities):
+                        file_hub = None if ref.entity_type in self.hot_entity_types() else file_id
+                        yield self._replica(ref, file_hub=file_hub, root_hub=project_id)
 
     def matrix_stratification_values(self, file: api.File) -> JSON:
         """

--- a/src/azul/plugins/metadata/hca/indexer/transform.py
+++ b/src/azul/plugins/metadata/hca/indexer/transform.py
@@ -464,38 +464,39 @@ class BaseTransformer(Transformer, metaclass=ABCMeta):
     @classmethod
     def aggregator(cls, entity_type: EntityType) -> EntityAggregator | None:
         if entity_type == 'files':
-            return FileAggregator()
+            agg_cls = FileAggregator
         elif entity_type in SampleTransformer.inner_entity_types():
-            return SampleAggregator()
+            agg_cls = SampleAggregator
         elif entity_type == 'specimens':
-            return SpecimenAggregator()
+            agg_cls = SpecimenAggregator
         elif entity_type == 'cell_suspensions':
-            return CellSuspensionAggregator()
+            agg_cls = CellSuspensionAggregator
         elif entity_type == 'cell_lines':
-            return CellLineAggregator()
+            agg_cls = CellLineAggregator
         elif entity_type == 'donors':
-            return DonorOrganismAggregator()
+            agg_cls = DonorOrganismAggregator
         elif entity_type == 'organoids':
-            return OrganoidAggregator()
+            agg_cls = OrganoidAggregator
         elif entity_type == 'projects':
-            return ProjectAggregator()
+            agg_cls = ProjectAggregator
         elif entity_type in (
             'analysis_protocols',
             'imaging_protocols',
             'library_preparation_protocols',
             'sequencing_protocols'
         ):
-            return ProtocolAggregator()
+            agg_cls = ProtocolAggregator
         elif entity_type == 'sequencing_inputs':
-            return SequencingInputAggregator()
+            agg_cls = SequencingInputAggregator
         elif entity_type == 'sequencing_processes':
-            return SequencingProcessAggregator()
+            agg_cls = SequencingProcessAggregator
         elif entity_type in ('matrices', 'contributed_analyses'):
-            return MatricesAggregator()
+            agg_cls = MatricesAggregator
         elif entity_type == 'dates':
-            return DateAggregator()
+            agg_cls = DateAggregator
         else:
-            return SimpleAggregator()
+            agg_cls = SimpleAggregator
+        return agg_cls(entity_type)
 
     def _replicate(self, entity: EntityReference) -> tuple[str, JSON]:
         if entity == self.api_bundle.ref:

--- a/src/azul/plugins/metadata/hca/indexer/transform.py
+++ b/src/azul/plugins/metadata/hca/indexer/transform.py
@@ -1432,7 +1432,12 @@ class FileTransformer(PartitionedTransformer[api.File], ReplicaTransformer):
     @classmethod
     def hot_entity_types(cls) -> dict[EntityType, EntityType]:
         return {
-            'project': 'projects'
+            'project': 'projects',
+            'donor_organism': 'donors',
+            **{
+                f'{protocol_type}_protocol': f'{protocol_type}_protocols'
+                for protocol_type in ['analysis', 'imaging', 'library_preparation', 'sequencing']
+            }
         }
 
     def _entities(self) -> Iterable[api.File]:

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -96,6 +96,9 @@ from azul.bytes import (
     azul_urlsafe_b64decode,
     azul_urlsafe_b64encode,
 )
+from azul.collections import (
+    getitem,
+)
 from azul.deployment import (
     aws,
 )
@@ -2052,7 +2055,7 @@ class VerbatimManifestGenerator(FileBasedManifestGenerator, metaclass=ABCMeta):
             document_ids = [
                 document_id
                 for entity_type in self.hot_entity_types
-                for inner_entity in hit['contents'].to_dict().get(entity_type, ())
+                for inner_entity in getitem(hit['contents'], entity_type, ())
                 for document_id in always_iterable(inner_entity['document_id'])
             ]
             yield self.ReplicaKeys(hub_id=hit['entity_id'],

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -116,6 +116,7 @@ from azul.plugins import (
     DocumentSlice,
     ManifestConfig,
     ManifestFormat,
+    MetadataPlugin,
     MutableManifestConfig,
     RepositoryPlugin,
     dotted,
@@ -806,6 +807,10 @@ class ManifestGenerator(metaclass=ABCMeta):
         catalog = self.catalog
         return RepositoryPlugin.load(catalog).create(catalog)
 
+    @property
+    def metadata_plugin(self) -> MetadataPlugin:
+        return self.service.metadata_plugin(self.catalog)
+
     @classmethod
     @abstractmethod
     def file_name_extension(cls) -> str:
@@ -848,7 +853,7 @@ class ManifestGenerator(metaclass=ABCMeta):
         The manifest config this generator uses. A manifest config is a mapping
         from document properties to manifest fields.
         """
-        return self.service.metadata_plugin(self.catalog).manifest_config
+        return self.metadata_plugin.manifest_config
 
     @cached_property
     def included_fields(self) -> list[FieldPath] | None:
@@ -2006,7 +2011,7 @@ class VerbatimManifestGenerator(FileBasedManifestGenerator, metaclass=ABCMeta):
 
     @property
     def implicit_hub_type(self) -> str:
-        return self.service.metadata_plugin(self.catalog).implicit_hub_type
+        return self.metadata_plugin.implicit_hub_type
 
     @property
     def include_orphans(self) -> bool:
@@ -2014,7 +2019,7 @@ class VerbatimManifestGenerator(FileBasedManifestGenerator, metaclass=ABCMeta):
         # data sets for AnVIL or projects for HCA, we include replicas of all
         # entities implicitly connected to the matching hubs, even replicas of
         # orphans, i.e., entities that aren't connected to files.
-        plugin = self.service.metadata_plugin(self.catalog)
+        plugin = self.metadata_plugin
         implicit_hub_fields = {
             field_name
             for field_name, field_path in plugin.field_mapping.items()
@@ -2123,9 +2128,8 @@ class PFBVerbatimManifestGenerator(VerbatimManifestGenerator):
         return ManifestFormat.verbatim_pfb
 
     def create_file(self) -> tuple[str, str | None]:
-        plugin = self.service.metadata_plugin(self.catalog)
         replicas = list(self._all_replicas())
-        replica_schemas = plugin.verbatim_pfb_schema(replicas)
+        replica_schemas = self.metadata_plugin.verbatim_pfb_schema(replicas)
         # Ensure field order is consistent for unit tests
         replica_schemas.sort(key=itemgetter('name'))
         replica_types = [s['name'] for s in replica_schemas]

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -72,6 +72,7 @@ from furl import (
     furl,
 )
 from more_itertools import (
+    always_iterable,
     chunked,
     one,
 )
@@ -1997,7 +1998,8 @@ class VerbatimManifestGenerator(FileBasedManifestGenerator, metaclass=ABCMeta):
     def entity_type(self) -> str:
         # Orphans only have projects/datasets as hubs, so we need to retrieve
         # aggregates of those types in order to join against orphan replicas
-        return self.implicit_hub_type if self.include_orphans else 'files'
+        root_entity_type = self.metadata_plugin.root_entity_type
+        return root_entity_type if self.include_orphans else 'files'
 
     @property
     def included_fields(self) -> list[FieldPath]:
@@ -2006,12 +2008,15 @@ class VerbatimManifestGenerator(FileBasedManifestGenerator, metaclass=ABCMeta):
         # "keys" used for the join.
         return [
             ('entity_id',),
-            ('contents', self.implicit_hub_type, 'document_id')
+            *(
+                ('contents', entity_type, 'document_id')
+                for entity_type in self.hot_entity_types
+            )
         ]
 
     @property
-    def implicit_hub_type(self) -> str:
-        return self.metadata_plugin.implicit_hub_type
+    def hot_entity_types(self) -> Iterable[str]:
+        return self.metadata_plugin.hot_entity_types
 
     @property
     def include_orphans(self) -> bool:
@@ -2020,12 +2025,12 @@ class VerbatimManifestGenerator(FileBasedManifestGenerator, metaclass=ABCMeta):
         # entities implicitly connected to the matching hubs, even replicas of
         # orphans, i.e., entities that aren't connected to files.
         plugin = self.metadata_plugin
-        implicit_hub_fields = {
+        root_entity_fields = {
             field_name
             for field_name, field_path in plugin.field_mapping.items()
-            if field_path[0] == 'contents' and field_path[1] == plugin.implicit_hub_type
+            if field_path[0] == 'contents' and field_path[1] == plugin.root_entity_type
         }
-        return self.filters.explicit.keys() < implicit_hub_fields
+        return self.filters.explicit.keys() < root_entity_fields
 
     @attrs.frozen(kw_only=True)
     class ReplicaKeys:
@@ -2039,17 +2044,19 @@ class VerbatimManifestGenerator(FileBasedManifestGenerator, metaclass=ABCMeta):
         or the replica's entity ID.
         """
         hub_id: str
-        replica_id: str
+        replica_ids: list[str]
 
     def _replica_keys(self) -> Iterable[ReplicaKeys]:
-        hub_type = self.implicit_hub_type
         request = self._create_request()
         for hit in request.scan():
-            replica_id = one(hit['contents'][hub_type])['document_id']
-            if self.entity_type != hub_type:
-                replica_id = one(replica_id)
+            document_ids = [
+                document_id
+                for entity_type in self.hot_entity_types
+                for inner_entity in hit['contents'].to_dict().get(entity_type, ())
+                for document_id in always_iterable(inner_entity['document_id'])
+            ]
             yield self.ReplicaKeys(hub_id=hit['entity_id'],
-                                   replica_id=replica_id)
+                                   replica_ids=document_ids)
 
     def _all_replicas(self) -> Iterable[JSON]:
         emitted_replica_ids = set()
@@ -2077,7 +2084,7 @@ class VerbatimManifestGenerator(FileBasedManifestGenerator, metaclass=ABCMeta):
         hub_ids, replica_ids = set(), set()
         for key in keys:
             hub_ids.add(key.hub_id)
-            replica_ids.add(key.replica_id)
+            replica_ids.update(key.replica_ids)
         request = request.query(Q('bool', should=[
             {'terms': {'hub_ids.keyword': list(hub_ids)}},
             {'terms': {'entity_id.keyword': list(replica_ids)}}

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -47,10 +47,8 @@ import time
 from typing import (
     ClassVar,
     IO,
-    Optional,
     Protocol,
     Self,
-    Type,
     cast,
 )
 import unicodedata
@@ -163,7 +161,7 @@ class ManifestUrlFunc(Protocol):
     def __call__(self,
                  *,
                  fetch: bool = True,
-                 token_or_key: Optional[str] = None,
+                 token_or_key: str | None = None,
                  **params: str
                  ) -> mutable_furl: ...
 
@@ -385,7 +383,7 @@ class ManifestKey(BareManifestKey):
         }
 
     @classmethod
-    def from_json(cls, json: JSON) -> 'ManifestKey':
+    def from_json(cls, json: JSON) -> Self:
         return cls(catalog=json['catalog'],
                    format=ManifestFormat(json['format']),
                    manifest_hash=UUID(json['manifest_hash']),
@@ -436,7 +434,7 @@ class Manifest:
         }
 
     @classmethod
-    def from_json(cls, json: JSON) -> 'Manifest':
+    def from_json(cls, json: JSON) -> Self:
         return cls(object_key=json['object_key'],
                    was_cached=json['was_cached'],
                    format=ManifestFormat(json['format']),
@@ -474,38 +472,38 @@ class ManifestPartition:
     #: portion of the file name. If all pages of all partitions yield the same
     #: base name, the file name on the last partition will incorporate the base
     #: name. Otherwise, a generic, content-independent file name will be used.
-    file_name: Optional[str] = None
+    file_name: str | None = None
 
     #: The cached configuration of the manifest that contains this partition.
     #: Manifest generators whose `manifest_config` property is expensive should
     #: cache the returned value here for subsequent partitions to reuse.
-    config: Optional[AnyJSON] = None
+    config: AnyJSON | None = None
 
     #: The ID of the S3 multi-part upload this partition is a part of. If a
     #: manifest consists of just one partition, this may be None, but it doesn't
     #: have to be.
-    multipart_upload_id: Optional[str] = None
+    multipart_upload_id: str | None = None
 
     #: The S3 ETag of each partition; the current one and all the ones before it
-    part_etags: Optional[tuple[str, ...]] = attrs.field(converter=tuple_or_none,
-                                                        default=None)
+    part_etags: tuple[str, ...] | None = attrs.field(converter=tuple_or_none,
+                                                     default=None)
 
     #: The index of the current page. The index is zero-based and global. For
     #: example, if the first partition contains five pages, the index of the
     #: first page in the second partition is 5. This is None for manifests whose
     #: partitions aren't split into pages.
-    page_index: Optional[int] = None
+    page_index: int | None = None
 
     #: True if the current page is the last page of the entire manifest. This is
     #: None for manifests whose partitions aren't split into pages.
-    is_last_page: Optional[bool] = None
+    is_last_page: bool | None = None
 
     #: The `sort` value of the first hit of the current page in this partition,
     #: or None if there is no current page.
-    search_after: Optional[tuple[str, str]] = None
+    search_after: tuple[str, str] | None = None
 
     @classmethod
-    def from_json(cls, partition: JSON) -> 'ManifestPartition':
+    def from_json(cls, partition: JSON) -> Self:
         return cls(**{
             k: tuple(v) if k == 'search_after' and v is not None else v
             for k, v in partition.items()
@@ -515,7 +513,7 @@ class ManifestPartition:
         return attrs.asdict(self)
 
     @classmethod
-    def first(cls) -> 'ManifestPartition':
+    def first(cls) -> Self:
         return cls(index=0,
                    is_last=False)
 
@@ -526,21 +524,21 @@ class ManifestPartition:
     def with_config(self, config: AnyJSON):
         return attrs.evolve(self, config=config)
 
-    def with_upload(self, multipart_upload_id) -> 'ManifestPartition':
+    def with_upload(self, multipart_upload_id) -> Self:
         return attrs.evolve(self,
                             multipart_upload_id=multipart_upload_id,
                             part_etags=())
 
-    def first_page(self) -> 'ManifestPartition':
+    def first_page(self) -> Self:
         assert self.index == 0, self
         return attrs.evolve(self,
                             page_index=0,
                             is_last_page=False)
 
     def next_page(self,
-                  file_name: Optional[str],
+                  file_name: str | None,
                   search_after: tuple[str, str]
-                  ) -> 'ManifestPartition':
+                  ) -> Self:
         assert self.page_index is not None, self
         # If different pages yield different file names, use default file name
         if self.page_index > 0:
@@ -554,12 +552,12 @@ class ManifestPartition:
     def last_page(self):
         return attrs.evolve(self, is_last_page=True)
 
-    def next(self, part_etag: str) -> 'ManifestPartition':
+    def next(self, part_etag: str) -> Self:
         return attrs.evolve(self,
                             index=self.index + 1,
                             part_etags=(*self.part_etags, part_etag))
 
-    def last(self, file_name: str) -> 'ManifestPartition':
+    def last(self, file_name: str) -> Self:
         return attrs.evolve(self,
                             file_name=file_name,
                             is_last=True)
@@ -583,7 +581,7 @@ class ManifestService(ElasticsearchService):
                      catalog: CatalogName,
                      filters: Filters,
                      partition: ManifestPartition,
-                     manifest_key: Optional[ManifestKey] = None
+                     manifest_key: ManifestKey | None = None
                      ) -> Manifest | ManifestPartition:
         """
         Return a fully populated manifest that ends with the given partition or
@@ -692,7 +690,7 @@ class ManifestService(ElasticsearchService):
         return self._get_cached_manifest(generator_cls, manifest_key)
 
     def _get_cached_manifest(self,
-                             generator_cls: Type['ManifestGenerator'],
+                             generator_cls: type['ManifestGenerator'],
                              manifest_key: ManifestKey
                              ) -> Manifest:
         file_name = self._get_cached_manifest_file_name(generator_cls, manifest_key)
@@ -705,9 +703,9 @@ class ManifestService(ElasticsearchService):
                                        was_cached=True)
 
     def _make_manifest(self,
-                       generator_cls: Type['ManifestGenerator'],
+                       generator_cls: type['ManifestGenerator'],
                        manifest_key: ManifestKey,
-                       file_name: Optional[str],
+                       file_name: str | None,
                        was_cached: bool
                        ) -> Manifest:
         if not generator_cls.use_content_disposition_file_name:
@@ -726,9 +724,9 @@ class ManifestService(ElasticsearchService):
     file_name_tag = 'azul_file_name'
 
     def _get_cached_manifest_file_name(self,
-                                       generator_cls: Type['ManifestGenerator'],
+                                       generator_cls: type['ManifestGenerator'],
                                        manifest_key: ManifestKey
-                                       ) -> Optional[str]:
+                                       ) -> str | None:
         """
         Return the proposed local file name of the manifest with the given
         object key if it was previously created, still exists in the bucket, and
@@ -770,9 +768,9 @@ class ManifestService(ElasticsearchService):
                 return None
 
     def command_lines(self,
-                      manifest: Optional[Manifest],
+                      manifest: Manifest | None,
                       url: furl,
-                      authentication: Optional[Authentication]
+                      authentication: Authentication | None
                       ) -> FlatJSON:
         format = None if manifest is None else manifest.format
         generator_cls = ManifestGenerator.cls_for_format(format)
@@ -867,7 +865,7 @@ class ManifestGenerator(metaclass=ABCMeta):
             if field_name is not None
         ]
 
-    _cls_for_format: dict[ManifestFormat, Type['ManifestGenerator']] = {}
+    _cls_for_format: dict[ManifestFormat, type['ManifestGenerator']] = {}
 
     def __init_subclass__(cls) -> None:
         super().__init_subclass__()
@@ -878,8 +876,8 @@ class ManifestGenerator(metaclass=ABCMeta):
 
     @classmethod
     def cls_for_format(cls,
-                       format: Optional[ManifestFormat]
-                       ) -> Type['ManifestGenerator']:
+                       format: ManifestFormat | None
+                       ) -> type['ManifestGenerator']:
         """
         Return the generator class  for the given format.
 
@@ -903,8 +901,8 @@ class ManifestGenerator(metaclass=ABCMeta):
     @classmethod
     def command_lines(cls,
                       url: furl,
-                      file_name: Optional[str],
-                      authentication: Optional[Authentication]
+                      file_name: str | None,
+                      authentication: Authentication | None
                       ) -> FlatJSON:
         # Normally we would have used --remote-name and --remote-header-name
         # which gets the file name from the content-disposition header. However,
@@ -1013,7 +1011,7 @@ class ManifestGenerator(metaclass=ABCMeta):
 
     def file_name(self,
                   manifest_key: ManifestKey,
-                  base_name: Optional[str] = None
+                  base_name: str | None = None
                   ) -> str:
         if base_name:
             file_name_prefix = unicodedata.normalize('NFKD', base_name)
@@ -1126,7 +1124,7 @@ class ManifestGenerator(metaclass=ABCMeta):
     def _azul_file_url(self,
                        file: JSON,
                        args: Mapping = frozendict()
-                       ) -> Optional[str]:
+                       ) -> str | None:
         download_cls = self.repository_plugin.file_download_class()
         if download_cls.needs_drs_uri and file['drs_uri'] is None:
             return None
@@ -1171,7 +1169,7 @@ class ManifestGenerator(metaclass=ABCMeta):
                  hash_value, time.time() - start_time, self.filters)
         return hash_value
 
-    def tagging(self, file_name: Optional[str]) -> Optional[Mapping[str, str]]:
+    def tagging(self, file_name: str | None) -> Mapping[str, str] | None:
         if file_name is None:
             return None
         else:
@@ -1319,7 +1317,7 @@ class FileBasedManifestGenerator(ManifestGenerator):
     """
 
     @abstractmethod
-    def create_file(self) -> tuple[str, Optional[str]]:
+    def create_file(self) -> tuple[str, str | None]:
         raise NotImplementedError
 
     def write(self,
@@ -1372,8 +1370,8 @@ class CurlManifestGenerator(PagedManifestGenerator):
     @classmethod
     def command_lines(cls,
                       url: furl,
-                      file_name: Optional[str],
-                      authentication: Optional[Authentication]
+                      file_name: str | None,
+                      authentication: Authentication | None
                       ) -> FlatJSON:
         authentication_option = [] if authentication is None else [
             '--header',
@@ -1724,7 +1722,7 @@ class PFBManifestGenerator(FileBasedManifestGenerator):
             doc = self._hit_to_doc(hit)
             yield doc
 
-    def create_file(self) -> tuple[str, Optional[str]]:
+    def create_file(self) -> tuple[str, str | None]:
         transformers = self.service.transformer_types(self.catalog)
         transformer = one(t for t in transformers if t.entity_type() == 'files')
         field_types = transformer.field_types()
@@ -1784,7 +1782,7 @@ class BDBagManifestGenerator(FileBasedManifestGenerator):
             for field_path, column_mapping in super().manifest_config.items()
         }
 
-    def create_file(self) -> tuple[str, Optional[str]]:
+    def create_file(self) -> tuple[str, str | None]:
         with TemporaryDirectory() as temp_path:
             bag_path = os.path.join(temp_path, 'manifest')
             os.makedirs(bag_path)
@@ -2096,7 +2094,7 @@ class JSONLVerbatimManifestGenerator(VerbatimManifestGenerator):
     def format(cls) -> ManifestFormat:
         return ManifestFormat.verbatim_jsonl
 
-    def create_file(self) -> tuple[str, Optional[str]]:
+    def create_file(self) -> tuple[str, str | None]:
         fd, path = mkstemp(suffix=f'.{self.file_name_extension()}')
         os.close(fd)
         with open(path, 'w') as f:
@@ -2124,7 +2122,7 @@ class PFBVerbatimManifestGenerator(VerbatimManifestGenerator):
     def format(cls) -> ManifestFormat:
         return ManifestFormat.verbatim_pfb
 
-    def create_file(self) -> tuple[str, Optional[str]]:
+    def create_file(self) -> tuple[str, str | None]:
         plugin = self.service.metadata_plugin(self.catalog)
         replicas = list(self._all_replicas())
         replica_schemas = plugin.verbatim_pfb_schema(replicas)

--- a/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T11:33:44.698028Z.results.json
+++ b/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T11:33:44.698028Z.results.json
@@ -3756,8 +3756,6 @@
             },
             "entity_id": "7b07b9d0-cc0e-4098-9f64-f4a569f7d746",
             "hub_ids": [
-                "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
-                "70d1af4a-82c8-478a-8960-e9028b3616ca",
                 "e8642221-4c2c-4fd7-b926-a68bce363c88"
             ],
             "replica_type": "donor_organism"
@@ -3800,8 +3798,6 @@
             },
             "entity_id": "9c32cf70-3ed7-4720-badc-5ee71e8a38af",
             "hub_ids": [
-                "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
-                "70d1af4a-82c8-478a-8960-e9028b3616ca",
                 "e8642221-4c2c-4fd7-b926-a68bce363c88"
             ],
             "replica_type": "library_preparation_protocol"
@@ -3838,8 +3834,6 @@
             },
             "entity_id": "61e629ed-0135-4492-ac8a-5c4ab3ccca8a",
             "hub_ids": [
-                "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
-                "70d1af4a-82c8-478a-8960-e9028b3616ca",
                 "e8642221-4c2c-4fd7-b926-a68bce363c88"
             ],
             "replica_type": "sequencing_protocol"

--- a/test/service/test_filters.py
+++ b/test/service/test_filters.py
@@ -34,7 +34,7 @@ class TestFilterReification(AzulTestCase):
         source_spec=MagicMock(),
         bundle_uuid=MagicMock(),
         bundle_version=MagicMock(),
-        implicit_hub_id=MagicMock()
+        root_entity_id=MagicMock()
     )
 
     @property

--- a/test/service/test_request_builder.py
+++ b/test/service/test_request_builder.py
@@ -66,7 +66,7 @@ class TestRequestBuilder(DCP1CannedBundleTestCase, WebServiceTestCase):
                                  source_spec='sourceSpec',
                                  bundle_uuid='bundleUuid',
                                  bundle_version='bundleVersion',
-                                 implicit_hub_id='projectId')
+                                 root_entity_id='projectId')
 
         @property
         def _field_mapping(self) -> MetadataPlugin._FieldMapping:


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Connected issues: #6648


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved connected issues to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the `trigger_child` job in the most recent Data Browser build for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines?scope=branches) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the `trigger_child` job in the most recent Data Browser build for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines?scope=branches) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the `trigger_child` job in the most recent Data Browser build for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines?scope=branches) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
