### PR TITLE
Hotfix prod: Reindex lm8 (#6997)

### DIFF
--- a/deployments/prod/environment.py
+++ b/deployments/prod/environment.py
@@ -1384,15 +1384,18 @@ lm7_sources = mkdict(lm6_sources, 2, mkdelta([
     # @formatter:on
 ]))
 
-lm8_sources = mkdict(lm7_sources, 9, mkdelta([
+lm8_sources = mkdict(lm7_sources, 12, mkdelta([
+    mksrc('bigquery', 'datarepo-3f02598d', 'lungmap_prod_00f056f273ff43ac97ff69ca10e38c89__20220308_20250325_lm8'),
     mksrc('bigquery', 'datarepo-2b15227b', 'lungmap_prod_1977dc4784144263a8706b0f207d8ab3__20240206_20241002_lm8'),
     mksrc('bigquery', 'datarepo-c9158593', 'lungmap_prod_20037472ea1d4ddb9cd356a11a6f0f76__20220307_20241002_lm8'),
+    mksrc('bigquery', 'datarepo-2f143f27', 'lungmap_prod_2620497955a349b28d2b53e0bdfcb176__20220308_20250325_lm8'),
     mksrc('bigquery', 'datarepo-35a6d7ca', 'lungmap_prod_3a02d15f9c6a4ef7852b4ddec733b70b__20241001_20241002_lm8'),
     mksrc('bigquery', 'datarepo-131a1234', 'lungmap_prod_4ae8c5c91520437198276935661f6c84__20231004_20241002_lm8'),
     mksrc('bigquery', 'datarepo-936db385', 'lungmap_prod_6135382f487d4adb9cf84d6634125b68__20230207_20241106_lm8'),
+    mksrc('bigquery', 'datarepo-42daf980', 'lungmap_prod_6511b041b11e4ccf85932b40148c437e__20240326_20250325_lm8'),
     mksrc('bigquery', 'datarepo-3c4905d2', 'lungmap_prod_834e0d1671b64425a8ab022b5000961c__20241001_20241002_lm8'),
     mksrc('bigquery', 'datarepo-d7447983', 'lungmap_prod_f899709cae2c4bb988f0131142e6c7ec__20220310_20241002_lm8'),
-    mksrc('bigquery', 'datarepo-c11ef363', 'lungmap_prod_fdadee7e209745d5bf81cc280bd8348e__20240206_20241002_lm8'),
+    mksrc('bigquery', 'datarepo-c11ef363', 'lungmap_prod_fdadee7e209745d5bf81cc280bd8348e__20240206_20241002_lm8')
 ]))
 
 


### PR DESCRIPTION
<!--
This is the PR template for hotfix PRs against `prod`.
-->

Connected issue: #6997

## Note

- Perform a [targeted reindex](https://github.com/DataBiosphere/azul/blob/develop/OPERATOR.rst#reindexing-a-specific-catalog-or-sources-in-gitlab) of `lm8`

## Checklist


### Author

- [x] Target branch is `prod`
- [x] Name of PR branch matches `hotfixes/<GitHub handle of author>/<issue#>-<slug>-prod`
- [x] On ZenHub, PR is connected to the issue it hotfixes
- [x] PR description links to connected issue
- [x] PR title is `Hotfix prod: ` followed by title of connected issue
- [x] PR title references the connected issue


### Author (hotfixes)

- [x] Added `h` tag to commit title <sub>or this PR does not include a temporary hotfix</sub>
- [x] Added `H` tag to commit title <sub>or this PR does not include a permanent hotfix</sub>
- [x] Added `hotfix` label to PR
- [x] This PR is labeled `partial` <sub>or represents a permanent hotfix</sub>


### Author (before every review)

- [x] Rebased PR branch on `prod`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled PR as `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] Moved connected issue to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Squashed PR branch and rebased onto `prod`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but excluded any `p` tags</sub>
- [x] Moved connected issue to *Merged stable* column in ZenHub
- [x] Pushed merge commit to GitHub


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `prod`
- [x] Build passes on GitLab `prod`
- [x] Reviewed build logs for anomalies on GitLab `prod`
- [x] Deleted PR branch from GitHub


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `prod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:prod`</sub>
- [x] Deindexed specific sources in `prod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:prod`</sub>
- [x] Indexed specific sources in `prod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:prod`</sub>
- [x] Started reindex in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Emptied fail queues in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/prod branch](https://gitlab.azul.data.humancellatlas.org/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fprod) on GitLab in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/prod branch](https://gitlab.azul.data.humancellatlas.org/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fprod) on GitLab in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Created backport PR and linked to it in a comment on this PR


### Operator

- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
