### PR TITLE
Automatic JSON serialization of attrs-decorated classes (#6821)

### DIFF
--- a/scripts/can_bundle.py
+++ b/scripts/can_bundle.py
@@ -29,7 +29,6 @@ from azul.files import (
 )
 from azul.indexer import (
     Bundle,
-    SourcedBundleFQIDJSON,
 )
 from azul.logging import (
     configure_script_logging,
@@ -100,8 +99,8 @@ def fetch_bundle(source: str, fqid_args: JSON) -> Bundle:
             log.debug('Searching for %r in catalog %r', source, catalog)
             for plugin_source_spec in plugin.sources:
                 if source_ref.spec.eq_ignoring_prefix(plugin_source_spec):
-                    fqid = SourcedBundleFQIDJSON(source=source_ref.to_json(), **fqid_args)
-                    fqid = plugin.bundle_fqid_from_json(fqid)
+                    fqid = dict(fqid_args, source=source_ref.to_json())
+                    fqid = plugin.bundle_fqid_cls.from_json(fqid)
                     bundle = plugin.fetch_bundle(fqid)
                     log.info('Fetched bundle %r version %r from catalog %r.',
                              fqid.uuid, fqid.version, catalog)

--- a/src/azul/attrs.py
+++ b/src/azul/attrs.py
@@ -1,18 +1,47 @@
+from abc import (
+    ABCMeta,
+    abstractmethod,
+)
+from types import (
+    UnionType,
+)
 from typing import (
+    Any,
+    Callable,
     Optional,
+    Self,
     Tuple,
+    TypeVar,
     Union,
+    get_args,
+    get_origin,
 )
 from uuid import (
     UUID,
 )
 
+from attr import (
+    AttrsInstance,
+)
 import attrs
+from more_itertools import (
+    flatten,
+    one,
+)
 
 from azul import (
+    JSON,
+    R,
+    json_mapping,
     require,
 )
+from azul.json import (
+    Serializable,
+)
 from azul.types import (
+    AnyJSON,
+    PrimitiveJSON,
+    derived_type_params,
     reify,
 )
 
@@ -129,3 +158,345 @@ def is_uuid(version):
             raise TypeError(f'Not a UUID{version}', field.name, value)
 
     return validator
+
+
+type Source = list[str | tuple[str, ...] | Source]
+
+
+class SerializableAttrs(Serializable, AttrsInstance):
+    """
+    >>> @attrs.frozen(kw_only=True)
+    ... class InnerBase(SerializableAttrs):
+    ...     x: int
+
+    >>> @attrs.frozen(kw_only=True)
+    ... class MiddleInner[T](InnerBase):
+    ...     y: T | None
+
+    >>> @attrs.frozen(kw_only=True)
+    ... class Inner(MiddleInner[str]): ...
+
+    >>> @attrs.frozen(kw_only=True)
+    ... class OuterBase[X, T: InnerBase](SerializableAttrs):
+    ...     inner: T
+
+    >>> class MiddleOuter[X](OuterBase[X, Inner]): ...
+
+    >>> class Outer(MiddleOuter[float]): ...
+
+    >>> outer = Outer(inner=Inner(x=1, y='b'))
+    >>> outer.to_json()
+    {'inner': {'x': 1, 'y': 'b'}}
+
+    >>> Outer.from_json(outer.to_json())
+    Outer(inner=Inner(x=1, y='b'))
+
+    >>> Outer.from_json({'inner': {'x': 'bad', 'y': 'b'}})
+    Traceback (most recent call last):
+    ...
+    ValueError: ('Invalid type of value', <class 'str'>, 'expecting', <class 'int'>)
+
+    >>> Outer.from_json({'inner': {'x': 1, 'y': None}})
+    Outer(inner=Inner(x=1, y=None))
+
+    A class with custom serialization (float serialized as string):
+
+    >>> @attrs.frozen(kw_only=True)
+    ... class CustomBase(SerializableAttrs):
+    ...     x: float
+    ...
+    ...     def to_json(self) -> JSON:
+    ...         return super().to_json() | {'x': str(self.x)}
+    ...
+    ...     @classmethod
+    ...     def _from_json(cls, json: JSON) -> dict[str, Any]:
+    ...         return dict(super()._from_json(json), x=float(json['x']))
+
+    >>> @attrs.frozen(kw_only=True)
+    ... class Custom(CustomBase):
+    ...     y: str
+
+    >>> Custom(x=1.23, y='y').to_json()
+    {'x': '1.23', 'y': 'y'}
+
+    >>> Custom.from_json({'x': '1.23', 'y': 'y'})
+    Custom(x=1.23, y='y')
+    """
+
+    @classmethod
+    def from_json(cls, json: AnyJSON) -> Self:
+        assert not cls._deferred_fields, R(
+            'Class has fields of unknown type', cls._deferred_fields)
+        kwargs = cls._from_json(json_mapping(json))
+        return cls(**kwargs)
+
+    @classmethod
+    def _from_json(cls, json: JSON) -> dict[str, Any]:
+        """
+        Return a dictionary with keyword arguments for the constructor. An
+        override must call the overridden method via super() but only need to
+        populate keyword arguments for the fields defined by the class that
+        overrides the method. Typically, the overrides in subclasses will be
+        generated automatically but if a subclass explicitly defines an
+        override, it will be left alone.
+        """
+        return {}
+
+    def to_json(self) -> dict[str, AnyJSON]:
+        """
+        Typically, the overrides in subclasses will be generated automatically
+        but if a subclass explicitly defines an override, it will be left alone.
+        """
+        return {}
+
+    def __init_subclass__(cls):
+        super().__init_subclass__()
+        try:
+            fields = attrs.fields(cls)
+        except attrs.exceptions.NotAnAttrsClassError:
+            pass
+        else:
+            cls._instrument(fields)
+
+    @classmethod
+    def __attrs_init_subclass__(cls):
+        cls._instrument(attrs.fields(cls))
+
+    #: The names of fields that we weren't able to generate code for in this
+    #: class because at least one of them was annotated with a variable type.
+    #: Generic descendants that use free type variables in their attrs field
+    #: annotations override this attribute to a non-empty set. The
+    #: responsibility to handle deferred fields falls on the descendant that
+    #: binds the last remaining free type variable.
+    #:
+    _deferred_fields: frozenset[str] = frozenset()
+
+    @classmethod
+    def _instrument(cls, fields: list[attrs.Attribute]):
+        """
+        Add overrides for to_json and _from_json to the given class. The
+        overrides will handle the serialization and deserialization of the
+        fields defined by the class, not those that it inherits. An override
+        will only be added if the class doesn't already provide one. This method
+        must be idempotent because it may be invoked twice for the same class,
+        before and after the attrs decorator did its work. Even for slotted
+        classes this method will be invoked twice, albeit the second time on a
+        copy of the class.
+        """
+        # When slots=True (the default for attrs.define), attrs makes a copy of
+        # the class so the subclass hook will be invoked twice, once for the
+        # original class, and again for the copy. The copy is likely to have
+        # additional fields defined so we need to start from scratch and reset
+        # any left-overs that would interfere with that.
+        #
+        if '_deferred_fields' in cls.__dict__:
+            del cls._deferred_fields
+        owned_fields = [
+            field
+            for field in fields
+            if field.name in cls.__annotations__ or field.name in cls._deferred_fields
+        ]
+        if owned_fields:
+            deferred_fields = cls._make(owned_fields)
+            if deferred_fields != cls._deferred_fields:
+                cls._deferred_fields = deferred_fields
+
+    @classmethod
+    def _make(cls, fields: list[attrs.Attribute]) -> frozenset[str]:
+        try:
+            _from_json = cls._make_from_json(fields)
+        except cls.Strategy.MustDefer:
+            deferred_fields = frozenset(field.name for field in fields)
+        else:
+            cls._define(_from_json)
+            deferred_fields = frozenset()
+            to_json = cls._make_to_json(fields)
+            cls._define(to_json)
+        return deferred_fields
+
+    @classmethod
+    def _make_from_json(cls, fields: list[attrs.Attribute]) -> Callable:
+        globals = {cls.__name__: cls}
+        source = cls._indent([
+            '@classmethod',
+            'def _from_json(cls, json):', [
+                f'kwargs = super({cls.__name__}, cls)._from_json(json)',
+                *flatten(
+                    [
+                        f'x = json["{field.name}"]',
+                        *(cls.Deserializer(cls, field, globals).handle()),
+                        f'kwargs["{field.name}"] = x'
+                    ]
+                    for field in fields
+                ),
+                'return kwargs'
+            ]
+        ])
+        return cls._compile(source, globals)
+
+    @classmethod
+    def _make_to_json(cls, fields: list[attrs.Attribute]) -> Callable:
+        globals = {cls.__name__: cls}
+        to_json = cls._indent([
+            'def to_json(self):', [
+                # Using the super() shortcut would require messing with the
+                # ``__closure__`` attribute of the function, and, we assume,
+                # would be slower.
+                f'json = super({cls.__name__}, self).to_json()',
+                *flatten(
+                    [
+                        f'x = self.{field.name}',
+                        'x = ' + cls.Serializer(cls, field, globals).handle(),
+                        f'json["{field.name}"] = x'
+                    ]
+                    for field in fields
+                ),
+                'return json'
+            ]
+        ])
+        return cls._compile(to_json, globals)
+
+    @classmethod
+    def _indent(cls, source: Source, level=0):
+        """
+        Indent and join the given list of source code items. An item can be
+        either a line, a tuple of words, or a nested list of items. The
+        indentation of lines is based on the nesting of the lists. Lines are
+        joined with a newline character, words are joined with a comma.
+        """
+        return '\n'.join(
+            cls._indent(v, level + 1)
+            if isinstance(v, list) else
+            ' ' * level * 4 + (', '.join(v) if isinstance(v, tuple) else v)
+            for v in source
+        )
+
+    @classmethod
+    def _compile(cls, source: str, globals: dict[str, Any]):
+        """
+        Compile a function definition from the given source & context
+        """
+        bytecode = compile(source, cls.__module__, 'exec')
+        locals: dict[str, Any] = {}
+        eval(bytecode, globals, locals)
+        function = one(locals.values())
+        return function
+
+    @classmethod
+    def _define(cls, function: Callable) -> None:
+        """
+        Add the given function as a method of the class to be instrumented
+        """
+        name = function.__name__
+        marker = '__azul_serializable__'
+        method = cls.__dict__.get(name)
+        # We should never replace a custom definition. However, an
+        # instrumentation during attrs' subclass hook must replace
+        # the definition from the standard subclass hook.
+        if method is None or hasattr(method, marker):
+            setattr(function, marker, None)
+            setattr(cls, name, function)
+
+    @attrs.frozen
+    class Strategy[T](metaclass=ABCMeta):
+        cls: type['SerializableAttrs']
+        field: attrs.Attribute
+        globals: dict[str, Any]
+
+        class MustDefer(Exception):
+            pass
+
+        def handle(self) -> T:
+            return self._handle(self._reify(self.field.type))
+
+        def _owner(self) -> type:
+            """
+            Find the nearest ancestor that introduced the given field
+            """
+            for base in self.cls.__mro__:
+                if self.field.name in base.__annotations__:
+                    assert isinstance(base, type)
+                    assert issubclass(base, SerializableAttrs)
+                    return base
+            assert False
+
+        def _reify(self, field_type: Any) -> Any:
+            """
+            Resolve the type parameters of the given type, or raise
+            MustDefer if that's not possible.
+            """
+            while isinstance(field_type, TypeVar):
+                owner = self._owner()
+                if owner is self.cls:
+                    raise self.MustDefer
+                params = derived_type_params(self.cls, root=owner)
+                try:
+                    field_type = params[field_type]
+                except KeyError:
+                    raise self.MustDefer
+            return field_type
+
+        def _handle(self, field_type: Any):
+            if isinstance(field_type, type):
+                if field_type in reify(PrimitiveJSON):
+                    return self._primitive(field_type)
+                elif issubclass(field_type, Serializable):
+                    inner_cls_name = field_type.__name__
+                    self.globals[inner_cls_name] = field_type
+                    return self._serializable(inner_cls_name)
+            else:
+                origin = get_origin(field_type)
+                if origin in (Union, UnionType):
+                    arg_types = set(get_args(field_type))
+                    arg_types.discard(type(None))
+                    if len(arg_types) == 1:
+                        field_type = self._reify(one(arg_types))
+                        return self._optional(field_type)
+            raise TypeError('Unserializable field', field_type, self.field)
+
+        @abstractmethod
+        def _primitive(self, field_type: type) -> T:
+            raise NotImplementedError
+
+        @abstractmethod
+        def _optional(self, field_type: type) -> T:
+            raise NotImplementedError
+
+        @abstractmethod
+        def _serializable(self, inner_cls_name: str) -> T:
+            raise NotImplementedError
+
+    class Deserializer(Strategy[Source]):
+
+        def _optional(self, field_type: type) -> Source:
+            return [
+                'if x is not None:', self._handle(field_type)
+            ]
+
+        def _serializable(self, inner_cls_name: str) -> Source:
+            return [
+                f'x = {inner_cls_name}.from_json(x)'
+            ]
+
+        def _primitive(self, field_type: type) -> Source:
+            return [
+                f'if not isinstance(x, {field_type.__name__}):', [
+                    'raise ValueError(', (
+                        '"Invalid type of value"',
+                        'type(x)',
+                        '"expecting"',
+                        field_type.__name__,
+                    ), ')'
+                ]
+            ]
+
+    class Serializer(Strategy[str]):
+
+        def _primitive(self, field_type: type) -> str:
+            return 'x'
+
+        def _optional(self, field_type: type) -> str:
+            return 'x'
+
+        def _serializable(self, inner_cls_name: str) -> str:
+            return 'x.to_json()'

--- a/src/azul/azulclient.py
+++ b/src/azul/azulclient.py
@@ -43,6 +43,7 @@ from azul import (
     cache,
     cached_property,
     config,
+    json_mapping,
 )
 from azul.es import (
     ESClientFactory,
@@ -54,7 +55,6 @@ from azul.http import (
     HasCachedHttpClient,
 )
 from azul.indexer import (
-    SourceJSON,
     SourceRef,
     SourcedBundleFQID,
 )
@@ -94,7 +94,7 @@ class AzulClient(SignatureHelper, HasCachedHttpClient):
         # only variant that would ever occur in the wild.
         return {
             'transaction_id': str(uuid.uuid4()),
-            'bundle_fqid': cast(JSON, bundle_fqid.to_json())
+            'bundle_fqid': bundle_fqid.to_json()
         }
 
     def bundle_message(self,
@@ -267,11 +267,9 @@ class AzulClient(SignatureHelper, HasCachedHttpClient):
     def remote_reindex_partition(self, message: JSON) -> None:
         catalog, prefix = message['catalog'], message['prefix']
         assert isinstance(catalog, str) and isinstance(prefix, str)
-        # FIXME: Adopt `trycast` for casting JSON to TypeDict
-        #        https://github.com/DataBiosphere/azul/issues/5171
-        source = cast(SourceJSON, message['source'])
+        source = json_mapping(message['source'])
         validate_uuid_prefix(prefix)
-        source = self.repository_plugin(catalog).source_from_json(source)
+        source = self.repository_plugin(catalog).source_ref_cls.from_json(source)
         bundle_fqids = self.list_bundles(catalog, source, prefix)
         # All AnVIL bundles and entities use the same version
         if not config.is_anvil_enabled(catalog):

--- a/src/azul/indexer/__init__.py
+++ b/src/azul/indexer/__init__.py
@@ -561,7 +561,7 @@ class SourceRef[SOURCE_SPEC: SourceSpec](SupportsLessAndGreaterThan):
 
     @classmethod
     def spec_cls(cls) -> type[SOURCE_SPEC]:
-        spec_cls, = derived_type_params(cls, root=SourceRef)
+        spec_cls = derived_type_params(cls, root=SourceRef)[SOURCE_SPEC]
         assert isinstance(spec_cls, type)
         assert issubclass(spec_cls, SourceSpec)
         return cast(type[SOURCE_SPEC], spec_cls)
@@ -596,7 +596,7 @@ class SourcedBundleFQID[SOURCE_REF: SourceRef](BundleFQID):
 
     @classmethod
     def source_ref_cls(cls) -> type[SOURCE_REF]:
-        ref_cls, = derived_type_params(cls, root=SourcedBundleFQID)
+        ref_cls = derived_type_params(cls, root=SourcedBundleFQID)[SOURCE_REF]
         assert isinstance(ref_cls, type)
         assert issubclass(ref_cls, SourceRef)
         return cast(type[SOURCE_REF], ref_cls)

--- a/src/azul/indexer/__init__.py
+++ b/src/azul/indexer/__init__.py
@@ -20,7 +20,6 @@ from typing import (
     Iterable,
     Iterator,
     Self,
-    TypedDict,
     cast,
     final,
 )
@@ -30,7 +29,14 @@ import attrs
 from azul import (
     R,
     config,
+    json_str,
     reject,
+)
+from azul.attrs import (
+    SerializableAttrs,
+)
+from azul.json import (
+    Serializable,
 )
 from azul.types import (
     AnyJSON,
@@ -50,17 +56,12 @@ BundleUUID = str
 BundleVersion = str
 
 
-class BundleFQIDJSON(TypedDict):
-    uuid: BundleUUID
-    version: BundleVersion
-
-
 # PyCharm can't handle mixing `attrs` with `total_ordering` and falsely claims
 # that comparison operators besides `__lt__` are not defined.
 # noinspection PyDataclass
 @attrs.frozen(kw_only=True, eq=False)
 @total_ordering
-class BundleFQID:
+class BundleFQID(SerializableAttrs):
     """
     A fully qualified bundle identifier. The attributes defined in this class
     must always be sufficient to decide whether two instances of this class or
@@ -128,7 +129,7 @@ class BundleFQID:
     def __hash__(self) -> int:
         return hash(self._nucleus())
 
-    def __init_subclass__(cls, **kwargs):
+    def __init_subclass__(cls):
         """
         >>> @attrs.frozen(kw_only=True)
         ... class FooBundleFQID(SourcedBundleFQID):
@@ -141,7 +142,7 @@ class BundleFQID:
         ... class FooBundleFQID(SourcedBundleFQID):
         ...     foo: str
         """
-        super().__init_subclass__(**kwargs)
+        super().__init_subclass__()
         assert cls.__eq__ is BundleFQID.__eq__, cls
         assert cls.__hash__ is BundleFQID.__hash__, cls
 
@@ -167,17 +168,6 @@ class BundleFQID:
         True
         """
         return self._nucleus() < other._nucleus()
-
-    @classmethod
-    def from_json(cls, json: BundleFQIDJSON) -> Self:
-        return cls(uuid=json['uuid'],
-                   version=json['version'])
-
-    def to_json(self) -> BundleFQIDJSON:
-        return {
-            'uuid': self.uuid,
-            'version': self.version
-        }
 
 
 @attrs.frozen(kw_only=True)
@@ -370,7 +360,7 @@ Prefix.of_everything = Prefix.parse('/0')
 
 
 @attrs.frozen(kw_only=True)
-class SourceSpec(metaclass=ABCMeta):
+class SourceSpec(Serializable, metaclass=ABCMeta):
     """
     The name of a repository source containing bundles to index. A repository
     has at least one source. Repository plugins whose repository source names
@@ -393,6 +383,13 @@ class SourceSpec(metaclass=ABCMeta):
         reject(sep == '', 'Invalid source specification', spec)
         prefix = Prefix.parse(prefix) if prefix else None
         return rest, prefix
+
+    @classmethod
+    def from_json(cls, json: AnyJSON) -> Self:
+        return cls.parse(json_str(json))
+
+    def to_json(self) -> AnyJSON:
+        return str(self)
 
     @property
     def _prefix_str(self) -> str:
@@ -467,13 +464,9 @@ class SimpleSourceSpec(SourceSpec):
         return f'{self.name}:{self._prefix_str}'
 
 
-class SourceJSON(TypedDict):
-    id: str
-    spec: str
-
-
 @attrs.frozen(kw_only=True, order=True)
-class SourceRef[SOURCE_SPEC: SourceSpec](SupportsLessAndGreaterThan):
+class SourceRef[SOURCE_SPEC: SourceSpec](SerializableAttrs,
+                                         SupportsLessAndGreaterThan):
     """
     A reference to a repository source containing bundles to index. A repository
     has at least one source. A source is primarily referenced by its ID but we
@@ -552,13 +545,6 @@ class SourceRef[SOURCE_SPEC: SourceSpec](SupportsLessAndGreaterThan):
             assert self.spec == spec, (self.spec, spec)
             return self
 
-    def to_json(self) -> SourceJSON:
-        return dict(id=self.id, spec=str(self.spec))
-
-    @classmethod
-    def from_json(cls, ref: SourceJSON) -> Self:
-        return cls(id=ref['id'], spec=cls.spec_cls().parse(ref['spec']))
-
     @classmethod
     def spec_cls(cls) -> type[SOURCE_SPEC]:
         spec_cls = derived_type_params(cls, root=SourceRef)[SOURCE_SPEC]
@@ -568,10 +554,6 @@ class SourceRef[SOURCE_SPEC: SourceSpec](SupportsLessAndGreaterThan):
 
     def with_prefix(self, prefix: Prefix) -> Self:
         return attrs.evolve(self, spec=attrs.evolve(self.spec, prefix=prefix))
-
-
-class SourcedBundleFQIDJSON(BundleFQIDJSON):
-    source: SourceJSON
 
 
 @attrs.frozen(kw_only=True, eq=False)
@@ -600,18 +582,6 @@ class SourcedBundleFQID[SOURCE_REF: SourceRef](BundleFQID):
         assert isinstance(ref_cls, type)
         assert issubclass(ref_cls, SourceRef)
         return cast(type[SOURCE_REF], ref_cls)
-
-    @classmethod
-    def from_json(cls, json: SourcedBundleFQIDJSON) -> Self:  # type: ignore[override]
-        return cls(uuid=json['uuid'],
-                   version=json['version'],
-                   source=cls.source_ref_cls().from_json(json['source']))
-
-    def to_json(self) -> SourcedBundleFQIDJSON:
-        return {
-            **super().to_json(),
-            'source': self.source.to_json()
-        }
 
 
 @attrs.define(kw_only=True)

--- a/src/azul/indexer/document.py
+++ b/src/azul/indexer/document.py
@@ -9,7 +9,6 @@ import re
 from typing import (
     ClassVar,
     Self,
-    cast,
     overload,
 )
 
@@ -22,15 +21,14 @@ from azul import (
     CatalogName,
     R,
     config,
+    json_sequence,
 )
 from azul.enums import (
     auto,
 )
 from azul.indexer import (
     BundleFQID,
-    BundleFQIDJSON,
     SimpleSourceSpec,
-    SourceJSON,
     SourceRef,
 )
 from azul.indexer.field import (
@@ -47,7 +45,6 @@ from azul.types import (
     AnyJSON,
     AnyMutableJSON,
     JSON,
-    JSONs,
     MutableJSON,
     json_int,
     json_mapping,
@@ -977,7 +974,7 @@ class Contribution[E: EntityReference](Document[ContributionCoordinates[E]]):
         self = super().from_json(coordinates=coordinates,
                                  document=document,
                                  version=version,
-                                 source=DocumentSource.from_json(cast(SourceJSON, document['source'])),
+                                 source=DocumentSource.from_json(document['source']),
                                  **kwargs)
         assert self.coordinates.document_id == document['document_id']
         assert self.coordinates.bundle.uuid == document['bundle_uuid']
@@ -1008,7 +1005,7 @@ class Contribution[E: EntityReference](Document[ContributionCoordinates[E]]):
 @attr.s(frozen=False, kw_only=True, auto_attribs=True)
 class Aggregate(Document[AggregateCoordinates]):
     sources: set[DocumentSource]
-    bundles: list[BundleFQIDJSON] | None
+    bundles: list[BundleFQID] | None
     num_contributions: int
 
     def __attrs_post_init__(self):
@@ -1042,13 +1039,16 @@ class Aggregate(Document[AggregateCoordinates]):
                   version: InternalVersion | None,
                   **kwargs
                   ) -> Self:
+        sources = set(map(DocumentSource.from_json, json_sequence(document['sources'])))
+        bundles = optional(json_sequence, document.get('bundles'))
+        bundles = None if bundles is None else list(map(BundleFQID.from_json, bundles))
+        num_contributions = json_int(document['num_contributions'])
         self = super().from_json(coordinates=coordinates,
                                  document=document,
                                  version=version,
-                                 num_contributions=document['num_contributions'],
-                                 sources=set(map(DocumentSource.from_json,
-                                                 cast(list[SourceJSON], document['sources']))),
-                                 bundles=document.get('bundles'))
+                                 num_contributions=num_contributions,
+                                 sources=sources,
+                                 bundles=bundles)
         assert isinstance(self, Aggregate)
         return self
 
@@ -1061,10 +1061,15 @@ class Aggregate(Document[AggregateCoordinates]):
         ]
 
     def to_json(self) -> JSON:
+        sources = [source.to_json() for source in self.sources]
+        if self.bundles is None:
+            bundles = None
+        else:
+            bundles = [bundle.to_json() for bundle in self.bundles]
         return dict(super().to_json(),
                     num_contributions=self.num_contributions,
-                    sources=cast(JSONs, [source.to_json() for source in self.sources]),
-                    bundles=cast(JSONs | None, self.bundles))
+                    sources=sources,
+                    bundles=bundles)
 
     @property
     def op_type(self) -> OpType:

--- a/src/azul/indexer/index_controller.py
+++ b/src/azul/indexer/index_controller.py
@@ -12,6 +12,9 @@ from enum import (
     Enum,
 )
 import http
+from itertools import (
+    batched,
+)
 import json
 import logging
 import time
@@ -303,7 +306,8 @@ class IndexController(AppController):
                 # Hopefully this is more or less atomic. If we crash below here,
                 # tallies will be inflated because some or all deferrals have
                 # been sent and the original tallies will be returned.
-                self._tallies_queue(retry=retry).send_messages(Entries=entries)
+                for batch in batched(entries, 10):
+                    self._tallies_queue(retry=retry).send_messages(Entries=batch)
 
         except BaseException:
             # Note that another problematic outcome is for the Lambda invocation

--- a/src/azul/indexer/index_controller.py
+++ b/src/azul/indexer/index_controller.py
@@ -20,7 +20,6 @@ import logging
 import time
 from typing import (
     Self,
-    cast,
 )
 import uuid
 
@@ -56,7 +55,6 @@ from azul.hmac import (
 )
 from azul.indexer import (
     BundlePartition,
-    SourcedBundleFQIDJSON,
 )
 from azul.indexer.document import (
     Contribution,
@@ -69,6 +67,7 @@ from azul.indexer.index_service import (
 )
 from azul.types import (
     JSON,
+    json_dict,
 )
 
 log = logging.getLogger(__name__)
@@ -215,9 +214,7 @@ class IndexController(AppController):
         representing one metadata entity in the index. Replicas of the original,
         untransformed metadata are returned as well.
         """
-        # FIXME: Adopt `trycast` for casting JSON to TypeDict
-        #        https://github.com/DataBiosphere/azul/issues/5171
-        bundle_fqid = cast(SourcedBundleFQIDJSON, notification['bundle_fqid'])
+        bundle_fqid = json_dict(notification['bundle_fqid'])
         try:
             partition = notification['partition']
         except KeyError:

--- a/src/azul/indexer/index_service.py
+++ b/src/azul/indexer/index_service.py
@@ -55,10 +55,8 @@ from azul.es import (
 from azul.indexer import (
     Bundle,
     BundleFQID,
-    BundleFQIDJSON,
     BundlePartition,
     BundleUUID,
-    SourcedBundleFQIDJSON,
 )
 from azul.indexer.aggregate import (
     Entities,
@@ -194,12 +192,9 @@ class IndexService(DocumentService):
             []
         )
 
-    def fetch_bundle(self,
-                     catalog: CatalogName,
-                     bundle_fqid: SourcedBundleFQIDJSON
-                     ) -> Bundle:
+    def fetch_bundle(self, catalog: CatalogName, bundle_fqid: JSON) -> Bundle:
         plugin = self.repository_plugin(catalog)
-        bundle_fqid = plugin.bundle_fqid_from_json(bundle_fqid)
+        bundle_fqid = plugin.bundle_fqid_cls.from_json(bundle_fqid)
         return plugin.fetch_bundle(bundle_fqid)
 
     def index(self, catalog: CatalogName, bundle: Bundle) -> None:
@@ -713,8 +708,8 @@ class IndexService(DocumentService):
             transformer = transformers[entity.catalog, entity.entity_type]
             contents = self._aggregate_entity(transformer, contributions)
             bundles = [
-                BundleFQIDJSON(uuid=c.coordinates.bundle.uuid,
-                               version=c.coordinates.bundle.version)
+                BundleFQID(uuid=c.coordinates.bundle.uuid,
+                           version=c.coordinates.bundle.version)
                 for c in contributions
             ]
             # FIXME: Replace hard coded limit with a config property

--- a/src/azul/json.py
+++ b/src/azul/json.py
@@ -8,6 +8,7 @@ from io import (
 )
 import json
 from typing import (
+    Self,
     overload,
 )
 
@@ -239,3 +240,27 @@ def json_hash(o: AnyJSON, hash=None):
     for chunk in encoder.iterencode(o):
         hash.update(chunk.encode())
     return hash
+
+
+class Serializable:
+    """
+    A class whose instances can be transformed to and from JSON
+    """
+
+    # This is more akin to an interface (like those in Java) as opposed to an
+    # abstract base class. We're intentionally refraining from using ABCMeta as
+    # a metaclass here so as to allow for implementations to be instances of a
+    # different metaclass.
+
+    @classmethod
+    def from_json(cls, json: AnyJSON) -> Self:
+        """
+        Deserialize an instance of this class from the given JSON value
+        """
+        raise NotImplementedError
+
+    def to_json(self) -> AnyJSON:
+        """
+        Serialize this instance to JSON in a form suitable for :meth:`from_json`
+        """
+        raise NotImplementedError

--- a/src/azul/plugins/__init__.py
+++ b/src/azul/plugins/__init__.py
@@ -17,6 +17,7 @@ from typing import (
     Self,
     Sequence,
     TYPE_CHECKING,
+    TypeVar,
     TypedDict,
     cast,
 )
@@ -216,7 +217,7 @@ class Plugin[BUNDLE: Bundle](metaclass=ABCMeta):
                    ) -> type[BUNDLE]:
         plugin_type_name = cls._plugin_type_name()
         plugin_cls = cls._load(plugin_type_name, plugin_package_name)
-        bundle_cls, = derived_type_params(plugin_cls, root=Plugin)
+        bundle_cls = derived_type_params(plugin_cls, root=Plugin)[BUNDLE]
         assert isinstance(bundle_cls, type)
         assert issubclass(bundle_cls, Bundle), bundle_cls
         return cast(type[BUNDLE], bundle_cls)
@@ -607,14 +608,14 @@ class RepositoryPlugin[BUNDLE: Bundle,
         return {source.id for source in self.list_sources(authentication)}
 
     @cached_property
-    def _generic_params(self) -> tuple[type, ...]:
+    def _generic_params(self) -> dict[TypeVar, type]:
         params = derived_type_params(type(self), root=RepositoryPlugin)
-        assert all(isinstance(p, type) for p in params)
-        return cast(tuple[type, ...], params)
+        assert all(isinstance(p, type) for p in params.values())
+        return cast(dict[TypeVar, type], params)
 
     @property
     def _source_ref_cls(self) -> type[SOURCE_REF]:
-        bundle_cls, spec_cls, ref_cls, fqid_cls = self._generic_params
+        ref_cls = self._generic_params[SOURCE_REF]
         assert issubclass(ref_cls, SourceRef)
         return ref_cls
 
@@ -627,7 +628,7 @@ class RepositoryPlugin[BUNDLE: Bundle,
 
     @property
     def _bundle_fqid_cls(self) -> type[BUNDLE_FQID]:
-        bundle_cls, spec_cls, ref_cls, fqid_cls = self._generic_params
+        fqid_cls = self._generic_params[BUNDLE_FQID]
         assert issubclass(fqid_cls, SourcedBundleFQID)
         return fqid_cls
 
@@ -640,7 +641,7 @@ class RepositoryPlugin[BUNDLE: Bundle,
 
     @property
     def _bundle_cls(self) -> type[BUNDLE]:
-        bundle_cls, spec_cls, ref_cls, fqid_cls = self._generic_params
+        bundle_cls = self._generic_params[BUNDLE]
         assert issubclass(bundle_cls, Bundle)
         return bundle_cls
 

--- a/src/azul/plugins/__init__.py
+++ b/src/azul/plugins/__init__.py
@@ -41,11 +41,9 @@ from azul.drs import (
 from azul.indexer import (
     Bundle,
     Prefix,
-    SourceJSON,
     SourceRef,
     SourceSpec,
     SourcedBundleFQID,
-    SourcedBundleFQIDJSON,
 )
 from azul.indexer.document import (
     Aggregate,
@@ -614,36 +612,16 @@ class RepositoryPlugin[BUNDLE: Bundle,
         return cast(dict[TypeVar, type], params)
 
     @property
-    def _source_ref_cls(self) -> type[SOURCE_REF]:
+    def source_ref_cls(self) -> type[SOURCE_REF]:
         ref_cls = self._generic_params[SOURCE_REF]
         assert issubclass(ref_cls, SourceRef)
         return ref_cls
 
-    def source_from_json(self, ref: SourceJSON) -> SOURCE_REF:
-        """
-        Instantiate a :class:`SourceRef` from its JSON representation. The
-        expected input format matches the output format of `SourceRef.to_json`.
-        """
-        return self._source_ref_cls.from_json(ref)
-
     @property
-    def _bundle_fqid_cls(self) -> type[BUNDLE_FQID]:
+    def bundle_fqid_cls(self) -> type[BUNDLE_FQID]:
         fqid_cls = self._generic_params[BUNDLE_FQID]
         assert issubclass(fqid_cls, SourcedBundleFQID)
         return fqid_cls
-
-    def bundle_fqid_from_json(self, fqid: SourcedBundleFQIDJSON) -> BUNDLE_FQID:
-        """
-        Instantiate a :class:`SourcedBundleFQID` from its JSON representation.
-        The expected input matches the output format of `SourcedBundleFQID.to_json`.
-        """
-        return self._bundle_fqid_cls.from_json(fqid)
-
-    @property
-    def _bundle_cls(self) -> type[BUNDLE]:
-        bundle_cls = self._generic_params[BUNDLE]
-        assert issubclass(bundle_cls, Bundle)
-        return bundle_cls
 
     def resolve_source(self, spec: str) -> SOURCE_REF:
         """
@@ -651,7 +629,7 @@ class RepositoryPlugin[BUNDLE: Bundle,
         matching the given specification or raise an exception if no such source
         exists.
         """
-        ref_cls = self._source_ref_cls
+        ref_cls = self.source_ref_cls
         spec = ref_cls.spec_cls().parse(spec)
         id = self._lookup_source_id(spec)
         return ref_cls(id=id, spec=spec)

--- a/src/azul/plugins/repository/tdr_anvil/__init__.py
+++ b/src/azul/plugins/repository/tdr_anvil/__init__.py
@@ -11,7 +11,6 @@ from typing import (
     AbstractSet,
     Callable,
     Iterable,
-    Self,
 )
 import uuid
 
@@ -35,7 +34,6 @@ from azul.drs import (
 )
 from azul.indexer import (
     Prefix,
-    SourcedBundleFQIDJSON,
 )
 from azul.indexer.document import (
     EntityReference,
@@ -165,30 +163,10 @@ class BundleType(Enum):
         return table_name not in (cls.primary.value, cls.duos.value)
 
 
-class TDRAnvilBundleFQIDJSON(SourcedBundleFQIDJSON):
-    table_name: str
-    batch_prefix: str | None
-
-
 @attrs.frozen(kw_only=True, eq=False)
 class TDRAnvilBundleFQID(TDRBundleFQID):
     table_name: str
     batch_prefix: str | None
-
-    @classmethod
-    def from_json(cls, json: TDRAnvilBundleFQIDJSON) -> Self:  # type: ignore[override]
-        return cls(uuid=json['uuid'],
-                   version=json['version'],
-                   source=cls.source_ref_cls().from_json(json['source']),
-                   table_name=json['table_name'],
-                   batch_prefix=json['batch_prefix'])
-
-    def to_json(self) -> TDRAnvilBundleFQIDJSON:
-        return {
-            **super().to_json(),
-            'table_name': self.table_name,
-            'batch_prefix': self.batch_prefix
-        }
 
     def __attrs_post_init__(self):
         should_be_batched = BundleType.is_batched(self.table_name)

--- a/src/azul/types.py
+++ b/src/azul/types.py
@@ -266,11 +266,10 @@ def reify(t):
     return tuple(OrderedSet(reify(t)))
 
 
-def derived_type_params(cls: type,
-                        /,
-                        *,
-                        root: type | None = None,
-                        ) -> tuple[type | TypeVar | ForwardRef, ...]:
+type TypeParams = dict[TypeVar, type | TypeVar | ForwardRef]
+
+
+def derived_type_params(cls: type, /, *, root: Any = None) -> TypeParams:
     """
     Inspect the type parameterization of a generic class, or a class derived
     from a generic class.
@@ -278,6 +277,26 @@ def derived_type_params(cls: type,
     Each of the returned values is either an instance of ``type``, of
     ``typing.TypeVar``, or of ``typing.ForwardRef``, depending on how the
     parameter is written in the definition of the root class.
+
+    The most common use case is to let a method in a potentially abstract base
+    class determine the value of a type parameter that is bound by deriving
+    from the class:
+
+    >>> class Base[T]:
+    ...     def make(self, s):
+    ...         cls = type(self)
+    ...         params = derived_type_params(cls, root=Base)
+    ...         t = params[T]
+    ...         assert isinstance(t, type)
+    ...         return t(s)
+
+    >>> class IntBase(Base[int]): ...
+    >>> IntBase().make('1')
+    1
+
+    >>> class FloatBase(Base[float]): ...
+    >>> FloatBase().make('1')
+    1.0
 
     Caveat: This function was only tested with classes that use the syntax from
     PEP-695 to define type parameters. Every class in the ancestry of the given
@@ -297,51 +316,60 @@ def derived_type_params(cls: type,
                  ancestry, the parameterization of every ancestor on the lineage
                  from ``cls`` to ``root`` is then inspected.
 
+    :return: A dictionary mapping a type parameter (an instance of
+             ``typing.TypeVar``) to its value. The value could be a reified
+             type (an instance of ``type``), another type variable
+             (``typing.TypeVar``) or a forward reference. For details on the
+             latter two scenarios, refer to the examples below.
+
     A generic class:
 
-    >>> class A[T1, T2]: pass
+    >>> class A[T1, T2]:
+    ...     @classmethod
+    ...     def t1(cls):
+    ...         return derived_type_params(cls, root=A)[T1]
+
+    Its parent (``object``) doesn't have any type parameters to be bound.
 
     >>> derived_type_params(A)
-    (T1, T2)
-
-    Both T1 and T2 are instances of ``TypeVar``.
+    {}
 
     A non-generic subclass:
 
-    >>> class B(A[int, float]): pass
+    >>> class B(A[int, float]): ...
 
     >>> derived_type_params(B)
-    (<class 'int'>, <class 'float'>)
+    {T1: <class 'int'>, T2: <class 'float'>}
 
     A non-generic subclass, using a forward reference. The reference is
     returned:
 
-    >>> class C(A['foo', int]): pass
+    >>> class C(A['foo', int]): ...
 
     >>> derived_type_params(C)
-    (ForwardRef('foo'), <class 'int'>)
+    {T1: ForwardRef('foo'), T2: <class 'int'>}
 
     A generic class that binds the first of the parent's parameters, but leaves
     the second one open:
 
-    >>> class D[T](A[int, T]): pass
+    >>> class D[T](A[int, T]): ...
 
     >>> derived_type_params(D)
-    (<class 'int'>, T)
+    {T1: <class 'int'>, T2: T}
 
     A non-generic subclass that binds the remaining parameter as well:
 
-    >>> class E(D[float]): pass
+    >>> class E(D[float]): ...
 
     The value that E bind's D's parameter to:
 
     >>> derived_type_params(E)
-    (<class 'float'>,)
+    {T: <class 'float'>}
 
     The equivalent invocation explicitly specifying the first parent class:
 
     >>> derived_type_params(E, root=D)
-    (<class 'float'>,)
+    {T: <class 'float'>}
 
     E does not inherit B, so an exception is raised:
 
@@ -355,58 +383,60 @@ def derived_type_params(cls: type,
     of E's grandparent.
 
     >>> derived_type_params(E, root=A)
-    (<class 'int'>, <class 'float'>)
+    {T1: <class 'int'>, T2: <class 'float'>}
 
     Same as above but through a parent that binds the second of the
     grandparent's parameters:
 
-    >>> class F[T](A[T, int]): pass
-    >>> class G(F[float]): pass
+    >>> class F[T3](A[T3, int]): ...
+    >>> class G(F[float]): ...
     >>> derived_type_params(G, root=A)
-    (<class 'float'>, <class 'int'>)
+    {T1: <class 'float'>, T2: <class 'int'>}
 
     A parent swapping the grandparent's type parameters:
 
-    >>> class H[T1, T2](A[T2, T1]): pass
-    >>> class J(H[int, float]): pass
-    >>> derived_type_params(J, root=A)
-    (<class 'float'>, <class 'int'>)
+    >>> class H[T1, T2](A[T2, T1]): ...
+    >>> class J(H[int, float]): ...
+    >>> (params := derived_type_params(J, root=A))
+    {T1: <class 'float'>, T2: <class 'int'>}
 
-    >>> t1, t2 = derived_type_params(A)
-    >>> derived_type_params(t1)
+    The first argument must be a type.
+
+    >>> from more_itertools import first
+    >>> derived_type_params(first(params.keys()))
     Traceback (most recent call last):
     ...
     AssertionError: R('Not a type', T1, <class 'typing.TypeVar'>)
 
     Ancestry that includes a non-generic base cass:
 
-    >>> class K(E): pass
+    >>> class K(E): ...
     >>> derived_type_params(K)
-    ()
+    {}
     >>> derived_type_params(K, root=E)
-    ()
+    {}
     >>> derived_type_params(K, root=D)
-    (<class 'float'>,)
+    {T: <class 'float'>}
     >>> derived_type_params(K, root=A)
-    (<class 'int'>, <class 'float'>)
+    {T1: <class 'int'>, T2: <class 'float'>}
 
     Ancestry with two strains of type variables:
 
-    >>> class L[T3](E): pass
-    >>> class M(L[str]): pass
+    >>> class L[T3](E): ...
+    >>> class M(L[str]): ...
     >>> derived_type_params(M)
-    (<class 'str'>,)
+    {T3: <class 'str'>}
     >>> derived_type_params(M, root=L)
-    (<class 'str'>,)
+    {T3: <class 'str'>}
     >>> derived_type_params(M, root=A)
-    (<class 'int'>, <class 'float'>)
+    {T1: <class 'int'>, T2: <class 'float'>}
     """
     from azul import (
         R,
     )
     assert isinstance(cls, type), R('Not a type', cls, type(cls))
 
-    def ancestors(cls) -> tuple[type, ...]:
+    def ancestors(cls) -> tuple[Any, ...]:
         for base in get_original_bases(cls):
             origin = get_origin(base)
             if origin is None:
@@ -420,29 +450,27 @@ def derived_type_params(cls: type,
         return ()
 
     if root is None:
-        base = get_original_bases(cls)[0]
-        return get_args(base)
+        root = get_original_bases(cls)[0]
+        bases = (root,)
     else:
-        bases = iter(ancestors(cls))
-        if None is (base := next(bases, None)):
+        bases = ancestors(cls)
+        if not bases:
             raise TypeError('Root is not an ancestor', root, cls)
+
+    mapping: TypeParams = {}
+    for base in bases:
+        values = get_args(base)
+        values = tuple(mapping.get(value, value) for value in values)
+        assert all(isinstance(value, (type, ForwardRef, TypeVar)) for value in values)
+        origin = get_origin(base)
+        if origin is None:
+            mapping = {}
         else:
-            mapping = None
-            while True:
-                values = get_args(base)
-                if mapping:
-                    values = tuple(mapping.get(value, value) for value in values)
-                if None is (next_base := next(bases, None)):
-                    return values
-                else:
-                    origin = get_origin(base)
-                    if origin is None:
-                        mapping = None
-                    else:
-                        assert origin is not None, (base, type(base))
-                        params = origin.__type_params__
-                        mapping = {param: value for param, value in zip(params, values)}
-                    base = next_base
+            params = origin.__type_params__
+            assert all(isinstance(param, TypeVar) for param in params)
+            mapping = dict(zip(params, values))
+    assert base is root or origin is root
+    return mapping
 
 
 class SupportsLessAndGreaterThan(Protocol):

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -108,6 +108,7 @@ from azul_test_case import (
 )
 from indexer import (
     DCP1CannedBundleTestCase,
+    DCP2CannedBundleTestCase,
     IndexerTestCase,
 )
 
@@ -177,6 +178,10 @@ class DCP1IndexerTestCase(DCP1CannedBundleTestCase, IndexerTestCase):
         contributions, replicas = transforms
         cls.index_service.replicate(cls.catalog, replicas)
         return cls.index_service.contribute(cls.catalog, contributions)
+
+
+class DCP2IndexerTestCase(DCP2CannedBundleTestCase, IndexerTestCase):
+    pass
 
 
 class TestDCP1Indexer(DCP1IndexerTestCase):

--- a/test/indexer/test_indexer_controller.py
+++ b/test/indexer/test_indexer_controller.py
@@ -8,13 +8,13 @@ from functools import (
     partial,
 )
 import json
-import os
 from unittest.mock import (
     MagicMock,
     call,
     patch,
 )
 
+import attrs
 from chalice.app import (
     SQSRecord,
 )
@@ -29,7 +29,6 @@ from moto import (
 )
 
 from azul import (
-    config,
     queues,
 )
 from azul.azulclient import (
@@ -52,16 +51,24 @@ from azul.logging import (
     configure_test_logging,
     get_test_logger,
 )
-from azul.plugins.repository.dss import (
-    DSSBundleFQID,
-    DSSSourceRef,
+from azul.plugins.repository.tdr import (
+    TDRBundleFQID,
+    TDRPlugin,
+)
+from azul.plugins.repository.tdr_hca import (
     Plugin,
+)
+from azul.terra import (
+    TDRSourceRef,
 )
 from azul.types import (
     JSONs,
 )
+from azul_test_case import (
+    DCP2TestCase,
+)
 from indexer.test_indexer import (
-    DCP1IndexerTestCase,
+    DCP2IndexerTestCase,
 )
 from sqs_test_case import (
     SqsTestCase,
@@ -76,8 +83,11 @@ def setUpModule():
 
 
 @mock_aws
-class TestIndexController(DCP1IndexerTestCase, SqsTestCase):
-    partition_prefix_length = 0
+class TestIndexController(DCP2IndexerTestCase, SqsTestCase):
+    source = DCP2TestCase.source.with_prefix(
+        attrs.evolve(DCP2TestCase.source.spec.prefix,
+                     partition=0)
+    )
 
     def setUp(self) -> None:
         super().setUp()
@@ -128,9 +138,9 @@ class TestIndexController(DCP1IndexerTestCase, SqsTestCase):
 
     def _fqid_from_notification(self, notification):
         fqid = notification['notification']['bundle_fqid']
-        return DSSBundleFQID(uuid=fqid['uuid'],
+        return TDRBundleFQID(uuid=fqid['uuid'],
                              version=fqid['version'],
-                             source=DSSSourceRef.from_json(fqid['source']))
+                             source=TDRSourceRef.from_json(fqid['source']))
 
     def test_invalid_notification(self):
         event = [
@@ -141,34 +151,34 @@ class TestIndexController(DCP1IndexerTestCase, SqsTestCase):
         ]
         self.assertRaises(KeyError, self.controller.contribute, event)
 
-    def test_remote_reindex(self):
-        with patch.dict(os.environ, dict(AZUL_DSS_QUERY_PREFIX='ff',
-                                         AZUL_DSS_SOURCE='foo_source:/0')):
-            source = DSSSourceRef.for_dss_source(config.dss_source)
-            self.index_service.repository_plugin(self.catalog)._assert_source(source)
-            self._create_mock_queues()
-            self.client.remote_reindex(self.catalog, {str(source.spec)})
-            notification = one(self._read_queue(self._notifications_queue))
-            expected_notification = dict(action='reindex',
-                                         catalog='test',
-                                         source=source.to_json(),
-                                         prefix='')
-            self.assertEqual(expected_notification, notification)
-            event = [self._mock_sqs_record(notification)]
+    @patch.object(TDRPlugin, 'resolve_source')
+    def test_remote_reindex(self, resolve_source):
+        source = self.source
+        resolve_source.return_value = source
+        self.index_service.repository_plugin(self.catalog)._assert_source(source)
+        self._create_mock_queues()
+        self.client.remote_reindex(self.catalog, {str(source.spec)})
+        notification = one(self._read_queue(self._notifications_queue))
+        expected_notification = dict(action='reindex',
+                                     catalog=self.catalog,
+                                     source=source.to_json(),
+                                     prefix='')
+        self.assertEqual(expected_notification, notification)
+        event = [self._mock_sqs_record(notification)]
 
-            bundle_fqids = [
-                DSSBundleFQID(source=source,
-                              uuid='ffa338fe-7554-4b5d-96a2-7df127a7640b',
-                              version='2018-03-28T15:10:23.074974Z')
-            ]
+        bundle_fqids = [
+            TDRBundleFQID(source=source,
+                          uuid='4426adc5-b3c5-5aab-ab86-51d8ce44dfbe',
+                          version='2020-08-10T21:24:26.174274Z')
+        ]
 
-            with patch.object(Plugin, 'list_bundles', return_value=bundle_fqids):
-                self.controller.contribute(event)
+        with patch.object(Plugin, 'list_bundles', return_value=bundle_fqids):
+            self.controller.contribute(event)
 
-            notification = one(self._read_queue(self._notifications_queue))
-            expected_source = dict(id=source.id, spec=str(source.spec))
-            source = notification['notification']['bundle_fqid']['source']
-            self.assertEqual(expected_source, source)
+        notification = one(self._read_queue(self._notifications_queue))
+        expected_source = dict(id=source.id, spec=str(source.spec))
+        source = notification['notification']['bundle_fqid']['source']
+        self.assertEqual(expected_source, source)
 
     def test_contribute_and_aggregate(self):
         """
@@ -181,14 +191,14 @@ class TestIndexController(DCP1IndexerTestCase, SqsTestCase):
         """
         self.maxDiff = None
         self._create_mock_queues()
-        source = DSSSourceRef.for_dss_source('foo_source:/0')
+        source = self.source
         fqids = [
-            DSSBundleFQID(source=source,
-                          uuid='56a338fe-7554-4b5d-96a2-7df127a7640b',
-                          version='2018-03-28T15:10:23.074974Z'),
-            DSSBundleFQID(source=source,
-                          uuid='b2216048-7eaa-45f4-8077-5a3fb4204953',
-                          version='2018-03-29T10:40:41.822717Z')
+            TDRBundleFQID(source=source,
+                          uuid='4426adc5-b3c5-5aab-ab86-51d8ce44dfbe',
+                          version='2020-08-10T21:24:26.174274Z'),
+            TDRBundleFQID(source=source,
+                          uuid='1b6d8348-d6e9-406a-aa6a-7ee886e52bf9',
+                          version='2019-09-24T09:35:06.958773Z')
         ]
 
         # Load canned bundles
@@ -225,12 +235,12 @@ class TestIndexController(DCP1IndexerTestCase, SqsTestCase):
             self.assertEqual([1, 1], expected_digest[entity_type])
 
         # Test partitioning and contribution
-        for i in range(2):
+        for i in range(3):
             mock_plugin = MagicMock()
             notified_fqids = list(map(self._fqid_from_notification, notifications))
             notified_bundles = [bundles[fqid] for fqid in notified_fqids]
             mock_plugin.fetch_bundle.side_effect = notified_bundles
-            mock_plugin.bundle_fqid_from_json.side_effect = DSSBundleFQID.from_json
+            mock_plugin.bundle_fqid_from_json.side_effect = TDRBundleFQID.from_json
             mock_plugin.sources = [source]
             with patch.object(IndexService, 'repository_plugin', return_value=mock_plugin):
                 with patch.object(BundlePartition, 'max_partition_size', 4):
@@ -245,23 +255,24 @@ class TestIndexController(DCP1IndexerTestCase, SqsTestCase):
 
             # Assert partitioned notifications, straight from the retry queue
             notifications = self._read_queue(self._notifications_retry_queue)
+            # Fingerprint the partitions from the resulting notifications
+            partitions = defaultdict(set)
+            for n in notifications:
+                fqid = self._fqid_from_notification(n)
+                partition = BundlePartition.from_json(n['notification']['partition'])
+                partitions[fqid].add(partition)
+            partitions = {k: len(v) for k, v in partitions.items()}
             if i == 0:
-                # Fingerprint the partitions from the resulting notifications
-                partitions = defaultdict(set)
-                for n in notifications:
-                    fqid = self._fqid_from_notification(n)
-                    partition = BundlePartition.from_json(n['notification']['partition'])
-                    partitions[fqid].add(partition)
-                # Assert that each bundle was partitioned ...
-                self.assertEqual(partitions.keys(), set(fqids))
-                # ... into two partitions. The number of partitions depends on
-                # the patched max_partition_size above and the number of
-                # entities in the canned bundles.
-                self.assertEqual([2] * len(fqids), list(map(len, partitions.values())))
-            else:
+                # Assert that each bundle was partitioned. The number of
+                # partitions for each bundle depends on the the number of
+                # entities in that bundle and the patched max_partition_size
+                self.assertEqual({fqids[0]: 2, fqids[1]: 8}, partitions)
+            elif i == 1:
                 # The partitions resulting from the first iteration should not
                 # need to be partitioned again
-                self.assertEqual([], notifications)
+                self.assertEqual({fqids[1]: 2}, partitions)
+            elif i == 2:
+                self.assertEqual({}, partitions)
 
         # We got a tally of one for each
         tallies = self._read_queue(self._tallies_queue)

--- a/test/indexer/test_indexer_controller.py
+++ b/test/indexer/test_indexer_controller.py
@@ -10,6 +10,7 @@ from functools import (
 import json
 from unittest.mock import (
     MagicMock,
+    PropertyMock,
     call,
     patch,
 )
@@ -240,7 +241,7 @@ class TestIndexController(DCP2IndexerTestCase, SqsTestCase):
             notified_fqids = list(map(self._fqid_from_notification, notifications))
             notified_bundles = [bundles[fqid] for fqid in notified_fqids]
             mock_plugin.fetch_bundle.side_effect = notified_bundles
-            mock_plugin.bundle_fqid_from_json.side_effect = TDRBundleFQID.from_json
+            type(mock_plugin).bundle_fqid_cls = PropertyMock(return_value=TDRBundleFQID)
             mock_plugin.sources = [source]
             with patch.object(IndexService, 'repository_plugin', return_value=mock_plugin):
                 with patch.object(BundlePartition, 'max_partition_size', 4):
@@ -248,8 +249,6 @@ class TestIndexController(DCP2IndexerTestCase, SqsTestCase):
                     self.controller.contribute(event)
 
             # Assert plugin calls by controller
-            expected_calls = [call(fqid.to_json()) for fqid in notified_fqids]
-            self.assertEqual(expected_calls, mock_plugin.bundle_fqid_from_json.mock_calls)
             expected_calls = list(map(call, notified_fqids))
             self.assertEqual(expected_calls, mock_plugin.fetch_bundle.mock_calls)
 

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -120,7 +120,6 @@ from azul.http import (
 )
 from azul.indexer import (
     Prefix,
-    SourceJSON,
     SourceRef,
     SourceSpec,
     SourcedBundleFQID,
@@ -1280,9 +1279,9 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
         special_fields = self.metadata_plugin(catalog).special_fields
         for hit in hits:
             source, bundle = one(hit['sources']), one(hit['bundles'])
-            source = SourceJSON(id=source[special_fields.source_id],
-                                spec=source[special_fields.source_spec])
-            source = self.repository_plugin(catalog).source_from_json(source)
+            source = dict(id=source[special_fields.source_id],
+                          spec=source[special_fields.source_spec])
+            source = self.repository_plugin(catalog).source_ref_cls.from_json(source)
             bundle_fqid = SourcedBundleFQID(uuid=bundle[special_fields.bundle_uuid],
                                             version=bundle[special_fields.bundle_version],
                                             source=source)


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Connected issues: #6821


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved connected issues to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
