### PR TITLE
Prototype mirroring of a single HCA file (#6857)

### DIFF
--- a/scripts/mirror_file.py
+++ b/scripts/mirror_file.py
@@ -1,0 +1,122 @@
+"""
+Copy a file in an HCA catalog from TDR to the current deployment's storage
+bucket and print a signed URL to the file's destination. Authentication is not
+supported, so the file must be publicly accessible.
+"""
+import argparse
+import logging
+import math
+import sys
+
+from azul import (
+    CatalogName,
+    config,
+)
+from azul.args import (
+    AzulArgumentHelpFormatter,
+)
+from azul.azulclient import (
+    AzulClient,
+)
+from azul.drs import (
+    AccessMethod,
+)
+from azul.http import (
+    http_client,
+)
+from azul.logging import (
+    configure_script_logging,
+)
+from azul.service import (
+    Filters,
+)
+from azul.service.repository_service import (
+    RepositoryService,
+)
+from azul.service.source_service import (
+    SourceService,
+)
+from azul.service.storage_service import (
+    StorageService,
+)
+from azul.types import (
+    JSON,
+    MutableJSON,
+)
+
+log = logging.getLogger(__name__)
+
+http = http_client(log)
+
+
+def get_file(catalog: CatalogName, file_uuid: str) -> MutableJSON:
+    source_ids = SourceService().list_source_ids(catalog, authentication=None)
+    filters = Filters(explicit={},
+                      source_ids=source_ids)
+    file = RepositoryService().get_data_file(catalog=catalog,
+                                             file_uuid=file_uuid,
+                                             file_version=None,
+                                             filters=filters)
+    if file is None:
+        raise RuntimeError(f'File {file_uuid!r} not found in catalog {catalog!r}')
+    return file
+
+
+def get_download_url(catalog: CatalogName, file: JSON) -> str:
+    drs_uri = file['drs_uri']
+    drs = AzulClient().repository_plugin(catalog).drs_client()
+    access = drs.get_object(drs_uri, AccessMethod.gs)
+    assert access.method is AccessMethod.https, access
+    return access.url
+
+
+def object_key(file: JSON) -> str:
+    # For non-HCA catalogs, a different hash may be more appropriate
+    return f'file/{file["sha256"]}.sha256'
+
+
+def mirror_file(catalog: CatalogName, file_uuid: str, part_size: int) -> str:
+    assert config.is_tdr_enabled(catalog), 'Only TDR catalogs are supported'
+    assert config.is_hca_enabled(catalog), 'Only HCA catalogs are supported'
+    file = get_file(catalog, file_uuid)
+    download_url = get_download_url(catalog, file)
+    key = object_key(file)
+    storage = StorageService()
+    upload = storage.create_multipart_upload(key, content_type=file['content-type'])
+
+    total_size = file['size']
+    part_count = math.ceil(total_size / part_size)
+    assert part_count <= 10000, (total_size, part_size, part_count)
+
+    def file_part(part_number: int) -> str:
+        start = part_number * part_size
+        end = min((part_number + 1) * part_size - 1, total_size)
+        response = http.request('GET',
+                                download_url,
+                                headers={'Range': f'bytes={start}-{end}'})
+        if response.status == 206:
+            return storage.upload_multipart_part(response.data,
+                                                 part_number + 1,
+                                                 upload)
+        else:
+            raise RuntimeError('Unexpected response from repository', response.status)
+
+    etags = list(map(file_part, range(part_count)))
+    storage.complete_multipart_upload(upload, etags)
+    return storage.get_presigned_url(key, file['name'])
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=AzulArgumentHelpFormatter)
+    parser.add_argument('-c', '--catalog')
+    parser.add_argument('-f', '--file-uuid')
+    parser.add_argument('-p', '--part-size', type=int, default=50 * 2 ** 20)
+    args = parser.parse_args(argv)
+    signed_url = mirror_file(args.catalog, args.file_uuid, args.part_size)
+    print(signed_url)
+
+
+if __name__ == '__main__':
+    configure_script_logging(log)
+    main(sys.argv[1:])

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -23,7 +23,6 @@ from logging import (
 import time
 from typing import (
     IO,
-    Optional,
     TYPE_CHECKING,
 )
 from urllib.parse import (
@@ -99,8 +98,8 @@ class StorageService:
     def put(self,
             object_key: str,
             data: bytes,
-            content_type: Optional[str] = None,
-            tagging: Optional[Tagging] = None,
+            content_type: str | None = None,
+            tagging: Tagging | None = None,
             **kwargs):
         self._s3.put_object(Bucket=self.bucket_name,
                             Key=object_key,
@@ -110,8 +109,8 @@ class StorageService:
 
     def create_multipart_upload(self,
                                 object_key: str,
-                                content_type: Optional[str] = None,
-                                tagging: Optional[Tagging] = None) -> MultipartUpload:
+                                content_type: str | None = None,
+                                tagging: Tagging | None = None) -> MultipartUpload:
         kwargs = self._object_creation_kwargs(content_type=content_type,
                                               tagging=tagging)
         return self._create_multipart_upload(object_key=object_key, **kwargs)
@@ -148,8 +147,8 @@ class StorageService:
     def upload(self,
                file_path: str,
                object_key: str,
-               content_type: Optional[str] = None,
-               tagging: Optional[Tagging] = None):
+               content_type: str | None = None,
+               tagging: Tagging | None = None):
         self._s3.upload_file(Filename=file_path,
                              Bucket=self.bucket_name,
                              Key=object_key,
@@ -160,8 +159,8 @@ class StorageService:
             self.put_object_tagging(object_key, tagging)
 
     def _object_creation_kwargs(self, *,
-                                content_type: Optional[str] = None,
-                                tagging: Optional[Tagging] = None):
+                                content_type: str | None = None,
+                                tagging: Tagging | None = None):
         kwargs = {}
         if content_type is not None:
             kwargs['ContentType'] = content_type
@@ -169,7 +168,7 @@ class StorageService:
             kwargs['Tagging'] = urlencode(tagging)
         return kwargs
 
-    def get_presigned_url(self, key: str, file_name: Optional[str] = None) -> str:
+    def get_presigned_url(self, key: str, file_name: str | None = None) -> str:
         """
         Return a pre-signed URL to the given key.
 
@@ -264,7 +263,7 @@ class StorageService:
 
 @dataclass
 class Part:
-    etag: Optional[str]  # If ETag is defined, the content is already pushed to S3.
+    etag: str | None  # If ETag is defined, the content is already pushed to S3.
     part_number: int
     content: bytes
 


### PR DESCRIPTION
Connected issues: #6857


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved connected issues to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
