### PR TITLE
Fix: Verbatim PFB handover fails when using a common prefix (#6843)

### DIFF
--- a/src/azul/indexer/__init__.py
+++ b/src/azul/indexer/__init__.py
@@ -370,6 +370,27 @@ class SourceSpec(Parseable, metaclass=ABCMeta):
     prefix: Prefix | None
 
     @classmethod
+    def parse_prefix_only(cls, spec: str) -> Prefix | None:
+        """
+        Parse only the prefix component of a string representation of a
+        `SourceSpec.` To parse the entire spec, use :meth:`parse`. A return
+        value of `None` indicates that no prefix is configured for the spec.
+
+        >>> SourceSpec.parse_prefix_only('foo:/0')
+        Prefix(common='', partition=0)
+
+        >>> SourceSpec.parse_prefix_only('foo:') is None
+        True
+
+        >>> SourceSpec.parse_prefix_only('foo')
+        Traceback (most recent call last):
+        ...
+        AssertionError: R('Invalid source specification', 'foo')
+        """
+        _, prefix = cls._parse(spec)
+        return prefix
+
+    @classmethod
     @abstractmethod
     def parse(cls, spec: str) -> Self:
         raise NotImplementedError

--- a/src/azul/indexer/__init__.py
+++ b/src/azul/indexer/__init__.py
@@ -29,7 +29,6 @@ import attrs
 from azul import (
     R,
     config,
-    reject,
 )
 from azul.attrs import (
     SerializableAttrs,
@@ -185,8 +184,8 @@ class Prefix:
         # partition_prefix is a valid UUID prefix, we restrict the number of
         # characters from the concatenation to be within the first
         # dash-seperated group.
-        reject(len(self.common) + self.partition > 8,
-               'Invalid common prefix and partition length', self)
+        assert len(self.common) + self.partition <= 8, R(
+            'Invalid common prefix and partition length', self)
 
     @classmethod
     def parse(cls, prefix: str) -> Self:
@@ -202,13 +201,13 @@ class Prefix:
         >>> Prefix.parse('aa/')
         Traceback (most recent call last):
         ...
-        azul.RequirementError: ('Prefix source cannot end in a delimiter', 'aa/', '/')
+        AssertionError: R('Prefix source cannot end in a delimiter', 'aa/', '/')
 
         >>> Prefix.parse('8f538f53/1').partition_prefixes() # doctest: +NORMALIZE_WHITESPACE
         Traceback (most recent call last):
         ...
-        azul.RequirementError: ('Invalid common prefix and partition length',
-                                Prefix(common='8f538f53', partition=1))
+        AssertionError: R('Invalid common prefix and partition length',
+                          Prefix(common='8f538f53', partition=1))
 
         >>> list(Prefix.parse('8f538f53/0').partition_prefixes())
         ['8f538f53']
@@ -221,12 +220,12 @@ class Prefix:
         >>> Prefix.parse('')
         Traceback (most recent call last):
         ...
-        azul.RequirementError: Cannot parse an empty prefix source
+        AssertionError: R('Cannot parse an empty prefix source')
         """
         source_delimiter = '/'
-        reject(prefix == '', 'Cannot parse an empty prefix source')
-        reject(prefix.endswith(source_delimiter),
-               'Prefix source cannot end in a delimiter', prefix, source_delimiter)
+        assert prefix != '', R('Cannot parse an empty prefix source')
+        assert not prefix.endswith(source_delimiter), R(
+            'Prefix source cannot end in a delimiter', prefix, source_delimiter)
         partition: str | int
         try:
             entry, partition = prefix.split(source_delimiter)
@@ -378,7 +377,7 @@ class SourceSpec(Parseable, metaclass=ABCMeta):
     @classmethod
     def _parse(cls, spec: str) -> tuple[str, Prefix | None]:
         rest, sep, prefix = spec.rpartition(':')
-        reject(sep == '', 'Invalid source specification', spec)
+        assert sep != '', R('Invalid source specification', spec)
         prefix = Prefix.parse(prefix) if prefix else None
         return rest, prefix
 
@@ -421,7 +420,7 @@ class SimpleSourceSpec(SourceSpec):
         >>> SimpleSourceSpec.parse('foo')
         Traceback (most recent call last):
         ...
-        azul.RequirementError: ('Invalid source specification', 'foo')
+        AssertionError: R('Invalid source specification', 'foo')
 
         >>> SimpleSourceSpec.parse('foo:8F53/0')
         Traceback (most recent call last):
@@ -641,4 +640,4 @@ class BundlePartition(UUIDPartition):
         # Most bits in a v4 or v5 UUID are pseudo-random, including the leading
         # 32 bits but those are followed by a couple of deterministic ones.
         # For simplicity, we'll limit ourselves to 2 ** 32 leaf partitions.
-        reject(self.prefix_length > 32)
+        assert self.prefix_length <= 32, R('Too many partitions', self.prefix_length)

--- a/src/azul/indexer/document.py
+++ b/src/azul/indexer/document.py
@@ -1109,6 +1109,8 @@ class Replica[E: EntityReference](Document[ReplicaCoordinates[E]]):
 
     contents: JSON
 
+    source: DocumentSource
+
     hub_ids: list[EntityID]
 
     needs_translation: ClassVar[bool] = False
@@ -1128,6 +1130,7 @@ class Replica[E: EntityReference](Document[ReplicaCoordinates[E]]):
 
     def to_json(self) -> JSON:
         return dict(super().to_json(),
+                    source=self.source.to_json(),
                     replica_type=self.replica_type,
                     # Ensure that index contents is deterministic for unit tests
                     hub_ids=sorted(set(self.hub_ids)))

--- a/src/azul/indexer/index_service.py
+++ b/src/azul/indexer/index_service.py
@@ -17,11 +17,7 @@ from operator import (
 )
 from typing import (
     Any,
-    MutableSet,
-    Optional,
     TYPE_CHECKING,
-    Type,
-    Union,
     cast,
 )
 
@@ -267,7 +263,7 @@ class IndexService(DocumentService):
                   partition: BundlePartition = BundlePartition.root,
                   *,
                   delete: bool,
-                  ) -> Union[list[BundlePartition], tuple[list[Contribution], list[Replica]]]:
+                  ) -> list[BundlePartition] | tuple[list[Contribution], list[Replica]]:
         """
         Return a list of contributions and a list of replicas for the entities
         in the given partition of the specified bundle, or a set of divisions of
@@ -353,7 +349,7 @@ class IndexService(DocumentService):
             )
 
         def setify(value: CompositeJSON
-                   ) -> Union[set[tuple[str, AnyJSON]], set[AnyJSON]]:
+                   ) -> set[tuple[str, AnyJSON]] | set[AnyJSON]:
             value = freeze(value)
             return set(
                 value.items()
@@ -578,7 +574,7 @@ class IndexService(DocumentService):
                             ) -> list[CataloguedContribution]:
         es_client = ESClientFactory.get()
 
-        entity_ids_by_index: dict[str, MutableSet[str]] = defaultdict(set)
+        entity_ids_by_index: dict[str, set[str]] = defaultdict(set)
         for entity in tallies.keys():
             index = str(IndexName.create(catalog=entity.catalog,
                                          qualifier=entity.entity_type,
@@ -696,7 +692,7 @@ class IndexService(DocumentService):
             )
 
         # Create lookup for transformer by entity type
-        transformers: dict[tuple[CatalogName, str], Type[Transformer]] = {
+        transformers: dict[tuple[CatalogName, str], type[Transformer]] = {
             (catalog, transformer_cls.entity_type()): transformer_cls
             for catalog in config.catalogs
             for transformer_cls in self.transformer_types(catalog)
@@ -734,7 +730,7 @@ class IndexService(DocumentService):
         return aggregates
 
     def _aggregate_entity(self,
-                          transformer: Type[Transformer],
+                          transformer: type[Transformer],
                           contributions: list[Contribution]
                           ) -> JSON:
         contents = self._reconcile(transformer, contributions)
@@ -756,7 +752,7 @@ class IndexService(DocumentService):
         return aggregate_contents
 
     def _reconcile(self,
-                   transformer: Type[Transformer],
+                   transformer: type[Transformer],
                    contributions: Sequence[Contribution],
                    ) -> Mapping[EntityType, Entities]:
         """
@@ -791,7 +787,7 @@ class IndexService(DocumentService):
 
     def _create_writer(self,
                        doc_type: DocumentType,
-                       catalog: Optional[CatalogName]
+                       catalog: CatalogName | None
                        ) -> 'IndexWriter':
         # We allow one conflict retry in the case of duplicate notifications and
         # switch from 'add' to 'update'. After that, there should be no
@@ -814,9 +810,9 @@ class IndexService(DocumentService):
 class IndexWriter:
 
     def __init__(self,
-                 catalog: Optional[CatalogName],
+                 catalog: CatalogName | None,
                  field_types: CataloguedFieldTypes,
-                 refresh: Union[bool, str],
+                 refresh: bool | str,
                  conflict_retry_limit: int,
                  error_retry_limit: int) -> None:
         """
@@ -843,7 +839,7 @@ class IndexWriter:
         self.es_client = ESClientFactory.get()
         self.errors: dict[DocumentCoordinates, int] = defaultdict(int)
         self.conflicts: dict[DocumentCoordinates, int] = defaultdict(int)
-        self.retries: Optional[MutableSet[DocumentCoordinates]] = None
+        self.retries: set[DocumentCoordinates] | None = None
 
     bulk_threshold = 32
 
@@ -945,7 +941,7 @@ class IndexWriter:
         else:
             log.debug('Successfully wrote %s.', coordinates)
 
-    def _on_error(self, doc: Document, e: Union[Exception, JSON]):
+    def _on_error(self, doc: Document, e: Exception | JSON):
         self.errors[doc.coordinates] += 1
         if self.error_retry_limit is None or self.errors[doc.coordinates] <= self.error_retry_limit:
             action = 'retrying'
@@ -956,7 +952,7 @@ class IndexWriter:
                     doc.coordinates, e, self.errors[doc.coordinates], action,
                     exc_info=isinstance(e, Exception))
 
-    def _on_conflict(self, doc: Document, e: Union[Exception, JSON]):
+    def _on_conflict(self, doc: Document, e: Exception | JSON):
         self.conflicts[doc.coordinates] += 1
         self.errors.pop(doc.coordinates, None)  # a conflict resets the error count
         if self.conflict_retry_limit is None or self.conflicts[doc.coordinates] <= self.conflict_retry_limit:

--- a/src/azul/indexer/transform.py
+++ b/src/azul/indexer/transform.py
@@ -149,6 +149,7 @@ class Transformer(metaclass=ABCMeta):
                        version=None,
                        replica_type=replica_type,
                        contents=contents,
+                       source=self.bundle.fqid.source,
                        # The other hubs will be added when the indexer
                        # consolidates duplicate replicas.
                        hub_ids=alist(file_hub, root_hub))

--- a/src/azul/service/avro_pfb.py
+++ b/src/azul/service/avro_pfb.py
@@ -34,8 +34,8 @@ from more_itertools import (
 )
 
 from azul import (
+    R,
     config,
-    reject,
 )
 from azul.indexer.field import (
     ClosedRange,
@@ -157,7 +157,7 @@ class PFBConverter:
 
 def _reversible_join(joiner: str, parts: Iterable[str]) -> str:
     parts = list(parts)
-    reject(any(joiner in part for part in parts), parts)
+    assert all(joiner not in part for part in parts), R('Found joiner in', parts)
     return joiner.join(parts)
 
 
@@ -173,7 +173,7 @@ class PFBEntity:
     namespace_uuid: ClassVar[UUID] = UUID('bc93372b-9218-4f0e-b64e-6f3b339687d6')
 
     def __attrs_post_init__(self):
-        reject(len(self.id) > 254, 'Terra requires IDs be no longer than 254 chars', )
+        assert len(self.id) <= 254, R('Terra requires IDs be no longer than 254 chars')
 
     @classmethod
     def for_aggregate(cls,

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -2143,6 +2143,40 @@ class PFBVerbatimManifestGenerator(VerbatimManifestGenerator):
     def format(cls) -> ManifestFormat:
         return ManifestFormat.verbatim_pfb
 
+    def _include_relations(self) -> bool:
+        # Terra will reject the handover if the manifest includes
+        # dangling relations, i.e., if any entity references another
+        # entity that isn't included in the manifest. There are three
+        # known cases where dangling relations can occur (note that
+        # currently only the AnVIL plugins support adding relations
+        # to the manifest):
+        #
+        # 1. If an entity occurs in both a replica bundle and a primary
+        #    bundle, but only the replica bundle is indexed, its
+        #    referenced entities may be missing from the index (and
+        #    consequently from the manifest). This can only occur when
+        #    the deployment is configured to index snapshots using a
+        #    common prefix. See
+        #    https://github.com/DataBiosphere/azul/issues/6843
+        #
+        # 2. When using a filter that matches some but not all of the
+        #    files derived from a particular activity, the activity will
+        #    be left with dangling relations to the derived files that
+        #    didn't match the filter.
+        #
+        # 3. The `anvil_assayactivity` table includes a foreign key into
+        #    the `anvil_antibody` table. We only index replicas from the
+        #    latter as orphans, so replicas from the former can include
+        #    dangling relations when orphans are not included.
+        #    See https://github.com/DataBiosphere/azul/issues/4440
+        #
+        # (1) can only occur when orphans are included, and (2) and (3)
+        # can only occur when orphans are *not* included. Because (1)
+        # can only occur on lower deployments, we make the inclusion of
+        # relations conditional on avoiding (2) and (3).
+        #
+        return config.enable_verbatim_relations and self.include_orphans
+
     def create_file(self) -> tuple[str, str | None]:
         replicas = list(self._all_replicas())
         plugin = self.metadata_plugin
@@ -2161,38 +2195,7 @@ class PFBVerbatimManifestGenerator(VerbatimManifestGenerator):
             for replica in replicas:
                 id = plugin.verbatim_pfb_entity_id(replica)
                 entity = avro_pfb.PFBEntity.for_replica(id, dict(replica))
-                # Terra will reject the handover if the manifest includes
-                # dangling relations, i.e., if any entity references another
-                # entity that isn't included in the manifest. There are three
-                # known cases where dangling relations can occur (note that
-                # currently only the AnVIL plugins support adding relations
-                # to the manifest):
-                #
-                # 1. If an entity occurs in both a replica bundle and a primary
-                #    bundle, but only the replica bundle is indexed, its
-                #    referenced entities may be missing from the index (and
-                #    consequently from the manifest). This can only occur when
-                #    the deployment is configured to index snapshots using a
-                #    common prefix. See
-                #    https://github.com/DataBiosphere/azul/issues/6843
-                #
-                # 2. When using a filter that matches some but not all of the
-                #    files derived from a particular activity, the activity will
-                #    be left with dangling relations to the derived files that
-                #    didn't match the filter.
-                #
-                # 3. The `anvil_assayactivity` table includes a foreign key into
-                #    the `anvil_antibody` table. We only index replicas from the
-                #    latter as orphans, so replicas from the former can include
-                #    dangling relations when orphans are not included.
-                #    See https://github.com/DataBiosphere/azul/issues/4440
-                #
-                # (1) can only occur when orphans are included, and (2) and (3)
-                # can only occur when orphans are *not* included. Because (1)
-                # can only occur on lower deployments, we make the inclusion of
-                # relations conditional on avoiding (2) and (3).
-                #
-                if config.enable_verbatim_relations and self.include_orphans:
+                if self._include_relations():
                     relations = plugin.verbatim_pfb_relations(replica)
                     entity_relations = [
                         PFBRelation(dst_name=replica_type, dst_id=entity_id)

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -80,7 +80,7 @@ import msgpack
 
 from azul import (
     CatalogName,
-    RequirementError,
+    R,
     cached_property,
     config,
     mutable_furl,
@@ -1547,19 +1547,19 @@ class CurlManifestGenerator(PagedManifestGenerator):
         >>> f('foo/bar/\\x1F/file') # doctest: +NORMALIZE_WHITESPACE
         Traceback (most recent call last):
         ...
-        azul.RequirementError: ('Invalid file path', 'foo/bar/\\x1f/file',
-                                'Control character or backslash at position', 8)
+        AssertionError: R('Invalid file path', 'foo/bar/\\x1f/file',
+                          'Control character or backslash at position', 8)
 
         >>> f('foo/bar/COM6/file') # doctest: +NORMALIZE_WHITESPACE
         Traceback (most recent call last):
         ...
-        azul.RequirementError: ('Invalid file path', 'foo/bar/COM6/file',
-                                'Use of reserved path component for Windows', {'COM6'})
+        AssertionError: R('Invalid file path', 'foo/bar/COM6/file',
+                          'Use of reserved path component for Windows', {'COM6'})
 
         >>> f('foo/bar/ / baz/file') # doctest: +NORMALIZE_WHITESPACE
         Traceback (most recent call last):
         ...
-        azul.RequirementError: ('Invalid file path', 'foo/bar/ / baz/file')
+        AssertionError: R('Invalid file path', 'foo/bar/ / baz/file')
 
         Substitutions:
 
@@ -1590,19 +1590,16 @@ class CurlManifestGenerator(PagedManifestGenerator):
         True
         """
         match = cls._malicious_chars.search(path)
-        if match is not None:
-            raise RequirementError('Invalid file path', path,
-                                   'Control character or backslash at position', match.start())
+        assert match is None, R('Invalid file path', path,
+                                'Control character or backslash at position', match.start())
 
         path = cls._problematic_chars.sub('_', path)
 
-        if cls._valid_path.fullmatch(path) is None:
-            raise RequirementError('Invalid file path', path)
+        assert cls._valid_path.fullmatch(path) is not None, R('Invalid file path', path)
 
         components = set(path.split('/')) & cls.special_dos_files
-        if components:
-            raise RequirementError('Invalid file path', path,
-                                   'Use of reserved path component for Windows', components)
+        assert not components, R('Invalid file path', path,
+                                 'Use of reserved path component for Windows', components)
 
         return path
 

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -102,6 +102,9 @@ from azul.collections import (
 from azul.deployment import (
     aws,
 )
+from azul.indexer import (
+    SourceSpec,
+)
 from azul.indexer.document import (
     DocumentType,
     FieldPath,
@@ -2143,7 +2146,7 @@ class PFBVerbatimManifestGenerator(VerbatimManifestGenerator):
     def format(cls) -> ManifestFormat:
         return ManifestFormat.verbatim_pfb
 
-    def _include_relations(self) -> bool:
+    def _include_relations(self, replica: JSON) -> bool:
         # Terra will reject the handover if the manifest includes
         # dangling relations, i.e., if any entity references another
         # entity that isn't included in the manifest. There are three
@@ -2171,11 +2174,14 @@ class PFBVerbatimManifestGenerator(VerbatimManifestGenerator):
         #    See https://github.com/DataBiosphere/azul/issues/4440
         #
         # (1) can only occur when orphans are included, and (2) and (3)
-        # can only occur when orphans are *not* included. Because (1)
-        # can only occur on lower deployments, we make the inclusion of
-        # relations conditional on avoiding (2) and (3).
+        # can only occur when orphans are *not* included.
         #
-        return config.enable_verbatim_relations and self.include_orphans
+        prefix = SourceSpec.parse_prefix_only(replica['source']['spec'])
+        return (
+            config.enable_verbatim_relations
+            and self.include_orphans
+            and not prefix.common
+        )
 
     def create_file(self) -> tuple[str, str | None]:
         replicas = list(self._all_replicas())
@@ -2195,7 +2201,13 @@ class PFBVerbatimManifestGenerator(VerbatimManifestGenerator):
             for replica in replicas:
                 id = plugin.verbatim_pfb_entity_id(replica)
                 entity = avro_pfb.PFBEntity.for_replica(id, dict(replica))
-                if self._include_relations():
+                # The inclusion of relations is determined on a case-by-case
+                # basis for each replica, which may result in inconsistent
+                # expression of relations across rows in the same manifest.
+                # We chose this approach because scanning all replicas in
+                # advance would present another obstacle to our goal of
+                # parallelizing the manifest generation.
+                if self._include_relations(replica):
                     relations = plugin.verbatim_pfb_relations(replica)
                     entity_relations = [
                         PFBRelation(dst_name=replica_type, dst_id=entity_id)

--- a/test/indexer/data/826dea02-e274-affe-aabc-eb3db63ad068.results.json
+++ b/test/indexer/data/826dea02-e274-affe-aabc-eb3db63ad068.results.json
@@ -440,6 +440,10 @@
                 "15b76f9c-6b46-433f-851d-34e89f1b9ba6",
                 "2370f948-2783-4eb6-afea-e022897f4dcf"
             ],
+            "source": {
+                "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
+                "spec": "tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2"
+            },
             "contents": {
                 "activity_type": "Sequencing",
                 "assay_type": [],
@@ -875,6 +879,10 @@
                 "15b76f9c-6b46-433f-851d-34e89f1b9ba6",
                 "2370f948-2783-4eb6-afea-e022897f4dcf"
             ],
+            "source": {
+                "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
+                "spec": "tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2"
+            },
             "contents": {
                 "data_modality": [],
                 "datarepo_row_id": "15b76f9c-6b46-433f-851d-34e89f1b9ba6",
@@ -909,6 +917,10 @@
                 "2370f948-2783-4eb6-afea-e022897f4dcf",
                 "3b17377b-16b1-431c-9967-e5d01fc5923f"
             ],
+            "source": {
+                "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
+                "spec": "tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2"
+            },
             "contents": {
                 "datarepo_row_id": "15d85d30-ad4a-4f50-87a8-a27f59dd1b5f",
                 "diagnosis_age_lower_bound": null,
@@ -1483,6 +1495,10 @@
             "hub_ids": [
                 "2370f948-2783-4eb6-afea-e022897f4dcf"
             ],
+            "source": {
+                "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
+                "spec": "tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2"
+            },
             "contents": {
                 "consent_group": [
                     "DS-BDIS"
@@ -1752,6 +1768,10 @@
                 "crc32": ""
             },
             "replica_type": "anvil_file",
+            "source": {
+                "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
+                "spec": "tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2"
+            },
             "hub_ids": [
                 "2370f948-2783-4eb6-afea-e022897f4dcf",
                 "3b17377b-16b1-431c-9967-e5d01fc5923f"
@@ -2199,6 +2219,10 @@
                 "2370f948-2783-4eb6-afea-e022897f4dcf",
                 "3b17377b-16b1-431c-9967-e5d01fc5923f"
             ],
+            "source": {
+                "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
+                "spec": "tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2"
+            },
             "contents": {
                 "activity_type": "Sequencing",
                 "assay_type": [],
@@ -2949,6 +2973,10 @@
                 "2370f948-2783-4eb6-afea-e022897f4dcf",
                 "3b17377b-16b1-431c-9967-e5d01fc5923f"
             ],
+            "source": {
+                "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
+                "spec": "tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2"
+            },
             "contents": {
                 "anatomical_site": null,
                 "apriori_cell_type": [],
@@ -3530,6 +3558,10 @@
                 "2370f948-2783-4eb6-afea-e022897f4dcf",
                 "3b17377b-16b1-431c-9967-e5d01fc5923f"
             ],
+            "source": {
+                "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
+                "spec": "tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2"
+            },
             "contents": {
                 "datarepo_row_id": "939a4bd3-86ed-4a8a-81f4-fbe0ee673461",
                 "diagnosis_age_lower_bound": null,
@@ -4114,6 +4146,10 @@
                 "version": "2022-06-01T00:00:00.000000Z"
             },
             "replica_type": "anvil_donor",
+            "source": {
+                "id": "6c87f0e1-509d-46a4-b845-7584df39263b",
+                "spec": "tdr:bigquery:gcp:test_anvil_project:anvil_snapshot:/2"
+            },
             "hub_ids": [
                 "15b76f9c-6b46-433f-851d-34e89f1b9ba6",
                 "2370f948-2783-4eb6-afea-e022897f4dcf",

--- a/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T11:33:44.698028Z.results.json
+++ b/test/indexer/data/aaa96233-bf27-44c7-82df-b4dc15ad4d9d.2018-11-02T11:33:44.698028Z.results.json
@@ -68,6 +68,10 @@
                 "schema_version": "1.1.3"
             },
             "entity_id": "aaa96233-bf27-44c7-82df-b4dc15ad4d9d",
+            "source": {
+                "id": "42848d8f-ecdc-5b32-a667-a7b5aedfc9f5",
+                "spec": "https://fake_dss_instance/v1:/2"
+            },
             "hub_ids": [
                 "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
                 "70d1af4a-82c8-478a-8960-e9028b3616ca",
@@ -3497,6 +3501,10 @@
             },
             "entity_id": "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
             "replica_type": "sequence_file",
+            "source": {
+                "id": "42848d8f-ecdc-5b32-a667-a7b5aedfc9f5",
+                "spec": "https://fake_dss_instance/v1:/2"
+            },
             "hub_ids": [
                 "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
                 "e8642221-4c2c-4fd7-b926-a68bce363c88"
@@ -3536,6 +3544,10 @@
             },
             "entity_id": "412898c5-5b9b-4907-b07c-e9b89666e204",
             "replica_type": "cell_suspension",
+            "source": {
+                "id": "42848d8f-ecdc-5b32-a667-a7b5aedfc9f5",
+                "spec": "https://fake_dss_instance/v1:/2"
+            },
             "hub_ids": [
                 "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
                 "70d1af4a-82c8-478a-8960-e9028b3616ca",
@@ -3569,6 +3581,10 @@
             },
             "entity_id": "70d1af4a-82c8-478a-8960-e9028b3616ca",
             "replica_type": "sequence_file",
+            "source": {
+                "id": "42848d8f-ecdc-5b32-a667-a7b5aedfc9f5",
+                "spec": "https://fake_dss_instance/v1:/2"
+            },
             "hub_ids": [
                 "70d1af4a-82c8-478a-8960-e9028b3616ca",
                 "e8642221-4c2c-4fd7-b926-a68bce363c88"
@@ -3622,6 +3638,10 @@
             },
             "entity_id": "a21dc760-a500-4236-bcff-da34a0e873d2",
             "replica_type": "specimen_from_organism",
+            "source": {
+                "id": "42848d8f-ecdc-5b32-a667-a7b5aedfc9f5",
+                "spec": "https://fake_dss_instance/v1:/2"
+            },
             "hub_ids": [
                 "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
                 "70d1af4a-82c8-478a-8960-e9028b3616ca",
@@ -3705,6 +3725,10 @@
             },
             "entity_id": "e8642221-4c2c-4fd7-b926-a68bce363c88",
             "replica_type": "project",
+            "source": {
+                "id": "42848d8f-ecdc-5b32-a667-a7b5aedfc9f5",
+                "spec": "https://fake_dss_instance/v1:/2"
+            },
             "hub_ids": [
                 "e8642221-4c2c-4fd7-b926-a68bce363c88"
             ]
@@ -3767,6 +3791,10 @@
                 "sex": "female"
             },
             "entity_id": "7b07b9d0-cc0e-4098-9f64-f4a569f7d746",
+            "source": {
+                "id": "42848d8f-ecdc-5b32-a667-a7b5aedfc9f5",
+                "spec": "https://fake_dss_instance/v1:/2"
+            },
             "hub_ids": [
                 "e8642221-4c2c-4fd7-b926-a68bce363c88"
             ],
@@ -3809,6 +3837,10 @@
                 "strand": "unstranded"
             },
             "entity_id": "9c32cf70-3ed7-4720-badc-5ee71e8a38af",
+            "source": {
+                "id": "42848d8f-ecdc-5b32-a667-a7b5aedfc9f5",
+                "spec": "https://fake_dss_instance/v1:/2"
+            },
             "hub_ids": [
                 "e8642221-4c2c-4fd7-b926-a68bce363c88"
             ],
@@ -3845,6 +3877,10 @@
                 }
             },
             "entity_id": "61e629ed-0135-4492-ac8a-5c4ab3ccca8a",
+            "source": {
+                "id": "42848d8f-ecdc-5b32-a667-a7b5aedfc9f5",
+                "spec": "https://fake_dss_instance/v1:/2"
+            },
             "hub_ids": [
                 "e8642221-4c2c-4fd7-b926-a68bce363c88"
             ],
@@ -3870,6 +3906,10 @@
                 "schema_type": "process"
             },
             "entity_id": "771ddaf6-3a4f-4314-97fe-6294ff8e25a4",
+            "source": {
+                "id": "42848d8f-ecdc-5b32-a667-a7b5aedfc9f5",
+                "spec": "https://fake_dss_instance/v1:/2"
+            },
             "hub_ids": [
                 "0c5ac7c0-817e-40d4-b1b1-34c3d5cfecdb",
                 "70d1af4a-82c8-478a-8960-e9028b3616ca",

--- a/test/indexer/test_indexer.py
+++ b/test/indexer/test_indexer.py
@@ -2174,6 +2174,7 @@ class TestDCP1IndexerWithIndexesSetUp(DCP1IndexerTestCase):
                           replica_type='file',
                           contents=contents,
                           hub_ids=[],
+                          source=self.source,
                           coordinates=coordinates)
 
         for case, hub_ids, expected_hub_ids in [

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -1737,6 +1737,76 @@ class AnvilManifestTestCase(ManifestTestCase, AnvilCannedBundleTestCase):
             cls.bundle_fqid(uuid='9a135c9a-069b-a90e-b588-eaf8d1aeeac9')
         ]
 
+    dataset_id_filters: FiltersJSON = {
+        'datasets.dataset_id': {'is': ['52ee7665-7033-63f2-a8d9-ce8e32666739']}
+    }
+
+    dataset_title_filters: FiltersJSON = {
+        'datasets.title': {'is': ['ANVIL_CMG_UWASH_DS_BDIS']}
+    }
+
+    neutral_file_filters: FiltersJSON = {
+        'files.is_supplementary': {'is': [True, False]}
+    }
+
+    # Whether orphans ought to be present in verbatim manifests generated with
+    # the given filters.
+    expect_orphans_by_filters = [
+        ({}, True),
+        (dataset_title_filters, True),
+        (dataset_id_filters, True),
+        (neutral_file_filters, False),
+        ({**neutral_file_filters, **dataset_title_filters}, False),
+    ]
+
+    def _test_verbatim_pfb_manifest(self, *, enable_relations: bool):
+        with patch.object(type(config),
+                          'enable_verbatim_relations',
+                          new=PropertyMock(return_value=enable_relations)):
+            for filters, expect_orphans in self.expect_orphans_by_filters:
+                with self.subTest(filters=filters):
+                    expect_relations = enable_relations and expect_orphans
+                    expected_manifest = self._expected_pfb_manifest(expect_orphans, expect_relations)
+                    expected_schema, expected_entities = expected_manifest
+                    response = self._get_manifest(ManifestFormat.verbatim_pfb, filters)
+                    self.assertEqual(200, response.status_code)
+                    self._assert_pfb(expected_schema, expected_entities, response)
+
+    @cache
+    def _expected_pfb_manifest(self,
+                               include_orphans: bool,
+                               include_relations: bool
+                               ) -> tuple[JSON, JSONs]:
+        canned_pfb = self._load_canned_pfb('verbatim', 'pfb', 'anvil')
+        pfb_schema, pfb_entities = canned_pfb
+        if not include_relations:
+            for entity in pfb_entities:
+                entity['relations'].clear()
+        if not include_orphans:
+            # To avoid dangling references, relations are only populated when
+            # including orphans
+            assert not include_relations
+            self.assertEqual('Entity', pfb_schema['name'])
+            object_field_schema = one(
+                field
+                for field in pfb_schema['fields']
+                if field['name'] == 'object'
+            )
+            # The `object` field is of a union type, so the schema's `type`
+            # property is an array
+            schemas = object_field_schema['type']
+            # The first AVRO record is the *metadata entity* in PFB terms,
+            # declaring higher level constraints that can't be expressed in
+            # the AVRO schema
+            metadata_entity = pfb_entities[0]
+            self.assertEqual('Metadata', metadata_entity['name'])
+            higher_schemas = metadata_entity['object']['nodes']
+            for part in [schemas, higher_schemas, pfb_entities]:
+                filtered = [e for e in part if e['name'] != 'non_schema_orphan_table']
+                assert len(filtered) < len(part), 'Expected to filter orphan references'
+                part[:] = filtered
+        return pfb_schema, pfb_entities
+
 
 class TestAnvilManifests(AnvilManifestTestCase):
 
@@ -2116,28 +2186,6 @@ class TestAnvilManifests(AnvilManifestTestCase):
             )
         ]
         self._assert_tsv(expected, response)
-
-    dataset_id_filters: FiltersJSON = {
-        'datasets.dataset_id': {'is': ['52ee7665-7033-63f2-a8d9-ce8e32666739']}
-    }
-
-    dataset_title_filters: FiltersJSON = {
-        'datasets.title': {'is': ['ANVIL_CMG_UWASH_DS_BDIS']}
-    }
-
-    neutral_file_filters: FiltersJSON = {
-        'files.is_supplementary': {'is': [True, False]}
-    }
-
-    # Whether orphans ought to be present in verbatim manifests generated with
-    # the given filters.
-    expect_orphans_by_filters = [
-        ({}, True),
-        (dataset_title_filters, True),
-        (dataset_id_filters, True),
-        (neutral_file_filters, False),
-        ({**neutral_file_filters, **dataset_title_filters}, False),
-    ]
 
     def test_verbatim_jsonl_manifest(self):
         base_path = ['verbatim', 'jsonl', 'anvil']

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -71,6 +71,7 @@ from azul.collections import (
     none_safe_tuple_key,
 )
 from azul.indexer import (
+    Prefix,
     SourcedBundleFQID,
 )
 from azul.indexer.document import (
@@ -1765,7 +1766,11 @@ class AnvilManifestTestCase(ManifestTestCase, AnvilCannedBundleTestCase):
                           new=PropertyMock(return_value=enable_relations)):
             for filters, expect_orphans in self.expect_orphans_by_filters:
                 with self.subTest(filters=filters):
-                    expect_relations = enable_relations and expect_orphans
+                    expect_relations = (
+                        enable_relations
+                        and expect_orphans
+                        and not self.source.spec.prefix.common
+                    )
                     expected_manifest = self._expected_pfb_manifest(expect_orphans, expect_relations)
                     expected_schema, expected_entities = expected_manifest
                     response = self._get_manifest(ManifestFormat.verbatim_pfb, filters)
@@ -2252,6 +2257,13 @@ class TestAnvilManifests(AnvilManifestTestCase):
                 assert len(filtered) < len(part), 'Expected to filter orphan references'
                 part[:] = filtered
         return pfb_schema, pfb_entities
+
+
+class TestAnvilManifestsWithCommonPrefix(AnvilManifestTestCase):
+    source = AnvilManifestTestCase.source.with_prefix(Prefix.parse('abc/0'))
+
+    def test(self):
+        self._test_verbatim_pfb_manifest(enable_relations=True)
 
 
 class TestPFB(CannedManifestTestCase):

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -1728,9 +1728,6 @@ class AnvilManifestTestCase(ManifestTestCase, AnvilCannedBundleTestCase):
     def _drs_domain(self) -> str:
         return self.mock_tdr_service_url.netloc
 
-
-class TestAnvilManifests(AnvilManifestTestCase):
-
     @classmethod
     def bundles(cls) -> list[SourcedBundleFQID]:
         return [
@@ -1739,6 +1736,9 @@ class TestAnvilManifests(AnvilManifestTestCase):
             cls.bundle_fqid(uuid='826dea02-e274-affe-aabc-eb3db63ad068'),
             cls.bundle_fqid(uuid='9a135c9a-069b-a90e-b588-eaf8d1aeeac9')
         ]
+
+
+class TestAnvilManifests(AnvilManifestTestCase):
 
     def test_compact_manifest(self):
         response = self._get_manifest(ManifestFormat.compact, filters={})
@@ -2129,19 +2129,21 @@ class TestAnvilManifests(AnvilManifestTestCase):
         'files.is_supplementary': {'is': [True, False]}
     }
 
+    # Whether orphans ought to be present in verbatim manifests generated with
+    # the given filters.
+    expect_orphans_by_filters = [
+        ({}, True),
+        (dataset_title_filters, True),
+        (dataset_id_filters, True),
+        (neutral_file_filters, False),
+        ({**neutral_file_filters, **dataset_title_filters}, False),
+    ]
+
     def test_verbatim_jsonl_manifest(self):
         base_path = ['verbatim', 'jsonl', 'anvil']
         linked_rows = self._load_canned_manifest(*base_path, 'linked.json')
         all_rows = linked_rows + self._load_canned_manifest(*base_path, 'orphans.json')
-
-        cases = [
-            ({}, True),
-            (self.dataset_title_filters, True),
-            (self.dataset_id_filters, True),
-            (self.neutral_file_filters, False),
-            ({**self.neutral_file_filters, **self.dataset_title_filters}, False),
-        ]
-        for filters, expect_orphans in cases:
+        for filters, expect_orphans in self.expect_orphans_by_filters:
             with self.subTest(filters=filters):
                 response = self._get_manifest(ManifestFormat.verbatim_jsonl, filters=filters)
                 self.assertEqual(200, response.status_code)
@@ -2159,15 +2161,10 @@ class TestAnvilManifests(AnvilManifestTestCase):
         with patch.object(type(config),
                           'enable_verbatim_relations',
                           new=PropertyMock(return_value=enable_relations)):
-            for orphans, filters in [
-                (True, {}),
-                (True, self.dataset_id_filters),
-                (True, self.dataset_title_filters),
-                (False, self.neutral_file_filters),
-                (False, {**self.neutral_file_filters, **self.dataset_title_filters})
-            ]:
-                with self.subTest(orphans=orphans, relations=enable_relations, filters=filters):
-                    expected_manifest = self._expected_pfb_manifest(orphans, enable_relations)
+            for filters, expect_orphans in self.expect_orphans_by_filters:
+                with self.subTest(filters=filters):
+                    expect_relations = enable_relations and expect_orphans
+                    expected_manifest = self._expected_pfb_manifest(expect_orphans, expect_relations)
                     expected_schema, expected_entities = expected_manifest
                     response = self._get_manifest(ManifestFormat.verbatim_pfb, filters)
                     self.assertEqual(200, response.status_code)
@@ -2176,16 +2173,17 @@ class TestAnvilManifests(AnvilManifestTestCase):
     @cache
     def _expected_pfb_manifest(self,
                                include_orphans: bool,
-                               enable_relations: bool
+                               include_relations: bool
                                ) -> tuple[JSON, JSONs]:
         canned_pfb = self._load_canned_pfb('verbatim', 'pfb', 'anvil')
         pfb_schema, pfb_entities = canned_pfb
-        # To avoid dangling references, relations are only populated when
-        # including orphans
-        if not enable_relations or not include_orphans:
+        if not include_relations:
             for entity in pfb_entities:
                 entity['relations'].clear()
         if not include_orphans:
+            # To avoid dangling references, relations are only populated when
+            # including orphans
+            assert not include_relations
             self.assertEqual('Entity', pfb_schema['name'])
             object_field_schema = one(
                 field

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -61,7 +61,7 @@ from requests import (
 )
 
 from azul import (
-    RequirementError,
+    R,
     cache,
     config,
 )
@@ -2230,5 +2230,6 @@ class TestPFB(CannedManifestTestCase):
     def test_pfb_entity_id(self):
         # Terra limits ID's 254 chars
         avro_pfb.PFBEntity(id='a' * 254, name='foo', object={})
-        with self.assertRaises(RequirementError):
+        with self.assertRaises(AssertionError) as e:
             avro_pfb.PFBEntity(id='a' * 255, name='foo', object={})
+        self.assertTrue(R.caused(e.exception))


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Connected issues: #6843


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved connected issues to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
