### PR TITLE
Implement mirror_partition (#6861)

### DIFF
--- a/scripts/post_deploy_tdr.py
+++ b/scripts/post_deploy_tdr.py
@@ -101,7 +101,7 @@ class TerraValidator:
                 require(source_spec.prefix.common == '', source_spec)
             self.tdr.check_bigquery_access(source_spec)
         else:
-            ref = plugin.partition_source(catalog, ref)
+            ref = plugin.partition_source_for_indexing(catalog, ref)
             subgraph_count = plugin.count_bundles(ref.spec)
             require(subgraph_count > 0, 'Common prefix is too long', ref.spec)
             require(subgraph_count <= 512, 'Common prefix is too short', ref.spec)

--- a/src/azul/azulclient.py
+++ b/src/azul/azulclient.py
@@ -325,7 +325,7 @@ class AzulClient(SignatureHelper, HasCachedHttpClient):
         plugin = self.repository_plugin(catalog)
         for source_spec in sources:
             source_ref = plugin.resolve_source(source_spec)
-            source_ref = plugin.partition_source(catalog, source_ref)
+            source_ref = plugin.partition_source_for_indexing(catalog, source_ref)
 
             def message(partition_prefix: str) -> SQSMessage:
                 log.info('Remotely reindexing prefix %r of source_ref %r into catalog %r',
@@ -607,7 +607,7 @@ class AzulClient(SignatureHelper, HasCachedHttpClient):
     def mirror_source(self, catalog: CatalogName, source_json: JSON):
         plugin = self.repository_plugin(catalog)
         source = plugin.source_ref_cls.from_json(source_json)
-        source = plugin.partition_source(catalog, source)
+        source = plugin.partition_source_for_indexing(catalog, source)
 
         def message(prefix: str) -> SQSMessage:
             log.info('Mirroring files in partition %r of source %r from catalog %r',

--- a/src/azul/azulclient.py
+++ b/src/azul/azulclient.py
@@ -68,6 +68,7 @@ from azul.json import (
     Serializable,
 )
 from azul.plugins import (
+    File,
     RepositoryPlugin,
 )
 from azul.queues import (
@@ -112,6 +113,7 @@ class IndexAction(Action):
 class MirrorAction(Action):
     mirror_source = auto()
     mirror_partition = auto()
+    mirror_file = auto()
 
 
 @attrs.frozen(kw_only=True)
@@ -193,6 +195,21 @@ class AzulClient(SignatureHelper, HasCachedHttpClient):
                 'prefix': prefix
             },
             group_id=f'{source.id}:{prefix}'
+        )
+
+    def mirror_file_message(self,
+                            catalog: CatalogName,
+                            source: SourceRef,
+                            file: File,
+                            ) -> SQSFifoMessage:
+        return SQSFifoMessage(
+            body={
+                'action': MirrorAction.mirror_file.to_json(),
+                'catalog': catalog,
+                'source': cast(JSON, source.to_json()),
+                'file': file.to_json()
+            },
+            group_id=f'{source.id}:{file.uuid}'
         )
 
     def local_reindex(self, catalog: CatalogName, prefix: str) -> int:
@@ -607,7 +624,7 @@ class AzulClient(SignatureHelper, HasCachedHttpClient):
     def mirror_source(self, catalog: CatalogName, source_json: JSON):
         plugin = self.repository_plugin(catalog)
         source = plugin.source_ref_cls.from_json(source_json)
-        source = plugin.partition_source_for_indexing(catalog, source)
+        source = plugin.partition_source_for_mirroring(catalog, source)
 
         def message(prefix: str) -> SQSMessage:
             log.info('Mirroring files in partition %r of source %r from catalog %r',
@@ -615,6 +632,18 @@ class AzulClient(SignatureHelper, HasCachedHttpClient):
             return self.mirror_partition_message(catalog, source, prefix)
 
         messages = map(message, source.spec.prefix.partition_prefixes())
+        self.queue_mirror_messages(messages)
+
+    def mirror_partition(self, catalog: CatalogName, source_json: JSON, prefix: str):
+        plugin = self.repository_plugin(catalog)
+        source = plugin.source_ref_cls.from_json(source_json)
+
+        def message(file: File) -> SQSMessage:
+            log.info('Mirroring file %r in source %r from catalog %r',
+                     file.uuid, str(source.spec), catalog)
+            return self.mirror_file_message(catalog, source, file)
+
+        messages = map(message, plugin.list_files(source, prefix))
         self.queue_mirror_messages(messages)
 
 

--- a/src/azul/indexer/mirror_controller.py
+++ b/src/azul/indexer/mirror_controller.py
@@ -20,6 +20,7 @@ from azul.indexer.action_controller import (
 )
 from azul.types import (
     JSON,
+    json_mapping,
     json_str,
 )
 
@@ -40,11 +41,14 @@ class MirrorController(ActionController[MirrorAction]):
         if action is MirrorAction.mirror_source:
             self.client.mirror_source(message['catalog'], message['source'])
         elif action is MirrorAction.mirror_partition:
-            # FIXME: Implement mirror_partition
-            #        https://github.com/DataBiosphere/azul/issues/6861
-            log.info('Would mirror files in partition %r of source %r',
-                     message['prefix'], message['source'])
-            time.sleep(10)
+            self.client.mirror_partition(message['catalog'],
+                                         message['source'],
+                                         message['prefix'])
+        elif action is MirrorAction.mirror_file:
+            # FIXME: Implement mirror_file, mirror_part & finalize_file
+            #        https://github.com/DataBiosphere/azul/issues/6862
+            log.info('Would mirror parts of file %r', json_mapping(message['file'])['uuid'])
+            time.sleep(1)
         else:
             # FIXME: Implement mirror_file, mirror_part & finalize_file
             #        https://github.com/DataBiosphere/azul/issues/6862

--- a/src/azul/plugins/__init__.py
+++ b/src/azul/plugins/__init__.py
@@ -672,6 +672,15 @@ class RepositoryPlugin[BUNDLE: Bundle,
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def count_files(self, source: SOURCE_SPEC) -> int:
+        """
+        The total number of files in the given source. The source's prefix
+        may be None, indicating that the source hasn't been partitioned yet and
+        that this method should count all files in the source.
+        """
+        raise NotImplementedError
+
     def partition_source_for_indexing(self,
                                       catalog: CatalogName,
                                       source: SOURCE_REF
@@ -682,6 +691,17 @@ class RepositoryPlugin[BUNDLE: Bundle,
         should be appropriate for indexing in the given catalog.
         """
         return self._partition_source(catalog, source, self.count_bundles)
+
+    def partition_source_for_mirroring(self,
+                                       catalog: CatalogName,
+                                       source: SOURCE_REF
+                                       ) -> SOURCE_REF:
+        """
+        If the source already has a prefix, return the source. Otherwise, return
+        an updated copy of the source with a heuristically computed prefix that
+        should be appropriate for mirroring in the given catalog.
+        """
+        return self._partition_source(catalog, source, self.count_files)
 
     def _partition_source(self,
                           catalog: CatalogName,
@@ -728,6 +748,20 @@ class RepositoryPlugin[BUNDLE: Bundle,
         :param bundle_fqid: The fully qualified ID of the bundle to fetch,
                             including its source.
         """
+        raise NotImplementedError
+
+    @abstractmethod
+    def list_files(self, source: SOURCE_REF, prefix: str) -> list['File']:
+        """
+        List the files in the given source whose digest value starts with the
+        given prefix.
+
+        :param source: A reference to the repository source that contains the
+                       files to list
+
+        :param prefix: A string of lower-case hexadecimal characters
+        """
+
         raise NotImplementedError
 
     @abstractmethod

--- a/src/azul/plugins/__init__.py
+++ b/src/azul/plugins/__init__.py
@@ -666,7 +666,8 @@ class RepositoryPlugin[BUNDLE: Bundle,
     def count_bundles(self, source: SOURCE_SPEC) -> int:
         """
         The total number of subgraphs in the given source. The source's prefix
-        may be None.
+        may be None, indicating that the source hasn't been partitioned yet and
+        that this method should count all bundles in the source.
         """
         raise NotImplementedError
 

--- a/src/azul/plugins/__init__.py
+++ b/src/azul/plugins/__init__.py
@@ -11,6 +11,7 @@ from inspect import (
 )
 from typing import (
     AbstractSet,
+    Callable,
     ClassVar,
     Iterable,
     Literal,
@@ -671,27 +672,35 @@ class RepositoryPlugin[BUNDLE: Bundle,
         """
         raise NotImplementedError
 
-    def partition_source(self,
-                         catalog: CatalogName,
-                         source: SOURCE_REF
-                         ) -> SOURCE_REF:
+    def partition_source_for_indexing(self,
+                                      catalog: CatalogName,
+                                      source: SOURCE_REF
+                                      ) -> SOURCE_REF:
         """
         If the source already has a prefix, return the source. Otherwise, return
         an updated copy of the source with a heuristically computed prefix that
         should be appropriate for indexing in the given catalog.
         """
+        return self._partition_source(catalog, source, self.count_bundles)
+
+    def _partition_source(self,
+                          catalog: CatalogName,
+                          source: SOURCE_REF,
+                          counter: Callable[[SOURCE_SPEC], int]
+                          ) -> SOURCE_REF:
         if source.spec.prefix is None:
-            count = self.count_bundles(source.spec)
+            count = counter(source.spec)
             is_main = config.deployment.is_main
             is_it = catalog in config.integration_test_catalogs
-            # We use the "lesser" heuristic during IT to avoid indexing an
-            # excessive number of bundles
+            # We use the "lesser" heuristic during IT to keep the cost and
+            # performance of the tests within reasonable limits
             if is_main and not is_it:
                 prefix = Prefix.for_main_deployment(count)
             else:
                 prefix = Prefix.for_lesser_deployment(count)
-            source = source.with_prefix(prefix)
-        return source
+            return source.with_prefix(prefix)
+        else:
+            return source
 
     @abstractmethod
     def list_bundles(self,

--- a/src/azul/plugins/repository/canned/__init__.py
+++ b/src/azul/plugins/repository/canned/__init__.py
@@ -164,7 +164,12 @@ class Plugin(RepositoryPlugin[CannedBundle, SimpleSourceSpec, CannedSourceRef, C
             return len(staging_area.links)
         else:
             prefix = source.spec.prefix.common
-            return sum(1 for links_id in staging_area.links if links_id.startswith(prefix))
+            assert prefix == prefix.lower(), source
+            return sum(
+                1
+                for links_id in staging_area.links
+                if links_id.lower().startswith(prefix)
+            )
 
     def list_bundles(self,
                      source: CannedSourceRef,
@@ -172,13 +177,14 @@ class Plugin(RepositoryPlugin[CannedBundle, SimpleSourceSpec, CannedSourceRef, C
                      ) -> list[CannedBundleFQID]:
         self._assert_source(source)
         self._assert_partition(source, prefix)
+        assert prefix == prefix.lower(), prefix
         staging_area = self.staging_area(source.spec.name)
         return [
             CannedBundleFQID(source=source,
                              uuid=link.uuid,
                              version=link.version)
             for link in staging_area.links.values()
-            if link.uuid.startswith(prefix)
+            if link.uuid.lower().startswith(prefix)
         ]
 
     def fetch_bundle(self, bundle_fqid: CannedBundleFQID) -> CannedBundle:

--- a/src/azul/plugins/repository/canned/__init__.py
+++ b/src/azul/plugins/repository/canned/__init__.py
@@ -50,6 +50,9 @@ from azul.plugins import (
     RepositoryFileDownload,
     RepositoryPlugin,
 )
+from azul.plugins.metadata.hca import (
+    HCAFile,
+)
 from azul.plugins.metadata.hca.bundle import (
     HCABundle,
 )
@@ -171,6 +174,19 @@ class Plugin(RepositoryPlugin[CannedBundle, SimpleSourceSpec, CannedSourceRef, C
                 if links_id.lower().startswith(prefix)
             )
 
+    def count_files(self, source: SimpleSourceSpec) -> int:
+        staging_area = self.staging_area(source.name)
+        if source.prefix is None:
+            return len(staging_area.descriptors)
+        else:
+            prefix = source.prefix.common
+            assert prefix == prefix.lower(), source
+            return sum(
+                1
+                for descriptor in staging_area.descriptors.values()
+                if descriptor.content['sha256'].lower().startswith(prefix)
+            )
+
     def list_bundles(self,
                      source: CannedSourceRef,
                      prefix: str
@@ -204,6 +220,20 @@ class Plugin(RepositoryPlugin[CannedBundle, SimpleSourceSpec, CannedSourceRef, C
         log.info('It took %.003fs to download bundle %s.%s',
                  time.time() - now, bundle.uuid, bundle.version)
         return bundle
+
+    def list_files(self, source: CannedSourceRef, prefix: str) -> list[HCAFile]:
+        self._assert_source(source)
+        self._assert_partition(source, prefix)
+        assert prefix == prefix.lower(), prefix
+        staging_area = self.staging_area(source.spec.name)
+        return [
+            HCAFile.from_descriptor(descriptor.content,
+                                    uuid=file_uuid,
+                                    name=descriptor.content['file_name'],
+                                    drs_uri=None)
+            for file_uuid, descriptor in staging_area.descriptors.items()
+            if descriptor.content['sha256'].lower().startswith(prefix)
+        ]
 
     def _construct_file_url(self, url: furl, file_name: str) -> furl:
         """

--- a/src/azul/plugins/repository/dss/__init__.py
+++ b/src/azul/plugins/repository/dss/__init__.py
@@ -119,6 +119,9 @@ class Plugin(RepositoryPlugin[DSSBundle, SimpleSourceSpec, DSSSourceRef, DSSBund
     def count_bundles(self, source: SimpleSourceSpec) -> NoReturn:
         assert False, 'DSS is EOL'
 
+    def count_files(self, source: SimpleSourceSpec) -> NoReturn:
+        assert False, 'DSS is EOL'
+
     def list_sources(self,
                      authentication: Authentication | None
                      ) -> list[DSSSourceRef]:
@@ -134,6 +137,9 @@ class Plugin(RepositoryPlugin[DSSBundle, SimpleSourceSpec, DSSSourceRef, DSSBund
         assert False, 'DSS is EOL'
 
     def fetch_bundle(self, bundle_fqid: DSSBundleFQID) -> NoReturn:
+        assert False, 'DSS is EOL'
+
+    def list_files(self, source: DSSSourceRef, prefix: str) -> NoReturn:
         assert False, 'DSS is EOL'
 
     def dss_subscription_query(self, prefix: str) -> JSON:

--- a/src/azul/plugins/repository/tdr_anvil/__init__.py
+++ b/src/azul/plugins/repository/tdr_anvil/__init__.py
@@ -467,7 +467,7 @@ class Plugin(TDRPlugin[TDRAnvilBundle, TDRAnvilBundleFQID]):
         source = bundle_fqid.source.spec
         result = TDRAnvilBundle(fqid=bundle_fqid)
         linked_file_refs = set()
-        for file_ref, file_row in self._get_batch(bundle_fqid):
+        for file_ref, file_row in self._get_bundle_batch(bundle_fqid):
             is_supplementary = file_row['is_supplementary']
             result.add_entity(file_ref,
                               self._version,
@@ -512,7 +512,7 @@ class Plugin(TDRPlugin[TDRAnvilBundle, TDRAnvilBundleFQID]):
         assert bundle_fqid.is_batched, bundle_fqid
         source = bundle_fqid.source.spec
         result = TDRAnvilBundle(fqid=bundle_fqid)
-        batch = self._get_batch(bundle_fqid)
+        batch = self._get_bundle_batch(bundle_fqid)
         dataset = self._get_dataset(source)
         for (ref, row) in itertools.chain([dataset], batch):
             result.add_entity(ref, self._version, dict(row), is_orphan=True)
@@ -529,20 +529,29 @@ class Plugin(TDRPlugin[TDRAnvilBundle, TDRAnvilBundleFQID]):
         return ref, row
 
     def _get_batch(self,
-                   bundle_fqid: TDRAnvilBundleFQID
+                   source: TDRSourceSpec,
+                   table_name: str,
+                   batch_prefix: str,
+                   *,
+                   id_column: str
                    ) -> Iterable[tuple[EntityReference, BigQueryRow]]:
-        source = bundle_fqid.source.spec
-        batch_prefix = bundle_fqid.batch_prefix
-        table_name = bundle_fqid.table_name
         columns = self._columns(table_name)
         assert not any(map(str.isupper, batch_prefix)), source
         for row in self._run_sql(f'''
             SELECT {', '.join(sorted(columns))}
             FROM {backtick(self._full_table_name(source, table_name))}
-            WHERE STARTS_WITH(LOWER(datarepo_row_id), {batch_prefix!r})
+            WHERE STARTS_WITH(LOWER({id_column}), {batch_prefix!r})
         '''):
             ref = EntityReference(entity_type=table_name, entity_id=row['datarepo_row_id'])
             yield ref, row
+
+    def _get_bundle_batch(self,
+                          bundle_fqid: TDRAnvilBundleFQID
+                          ) -> Iterable[tuple[EntityReference, BigQueryRow]]:
+        return self._get_batch(bundle_fqid.source.spec,
+                               bundle_fqid.table_name,
+                               bundle_fqid.batch_prefix,
+                               id_column='datarepo_row_id')
 
     def _bundle_entity(self, bundle_fqid: TDRAnvilBundleFQID) -> KeyReference:
         source = bundle_fqid.source

--- a/src/azul/plugins/repository/tdr_anvil/__init__.py
+++ b/src/azul/plugins/repository/tdr_anvil/__init__.py
@@ -42,6 +42,9 @@ from azul.indexer.document import (
     EntityReference,
     EntityType,
 )
+from azul.plugins.metadata.anvil import (
+    AnvilFile,
+)
 from azul.plugins.metadata.anvil.bundle import (
     AnvilBundle,
     EntityLink,
@@ -241,6 +244,16 @@ class Plugin(TDRPlugin[TDRAnvilBundle, TDRAnvilBundleFQID]):
                               self.batch_uuid_version,
                               self.bundle_uuid_version)
 
+    def count_files(self, source: TDRSourceSpec) -> int:
+        prefix = '' if source.prefix is None else source.prefix.common
+        assert prefix == prefix.lower(), source
+        query = f'''
+        SELECT COUNT(*) AS count
+        FROM {backtick(self._full_table_name(source, 'anvil_file'))}
+        WHERE STARTS_WITH(LOWER(file_md5sum), {prefix!r})
+        '''
+        return one(self._run_sql(query))['count']
+
     def count_bundles(self, source: TDRSourceSpec) -> int:
         prefix = '' if source.prefix is None else source.prefix.common
         assert prefix == prefix.lower(), source
@@ -315,6 +328,23 @@ class Plugin(TDRPlugin[TDRAnvilBundle, TDRAnvilBundleFQID]):
                                                   table_name=table_name,
                                                   batch_prefix=batch_prefix))
         return bundles
+
+    def list_files(self, source: TDRSourceRef, prefix: str) -> list[AnvilFile]:
+        self._assert_source(source)
+        self._assert_partition(source, prefix)
+        batch = self._get_batch(source.spec,
+                                'anvil_file',
+                                prefix,
+                                key_column='file_md5sum')
+        return [
+            AnvilFile(uuid=ref.entity_id,
+                      name=row['file_name'],
+                      version=self._version,
+                      size=row['file_size'],
+                      md5=row['file_md5sum'],
+                      drs_uri=row['file_ref'])
+            for ref, row in batch
+        ]
 
     def _emulate_bundle(self, bundle_fqid: TDRAnvilBundleFQID) -> TDRAnvilBundle:
         if bundle_fqid.table_name == BundleType.primary.value:
@@ -533,14 +563,14 @@ class Plugin(TDRPlugin[TDRAnvilBundle, TDRAnvilBundleFQID]):
                    table_name: str,
                    batch_prefix: str,
                    *,
-                   id_column: str
+                   key_column: str
                    ) -> Iterable[tuple[EntityReference, BigQueryRow]]:
         columns = self._columns(table_name)
         assert not any(map(str.isupper, batch_prefix)), source
         for row in self._run_sql(f'''
             SELECT {', '.join(sorted(columns))}
             FROM {backtick(self._full_table_name(source, table_name))}
-            WHERE STARTS_WITH(LOWER({id_column}), {batch_prefix!r})
+            WHERE STARTS_WITH(LOWER({key_column}), {batch_prefix!r})
         '''):
             ref = EntityReference(entity_type=table_name, entity_id=row['datarepo_row_id'])
             yield ref, row
@@ -551,7 +581,7 @@ class Plugin(TDRPlugin[TDRAnvilBundle, TDRAnvilBundleFQID]):
         return self._get_batch(bundle_fqid.source.spec,
                                bundle_fqid.table_name,
                                bundle_fqid.batch_prefix,
-                               id_column='datarepo_row_id')
+                               key_column='datarepo_row_id')
 
     def _bundle_entity(self, bundle_fqid: TDRAnvilBundleFQID) -> KeyReference:
         source = bundle_fqid.source

--- a/src/azul/plugins/repository/tdr_anvil/__init__.py
+++ b/src/azul/plugins/repository/tdr_anvil/__init__.py
@@ -243,15 +243,16 @@ class Plugin(TDRPlugin[TDRAnvilBundle, TDRAnvilBundleFQID]):
 
     def count_bundles(self, source: TDRSourceSpec) -> int:
         prefix = '' if source.prefix is None else source.prefix.common
+        assert prefix == prefix.lower(), source
         primary_count = one(self._run_sql(f'''
             SELECT COUNT(*) AS count
             FROM {backtick(self._full_table_name(source, BundleType.primary.value))}
-            WHERE STARTS_WITH(datarepo_row_id, {prefix!r})
+            WHERE STARTS_WITH(LOWER(datarepo_row_id), {prefix!r})
         '''))['count']
         duos_count = 0 if config.duos_service_url is None else one(self._run_sql(f'''
             SELECT COUNT(*) AS count
             FROM {backtick(self._full_table_name(source, BundleType.duos.value))}
-            WHERE STARTS_WITH(datarepo_row_id, {prefix!r})
+            WHERE STARTS_WITH(LOWER(datarepo_row_id), {prefix!r})
         '''))['count']
         sizes_by_table = self._batch_tables(source, prefix)
         batched_count = sum(batch_size for (_, batch_size) in sizes_by_table.values())
@@ -263,6 +264,7 @@ class Plugin(TDRPlugin[TDRAnvilBundle, TDRAnvilBundleFQID]):
                      ) -> list[TDRAnvilBundleFQID]:
         self._assert_source(source)
         self._assert_partition(source, prefix)
+        assert prefix == prefix.lower(), prefix
         bundles = []
         spec = source.spec
 
@@ -290,7 +292,7 @@ class Plugin(TDRPlugin[TDRAnvilBundle, TDRAnvilBundleFQID]):
         for row in self._run_sql(f'''
             SELECT datarepo_row_id
             FROM {backtick(self._full_table_name(spec, BundleType.primary.value))}
-            WHERE STARTS_WITH(datarepo_row_id, {prefix!r})
+            WHERE STARTS_WITH(LOWER(datarepo_row_id), {prefix!r})
         '''):
             bundle_uuid = change_version(row['datarepo_row_id'],
                                          self.datarepo_row_uuid_version,
@@ -355,6 +357,7 @@ class Plugin(TDRPlugin[TDRAnvilBundle, TDRAnvilBundleFQID]):
         this affects this method's return value is very small, but nonzero.
         https://cloud.google.com/bigquery/docs/reference/standard-sql/aggregate_functions#avg
         """
+        assert prefix == prefix.lower(), prefix
         max_length = 4
 
         def repeat(fmt):
@@ -383,10 +386,10 @@ class Plugin(TDRPlugin[TDRAnvilBundle, TDRAnvilBundleFQID]):
                     COUNT(*) AS num_batches
                 FROM (
                     SELECT
-                        {repeat(f'SUBSTR(datarepo_row_id, {prefix_len} + {{i}}, 1) AS p{{i}}')},
+                        {repeat(f'LOWER(SUBSTR(datarepo_row_id, {prefix_len} + {{i}}, 1)) AS p{{i}}')},
                         COUNT(*) AS num_rows
                     FROM {backtick(self._full_table_name(source, table_name))}
-                    WHERE STARTS_WITH(datarepo_row_id, {prefix!r})
+                    WHERE STARTS_WITH(LOWER(datarepo_row_id), {prefix!r})
                     GROUP BY ROLLUP ({repeat('p{i}')})
                 )
                 GROUP BY batch_prefix_length
@@ -532,10 +535,11 @@ class Plugin(TDRPlugin[TDRAnvilBundle, TDRAnvilBundleFQID]):
         batch_prefix = bundle_fqid.batch_prefix
         table_name = bundle_fqid.table_name
         columns = self._columns(table_name)
+        assert not any(map(str.isupper, batch_prefix)), source
         for row in self._run_sql(f'''
             SELECT {', '.join(sorted(columns))}
             FROM {backtick(self._full_table_name(source, table_name))}
-            WHERE STARTS_WITH(datarepo_row_id, {batch_prefix!r})
+            WHERE STARTS_WITH(LOWER(datarepo_row_id), {batch_prefix!r})
         '''):
             ref = EntityReference(entity_type=table_name, entity_id=row['datarepo_row_id'])
             yield ref, row

--- a/src/azul/plugins/repository/tdr_hca/__init__.py
+++ b/src/azul/plugins/repository/tdr_hca/__init__.py
@@ -74,8 +74,8 @@ from azul.types import (
     MutableJSON,
     MutableJSONs,
 )
-from humancellatlas.data.metadata.api import (
-    Entity,
+from humancellatlas.data.metadata import (
+    api,
 )
 
 log = logging.getLogger(__name__)
@@ -187,7 +187,7 @@ class TDRHCABundle(HCABundle[TDRBundleFQID], TDRBundle):
         descriptor = json.loads(row['descriptor'])
         # FIXME: Move validation of descriptor to the metadata API
         #        https://github.com/DataBiosphere/azul/issues/6299
-        Entity.validate_described_by(descriptor)
+        api.Entity.validate_described_by(descriptor)
         return HCAFile.from_descriptor(descriptor,
                                        uuid=descriptor['file_id'],
                                        name=row['file_name'],

--- a/src/azul/plugins/repository/tdr_hca/__init__.py
+++ b/src/azul/plugins/repository/tdr_hca/__init__.py
@@ -250,7 +250,7 @@ class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
         current_bundles = self._query_unique_sorted(f'''
             SELECT links_id, version
             FROM {backtick(self._full_table_name(source.spec, 'links'))}
-            WHERE STARTS_WITH(links_id, '{prefix}')
+            WHERE STARTS_WITH(links_id, {prefix!r})
         ''', group_by='links_id')
         return [
             TDRBundleFQID(source=source,

--- a/src/azul/plugins/repository/tdr_hca/__init__.py
+++ b/src/azul/plugins/repository/tdr_hca/__init__.py
@@ -233,10 +233,11 @@ class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
 
     def count_bundles(self, source: TDRSourceSpec) -> int:
         prefix = '' if source.prefix is None else source.prefix.common
+        assert prefix == prefix.lower(), source
         query = f'''
         SELECT COUNT(*) AS count
         FROM {backtick(self._full_table_name(source, 'links'))}
-        WHERE STARTS_WITH(datarepo_row_id, {prefix!r})
+        WHERE STARTS_WITH(LOWER(datarepo_row_id), {prefix!r})
         '''
         rows = self._run_sql(query)
         return one(rows)['count']
@@ -247,10 +248,11 @@ class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
                      ) -> list[TDRBundleFQID]:
         self._assert_source(source)
         self._assert_partition(source, prefix)
+        assert prefix == prefix.lower(), source
         current_bundles = self._query_unique_sorted(f'''
             SELECT links_id, version
             FROM {backtick(self._full_table_name(source.spec, 'links'))}
-            WHERE STARTS_WITH(links_id, {prefix!r})
+            WHERE STARTS_WITH(LOWER(links_id), {prefix!r})
         ''', group_by='links_id')
         return [
             TDRBundleFQID(source=source,

--- a/src/azul/plugins/repository/tdr_hca/__init__.py
+++ b/src/azul/plugins/repository/tdr_hca/__init__.py
@@ -242,6 +242,22 @@ class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
         rows = self._run_sql(query)
         return one(rows)['count']
 
+    def count_files(self, source: TDRSourceSpec) -> int:
+        prefix = '' if source.prefix is None else source.prefix.common
+        assert prefix == prefix.lower(), source
+        query = ' UNION ALL '.join(
+            f'''
+            SELECT COUNT(*) AS count
+            FROM {backtick(self._full_table_name(source, entity_type))}
+            WHERE STARTS_WITH(LOWER(JSON_EXTRACT_SCALAR(descriptor, "$.sha256")),
+                              {prefix!r})
+            '''
+            for entity_type, entity_cls in api.entity_types.items()
+            if entity_type.endswith('_file')
+        )
+        rows = self._run_sql(query)
+        return sum(row['count'] for row in rows)
+
     def list_bundles(self,
                      source: TDRSourceRef,
                      prefix: str
@@ -260,6 +276,22 @@ class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
                           version=self.format_version(row['version']))
             for row in current_bundles
         ]
+
+    def list_files(self, source: TDRSourceRef, prefix: str) -> list[HCAFile]:
+        self._assert_source(source)
+        self._assert_partition(source, prefix)
+        assert prefix == prefix.lower(), prefix
+        rows = self._run_sql(' UNION ALL '.join(
+            f'''
+            SELECT {', '.join(TDRHCABundle.data_columns)}
+            FROM {backtick(self._full_table_name(source.spec, entity_type))}
+            WHERE STARTS_WITH(LOWER(JSON_EXTRACT_SCALAR(descriptor, "$.sha256")),
+                              {prefix!r})
+            '''
+            for entity_type, entity_cls in api.entity_types.items()
+            if entity_type.endswith('_file')
+        ))
+        return list(map(TDRHCABundle.file_from_row, rows))
 
     def _query_unique_sorted(self,
                              query: str,

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -17,9 +17,15 @@ from azul import (
 from azul.indexer.mirror_controller import (
     MirrorController,
 )
+from azul.json import (
+    copy_json,
+)
 from azul.logging import (
     configure_test_logging,
     get_test_logger,
+)
+from azul.plugins.metadata.hca import (
+    HCAFile,
 )
 from azul_test_case import (
     DCP2TestCase,
@@ -69,6 +75,7 @@ class TestMirrorController(DCP2TestCase, WorkQueueTestCase):
             controller = MirrorController(app=MagicMock())
             controller.mirror(event)
             partition_messages = self._read_queue(self.client.mirror_queue())
+            partition_message = copy_json(partition_messages[0])
             partitions = []
             for message in partition_messages:
                 partitions.append(message.pop('prefix'))
@@ -77,3 +84,22 @@ class TestMirrorController(DCP2TestCase, WorkQueueTestCase):
                                       source=self.source.to_json()),
                                  message)
             self.assertEqual(list(self.source.spec.prefix.partition_prefixes()), partitions)
+
+        with self.subTest('mirror_partition'):
+            event = [self._mock_sqs_record(partition_message)]
+            file = HCAFile(uuid='405852c9-a0cc-4cd8-b9ff-7c6296223661',
+                           name='foo.txt',
+                           version=None,
+                           drs_uri=None,
+                           size=0,
+                           content_type='text/plain',
+                           sha256='123')
+            plugin_cls = type(self.client.repository_plugin(self.catalog))
+            with patch.object(plugin_cls, 'list_files', return_value=[file]):
+                controller.mirror(event)
+            file_message = one(self._read_queue(self.client.mirror_queue()))
+            expected_message = dict(action='mirror_file',
+                                    catalog=self.catalog,
+                                    source=self.source.to_json(),
+                                    file=file.to_json())
+            self.assertEqual(expected_message, file_message)

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -1277,7 +1277,7 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
         bundle_fqids = set()
         notifications = []
         for source in sources:
-            source = plugin.partition_source(catalog, source)
+            source = plugin.partition_source_for_indexing(catalog, source)
             # Some partitions may be empty, but we include them anyway to
             # ensure test coverage for handling multiple partitions per source
             for partition_prefix in source.spec.prefix.partition_prefixes():


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Connected issues: #6861


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved connected issues to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
