### PR TITLE
Fix: test_verbatim_pfb_manifest fails when relations are disabled (#6949)

### DIFF
--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -2167,16 +2167,24 @@ class TestAnvilManifests(AnvilManifestTestCase):
                 (False, {**self.neutral_file_filters, **self.dataset_title_filters})
             ]:
                 with self.subTest(orphans=orphans, relations=enable_relations, filters=filters):
-                    expected_manifest = self._expected_pfb_manifest(orphans)
+                    expected_manifest = self._expected_pfb_manifest(orphans, enable_relations)
                     expected_schema, expected_entities = expected_manifest
                     response = self._get_manifest(ManifestFormat.verbatim_pfb, filters)
                     self.assertEqual(200, response.status_code)
                     self._assert_pfb(expected_schema, expected_entities, response)
 
     @cache
-    def _expected_pfb_manifest(self, include_orphans: bool) -> tuple[JSON, JSONs]:
+    def _expected_pfb_manifest(self,
+                               include_orphans: bool,
+                               enable_relations: bool
+                               ) -> tuple[JSON, JSONs]:
         canned_pfb = self._load_canned_pfb('verbatim', 'pfb', 'anvil')
         pfb_schema, pfb_entities = canned_pfb
+        # To avoid dangling references, relations are only populated when
+        # including orphans
+        if not enable_relations or not include_orphans:
+            for entity in pfb_entities:
+                entity['relations'].clear()
         if not include_orphans:
             self.assertEqual('Entity', pfb_schema['name'])
             object_field_schema = one(
@@ -2197,10 +2205,6 @@ class TestAnvilManifests(AnvilManifestTestCase):
                 filtered = [e for e in part if e['name'] != 'non_schema_orphan_table']
                 assert len(filtered) < len(part), 'Expected to filter orphan references'
                 part[:] = filtered
-            # To avoid dangling references, relations are only populated when
-            # including orphans
-            for entity in pfb_entities:
-                entity['relations'].clear()
         return pfb_schema, pfb_entities
 
 

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -2151,6 +2151,10 @@ class TestAnvilManifests(AnvilManifestTestCase):
     def test_verbatim_pfb_manifest_with_relations(self):
         self._test_verbatim_pfb_manifest(enable_relations=True)
 
+    # Due to manifest caching, these must be separate tests
+    def test_verbatim_pfb_manifest_without_relations(self):
+        self._test_verbatim_pfb_manifest(enable_relations=False)
+
     def _test_verbatim_pfb_manifest(self, *, enable_relations: bool):
         with patch.object(type(config),
                           'enable_verbatim_relations',

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -61,6 +61,7 @@ from requests import (
 
 from azul import (
     RequirementError,
+    cache,
     config,
 )
 from azul.collections import (
@@ -2147,57 +2148,49 @@ class TestAnvilManifests(AnvilManifestTestCase):
                 self._assert_jsonl(expected_rows, response)
 
     def test_verbatim_pfb_manifest(self):
+        for orphans, filters in [
+            (True, {}),
+            (True, self.dataset_id_filters),
+            (True, self.dataset_title_filters),
+            (False, self.neutral_file_filters),
+            (False, {**self.neutral_file_filters, **self.dataset_title_filters})
+        ]:
+            with self.subTest(orphans=orphans, filters=filters):
+                expected_manifest = self._expected_pfb_manifest(orphans)
+                expected_schema, expected_entities = expected_manifest
+                response = self._get_manifest(ManifestFormat.verbatim_pfb, filters)
+                self.assertEqual(200, response.status_code)
+                self._assert_pfb(expected_schema, expected_entities, response)
+
+    @cache
+    def _expected_pfb_manifest(self, include_orphans: bool) -> tuple[JSON, JSONs]:
         canned_pfb = self._load_canned_pfb('verbatim', 'pfb', 'anvil')
-        expected_schema, expected_entities = canned_pfb
-
-        def test(filters):
-            response = self._get_manifest(ManifestFormat.verbatim_pfb, filters)
-            self.assertEqual(200, response.status_code)
-            self._assert_pfb(expected_schema, expected_entities, response)
-
-        with self.subTest(orphans=True):
-            for filters in [
-                {},
-                self.dataset_id_filters,
-                self.dataset_title_filters
-            ]:
-                with self.subTest(filters=filters):
-                    test(filters)
-
-        with self.subTest(orphans=False):
-            # Dynamically edit out references to the orphaned entities (and
-            # their schemas) that are only expected when filtering by dataset
-            # ID. This subtest modifies the expectations in place, and therefore
-            # needs to come last.
-            self.assertEqual('Entity', expected_schema['name'])
+        pfb_schema, pfb_entities = canned_pfb
+        if not include_orphans:
+            self.assertEqual('Entity', pfb_schema['name'])
             object_field_schema = one(
                 field
-                for field in expected_schema['fields']
+                for field in pfb_schema['fields']
                 if field['name'] == 'object'
             )
             # The `object` field is of a union type, so the schema's `type`
             # property is an array
             schemas = object_field_schema['type']
             # The first AVRO record is the *metadata entity* in PFB terms,
-            # declaring higher level constraints that can't expressed in the
-            # AVRO schema
-            metadata_entity = expected_entities[0]
+            # declaring higher level constraints that can't be expressed in
+            # the AVRO schema
+            metadata_entity = pfb_entities[0]
             self.assertEqual('Metadata', metadata_entity['name'])
             higher_schemas = metadata_entity['object']['nodes']
-            for part in [schemas, higher_schemas, expected_entities]:
+            for part in [schemas, higher_schemas, pfb_entities]:
                 filtered = [e for e in part if e['name'] != 'non_schema_orphan_table']
                 assert len(filtered) < len(part), 'Expected to filter orphan references'
                 part[:] = filtered
             # To avoid dangling references, relations are only populated when
             # including orphans
-            for entity in expected_entities:
+            for entity in pfb_entities:
                 entity['relations'].clear()
-            for filters in [
-                self.neutral_file_filters,
-                {**self.neutral_file_filters, **self.dataset_title_filters}
-            ]:
-                with self.subTest(filters=filters):
-                    test(filters)
+        return pfb_schema, pfb_entities
 
 
 class TestPFB(CannedManifestTestCase):

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -33,6 +33,7 @@ from typing import (
 )
 from unittest.mock import (
     MagicMock,
+    PropertyMock,
     patch,
 )
 import unittest.result
@@ -2147,20 +2148,26 @@ class TestAnvilManifests(AnvilManifestTestCase):
                 expected_rows = all_rows if expect_orphans else linked_rows
                 self._assert_jsonl(expected_rows, response)
 
-    def test_verbatim_pfb_manifest(self):
-        for orphans, filters in [
-            (True, {}),
-            (True, self.dataset_id_filters),
-            (True, self.dataset_title_filters),
-            (False, self.neutral_file_filters),
-            (False, {**self.neutral_file_filters, **self.dataset_title_filters})
-        ]:
-            with self.subTest(orphans=orphans, filters=filters):
-                expected_manifest = self._expected_pfb_manifest(orphans)
-                expected_schema, expected_entities = expected_manifest
-                response = self._get_manifest(ManifestFormat.verbatim_pfb, filters)
-                self.assertEqual(200, response.status_code)
-                self._assert_pfb(expected_schema, expected_entities, response)
+    def test_verbatim_pfb_manifest_with_relations(self):
+        self._test_verbatim_pfb_manifest(enable_relations=True)
+
+    def _test_verbatim_pfb_manifest(self, *, enable_relations: bool):
+        with patch.object(type(config),
+                          'enable_verbatim_relations',
+                          new=PropertyMock(return_value=enable_relations)):
+            for orphans, filters in [
+                (True, {}),
+                (True, self.dataset_id_filters),
+                (True, self.dataset_title_filters),
+                (False, self.neutral_file_filters),
+                (False, {**self.neutral_file_filters, **self.dataset_title_filters})
+            ]:
+                with self.subTest(orphans=orphans, relations=enable_relations, filters=filters):
+                    expected_manifest = self._expected_pfb_manifest(orphans)
+                    expected_schema, expected_entities = expected_manifest
+                    response = self._get_manifest(ManifestFormat.verbatim_pfb, filters)
+                    self.assertEqual(200, response.status_code)
+                    self._assert_pfb(expected_schema, expected_entities, response)
 
     @cache
     def _expected_pfb_manifest(self, include_orphans: bool) -> tuple[JSON, JSONs]:


### PR DESCRIPTION
Connected issues: #6949


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [ ] ~PR is awaiting requested review from system administrator~
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [ ] ~Actually approved the PR~
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [ ] ~`N reviews` label is accurate~
- [x] Moved connected issues to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
