### PR TITLE
Optimize joiner rejection and re-enable it for AnVIL (#5256)

### DIFF
--- a/src/azul/indexer/__init__.py
+++ b/src/azul/indexer/__init__.py
@@ -8,6 +8,7 @@ from functools import (
 from itertools import (
     product,
 )
+import json
 import logging
 import math
 from threading import (
@@ -16,6 +17,7 @@ from threading import (
 from typing import (
     ClassVar,
     Generic,
+    Iterable,
     Iterator,
     Self,
     TypeVar,
@@ -625,19 +627,16 @@ class Bundle(Generic[BUNDLE_FQID], metaclass=ABCMeta):
         """
         raise NotImplementedError
 
-    def _reject_joiner(self, value: AnyJSON):
-        if isinstance(value, dict):
-            # Since the keys in the metadata files and manifest are pre-defined,
-            # we save some time here by not looking for the joiner in the keys.
-            for v in value.values():
-                self._reject_joiner(v)
-        elif isinstance(value, list):
-            for v in value:
-                self._reject_joiner(v)
-        elif isinstance(value, str):
-            if config.manifest_column_joiner in value:
-                msg = f'{config.manifest_column_joiner!r} is disallowed in metadata'
-                raise RequirementError(msg, self.fqid)
+    def _reject_joiner(self, values: Iterable[AnyJSON]):
+        joiner = config.manifest_column_joiner
+        # We expect that skipping the check for circular references will provide
+        # a small performance benefit. The tradeoff is a risk of infinite
+        # recursion, which we consider unlikely enough to be acceptable.
+        encoder = json.JSONEncoder(check_circular=False)
+        for value in values:
+            for chunk in encoder.iterencode(value):
+                if joiner in chunk:
+                    raise RequirementError(f'{joiner!r} is disallowed in metadata', self.fqid)
 
     @abstractmethod
     def reject_joiner(self):

--- a/src/azul/indexer/__init__.py
+++ b/src/azul/indexer/__init__.py
@@ -26,7 +26,6 @@ from typing import (
 import attrs
 
 from azul import (
-    CatalogName,
     RequirementError,
     config,
     reject,
@@ -641,7 +640,7 @@ class Bundle(Generic[BUNDLE_FQID], metaclass=ABCMeta):
                 raise RequirementError(msg, self.fqid)
 
     @abstractmethod
-    def reject_joiner(self, catalog: CatalogName):
+    def reject_joiner(self):
         """
         Raise a requirement error if the manifest joiner occurs in this bundle
         """

--- a/src/azul/indexer/__init__.py
+++ b/src/azul/indexer/__init__.py
@@ -643,7 +643,7 @@ class Bundle(Generic[BUNDLE_FQID], metaclass=ABCMeta):
     @abstractmethod
     def reject_joiner(self, catalog: CatalogName):
         """
-        Raise a requirement error if the given string is found in the bundle
+        Raise a requirement error if the manifest joiner occurs in this bundle
         """
         raise NotImplementedError
 

--- a/src/azul/indexer/index_service.py
+++ b/src/azul/indexer/index_service.py
@@ -287,7 +287,7 @@ class IndexService(DocumentService):
                        of additions.
         """
         plugin = self.metadata_plugin(catalog)
-        bundle.reject_joiner(catalog)
+        bundle.reject_joiner()
         transformers = plugin.transformers(bundle, delete=delete)
         log.info('Estimating size of partition %s of bundle %s, version %s.',
                  partition, bundle.uuid, bundle.version)

--- a/src/azul/plugins/metadata/anvil/bundle.py
+++ b/src/azul/plugins/metadata/anvil/bundle.py
@@ -4,6 +4,9 @@ from abc import (
 from collections import (
     defaultdict,
 )
+from itertools import (
+    chain,
+)
 from typing import (
     AbstractSet,
     Generic,
@@ -122,9 +125,9 @@ class AnvilBundle(Bundle[BUNDLE_FQID], ABC):
     orphans: dict[EntityReference, MutableJSON] = attrs.field(factory=dict)
 
     def reject_joiner(self):
-        # FIXME: Optimize joiner rejection and re-enable it for AnVIL
-        #        https://github.com/DataBiosphere/azul/issues/5256
-        pass
+        # We can skip the `links` attribute because the only strings it contains
+        # are UUIDs and table names
+        self._reject_joiner(chain(self.entities.values(), self.orphans.values()))
 
     def to_json(self) -> MutableJSON:
         def to_json(entities):

--- a/src/azul/plugins/metadata/anvil/bundle.py
+++ b/src/azul/plugins/metadata/anvil/bundle.py
@@ -14,9 +14,6 @@ from typing import (
 
 import attrs
 
-from azul import (
-    CatalogName,
-)
 from azul.collections import (
     aset,
     none_safe_apply,
@@ -124,7 +121,7 @@ class AnvilBundle(Bundle[BUNDLE_FQID], ABC):
     links: set[EntityLink] = attrs.field(factory=set)
     orphans: dict[EntityReference, MutableJSON] = attrs.field(factory=dict)
 
-    def reject_joiner(self, catalog: CatalogName):
+    def reject_joiner(self):
         # FIXME: Optimize joiner rejection and re-enable it for AnVIL
         #        https://github.com/DataBiosphere/azul/issues/5256
         pass

--- a/src/azul/plugins/metadata/hca/bundle.py
+++ b/src/azul/plugins/metadata/hca/bundle.py
@@ -5,9 +5,6 @@ import logging
 
 import attrs
 
-from azul import (
-    CatalogName,
-)
 from azul.indexer import (
     BUNDLE_FQID,
     Bundle,
@@ -42,7 +39,7 @@ class HCABundle(Bundle[BUNDLE_FQID], ABC):
     links: MutableJSON
     stitched: set[str] = attrs.field(factory=set)
 
-    def reject_joiner(self, catalog: CatalogName):
+    def reject_joiner(self):
         # We can skip the `stitched` attribute because it only contains UUIDs
         self._reject_joiner(self.manifest)
         self._reject_joiner(self.metadata)

--- a/src/azul/plugins/metadata/hca/bundle.py
+++ b/src/azul/plugins/metadata/hca/bundle.py
@@ -43,6 +43,7 @@ class HCABundle(Bundle[BUNDLE_FQID], ABC):
     stitched: set[str] = attrs.field(factory=set)
 
     def reject_joiner(self, catalog: CatalogName):
+        # We can skip the `stitched` attribute because it only contains UUIDs
         self._reject_joiner(self.manifest)
         self._reject_joiner(self.metadata)
         self._reject_joiner(self.links)

--- a/src/azul/plugins/metadata/hca/bundle.py
+++ b/src/azul/plugins/metadata/hca/bundle.py
@@ -41,9 +41,7 @@ class HCABundle(Bundle[BUNDLE_FQID], ABC):
 
     def reject_joiner(self):
         # We can skip the `stitched` attribute because it only contains UUIDs
-        self._reject_joiner(self.manifest)
-        self._reject_joiner(self.metadata)
-        self._reject_joiner(self.links)
+        self._reject_joiner([self.manifest, self.metadata, self.links])
 
     def to_json(self) -> MutableJSON:
         return {


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Connected issues: #5256


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved connected issues to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the `trigger_child` job in the most recent Data Browser build for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines?scope=branches) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the `trigger_child` job in the most recent Data Browser build for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines?scope=branches) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the `trigger_child` job in the most recent Data Browser build for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines?scope=branches) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
