### PR TITLE
Hotfix prod: Make dcp45 the default catalog on prod (#6806)

### DIFF
--- a/deployments/prod/environment.py
+++ b/deployments/prod/environment.py
@@ -1390,7 +1390,6 @@ def env() -> Mapping[str, Optional[str]]:
                                                     repository=dict(name='tdr_hca')),
                                        sources=mklist(sources))
             for atlas, catalog, sources in [
-                ('hca', 'dcp44', dcp44_sources),
                 ('hca', 'dcp45', dcp45_sources),
                 ('lungmap', 'lm7', lm7_sources),
                 ('lungmap', 'lm8', lm8_sources)


### PR DESCRIPTION
Connected issue: #6806

## Notes

- Manually deindex the `dcp44` & `dcp44-it` catalog sources from `prod`

## Checklist


### Author

- [x] Target branch is `prod`
- [x] Name of PR branch matches `hotfixes/<GitHub handle of author>/<issue#>-<slug>-prod`
- [x] On ZenHub, PR is connected to the issue it hotfixes
- [x] PR description links to connected issue
- [x] PR title is `Hotfix prod: ` followed by title of connected issue
- [x] PR title references the connected issue


### Author (hotfixes)

- [x] Added `h` tag to commit title <sub>or this PR does not include a temporary hotfix</sub>
- [x] Added `H` tag to commit title <sub>or this PR does not include a permanent hotfix</sub>
- [x] Added `hotfix` label to PR
- [x] This PR is labeled `partial` <sub>or represents a permanent hotfix</sub>


### Author (before every review)

- [x] Rebased PR branch on `prod`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled PR as `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] Moved connected issue to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Squashed PR branch and rebased onto `prod`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but excluded any `p` tags</sub>
- [x] Moved connected issue to *Merged stable* column in ZenHub
- [x] Pushed merge commit to GitHub


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `prod`
- [x] Build passes on GitLab `prod`
- [x] Reviewed build logs for anomalies on GitLab `prod`
- [x] Deleted PR branch from GitHub


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `prod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:prod`</sub>
- [x] Deindexed specific sources in `prod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:prod`</sub>
- [x] Indexed specific sources in `prod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:prod`</sub>
- [x] Started reindex in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Emptied fail queues in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Restarted the `trigger_child` job in the most recent Data Browser build for the [ucsc/hca/prod branch](https://gitlab.azul.data.humancellatlas.org/ucsc/data-browser/-/pipelines?scope=branches) on GitLab in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Restarted the `trigger_child` job in the most recent Data Browser build for the [ucsc/lungmap/prod branch](https://gitlab.azul.data.humancellatlas.org/ucsc/data-browser/-/pipelines?scope=branches) on GitLab in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Restarted `deploy` job in the GitLab pipeline for this PR in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Created [backport PR and linked](https://github.com/DataBiosphere/azul/pull/6825#issuecomment-2597118435) to it in a comment on this PR


### Operator

- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
