### PR TITLE
Fix: GitHub CI workflow selects dev when building prod branch (#5428, #6823)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 !Makefile
 !common.mk
 !requirements*.txt
+!environment
 !bin/keys/docker-apt-keyring.pgp
 # FIXME: Remove fips_enabled
 #        https://github.com/DataBiosphere/azul/issues/6675

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,14 @@ jobs:
 
       - name: 'Run unit tests and other checks'
         run: |
-          source environment
-          _link dev
-          _refresh
-
+          source environment  # load global defaults
           make virtualenv
           source .venv/bin/activate
           make requirements
+          deployment=$(python scripts/check_branch.py --print)
+          _link $deployment
+          _refresh
+
 
           make environment.boot
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,15 +64,15 @@ RUN --mount=type=bind,source=fips_enabled,target=${azul_proc_sys_crypto}/fips_en
 #
 RUN mkdir /build
 WORKDIR /build
-ENV project_root=/build
 
 # Install Azul dependencies
 #
 ARG PIP_DISABLE_PIP_VERSION_CHECK
 ENV PIP_DISABLE_PIP_VERSION_CHECK=${PIP_DISABLE_PIP_VERSION_CHECK}
-COPY requirements*.txt common.mk Makefile ./
+COPY environment requirements*.txt common.mk Makefile ./
 ARG make_target
-RUN make virtualenv \
+RUN source environment \
+    && make virtualenv \
     && source .venv/bin/activate \
     && make $make_target \
     && rm requirements*.txt common.mk Makefile

--- a/requirements.all.txt
+++ b/requirements.all.txt
@@ -10,7 +10,7 @@ blinker==1.9.0
 boto3==1.36.5
 boto3-stubs-lite==1.36.5
 botocore==1.36.5
-botocore-stubs==1.36.11
+botocore-stubs==1.36.12
 brotli==1.1.0
 cachetools==5.5.1
 certifi==2025.1.31
@@ -80,7 +80,7 @@ mypy-boto3-dynamodb==1.36.0
 mypy-boto3-ec2==1.36.8
 mypy-boto3-ecr==1.36.10
 mypy-boto3-es==1.36.0
-mypy-boto3-iam==1.36.0
+mypy-boto3-iam==1.36.13
 mypy-boto3-kms==1.36.0
 mypy-boto3-lambda==1.36.0
 mypy-boto3-s3==1.36.9

--- a/requirements.all.txt
+++ b/requirements.all.txt
@@ -10,7 +10,7 @@ blinker==1.9.0
 boto3==1.36.5
 boto3-stubs-lite==1.36.5
 botocore==1.36.5
-botocore-stubs==1.36.12
+botocore-stubs==1.36.15
 brotli==1.1.0
 cachetools==5.5.1
 certifi==2025.1.31
@@ -83,7 +83,7 @@ mypy-boto3-es==1.36.0
 mypy-boto3-iam==1.36.13
 mypy-boto3-kms==1.36.0
 mypy-boto3-lambda==1.36.0
-mypy-boto3-s3==1.36.9
+mypy-boto3-s3==1.36.15
 mypy-boto3-secretsmanager==1.36.0
 mypy-boto3-securityhub==1.36.0
 mypy-boto3-sns==1.36.3

--- a/requirements.dev.trans.txt
+++ b/requirements.dev.trans.txt
@@ -1,6 +1,6 @@
 blessed==1.20.0
 blinker==1.9.0
-botocore-stubs==1.36.11
+botocore-stubs==1.36.12
 brotli==1.1.0
 click==8.1.8
 colorama==0.4.6
@@ -30,7 +30,7 @@ mypy-boto3-dynamodb==1.36.0
 mypy-boto3-ec2==1.36.8
 mypy-boto3-ecr==1.36.10
 mypy-boto3-es==1.36.0
-mypy-boto3-iam==1.36.0
+mypy-boto3-iam==1.36.13
 mypy-boto3-kms==1.36.0
 mypy-boto3-lambda==1.36.0
 mypy-boto3-s3==1.36.9

--- a/requirements.dev.trans.txt
+++ b/requirements.dev.trans.txt
@@ -1,6 +1,6 @@
 blessed==1.20.0
 blinker==1.9.0
-botocore-stubs==1.36.12
+botocore-stubs==1.36.15
 brotli==1.1.0
 click==8.1.8
 colorama==0.4.6
@@ -33,7 +33,7 @@ mypy-boto3-es==1.36.0
 mypy-boto3-iam==1.36.13
 mypy-boto3-kms==1.36.0
 mypy-boto3-lambda==1.36.0
-mypy-boto3-s3==1.36.9
+mypy-boto3-s3==1.36.15
 mypy-boto3-secretsmanager==1.36.0
 mypy-boto3-securityhub==1.36.0
 mypy-boto3-sns==1.36.3

--- a/scripts/check_branch.py
+++ b/scripts/check_branch.py
@@ -52,7 +52,32 @@ def target_branch() -> str | None:
     built or, if the build is for a feature branch involving a pull request, the
     base branch of that feature branch.
     """
-    for variable in 'CI_COMMIT_REF_NAME', 'GITHUB_BASE_REF', 'GITHUB_HEAD_REF':
+    # The comments on the environment variable names below are taken from
+    #
+    # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables
+    #
+    # and
+    #
+    # https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
+    #
+    for variable in [
+        # The name of the base ref or target branch of the pull request in a
+        # workflow run. This is only set when the event that triggers a workflow
+        # run is either pull_request or pull_request_target. For example, main.
+        #
+        'GITHUB_BASE_REF',
+
+        # The short ref name of the branch or tag that triggered the workflow
+        # run. This value matches the branch or tag name shown on GitHub. For
+        # example, feature-branch-1. For pull requests, the format is
+        # <pr_number>/merge.
+        #
+        'GITHUB_REF_NAME',
+
+        # The branch or tag name for which project is built.
+        #
+        'CI_COMMIT_REF_NAME',
+    ]:
         try:
             branch = os.environ[variable]
         except KeyError:
@@ -60,7 +85,7 @@ def target_branch() -> str | None:
         else:
             return branch
     repo = git.Repo(config.project_root)
-    return None if repo.head.is_detached else repo.active_branch.name
+    return None if repo.head.is_detached else repo.head.reference.name
 
 
 def main(argv):

--- a/scripts/check_branch.py
+++ b/scripts/check_branch.py
@@ -44,19 +44,21 @@ def check_branch(branch: str | None, deployment: str) -> None:
             raise BranchDeploymentMismatch(branch, deployment, deployments)
 
 
-def gitlab_branch() -> str | None:
+def target_branch() -> str | None:
     """
-    Return the current branch if we're on GitLab, else `None`
+    In a local clone, this method returns the name of the branch currently
+    checked out or ``None``, if no branch is checked out (detached HEAD). On
+    GitHub and GitLab this returns the name of either the branch currently being
+    built or, if the build is for a feature branch involving a pull request, the
+    base branch of that feature branch.
     """
-    # Gitlab checks out a specific commit which results in a detached HEAD
-    # (no active branch). Extract the branch name from the runner environment.
-    return os.environ.get('CI_COMMIT_REF_NAME')
-
-
-def local_branch() -> str | None:
-    """
-    Return `None` if detached head, else the current branch
-    """
+    for variable in 'CI_COMMIT_REF_NAME', 'GITHUB_BASE_REF', 'GITHUB_HEAD_REF':
+        try:
+            branch = os.environ[variable]
+        except KeyError:
+            pass
+        else:
+            return branch
     repo = git.Repo(config.project_root)
     return None if repo.head.is_detached else repo.active_branch.name
 
@@ -70,7 +72,7 @@ def main(argv):
                         help='Print the deployment matching the current branch or exit '
                              'with non-zero status code if no such deployment exists.')
     args = parser.parse_args(argv)
-    branch = gitlab_branch() or local_branch()
+    branch = target_branch()
     if args.print:
         deployment = default_deployment(branch)
         if deployment is None:

--- a/scripts/check_branch.py
+++ b/scripts/check_branch.py
@@ -1,7 +1,6 @@
 import os
 import sys
 from typing import (
-    Optional,
     Sequence,
 )
 
@@ -16,7 +15,7 @@ Ensure that the currently checked out branch matches the selected deployment
 """
 
 
-def default_deployment(branch: Optional[str]) -> Optional[str]:
+def default_deployment(branch: str | None) -> str | None:
     deployments = config.shared_deployments_for_branch(branch)
     return None if deployments is None else deployments[0].name
 
@@ -24,9 +23,9 @@ def default_deployment(branch: Optional[str]) -> Optional[str]:
 class BranchDeploymentMismatch(Exception):
 
     def __init__(self,
-                 branch: Optional[str],
+                 branch: str | None,
                  deployment: config.Deployment,
-                 allowed: Optional[Sequence[config.Deployment]]
+                 allowed: Sequence[config.Deployment] | None
                  ) -> None:
         branch = 'Detached head' if branch is None else f'Branch {branch!r}'
         if allowed is None:
@@ -37,7 +36,7 @@ class BranchDeploymentMismatch(Exception):
                          f'only {allowed}personal deployments.')
 
 
-def check_branch(branch: Optional[str], deployment: str) -> None:
+def check_branch(branch: str | None, deployment: str) -> None:
     deployment = config.Deployment(deployment)
     if deployment.is_shared:
         deployments = config.shared_deployments_for_branch(branch)
@@ -45,7 +44,7 @@ def check_branch(branch: Optional[str], deployment: str) -> None:
             raise BranchDeploymentMismatch(branch, deployment, deployments)
 
 
-def gitlab_branch() -> Optional[str]:
+def gitlab_branch() -> str | None:
     """
     Return the current branch if we're on GitLab, else `None`
     """
@@ -54,7 +53,7 @@ def gitlab_branch() -> Optional[str]:
     return os.environ.get('CI_COMMIT_REF_NAME')
 
 
-def local_branch() -> Optional[str]:
+def local_branch() -> str | None:
     """
     Return `None` if detached head, else the current branch
     """

--- a/test/test_check_branch.py
+++ b/test/test_check_branch.py
@@ -70,3 +70,18 @@ class TestCheckBranch(AzulUnitTestCase):
                              'prod',
                              "Branch 'feature/foo' cannot be deployed to 'prod', "
                              "only one of {'sandbox'} or personal deployments.")
+
+        variables = ['CI_COMMIT_REF_NAME', 'GITHUB_BASE_REF', 'GITHUB_HEAD_REF']
+
+        for variable in variables:
+            if variable == 'GITHUB_HEAD_REF':
+                branches = ['foo/bar']
+            else:
+                branches = ['develop', 'prod']
+            for branch in branches:
+                with patch.dict(os.environ) as env:
+                    for var in variables:
+                        env.pop(var, None)
+                    env[var] = branch
+                    with self.subTest(branch=branch, variable=variable):
+                        self.assertEqual(branch, script.target_branch())

--- a/test/test_check_branch.py
+++ b/test/test_check_branch.py
@@ -1,8 +1,11 @@
 import json
 import os
 from unittest.mock import (
+    PropertyMock,
     patch,
 )
+
+import git
 
 from azul.modules import (
     load_script,
@@ -14,7 +17,7 @@ from azul_test_case import (
 
 class TestCheckBranch(AzulUnitTestCase):
 
-    def test(self):
+    def test_check_branch(self):
         script = load_script('check_branch')
         check_branch = script.check_branch
 
@@ -71,17 +74,77 @@ class TestCheckBranch(AzulUnitTestCase):
                              "Branch 'feature/foo' cannot be deployed to 'prod', "
                              "only one of {'sandbox'} or personal deployments.")
 
-        variables = ['CI_COMMIT_REF_NAME', 'GITHUB_BASE_REF', 'GITHUB_HEAD_REF']
+    def test_target_branch(self):
+        script = load_script('check_branch')
 
-        for variable in variables:
-            if variable == 'GITHUB_HEAD_REF':
-                branches = ['foo/bar']
-            else:
-                branches = ['develop', 'prod']
-            for branch in branches:
-                with patch.dict(os.environ) as env:
-                    for var in variables:
-                        env.pop(var, None)
-                    env[var] = branch
-                    with self.subTest(branch=branch, variable=variable):
-                        self.assertEqual(branch, script.target_branch())
+        develop, prod = 'develop', 'prod'
+        feature, merge = 'issues/foo/1234-bar', '2345/merge'
+        cases = [
+            (
+                'Local build',
+                feature,
+                {},
+                feature
+            ),
+            (
+                'Local build with detached head',
+                None,
+                {},
+                None
+            ),
+            (
+                'GitHub building develop',
+                develop,
+                {'GITHUB_REF_NAME': develop},
+                develop
+            ),
+            (
+                'GitHub building prod',
+                prod,
+                {'GITHUB_REF_NAME': prod},
+                prod
+            ),
+            (
+                'GitHub PR against develop',
+                merge,
+                {
+                    'GITHUB_REF_NAME': merge,
+                    'GITHUB_HEAD_REF': feature,
+                    'GITHUB_BASE_REF': develop
+                },
+                develop
+            ),
+            (
+                'GitHub PR against prod',
+                merge,
+                {
+                    'GITHUB_REF_NAME': merge,
+                    'GITHUB_HEAD_REF': feature,
+                    'GITHUB_BASE_REF': prod
+                },
+                prod
+            ),
+            (
+                'Sandbox build on GitLab',
+                None,
+                {'CI_COMMIT_REF_NAME': feature},
+                feature
+            ),
+            (
+                'Non-sandbox build on GitLab',
+                None,
+                {'CI_COMMIT_REF_NAME': develop},
+                develop
+            ),
+        ]
+        variables = {v for case in cases for v in case[2]}
+        for sub_test, current_branch, new_env, target_branch in cases:
+            with self.subTest(sub_test):
+                with patch.object(git.Repo, 'head', new_callable=PropertyMock) as head:
+                    head.return_value.is_detached = current_branch is None
+                    head.return_value.reference.name = current_branch
+                    with patch.dict(os.environ) as env:
+                        for variable in variables:
+                            env.pop(variable, None)
+                        env.update(new_env)
+                        self.assertEqual(target_branch, script.target_branch())


### PR DESCRIPTION
Connected issues: #5428, #6823


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved connected issues to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the `trigger_child` job in the most recent Data Browser build for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines?scope=branches) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the `trigger_child` job in the most recent Data Browser build for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines?scope=branches) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the `trigger_child` job in the most recent Data Browser build for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines?scope=branches) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
