### PR TITLE
Implement executive order M-21-31 (#6070)

### DIFF
--- a/scripts/import_cloudwatch_log_groups.py
+++ b/scripts/import_cloudwatch_log_groups.py
@@ -1,0 +1,61 @@
+import boto3
+
+from azul import (
+    config,
+    logging,
+)
+from azul.logging import (
+    configure_script_logging,
+)
+from azul.terraform import (
+    terraform,
+)
+
+log = logging.getLogger(__name__)
+
+
+def main():
+    tf_component = config.terraform_component
+    if tf_component == '':
+        pass
+    elif tf_component in ('browser', 'gitlab'):
+        pass
+    elif tf_component == 'shared':
+        if config.slack_integration:
+            import_log_groups(chatbot_log_groups())
+    else:
+        assert False
+
+
+def log_group_name(name: str) -> str:
+    return 'aws_cloudwatch_log_group.' + name
+
+
+def chatbot_log_groups() -> dict[str, str]:
+    name = log_group_name('chatbot')
+    log_group = '/aws/chatbot/' + config.qualified_resource_name('chatbot')
+    return {name: log_group}
+
+
+def import_log_groups(log_groups: dict[str, str]) -> None:
+    log_client = boto3.client('logs')
+    paginator = log_client.get_paginator('describe_log_groups')
+    existing_log_groups = {
+        log_group['logGroupName']
+        for page in paginator.paginate()
+        for log_group in page['logGroups']
+    }
+    resources = terraform.run('state', 'list').splitlines()
+    for resource_name, log_group in log_groups.items():
+        if resource_name in resources:
+            log.info('Skipping import of %r, resource already imported', resource_name)
+        elif log_group not in existing_log_groups:
+            log.info('Skipping import of %r, resource does not exist', resource_name)
+        else:
+            log.info('Importing resource %r', resource_name)
+            terraform.run('import', resource_name, log_group)
+
+
+if __name__ == '__main__':
+    configure_script_logging()
+    main()

--- a/scripts/import_cloudwatch_log_groups.py
+++ b/scripts/import_cloudwatch_log_groups.py
@@ -1,4 +1,9 @@
+import json
+
 import boto3
+from more_itertools import (
+    one,
+)
 
 from azul import (
     config,
@@ -17,7 +22,7 @@ log = logging.getLogger(__name__)
 def main():
     tf_component = config.terraform_component
     if tf_component == '':
-        pass
+        import_log_groups(lambda_function_log_groups())
     elif tf_component in ('browser', 'gitlab'):
         pass
     elif tf_component == 'shared':
@@ -35,6 +40,22 @@ def chatbot_log_groups() -> dict[str, str]:
     name = log_group_name('chatbot')
     log_group = '/aws/chatbot/' + config.qualified_resource_name('chatbot')
     return {name: log_group}
+
+
+def lambda_function_log_groups() -> dict[str, str]:
+    tf_path = config.project_root + '/terraform/api_gateway.tf.json'
+    with open(tf_path, 'r') as f:
+        tf_json = json.load(f)
+    log_groups = {}
+    for resources_by_type in tf_json['resource']:
+        resource_type, resources = one(resources_by_type.items())
+        if resource_type == 'aws_lambda_function':
+            for resource in resources:
+                for resource_name, resource_def in resource.items():
+                    name = log_group_name(resource_name + '_lambda')
+                    log_group = '/aws/lambda/' + resource_def['function_name']
+                    log_groups[name] = log_group
+    return log_groups
 
 
 def import_log_groups(log_groups: dict[str, str]) -> None:

--- a/scripts/import_cloudwatch_log_groups.py
+++ b/scripts/import_cloudwatch_log_groups.py
@@ -22,7 +22,8 @@ log = logging.getLogger(__name__)
 def main():
     tf_component = config.terraform_component
     if tf_component == '':
-        import_log_groups(lambda_function_log_groups())
+        log_groups = lambda_function_log_groups() | api_gateway_execution_log_groups()
+        import_log_groups(log_groups)
     elif tf_component in ('browser', 'gitlab'):
         pass
     elif tf_component == 'shared':
@@ -55,6 +56,20 @@ def lambda_function_log_groups() -> dict[str, str]:
                     name = log_group_name(resource_name + '_lambda')
                     log_group = '/aws/lambda/' + resource_def['function_name']
                     log_groups[name] = log_group
+    return log_groups
+
+
+def api_gateway_execution_log_groups() -> dict[str, str]:
+    api_client = boto3.client('apigateway')
+    paginator = api_client.get_paginator('get_rest_apis')
+    log_groups = {}
+    for api_page in paginator.paginate():
+        for api in api_page['items']:
+            name, stage = config.unqualified_resource_name(api['name'])
+            if stage == config.deployment_stage:
+                name = log_group_name(name + '_api_execution')
+                log_group = f"API-Gateway-Execution-Logs_{api['id']}/{stage}"
+                log_groups[name] = log_group
     return log_groups
 
 

--- a/src/azul/terraform.py
+++ b/src/azul/terraform.py
@@ -769,6 +769,15 @@ class Chalice:
             resource['source_code_hash'] = '${filebase64sha256("%s")}' % package_zip
             resource['filename'] = package_zip
 
+        assert 'aws_cloudwatch_log_group' not in resources
+        resources['aws_cloudwatch_log_group'] = {
+            f'{resource_name}_lambda': {
+                'name': f'/aws/lambda/{resource['function_name']}',
+                'retention_in_days': config.audit_log_retention_days
+            }
+            for resource_name, resource in resources['aws_lambda_function'].items()
+        }
+
         for resource_type, argument in [
             ('aws_cloudwatch_event_rule', 'name'),
             ('aws_cloudwatch_event_target', 'target_id')

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -38,6 +38,8 @@ rename_resources: validate
 
 .PHONY: import_resources
 import_resources: rename_resources
+	@# FIXME: Remove once the log groups have been imported into all deployments
+	@#        https://github.com/DataBiosphere/azul/issues/6911
 	python $(project_root)/scripts/import_cloudwatch_log_groups.py
 
 .PHONY: plan

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -38,6 +38,7 @@ rename_resources: validate
 
 .PHONY: import_resources
 import_resources: rename_resources
+	python $(project_root)/scripts/import_cloudwatch_log_groups.py
 
 .PHONY: plan
 plan: import_resources

--- a/terraform/api_gateway.tf.json.template.py
+++ b/terraform/api_gateway.tf.json.template.py
@@ -510,8 +510,11 @@ emit_tf({
             }
         },
         *(
+            chalice.tf_config(app.name)['resource']
+            for app in apps
+        ),
+        *(
             {
-                **chalice.tf_config(app.name)['resource'],
                 'aws_api_gateway_stage': {
                     app.name: {
                         'rest_api_id': '${aws_api_gateway_rest_api.%s.id}' % app.name,

--- a/terraform/api_gateway.tf.json.template.py
+++ b/terraform/api_gateway.tf.json.template.py
@@ -652,6 +652,12 @@ emit_tf({
                     app.name: {
                         'name': '/aws/apigateway/' + config.qualified_resource_name(app.name),
                         'retention_in_days': config.audit_log_retention_days,
+                    },
+                    f'{app.name}_api_execution': {
+                        'name': 'API-Gateway-Execution-Logs_' +
+                                '${aws_api_gateway_rest_api.%s.id}' % app.name +
+                                '/%s' % config.deployment_stage,
+                        'retention_in_days': config.audit_log_retention_days,
                     }
                 },
                 'aws_iam_role': {

--- a/terraform/shared/Makefile
+++ b/terraform/shared/Makefile
@@ -31,6 +31,8 @@ rename_resources: config
 .PHONY: import_resources
 import_resources: rename_resources
 	python $(project_root)/scripts/import_default_vpc.py
+	@# FIXME: Remove once the log groups have been imported into all deployments
+	@#        https://github.com/DataBiosphere/azul/issues/6911
 	python $(project_root)/scripts/import_cloudwatch_log_groups.py
 
 .PHONY: apply

--- a/terraform/shared/Makefile
+++ b/terraform/shared/Makefile
@@ -31,6 +31,7 @@ rename_resources: config
 .PHONY: import_resources
 import_resources: rename_resources
 	python $(project_root)/scripts/import_default_vpc.py
+	python $(project_root)/scripts/import_cloudwatch_log_groups.py
 
 .PHONY: apply
 apply: validate import_resources

--- a/terraform/shared/shared.tf.json.template.py
+++ b/terraform/shared/shared.tf.json.template.py
@@ -474,7 +474,17 @@ tf_config = {
             vpc.default_vpc_name: {
                 'name': '/aws/vpc/' + config.qualified_resource_name(vpc.default_vpc_name),
                 'retention_in_days': config.audit_log_retention_days
-            }
+            },
+            **(
+                {
+                    'chatbot': {
+                        'name': '/aws/chatbot/' + config.qualified_resource_name('chatbot'),
+                        'retention_in_days': config.audit_log_retention_days
+                    }
+                }
+                if config.slack_integration else
+                {}
+            ),
         },
         'aws_cloudwatch_log_metric_filter': {
             **{

--- a/terraform/shared/shared.tf.json.template.py
+++ b/terraform/shared/shared.tf.json.template.py
@@ -344,7 +344,7 @@ tf_config = {
                         }
                     }
                 }
-                for bucket in ['logs', 'trail']
+                for bucket in ['aws_config', 'logs', 'trail']
             }
         },
         'aws_s3_bucket_versioning': {


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Connected issues: #6070


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved connected issues to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
