### PR TITLE
Optionally use external bucket for mirroring (#7099)

### DIFF
--- a/deployments/prod/environment.py
+++ b/deployments/prod/environment.py
@@ -1719,4 +1719,6 @@ def env() -> Mapping[str, Optional[str]]:
         # 'azul_waf_download_rate_limit': '59/600@2.9'
 
         'AZUL_ENABLE_VERBATIM_RELATIONS': '0',
+
+        'AZUL_MIRROR_BUCKET': 'humancellatlas'
     }

--- a/environment.py
+++ b/environment.py
@@ -644,10 +644,17 @@ def env() -> Mapping[str, Optional[str]]:
         #
         'AZUL_DSS_SOURCE': None,
 
-        # Mirror data files from the indexed repository in a dedicated S3 bucket
+        # Mirror data files from the indexed repository in an S3 bucket
         # (1 yes, 0 no).
         #
         'AZUL_ENABLE_MIRRORING': '0',
+
+        # The name of an external bucket to use for mirroring. This requires
+        # deploying the GitLab component to update the boundary policy.
+        #
+        # If None, a provisioned bucket will be used.
+        #
+        'AZUL_MIRROR_BUCKET': None,
 
         # A short string (no punctuation allowed) that identifies a Terraform
         # component i.e., a distinct set of Terraform resources to be deployed

--- a/scripts/mirror_file.py
+++ b/scripts/mirror_file.py
@@ -67,7 +67,7 @@ def mirror_file(catalog: CatalogName, file_uuid: str, part_size: int) -> str:
     # FIXME: mirror_file script is broken+
     #        https://github.com/DataBiosphere/azul/issues/7105
     service = MirrorService(schema_url_func=...)
-    upload_id = service.begin_mirroring_file(file)
+    upload_id = service.begin_mirroring_file(catalog, file)
     digest_value, digest_type = file.digest()
     hasher = get_resumable_hasher(digest_type)
 
@@ -78,8 +78,8 @@ def mirror_file(catalog: CatalogName, file_uuid: str, part_size: int) -> str:
             part = part.next(file)
 
     etags = list(mirror_parts())
-    service.finish_mirroring_file(file, upload_id, etags=etags, hasher=hasher)
-    return service.get_mirror_url(file)
+    service.finish_mirroring_file(catalog, file, upload_id, etags=etags, hasher=hasher)
+    return service.get_mirror_url(catalog, file)
 
 
 def main(argv):

--- a/scripts/mirror_file.py
+++ b/scripts/mirror_file.py
@@ -78,7 +78,11 @@ def mirror_file(catalog: CatalogName, file_uuid: str, part_size: int) -> str:
             part = part.next(file)
 
     etags = list(mirror_parts())
-    service.finish_mirroring_file(catalog, file, upload_id, etags=etags, hasher=hasher)
+    service.finish_mirroring_file(catalog=catalog,
+                                  file=file,
+                                  upload_id=upload_id,
+                                  etags=etags,
+                                  hasher=hasher)
     return service.get_mirror_url(catalog, file)
 
 

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -1806,6 +1806,10 @@ class Config:
     def enable_mirroring(self) -> bool:
         return self._boolean(self.environ['AZUL_ENABLE_MIRRORING'])
 
+    @property
+    def external_mirror_bucket(self) -> str | None:
+        return self.environ.get('AZUL_MIRROR_BUCKET')
+
 
 config: Config = Config()  # yes, the type hint does help PyCharm
 

--- a/src/azul/indexer/lambda_iam_policy.py
+++ b/src/azul/indexer/lambda_iam_policy.py
@@ -118,20 +118,14 @@ policy = {
                 {
                     'Effect': 'Allow',
                     'Action': [
-                        's3:PutObject',
+                        's3:ListBucket',
                         's3:GetObject',
+                        's3:PutObject',
                     ],
                     'Resource': [
-                        f'arn:aws:s3:::{aws.mirror_bucket}/*'
-                    ]
-                },
-                {
-                    'Effect': 'Allow',
-                    'Action': [
-                        's3:ListBucket'
-                    ],
-                    'Resource': [
-                        f'arn:aws:s3:::{aws.mirror_bucket}'
+                        f'arn:aws:s3:::{resource}'
+                        for bucket in [aws.mirror_bucket]
+                        for resource in [bucket, f'{bucket}/*']
                     ]
                 }
             ] if config.enable_mirroring else []

--- a/src/azul/indexer/lambda_iam_policy.py
+++ b/src/azul/indexer/lambda_iam_policy.py
@@ -1,6 +1,9 @@
 from azul import (
     config,
 )
+from azul.collections import (
+    alist,
+)
 from azul.deployment import (
     aws,
 )
@@ -124,7 +127,7 @@ policy = {
                     ],
                     'Resource': [
                         f'arn:aws:s3:::{resource}'
-                        for bucket in [aws.mirror_bucket]
+                        for bucket in alist(aws.mirror_bucket, config.external_mirror_bucket)
                         for resource in [bucket, f'{bucket}/*']
                     ]
                 }

--- a/src/azul/indexer/mirror_controller.py
+++ b/src/azul/indexer/mirror_controller.py
@@ -206,7 +206,11 @@ class MirrorController(ActionController[MirrorAction]):
         file = self.load_file(catalog, file_json)
         assert len(etags) > 0
         hasher = hasher_from_str(hasher_data)
-        self.service.finish_mirroring_file(catalog, file, upload_id, etags, hasher)
+        self.service.finish_mirroring_file(catalog=catalog,
+                                           file=file,
+                                           upload_id=upload_id,
+                                           etags=etags,
+                                           hasher=hasher)
         log.info('Successfully mirrored file %r via multi-part upload', file.uuid)
 
     def load_file(self, catalog: CatalogName, file: JSON) -> File:

--- a/src/azul/indexer/mirror_controller.py
+++ b/src/azul/indexer/mirror_controller.py
@@ -119,7 +119,7 @@ class MirrorController(ActionController[MirrorAction]):
     def mirror_partition(self, catalog: CatalogName, source_json: JSON, prefix: str):
         plugin = self.repository_plugin(catalog)
         source = plugin.source_ref_cls.from_json(source_json)
-        already_mirrored = self.service.list_info_objects(prefix)
+        already_mirrored = self.service.list_info_objects(catalog, prefix)
 
         def messages() -> Iterable[SQSMessage]:
             for file in plugin.list_files(source, prefix):
@@ -158,7 +158,7 @@ class MirrorController(ActionController[MirrorAction]):
                 log.info('Mirroring file %r via multi-part upload', file.uuid)
                 _, digest_type = file.digest()
                 hasher = get_resumable_hasher(digest_type)
-                upload_id = self.service.begin_mirroring_file(file)
+                upload_id = self.service.begin_mirroring_file(catalog, file)
                 first_part = FilePart.first(file, part_size)
                 etag = self.service.mirror_file_part(catalog, file, first_part, upload_id, hasher)
                 next_part = first_part.next(file)
@@ -206,7 +206,7 @@ class MirrorController(ActionController[MirrorAction]):
         file = self.load_file(catalog, file_json)
         assert len(etags) > 0
         hasher = hasher_from_str(hasher_data)
-        self.service.finish_mirroring_file(file, upload_id, etags, hasher)
+        self.service.finish_mirroring_file(catalog, file, upload_id, etags, hasher)
         log.info('Successfully mirrored file %r via multi-part upload', file.uuid)
 
     def load_file(self, catalog: CatalogName, file: JSON) -> File:

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -130,7 +130,11 @@ class MirrorService(HasCachedHttpClient):
     schema_url_func: SchemaUrlFunc
 
     def _bucket_name(self, catalog: CatalogName) -> str:
-        return aws.mirror_bucket
+        external_bucket = config.external_mirror_bucket
+        if external_bucket is None or catalog in config.integration_test_catalogs:
+            return aws.mirror_bucket
+        else:
+            return external_bucket
 
     @cache
     def _storage(self, catalog: CatalogName) -> StorageService:

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -192,6 +192,7 @@ class MirrorService(HasCachedHttpClient):
                                                             upload)
 
     def finish_mirroring_file(self,
+                              *,
                               catalog: CatalogName,
                               file: File,
                               upload_id: str,

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -18,7 +18,6 @@ from azul import (
     JSON,
     R,
     cache,
-    cached_property,
     config,
 )
 from azul.attrs import (
@@ -130,9 +129,12 @@ class FilePart(SerializableAttrs):
 class MirrorService(HasCachedHttpClient):
     schema_url_func: SchemaUrlFunc
 
-    @cached_property
-    def _storage(self) -> StorageService:
-        return StorageService(bucket_name=aws.mirror_bucket)
+    def _bucket_name(self, catalog: CatalogName) -> str:
+        return aws.mirror_bucket
+
+    @cache
+    def _storage(self, catalog: CatalogName) -> StorageService:
+        return StorageService(bucket_name=self._bucket_name(catalog))
 
     @cache
     def repository_plugin(self, catalog: CatalogName) -> RepositoryPlugin:
@@ -143,26 +145,27 @@ class MirrorService(HasCachedHttpClient):
         Upload the file in a single request. For larger files, use
         :meth:`begin_mirroring_file` instead.
         """
-        if self._check_info(file):
+        if self._check_info(catalog, file):
             log.info('File %r is already mirrored, skipping upload', file.uuid)
         else:
             file_content = self._download(catalog, file)
-            self._storage.put(object_key=self.mirror_object_key(file),
-                              data=file_content,
-                              content_type=file.content_type)
+            self._storage(catalog).put(object_key=self.mirror_object_key(file),
+                                       data=file_content,
+                                       content_type=file.content_type)
             _, digest_type = file.digest()
             hasher = get_resumable_hasher(digest_type)
             hasher.update(file_content)
             self._verify_digest(file, hasher)
-            self._put_info(file)
+            self._put_info(catalog, file)
 
-    def begin_mirroring_file(self, file: File) -> str:
+    def begin_mirroring_file(self, catalog: CatalogName, file: File) -> str:
         """
         Initiate a multipart upload of the file's content and return the upload
         ID.
         """
-        upload = self._storage.create_multipart_upload(object_key=self.mirror_object_key(file),
-                                                       content_type=file.content_type)
+        storage = self._storage(catalog)
+        upload = storage.create_multipart_upload(object_key=self.mirror_object_key(file),
+                                                 content_type=file.content_type)
         return upload.id
 
     def mirror_file_part(self,
@@ -177,14 +180,15 @@ class MirrorService(HasCachedHttpClient):
         :meth:`begin_mirroring_file` and return the uploaded part's ETag.
         The provided hasher is mutated to incorporated the part's content.
         """
-        upload = self._get_upload(file, upload_id)
+        upload = self._get_upload(catalog, file, upload_id)
         file_content = self._download(catalog, file, part)
         hasher.update(file_content)
-        return self._storage.upload_multipart_part(file_content,
-                                                   part.index + 1,
-                                                   upload)
+        return self._storage(catalog).upload_multipart_part(file_content,
+                                                            part.index + 1,
+                                                            upload)
 
     def finish_mirroring_file(self,
+                              catalog: CatalogName,
                               file: File,
                               upload_id: str,
                               etags: Sequence[str],
@@ -193,23 +197,23 @@ class MirrorService(HasCachedHttpClient):
         """
         Complete a multipart upload begun with :meth:`begin_mirroring_file`.
         """
-        upload = self._get_upload(file, upload_id)
-        self._storage.complete_multipart_upload(upload, etags)
+        upload = self._get_upload(catalog, file, upload_id)
+        self._storage(catalog).complete_multipart_upload(upload, etags)
         self._verify_digest(file, hasher)
-        self._check_info(file)
-        self._put_info(file)
+        self._check_info(catalog, file)
+        self._put_info(catalog, file)
 
-    def list_info_objects(self, prefix: str) -> OrderedSet[str]:
-        return self._storage.list('info/' + prefix)
+    def list_info_objects(self, catalog: CatalogName, prefix: str) -> OrderedSet[str]:
+        return self._storage(catalog).list('info/' + prefix)
 
-    def get_mirror_url(self, file: File) -> str:
-        return self._storage.get_presigned_url(key=self.mirror_object_key(file),
-                                               file_name=file.name)
+    def get_mirror_url(self, catalog: CatalogName, file: File) -> str:
+        return self._storage(catalog).get_presigned_url(key=self.mirror_object_key(file),
+                                                        file_name=file.name)
 
-    def _check_info(self, file: File) -> bool:
+    def _check_info(self, catalog: CatalogName, file: File) -> bool:
         key = self.info_object_key(file)
         try:
-            content = self._storage.get(key)
+            content = self._storage(catalog).get(key)
         except StorageObjectNotFound:
             return False
         else:
@@ -224,12 +228,12 @@ class MirrorService(HasCachedHttpClient):
             '$schema': str(self.schema_url_func(schema_name='info', version=1))
         }
 
-    def _put_info(self, file: File):
+    def _put_info(self, catalog: CatalogName, file: File):
         key = self.info_object_key(file)
         content = self.info_object(file)
-        self._storage.put(object_key=key,
-                          data=json.dumps(content).encode(),
-                          content_type='application/json')
+        self._storage(catalog).put(object_key=key,
+                                   data=json.dumps(content).encode(),
+                                   content_type='application/json')
 
     def mirror_object_key(self, file: File) -> str:
         return self._file_key('file', file)
@@ -277,9 +281,14 @@ class MirrorService(HasCachedHttpClient):
         else:
             raise RuntimeError('Unexpected response from repository', response.status)
 
-    def _get_upload(self, file: File, upload_id: str) -> 'MultipartUpload':
-        return self._storage.load_multipart_upload(object_key=self.mirror_object_key(file),
-                                                   upload_id=upload_id)
+    def _get_upload(self,
+                    catalog: CatalogName,
+                    file: File,
+                    upload_id: str
+                    ) -> 'MultipartUpload':
+        storage = self._storage(catalog)
+        return storage.load_multipart_upload(object_key=self.mirror_object_key(file),
+                                             upload_id=upload_id)
 
     def _verify_digest(self, file: File, hasher: Hasher):
         expected_digest_value, digest_type = file.digest()

--- a/terraform/gitlab/gitlab.tf.json.template.py
+++ b/terraform/gitlab/gitlab.tf.json.template.py
@@ -16,6 +16,7 @@ from azul import (
     config,
 )
 from azul.collections import (
+    alist,
     dict_merge,
 )
 from azul.deployment import (
@@ -345,10 +346,11 @@ emit_tf({} if config.terraform_component != 'gitlab' else {
                             [
                                 f'arn:aws:s3:::{bucket_name}',
                                 f'arn:aws:s3:::{bucket_name}/*'
-                            ] for bucket_name in [
+                            ] for bucket_name in alist(
                                 aws.qualified_bucket_name('*'),
+                                config.external_mirror_bucket,
                                 *aws_managed_buckets_for_ssm_agent
-                            ]
+                            )
                         )
                     },
                     {


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Connected issues: #7099


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [ ] ~PR is marked as approved~
- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved connected issues to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Confirmed all checks in PR are OK and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
