### PR TITLE
Improve logging in mirror controller and service (partial #7109)

### DIFF
--- a/src/azul/indexer/mirror_controller.py
+++ b/src/azul/indexer/mirror_controller.py
@@ -107,31 +107,35 @@ class MirrorController(ActionController[MirrorAction]):
         plugin = self.repository_plugin(catalog)
         source = plugin.source_ref_cls.from_json(source_json)
         source = plugin.partition_source_for_mirroring(catalog, source)
+        prefix = source.spec.prefix
+        log.info('Queueing %d partitions of source %r in catalog %r',
+                 prefix.num_partitions, str(source.spec), catalog)
 
-        def message(prefix: str) -> SQSMessage:
-            log.info('Mirroring files in partition %r of source %r from catalog %r',
-                     prefix, str(source.spec), catalog)
-            return self.mirror_partition_message(catalog, source, prefix)
+        def message(partition: str) -> SQSMessage:
+            log.debug('Queueing partition %r', partition)
+            return self.mirror_partition_message(catalog, source, partition)
 
-        messages = map(message, source.spec.prefix.partition_prefixes())
+        messages = map(message, prefix.partition_prefixes())
         self.client.queue_mirror_messages(messages)
 
     def mirror_partition(self, catalog: CatalogName, source_json: JSON, prefix: str):
         plugin = self.repository_plugin(catalog)
         source = plugin.source_ref_cls.from_json(source_json)
         already_mirrored = self.service.list_info_objects(catalog, prefix)
+        files = plugin.list_files(source, prefix)
 
         def messages() -> Iterable[SQSMessage]:
-            for file in plugin.list_files(source, prefix):
+            for file in files:
                 info_key = self.service.info_object_key(file)
                 if info_key in already_mirrored:
-                    log.info('Not mirroring file %r because info object already exists at %r',
-                             file.uuid, info_key)
+                    log.debug('Not queueing file %r because info object already exists', file)
                 else:
-                    log.info('Mirroring file %r', file.uuid)
+                    log.debug('Queueing file %r', file)
                     yield self.mirror_file_message(catalog, source, file)
 
-        self.client.queue_mirror_messages(messages())
+        message_count = self.client.queue_mirror_messages(messages())
+        log.info('Queued %d/%d files in partition %r of source %r in catalog %r',
+                 message_count, len(files), prefix, str(source), catalog)
 
     def mirror_file(self,
                     catalog: CatalogName,
@@ -145,26 +149,27 @@ class MirrorController(ActionController[MirrorAction]):
                                 and not config.deployment.is_unit_test
                                 and catalog not in config.integration_test_catalogs)
         if file_is_large and not deployment_is_stable:
-            log.info('Not mirroring file %r (%d bytes) to save cost',
-                     file.uuid, file.size)
+            log.info('Not mirroring file to save cost: %r', file)
         else:
             # Ensure we test with multiple parts on lower deployments
             part_size = FilePart.default_size if deployment_is_stable else FilePart.min_size
             if file.size <= part_size:
-                log.info('Mirroring file %r via standard upload', file.uuid)
+                log.info('Mirroring file via standard upload: %r', file)
                 self.service.mirror_file(catalog, file)
-                log.info('Successfully mirrored file %r via standard upload', file.uuid)
+                log.info('Successfully mirrored file via standard upload: %r', file)
             else:
-                log.info('Mirroring file %r via multi-part upload', file.uuid)
+                log.info('Mirroring file via multi-part upload: %r', file)
                 _, digest_type = file.digest()
                 hasher = get_resumable_hasher(digest_type)
                 upload_id = self.service.begin_mirroring_file(catalog, file)
                 first_part = FilePart.first(file, part_size)
+                log.info('Uploading part #%d of file %r', first_part.index, file)
                 etag = self.service.mirror_file_part(catalog, file, first_part, upload_id, hasher)
                 next_part = first_part.next(file)
                 assert next_part is not None
-                messages = [self.mirror_part_message(catalog, file, next_part, upload_id, [etag], hasher)]
-                self.client.queue_mirror_messages(messages)
+                log.info('Queueing part #%d of file %r', next_part.index, file)
+                message = self.mirror_part_message(catalog, file, next_part, upload_id, [etag], hasher)
+                self.client.queue_mirror_messages([message])
 
     def mirror_file_part(self,
                          catalog: CatalogName,
@@ -177,17 +182,19 @@ class MirrorController(ActionController[MirrorAction]):
         file = self.load_file(catalog, file_json)
         part = FilePart.from_json(part_json)
         hasher = hasher_from_str(hasher_data)
+        log.info('Uploading part #%d of file %r', part.index, file)
         etag = self.service.mirror_file_part(catalog, file, part, upload_id, hasher)
         etags = [*etags, etag]
         next_part = part.next(file)
         if next_part is None:
-            log.info('File %r fully uploaded in %d parts', file.uuid, len(etags))
+            log.info('File fully uploaded in %d parts: %r', len(etags), file)
             message = self.finalize_file_message(catalog,
                                                  file,
                                                  upload_id,
                                                  etags,
                                                  hasher)
         else:
+            log.info('Queueing part #%d of file %r', next_part.index, file)
             message = self.mirror_part_message(catalog,
                                                file,
                                                next_part,
@@ -211,7 +218,7 @@ class MirrorController(ActionController[MirrorAction]):
                                            upload_id=upload_id,
                                            etags=etags,
                                            hasher=hasher)
-        log.info('Successfully mirrored file %r via multi-part upload', file.uuid)
+        log.info('Successfully mirrored file via multi-part upload: %r', file)
 
     def load_file(self, catalog: CatalogName, file: JSON) -> File:
         return self.client.metadata_plugin(catalog).file_class.from_json(file)

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -150,7 +150,7 @@ class MirrorService(HasCachedHttpClient):
         :meth:`begin_mirroring_file` instead.
         """
         if self._check_info(catalog, file):
-            log.info('File %r is already mirrored, skipping upload', file.uuid)
+            log.info('File is already mirrored, skipping upload: %r', file)
         else:
             file_content = self._download(catalog, file)
             self._storage(catalog).put(object_key=self.mirror_object_key(file),
@@ -224,7 +224,7 @@ class MirrorService(HasCachedHttpClient):
         else:
             content_type = json.loads(content)['content_type']
             assert content_type == file.content_type, R(
-                'Conflicting content type', file.uuid, key, content_type, file.content_type)
+                'Conflicting content type', content_type, file)
             return True
 
     def info_object(self, file: File) -> JSON:
@@ -255,7 +255,7 @@ class MirrorService(HasCachedHttpClient):
     @cache
     def _get_repository_url(self, catalog: CatalogName, file: File):
         assert config.is_tdr_enabled(catalog), R('Only TDR catalogs are supported', catalog)
-        assert file.drs_uri is not None, R('File cannot be downloaded', file.uuid)
+        assert file.drs_uri is not None, R('File cannot be downloaded', file)
         drs = self.repository_plugin(catalog).drs_client(authentication=None)
         access = drs.get_object(file.drs_uri, AccessMethod.gs)
         assert access.method is AccessMethod.https, access
@@ -280,8 +280,8 @@ class MirrorService(HasCachedHttpClient):
         # from streams that are seekable.
         response = self._http_client.request('GET', download_url, headers=headers)
         if response.status == expected_status:
-            log.info('Downloaded %d bytes of file %r in %.3fs',
-                     size, file.uuid, time.time() - start)
+            log.info('Downloaded %d bytes in %.3fs from file %r',
+                     size, time.time() - start, file)
             return response.data
         else:
             raise RuntimeError('Unexpected response from repository', response.status)
@@ -300,4 +300,4 @@ class MirrorService(HasCachedHttpClient):
         actual_digest_value = hasher.hexdigest()
         assert expected_digest_value == actual_digest_value, R(
             'File digest value does not match its contents',
-            file.uuid, digest_type, expected_digest_value, actual_digest_value)
+            digest_type, expected_digest_value, file)


### PR DESCRIPTION
Connected issues: #7109


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or [comment in PR explains why they're different](https://github.com/DataBiosphere/azul/pull/7116#issuecomment-2878638779)</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [ ] ~PR is marked as approved~
- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved connected issues to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `prod`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select prod.shared && CI_COMMIT_REF_NAME=prod make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select prod.gitlab && CI_COMMIT_REF_NAME=prod make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] ~Ran `_select prod.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused`~ <sub>~or this PR is not labeled `deploy:shared`~</sub>
- [ ] ~Ran `_select prod.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply`~ <sub>~or this PR is not labeled `deploy:gitlab`~</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for `prod.gitlab` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] ~Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete~ <sub>~or this PR is not labeled `deploy:gitlab`~</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select prod.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] ~Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner`~ <sub>~or this PR is not labeled `deploy:runner`~</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Confirmed all checks in PR are OK and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [ ] ~Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>~
- [ ] ~Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>~
- [ ] ~Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>~
- [ ] ~Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>~


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `prod`
- [ ] ~Pushed merge commit to GitLab `anvildev`~
- [x] Build passes on GitLab `prod`
- [x] Reviewed build logs for anomalies on GitLab `prod`
- [ ] ~Build passes on GitLab `anvildev`~
- [ ] ~Reviewed build logs for anomalies on GitLab `anvildev`~
- [x] Ran `_select prod.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared` </sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [ ] ~Deleted PR branch from GitLab `dev`~
- [ ] ~Deleted PR branch from GitLab `anvildev`~


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Backport this and other `prod` hotfixes
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
