### PR TITLE
Fix: AssertionError indexing snapshot not registered in DUOS (#6883)

### DIFF
--- a/src/azul/terra.py
+++ b/src/azul/terra.py
@@ -664,7 +664,7 @@ class TDRClient(SAMClient):
         body = self._retrieve_source(source)
         try:
             duos_id = json_str(json_dict(body['duosFirecloudGroup'])['duosId'])
-        except (KeyError, TypeError):
+        except (KeyError, AssertionError):
             log.warning('No DUOS ID available for %r', source.spec)
             return None, None
         else:

--- a/test/azul_test_case.py
+++ b/test/azul_test_case.py
@@ -5,6 +5,7 @@ from abc import (
 from collections.abc import (
     Set,
 )
+import contextlib
 from contextlib import (
     AbstractContextManager,
 )
@@ -16,6 +17,7 @@ from re import (
     escape,
 )
 from typing import (
+    Iterable,
     Optional,
 )
 from unittest import (
@@ -218,6 +220,13 @@ class AzulTestCase(TestCase):
             cleanup = instance.stop
         instance.start()
         self.addCleanup(cleanup)
+
+    @contextlib.contextmanager
+    def stacked_patches(self, patches: Iterable[patch]):
+        with contextlib.ExitStack() as context:
+            for cm in patches:
+                context.enter_context(cm)
+            yield
 
 
 class AlwaysTearDownTestCase(TestCase):

--- a/test/indexer/test_anvil.py
+++ b/test/indexer/test_anvil.py
@@ -9,6 +9,7 @@ from operator import (
     itemgetter,
 )
 from typing import (
+    Iterable,
     Type,
     cast,
 )
@@ -49,6 +50,10 @@ from azul.plugins.repository.tdr_anvil import (
 from azul.terra import (
     TDRClient,
 )
+from azul.types import (
+    JSONs,
+    MutableJSONs,
+)
 from azul_test_case import (
     TDRTestCase,
 )
@@ -68,37 +73,37 @@ def setUpModule():
 
 class DUOSTestCase(TDRTestCase, ABC):
 
-    @classmethod
-    def setUpClass(cls) -> None:
-        super().setUpClass()
-        cls._patch_duos()
+    def _mock_normal_duos(self):
+        for p in self._duos_patches(self.normal_response_bodies):
+            self.addPatch(p)
 
-    mock_duos_url = furl('https://mock_duos.lan')
+    @property
+    def normal_response_bodies(self) -> MutableJSONs:
+        duos_id = 'DUOS-000000'
+        return [
+            # TDR's /snapshots/{snapshot_id} response:
+            {
+                'name': self.source.spec.name,
+                'duosFirecloudGroup': {'duosId': duos_id}
+            },
+            # DUOS' /dataset/registration/{duos_id}:
+            {
+                'consentGroups': [{'datasetIdentifier': duos_id}],
+                'studyDescription': 'Study description from DUOS'
+            }
+        ]
 
-    duos_id = 'DUOS-000000'
-    duos_description = 'Study description from DUOS'
-
-    @classmethod
-    def _patch_duos(cls) -> None:
-        cls.addClassPatch(patch.object(type(config),
-                                       'duos_service_url',
-                                       new=PropertyMock(return_value=cls.mock_duos_url)))
-        cls.addClassPatch(patch.object(TDRClient,
-                                       '_request',
-                                       side_effect=[
-                                           Mock(spec=HTTPResponse, status=200, data=json.dumps({
-                                               'name': cls.source.spec.name,
-                                               'duosFirecloudGroup': {
-                                                   'duosId': cls.duos_id
-                                               }
-                                           })),
-                                           Mock(spec=HTTPResponse, status=200, data=json.dumps({
-                                               'consentGroups': [{
-                                                   'datasetIdentifier': cls.duos_id
-                                               }],
-                                               'studyDescription': cls.duos_description
-                                           }))
-                                       ]))
+    def _duos_patches(self, bodies: JSONs) -> Iterable[patch]:
+        responses = [
+            Mock(spec=HTTPResponse, status=200, data=json.dumps(body))
+            for body in bodies
+        ]
+        mock_url = PropertyMock(return_value=furl('https://mock_duos.lan'))
+        patches = [
+            patch.object(type(config), 'duos_service_url', new=mock_url),
+            patch.object(TDRClient, '_request', side_effect=responses)
+        ]
+        return patches
 
 
 class AnvilIndexerTestCase(AnvilCannedBundleTestCase, IndexerTestCase):
@@ -173,6 +178,7 @@ class TestAnvilIndexer(AnvilIndexerTestCase,
                         self.index_service.delete_indices(self.catalog)
 
     def test_list_and_fetch_bundles(self):
+        self._mock_normal_duos()
         source_ref = self.source
         self._make_mock_tdr_tables(source_ref)
         canned_bundle_fqids = [

--- a/test/indexer/test_anvil.py
+++ b/test/indexer/test_anvil.py
@@ -218,6 +218,35 @@ class TestAnvilIndexer(AnvilIndexerTestCase,
                 self.assertEqual(canned_bundle.links, bundle.links)
                 self.assertEqual(canned_bundle.orphans, bundle.orphans)
 
+    def test_absent_duos_id(self):
+        source_ref = self.source
+        self._make_mock_tdr_tables(source_ref)
+        cases = {
+            'Absent duosFirecloudGroup': [
+                {'name': self.source.spec.name}
+            ],
+            'Empty duosFirecloudGroup': [
+                {
+                    'name': self.source.spec.name,
+                    'duosFirecloudGroup': {}
+                }
+            ],
+            'Null duosId': [
+                {
+                    'name': self.source.spec.name,
+                    'duosFirecloudGroup': {'duosId': None}
+                }
+            ]
+        }
+        for sub_test, response_bodies in cases.items():
+            with self.subTest(sub_test):
+                with self.stacked_patches(self._duos_patches(response_bodies)):
+                    plugin = self.plugin_for_source_spec(source_ref.spec)
+                    bundle = plugin.fetch_bundle(self.duos_bundle())
+                    self.assertIsInstance(bundle, TDRAnvilBundle)
+                    self.assertEqual({}, bundle.entities)
+                    self.assertEqual(1, len(bundle.orphans))
+
 
 class TestAnvilIndexerWithIndexesSetUp(AnvilIndexerTestCase):
     """

--- a/test/indexer/test_anvil.py
+++ b/test/indexer/test_anvil.py
@@ -73,7 +73,7 @@ class DUOSTestCase(TDRTestCase, ABC):
         super().setUpClass()
         cls._patch_duos()
 
-    mock_duos_url = furl('https:://mock_duos.lan')
+    mock_duos_url = furl('https://mock_duos.lan')
 
     duos_id = 'DUOS-000000'
     duos_description = 'Study description from DUOS'


### PR DESCRIPTION
Connected issues: #6883 


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved connected issues to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
