### PR TITLE
Implement mirror_file, mirror_part & finalize_file (#6862)

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -52,7 +52,8 @@ modules =
     azul.indexer.field,
     azul.indexer.action_controller,
     azul.indexer.mirror_controller,
-    azul.service.app_controller
+    azul.service.app_controller,
+    azul.indexer.mirror_service
 packages =
     azul.openapi
 

--- a/lambdas/indexer/.chalice/config.json.template.py
+++ b/lambdas/indexer/.chalice/config.json.template.py
@@ -57,7 +57,7 @@ emit({
                     {
                         indexer.mirror.name: {
                             'reserved_concurrency': config.mirroring_concurrency,
-                            'lambda_memory_size': 256,
+                            'lambda_memory_size': 512,
                             'lambda_timeout': config.mirror_lambda_timeout
                         },
                     }

--- a/scripts/mirror.py
+++ b/scripts/mirror.py
@@ -1,7 +1,6 @@
 """
 Copy all files from the public sources in a catalog to the current deployment's
-mirroring bucket. The actual file-copying is not yet implemented, so all this
-currently does is send messages to the indexer app that don't do anything.
+mirroring bucket.
 """
 import argparse
 import logging

--- a/scripts/mirror_file.py
+++ b/scripts/mirror_file.py
@@ -5,8 +5,6 @@ supported, so the file must be publicly accessible.
 """
 import argparse
 import logging
-import math
-import string
 import sys
 
 from azul import (
@@ -17,23 +15,15 @@ from azul import (
 from azul.args import (
     AzulArgumentHelpFormatter,
 )
-from azul.azulclient import (
-    AzulClient,
-)
-from azul.deployment import (
-    aws,
-)
-from azul.drs import (
-    AccessMethod,
-)
 from azul.http import (
     http_client,
 )
+from azul.indexer.mirror_service import (
+    FilePart,
+    MirrorService,
+)
 from azul.logging import (
     configure_script_logging,
-)
-from azul.plugins import (
-    File,
 )
 from azul.plugins.metadata.hca import (
     HCAFile,
@@ -46,9 +36,6 @@ from azul.service.repository_service import (
 )
 from azul.service.source_service import (
     SourceService,
-)
-from azul.service.storage_service import (
-    StorageService,
 )
 
 log = logging.getLogger(__name__)
@@ -70,55 +57,22 @@ def get_file(catalog: CatalogName, file_uuid: str) -> HCAFile:
     return file
 
 
-def get_download_url(catalog: CatalogName, file: File) -> str:
-    drs_uri = file.drs_uri
-    drs = AzulClient().repository_plugin(catalog).drs_client()
-    access = drs.get_object(drs_uri, AccessMethod.gs)
-    assert access.method is AccessMethod.https, access
-    return access.url
-
-
-def object_key(file: File) -> str:
-    digest, digest_type = file.digest()
-    assert all(c in string.hexdigits for c in digest), R(
-        'Expected a hexadecimal digest', digest)
-    return f'file/{digest.lower()}.{digest_type}'
-
-
 def mirror_file(catalog: CatalogName, file_uuid: str, part_size: int) -> str:
     assert config.enable_mirroring, R('Mirroring must be enabled')
     assert config.is_tdr_enabled(catalog), R('Only TDR catalogs are supported')
-    assert config.is_hca_enabled(catalog), R('Only HCA catalogs are supported')
-    # https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
-    assert 5 * 2 ** 20 <= part_size <= 5 * 2 ** 30, R(
-        'Invalid part size', part_size)
     file = get_file(catalog, file_uuid)
-    download_url = get_download_url(catalog, file)
-    key = object_key(file)
-    storage = StorageService(bucket_name=aws.mirror_bucket)
-    upload = storage.create_multipart_upload(key, content_type=file.content_type)
+    service = MirrorService()
+    upload_id = service.begin_mirroring_file(file)
 
-    total_size = file.size
-    part_count = math.ceil(total_size / part_size)
-    assert part_count <= 10000, R('Part size is too small for this file',
-                                  total_size, part_size, part_count)
+    def mirror_parts():
+        part = FilePart.first(file, part_size)
+        while part is not None:
+            yield service.mirror_file_part(catalog, file, part, upload_id)
+            part = part.next(file)
 
-    def file_part(part_number: int) -> str:
-        start = part_number * part_size
-        end = min((part_number + 1) * part_size - 1, total_size)
-        response = http.request('GET',
-                                download_url,
-                                headers={'Range': f'bytes={start}-{end}'})
-        if response.status == 206:
-            return storage.upload_multipart_part(response.data,
-                                                 part_number + 1,
-                                                 upload)
-        else:
-            raise RuntimeError('Unexpected response from repository', response.status)
-
-    etags = list(map(file_part, range(part_count)))
-    storage.complete_multipart_upload(upload, etags)
-    return storage.get_presigned_url(key, file.name)
+    etags = list(mirror_parts())
+    service.finish_mirroring_file(file, upload_id, etags=etags)
+    return service.get_mirror_url(file)
 
 
 def main(argv):
@@ -126,7 +80,7 @@ def main(argv):
                                      formatter_class=AzulArgumentHelpFormatter)
     parser.add_argument('-c', '--catalog', default=config.default_catalog)
     parser.add_argument('-f', '--file-uuid')
-    parser.add_argument('-p', '--part-size', type=int, default=50 * 2 ** 20)
+    parser.add_argument('-p', '--part-size', type=int, default=FilePart.default_size)
     args = parser.parse_args(argv)
     signed_url = mirror_file(args.catalog, args.file_uuid, args.part_size)
     print(signed_url)

--- a/src/azul/azulclient.py
+++ b/src/azul/azulclient.py
@@ -24,6 +24,7 @@ from pprint import (
 )
 from typing import (
     Self,
+    Sequence,
     TYPE_CHECKING,
     cast,
 )
@@ -63,11 +64,16 @@ from azul.indexer import (
 from azul.indexer.index_service import (
     IndexService,
 )
+from azul.indexer.mirror_service import (
+    FilePart,
+    MirrorService,
+)
 from azul.json import (
     Serializable,
 )
 from azul.plugins import (
     File,
+    MetadataPlugin,
     RepositoryPlugin,
 )
 from azul.queues import (
@@ -113,6 +119,8 @@ class MirrorAction(Action):
     mirror_source = auto()
     mirror_partition = auto()
     mirror_file = auto()
+    mirror_part = auto()
+    finalize_file = auto()
 
 
 @attrs.frozen(kw_only=True)
@@ -121,6 +129,9 @@ class AzulClient(SignatureHelper, HasCachedHttpClient):
 
     def repository_plugin(self, catalog: CatalogName) -> RepositoryPlugin:
         return self.index_service.repository_plugin(catalog)
+
+    def metadata_plugin(self, catalog: CatalogName) -> MetadataPlugin:
+        return self.index_service.metadata_plugin(catalog)
 
     def notification(self, bundle_fqid: SourcedBundleFQID) -> JSON:
         """
@@ -208,6 +219,42 @@ class AzulClient(SignatureHelper, HasCachedHttpClient):
                 'file': file.to_json()
             },
             group_id=f'{source.id}:{file.uuid}'
+        )
+
+    def mirror_part_message(self,
+                            catalog: CatalogName,
+                            file: File,
+                            part: FilePart,
+                            upload_id: str,
+                            etags: Sequence[str]
+                            ) -> SQSFifoMessage:
+        return SQSFifoMessage(
+            body={
+                'catalog': catalog,
+                'file': file.to_json(),
+                'upload_id': upload_id,
+                'action': MirrorAction.mirror_part.to_json(),
+                'part': part.to_json(),
+                'etags': etags
+            },
+            group_id=self.mirror_service.mirror_object_key(file)
+        )
+
+    def finalize_file_message(self,
+                              catalog: CatalogName,
+                              file: File,
+                              upload_id: str,
+                              etags: Sequence[str]
+                              ) -> SQSFifoMessage:
+        return SQSFifoMessage(
+            body={
+                'catalog': catalog,
+                'file': file.to_json(),
+                'upload_id': upload_id,
+                'action': MirrorAction.finalize_file.to_json(),
+                'etags': etags
+            },
+            group_id=self.mirror_service.mirror_object_key(file)
         )
 
     def local_reindex(self, catalog: CatalogName, prefix: str) -> int:
@@ -488,6 +535,10 @@ class AzulClient(SignatureHelper, HasCachedHttpClient):
     def index_service(self) -> IndexService:
         return IndexService()
 
+    @cached_property
+    def mirror_service(self) -> MirrorService:
+        return MirrorService()
+
     def delete_all_indices(self, catalog: CatalogName):
         self.index_service.delete_indices(catalog)
 
@@ -643,6 +694,67 @@ class AzulClient(SignatureHelper, HasCachedHttpClient):
 
         messages = map(message, plugin.list_files(source, prefix))
         self.queue_mirror_messages(messages)
+
+    def mirror_file(self,
+                    catalog: CatalogName,
+                    file_json: JSON
+                    ):
+        file = self.load_file(catalog, file_json)
+        assert file.size is not None, R('File size unknown', file)
+        part_size = FilePart.default_size
+        if file.size <= part_size:
+            log.info('Mirroring file %r via standard upload', file.uuid)
+            self.mirror_service.mirror_file(catalog, file)
+            log.info('Successfully mirrored file %r via standard upload', file.uuid)
+        else:
+            log.info('Mirroring file %r via multi-part upload', file.uuid)
+            upload_id = self.mirror_service.begin_mirroring_file(file)
+            first_part = FilePart.first(file, part_size)
+            etag = self.mirror_service.mirror_file_part(catalog, file, first_part, upload_id)
+            next_part = first_part.next(file)
+            assert next_part is not None
+            messages = [self.mirror_part_message(catalog, file, next_part, upload_id, [etag])]
+            self.queue_mirror_messages(messages)
+
+    def mirror_file_part(self,
+                         catalog: CatalogName,
+                         file_json: JSON,
+                         part_json: JSON,
+                         upload_id: str,
+                         etags: Sequence[str]
+                         ):
+        file = self.load_file(catalog, file_json)
+        part = FilePart.from_json(part_json)
+        etag = self.mirror_service.mirror_file_part(catalog, file, part, upload_id)
+        etags = [*etags, etag]
+        next_part = part.next(file)
+        if next_part is None:
+            log.info('File %r fully uploaded in %d parts', file.uuid, len(etags))
+            message = self.finalize_file_message(catalog,
+                                                 file,
+                                                 upload_id,
+                                                 etags)
+        else:
+            message = self.mirror_part_message(catalog,
+                                               file,
+                                               next_part,
+                                               upload_id,
+                                               etags)
+        self.queue_mirror_messages([message])
+
+    def finalize_file(self,
+                      catalog: CatalogName,
+                      file_json: JSON,
+                      upload_id: str,
+                      etags: Sequence[str]
+                      ):
+        file = self.load_file(catalog, file_json)
+        assert len(etags) > 0
+        self.mirror_service.finish_mirroring_file(file, upload_id, etags)
+        log.info('Successfully mirrored file %r via multi-part upload', file.uuid)
+
+    def load_file(self, catalog: CatalogName, file: JSON) -> File:
+        return self.metadata_plugin(catalog).file_class.from_json(file)
 
 
 class AzulClientError(RuntimeError):

--- a/src/azul/azulclient.py
+++ b/src/azul/azulclient.py
@@ -41,7 +41,6 @@ from urllib3.exceptions import (
 from azul import (
     CatalogName,
     R,
-    cache,
     cached_property,
     config,
 )
@@ -120,9 +119,8 @@ class MirrorAction(Action):
 class AzulClient(SignatureHelper, HasCachedHttpClient):
     num_workers: int = 16
 
-    @cache
     def repository_plugin(self, catalog: CatalogName) -> RepositoryPlugin:
-        return RepositoryPlugin.load(catalog).create(catalog)
+        return self.index_service.repository_plugin(catalog)
 
     def notification(self, bundle_fqid: SourcedBundleFQID) -> JSON:
         """

--- a/src/azul/azulclient.py
+++ b/src/azul/azulclient.py
@@ -701,20 +701,30 @@ class AzulClient(SignatureHelper, HasCachedHttpClient):
                     ):
         file = self.load_file(catalog, file_json)
         assert file.size is not None, R('File size unknown', file)
-        part_size = FilePart.default_size
-        if file.size <= part_size:
-            log.info('Mirroring file %r via standard upload', file.uuid)
-            self.mirror_service.mirror_file(catalog, file)
-            log.info('Successfully mirrored file %r via standard upload', file.uuid)
+
+        file_is_large = file.size > 10 * 1024 ** 2
+        deployment_is_stable = (config.deployment.is_stable
+                                and not config.deployment.is_unit_test
+                                and catalog not in config.integration_test_catalogs)
+        if file_is_large and not deployment_is_stable:
+            log.info('Not mirroring file %r (%d bytes) to save cost',
+                     file.uuid, file.size)
         else:
-            log.info('Mirroring file %r via multi-part upload', file.uuid)
-            upload_id = self.mirror_service.begin_mirroring_file(file)
-            first_part = FilePart.first(file, part_size)
-            etag = self.mirror_service.mirror_file_part(catalog, file, first_part, upload_id)
-            next_part = first_part.next(file)
-            assert next_part is not None
-            messages = [self.mirror_part_message(catalog, file, next_part, upload_id, [etag])]
-            self.queue_mirror_messages(messages)
+            # Ensure we test with multiple parts on lower deployments
+            part_size = FilePart.default_size if deployment_is_stable else FilePart.min_size
+            if file.size <= part_size:
+                log.info('Mirroring file %r via standard upload', file.uuid)
+                self.mirror_service.mirror_file(catalog, file)
+                log.info('Successfully mirrored file %r via standard upload', file.uuid)
+            else:
+                log.info('Mirroring file %r via multi-part upload', file.uuid)
+                upload_id = self.mirror_service.begin_mirroring_file(file)
+                first_part = FilePart.first(file, part_size)
+                etag = self.mirror_service.mirror_file_part(catalog, file, first_part, upload_id)
+                next_part = first_part.next(file)
+                assert next_part is not None
+                messages = [self.mirror_part_message(catalog, file, next_part, upload_id, [etag])]
+                self.queue_mirror_messages(messages)
 
     def mirror_file_part(self,
                          catalog: CatalogName,

--- a/src/azul/indexer/lambda_iam_policy.py
+++ b/src/azul/indexer/lambda_iam_policy.py
@@ -113,6 +113,20 @@ policy = {
                 },
             ] if config.enable_log_forwarding else []
         ),
+        *(
+            [
+                {
+                    'Effect': 'Allow',
+                    'Action': [
+                        's3:PutObject',
+                        's3:GetObject',
+                    ],
+                    'Resource': [
+                        f'arn:aws:s3:::{aws.mirror_bucket}/*'
+                    ]
+                }
+            ] if config.enable_mirroring else []
+        ),
         {
             'Effect': 'Allow',
             'Action': [

--- a/src/azul/indexer/mirror_controller.py
+++ b/src/azul/indexer/mirror_controller.py
@@ -1,5 +1,4 @@
 import logging
-import time
 from typing import (
     Iterable,
 )
@@ -18,9 +17,11 @@ from azul.azulclient import (
 from azul.indexer.action_controller import (
     ActionController,
 )
+from azul.indexer.mirror_service import (
+    MirrorService,
+)
 from azul.types import (
     JSON,
-    json_mapping,
     json_str,
 )
 
@@ -32,6 +33,10 @@ class MirrorController(ActionController[MirrorAction]):
     @cached_property
     def client(self) -> AzulClient:
         return AzulClient()
+
+    @property
+    def service(self) -> MirrorService:
+        return self.client.mirror_service
 
     def mirror(self, event: Iterable[SQSRecord]):
         self._handle_events(event, self._mirror)
@@ -45,11 +50,18 @@ class MirrorController(ActionController[MirrorAction]):
                                          message['source'],
                                          message['prefix'])
         elif action is MirrorAction.mirror_file:
-            # FIXME: Implement mirror_file, mirror_part & finalize_file
-            #        https://github.com/DataBiosphere/azul/issues/6862
-            log.info('Would mirror parts of file %r', json_mapping(message['file'])['uuid'])
-            time.sleep(1)
+            self.client.mirror_file(message['catalog'],
+                                    message['file'])
+        elif action is MirrorAction.mirror_part:
+            self.client.mirror_file_part(message['catalog'],
+                                         message['file'],
+                                         message['part'],
+                                         message['upload_id'],
+                                         message['etags'])
+        elif action is MirrorAction.finalize_file:
+            self.client.finalize_file(message['catalog'],
+                                      message['file'],
+                                      message['upload_id'],
+                                      message['etags'])
         else:
-            # FIXME: Implement mirror_file, mirror_part & finalize_file
-            #        https://github.com/DataBiosphere/azul/issues/6862
             assert False, action

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -123,6 +123,16 @@ class MirrorService(HasCachedHttpClient):
     def repository_plugin(self, catalog: CatalogName) -> RepositoryPlugin:
         return RepositoryPlugin.load(catalog).create(catalog)
 
+    def mirror_file(self, catalog: CatalogName, file: File):
+        """
+        Upload the file in a single request. For larger files, use
+        :meth:`begin_mirroring_file` instead.
+        """
+        file_content = self._download(catalog, file)
+        self._storage.put(object_key=self.mirror_object_key(file),
+                          data=file_content,
+                          content_type=file.content_type)
+
     def begin_mirroring_file(self, file: File) -> str:
         """
         Initiate a multipart upload of the file's content and return the upload
@@ -136,10 +146,11 @@ class MirrorService(HasCachedHttpClient):
                          catalog: CatalogName,
                          file: File,
                          part: FilePart,
-                         upload_id: str):
+                         upload_id: str
+                         ) -> str:
         """
         Upload a part of a file to a multipart upload begun with
-        :meth:`begin_mirroring_file`
+        :meth:`begin_mirroring_file` and return the uploaded part's ETag.
         """
         upload = self._get_upload(file, upload_id)
         file_content = self._download(catalog, file, part)

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -1,0 +1,209 @@
+import logging
+import math
+import string
+import time
+from typing import (
+    ClassVar,
+    Self,
+    Sequence,
+    TYPE_CHECKING,
+)
+
+import attr
+import attrs
+
+from azul import (
+    CatalogName,
+    R,
+    cache,
+    cached_property,
+    config,
+)
+from azul.attrs import (
+    SerializableAttrs,
+)
+from azul.deployment import (
+    aws,
+)
+from azul.drs import (
+    AccessMethod,
+)
+from azul.http import (
+    HasCachedHttpClient,
+)
+from azul.plugins import (
+    File,
+    RepositoryPlugin,
+)
+from azul.service.storage_service import (
+    StorageService,
+)
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3.service_resource import (
+        MultipartUpload,
+    )
+
+log = logging.getLogger(__name__)
+
+
+@attrs.frozen(auto_attribs=True, kw_only=True)
+class FilePart(SerializableAttrs):
+    """
+    A part of a mirrored file
+    """
+    #: The part number, starting at 0 for the first part, unlike S3 API part
+    #: numbers, which start at 1.
+    #:
+    index: int
+
+    #: Offset of the first byte of this part, relative to the start of the file
+    offset: int
+
+    #: The size of this part
+    #:
+    size: int
+
+    #: Various S3 quotas related to parts and part sizes
+    #: https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
+    #:
+    min_size: ClassVar[int] = 5 * 1024 ** 2
+    max_size: ClassVar[int] = 5 * 1024 ** 3
+    max_num_parts: ClassVar[int] = 10000
+
+    #: We observe a download rate of ~14 MB/s. Download time should ideally be
+    #: 1/4 of the Lambda timeout. Since we track the ETag of each part in SQS
+    #: messages, message size becomes another constraint: we observe ETags to be
+    #: 32 byte hexadecimal strings which, if represented in a JSON array, take
+    #: up 35 bytes per item, 36 if the comma is followed by a space. With a
+    #: maximum SQS message size of 256 KiB, we can store approximately 7280
+    #: ETags in an SQS messages, so the largest file we can mirror using a part
+    #: size of 256 MiB is 1.5 TiB.
+    #:
+    default_size: ClassVar[int] = 256 * 1024 ** 2
+
+    @classmethod
+    def first(cls, file: File, part_size: int) -> Self:
+        """
+        The first part of the given file, using the given part size.
+        """
+        assert file.size is not None, R(
+            'File size unknown', file)
+        assert cls.min_size <= part_size <= cls.max_size, R(
+            'Invalid part size', part_size)
+        part_count = math.ceil(file.size / part_size)
+        assert part_count <= cls.max_num_parts, R(
+            'Part size is too small for this file', part_size, file)
+        return cls(index=0, offset=0, size=min(part_size, file.size))
+
+    def next(self, file: File) -> Self | None:
+        """
+        The part following this part in the given file, or None if this is the
+        last part.
+        """
+        assert file.size is not None, R('File size unknown', file)
+        next_offset = self.offset + self.size
+        if next_offset == file.size:
+            return None
+        elif 0 < next_offset < file.size:
+            next_index = self.index + 1
+            next_size = min(self.size, file.size - next_offset)
+            return attr.evolve(self, index=next_index, offset=next_offset, size=next_size)
+        else:
+            assert False, R('Part range exceeds file size', self, file)
+
+
+class MirrorService(HasCachedHttpClient):
+
+    @cached_property
+    def _storage(self) -> StorageService:
+        return StorageService(bucket_name=aws.mirror_bucket)
+
+    @cache
+    def repository_plugin(self, catalog: CatalogName) -> RepositoryPlugin:
+        return RepositoryPlugin.load(catalog).create(catalog)
+
+    def begin_mirroring_file(self, file: File) -> str:
+        """
+        Initiate a multipart upload of the file's content and return the upload
+        ID.
+        """
+        upload = self._storage.create_multipart_upload(object_key=self.mirror_object_key(file),
+                                                       content_type=file.content_type)
+        return upload.id
+
+    def mirror_file_part(self,
+                         catalog: CatalogName,
+                         file: File,
+                         part: FilePart,
+                         upload_id: str):
+        """
+        Upload a part of a file to a multipart upload begun with
+        :meth:`begin_mirroring_file`
+        """
+        upload = self._get_upload(file, upload_id)
+        file_content = self._download(catalog, file, part)
+        return self._storage.upload_multipart_part(file_content,
+                                                   part.index + 1,
+                                                   upload)
+
+    def finish_mirroring_file(self,
+                              file: File,
+                              upload_id: str,
+                              etags: Sequence[str]):
+        """
+        Complete a multipart upload begun with :meth:`begin_mirroring_file`.
+        """
+        upload = self._get_upload(file, upload_id)
+        self._storage.complete_multipart_upload(upload, etags)
+
+    def get_mirror_url(self, file: File) -> str:
+        return self._storage.get_presigned_url(key=self.mirror_object_key(file),
+                                               file_name=file.name)
+
+    def mirror_object_key(self, file: File) -> str:
+        return self._file_key('file', file)
+
+    def _file_key(self, prefix: str, file: File) -> str:
+        digest, digest_type = file.digest()
+        assert all(c in string.hexdigits for c in digest), R(
+            'Expected a hexadecimal digest', digest)
+        return f'{prefix}/{digest.lower()}.{digest_type}'
+
+    @cache
+    def _get_repository_url(self, catalog: CatalogName, file: File):
+        assert config.is_tdr_enabled(catalog), R('Only TDR catalogs are supported', catalog)
+        assert file.drs_uri is not None, R('File cannot be downloaded', file.uuid)
+        drs = self.repository_plugin(catalog).drs_client(authentication=None)
+        access = drs.get_object(file.drs_uri, AccessMethod.gs)
+        assert access.method is AccessMethod.https, access
+        return access.url
+
+    def _download(self,
+                  catalog: CatalogName,
+                  file: File,
+                  part: FilePart | None = None
+                  ) -> bytes:
+        download_url = self._get_repository_url(catalog, file)
+        start = time.time()
+        if part is None:
+            headers = {}
+            size = file.size
+            expected_status = 200
+        else:
+            headers = {'Range': f'bytes={part.offset}-{part.offset + part.size + 1}'}
+            size = part.size
+            expected_status = 206
+        # Ideally we would stream the response, but boto only supports uploading
+        # from streams that are seekable.
+        response = self._http_client.request('GET', download_url, headers=headers)
+        if response.status == expected_status:
+            log.info('Downloaded %d bytes of file %r in %.3fs',
+                     size, file.uuid, time.time() - start)
+            return response.data
+        else:
+            raise RuntimeError('Unexpected response from repository', response.status)
+
+    def _get_upload(self, file: File, upload_id: str) -> 'MultipartUpload':
+        return self._storage.load_multipart_upload(object_key=self.mirror_object_key(file),
+                                                   upload_id=upload_id)

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -29,6 +29,9 @@ from urllib.parse import (
     urlencode,
 )
 
+from botocore.response import (
+    StreamingBody,
+)
 from werkzeug.http import (
     parse_dict_header,
 )
@@ -128,9 +131,10 @@ class StorageService:
         return s3.MultipartUpload(self.bucket_name, object_key, upload_id)
 
     def upload_multipart_part(self,
-                              buffer: IO[bytes],
+                              buffer: str | bytes | IO | StreamingBody,
                               part_number: int,
-                              upload: MultipartUpload) -> str:
+                              upload: MultipartUpload
+                              ) -> str:
         return upload.Part(part_number).upload(Body=buffer)['ETag']
 
     def complete_multipart_upload(self,

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -1,3 +1,4 @@
+import hashlib
 from unittest.mock import (
     MagicMock,
     PropertyMock,
@@ -14,8 +15,14 @@ from moto import (
 from azul import (
     config,
 )
+from azul.deployment import (
+    aws,
+)
 from azul.indexer.mirror_controller import (
     MirrorController,
+)
+from azul.indexer.mirror_service import (
+    MirrorService,
 )
 from azul.json import (
     copy_json,
@@ -30,6 +37,9 @@ from azul.plugins.metadata.hca import (
 from azul_test_case import (
     DCP2TestCase,
 )
+from service import (
+    S3TestCase,
+)
 from sqs_test_case import (
     WorkQueueTestCase,
 )
@@ -43,7 +53,7 @@ def setUpModule():
 
 
 @mock_aws
-class TestMirrorController(DCP2TestCase, WorkQueueTestCase):
+class TestMirrorController(DCP2TestCase, WorkQueueTestCase, S3TestCase):
 
     @classmethod
     def _patch_enable_mirroring(cls):
@@ -60,6 +70,11 @@ class TestMirrorController(DCP2TestCase, WorkQueueTestCase):
         super().setUp()
         self._create_mock_queues(config.mirror_queue.name,
                                  config.mirror_queue.to_fail.name)
+        self._create_test_bucket(self.bucket)
+
+    @property
+    def bucket(self) -> str:
+        return aws.mirror_bucket
 
     def test_mirroring(self):
         with self.subTest('remote_mirror'):
@@ -85,15 +100,17 @@ class TestMirrorController(DCP2TestCase, WorkQueueTestCase):
                                  message)
             self.assertEqual(list(self.source.spec.prefix.partition_prefixes()), partitions)
 
+        file_contents = b'lorem ipsum dolor sit\n'
+
         with self.subTest('mirror_partition'):
             event = [self._mock_sqs_record(partition_message)]
             file = HCAFile(uuid='405852c9-a0cc-4cd8-b9ff-7c6296223661',
                            name='foo.txt',
                            version=None,
-                           drs_uri=None,
-                           size=0,
+                           drs_uri='drs://fake-domain.lan/foo',
+                           size=len(file_contents),
                            content_type='text/plain',
-                           sha256='123')
+                           sha256=hashlib.sha256(file_contents).hexdigest())
             plugin_cls = type(self.client.repository_plugin(self.catalog))
             with patch.object(plugin_cls, 'list_files', return_value=[file]):
                 controller.mirror(event)
@@ -103,3 +120,12 @@ class TestMirrorController(DCP2TestCase, WorkQueueTestCase):
                                     source=self.source.to_json(),
                                     file=file.to_json())
             self.assertEqual(expected_message, file_message)
+
+        with self.subTest('mirror_file'):
+            event = [self._mock_sqs_record(file_message)]
+            with patch.object(MirrorService, '_download', return_value=file_contents):
+                controller.mirror(event)
+            response = self._s3.get_object(Bucket=self.bucket,
+                                           Key=controller.service.mirror_object_key(file))
+            mirrored_file_contents = response['Body'].read()
+            self.assertEqual(mirrored_file_contents, file_contents)


### PR DESCRIPTION
Connected issues: #6862


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is marked as approved
- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved connected issues to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Confirmed all checks in PR are OK and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
