### PR TITLE
Make mirror_file fail if file object already exists (#7134)

### DIFF
--- a/src/azul/indexer/mirror_controller.py
+++ b/src/azul/indexer/mirror_controller.py
@@ -152,8 +152,13 @@ class MirrorController(ActionController[MirrorAction]):
         deployment_is_stable = (config.deployment.is_stable
                                 and not config.deployment.is_unit_test
                                 and catalog not in config.integration_test_catalogs)
+
         if file_is_large and not deployment_is_stable:
             log.info('Not mirroring file to save cost: %r', file)
+        elif self.service.info_exists(catalog, file):
+            log.info('File is already mirrored, skipping upload: %r', file)
+        elif self.service.file_exists(catalog, file):
+            assert False, R('File object is already present', file)
         else:
             # Ensure we test with multiple parts on lower deployments
             part_size = FilePart.default_size if deployment_is_stable else FilePart.min_size

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -194,6 +194,14 @@ class BaseMirrorService:
     def info_exists(self, catalog: CatalogName, file: File) -> bool:
         return self._get_info(catalog, file) is not None
 
+    def file_exists(self, catalog: CatalogName, file: File) -> bool:
+        try:
+            self._storage(catalog).head(self.mirror_object_key(file))
+        except StorageObjectNotFound:
+            return False
+        else:
+            return True
+
     def _file_key(self, prefix: str, file: File, *, extension: str = '') -> str:
         digest = file.digest
         assert all(c in string.hexdigits for c in digest.value), R(
@@ -214,17 +222,15 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
         Upload the file in a single request. For larger files, use
         :meth:`begin_mirroring_file` instead.
         """
-        if self.info_exists(catalog, file):
-            log.info('File is already mirrored, skipping upload: %r', file)
-        else:
-            file_content = self._download(catalog, file)
-            self._storage(catalog).put(object_key=self.mirror_object_key(file),
-                                       data=file_content,
-                                       content_type=file.content_type)
-            hasher = get_resumable_hasher(file.digest.type)
-            hasher.update(file_content)
-            self._verify_digest(file, hasher)
-            self._put_info(catalog, file)
+        file_content = self._download(catalog, file)
+        self._storage(catalog).put(object_key=self.mirror_object_key(file),
+                                   data=file_content,
+                                   content_type=file.content_type,
+                                   overwrite=False)
+        hasher = get_resumable_hasher(file.digest.type)
+        hasher.update(file_content)
+        self._verify_digest(file, hasher)
+        self._put_info(catalog, file)
 
     def begin_mirroring_file(self, catalog: CatalogName, file: File) -> str:
         """
@@ -268,7 +274,9 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
         Complete a multipart upload begun with :meth:`begin_mirroring_file`.
         """
         upload = self._get_upload(catalog, file, upload_id)
-        self._storage(catalog).complete_multipart_upload(upload, etags)
+        self._storage(catalog).complete_multipart_upload(upload,
+                                                         etags,
+                                                         overwrite=False)
         self._verify_digest(file, hasher)
         self._get_info(catalog, file)
         self._put_info(catalog, file)

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -191,7 +191,7 @@ class BaseMirrorService:
     def info_object_key(self, file: File) -> str:
         return self._file_key('info', file, extension='.json')
 
-    def is_mirrored(self, catalog: CatalogName, file: File) -> bool:
+    def info_exists(self, catalog: CatalogName, file: File) -> bool:
         return self._get_info(catalog, file) is not None
 
     def _file_key(self, prefix: str, file: File, *, extension: str = '') -> str:
@@ -214,7 +214,7 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
         Upload the file in a single request. For larger files, use
         :meth:`begin_mirroring_file` instead.
         """
-        if self.is_mirrored(catalog, file):
+        if self.info_exists(catalog, file):
             log.info('File is already mirrored, skipping upload: %r', file)
         else:
             file_content = self._download(catalog, file)

--- a/src/azul/service/repository_controller.py
+++ b/src/azul/service/repository_controller.py
@@ -266,7 +266,7 @@ class RepositoryController(SourceController):
         plugin = self.repository_plugin(catalog)
 
         is_mirrored = (config.enable_mirroring
-                       and self.mirror_service.is_mirrored(catalog, file))
+                       and self.mirror_service.info_exists(catalog, file))
         if is_mirrored:
             download = MirrorFileDownload(
                 file=file,

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -179,9 +179,11 @@ class StorageService:
         if tagging:
             self.put_object_tagging(object_key, tagging)
 
-    def _object_creation_kwargs(self, *,
+    def _object_creation_kwargs(self,
+                                *,
                                 content_type: str | None = None,
-                                tagging: Tagging | None = None):
+                                tagging: Tagging | None = None
+                                ) -> Mapping[str, str]:
         kwargs = {}
         if content_type is not None:
             kwargs['ContentType'] = content_type

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -92,7 +92,7 @@ class StorageService:
                                         Key=object_key)
         except self._s3.exceptions.ClientError as e:
             if int(e.response['Error']['Code']) == 404:
-                raise StorageObjectNotFound
+                raise StorageObjectNotFound(object_key)
             else:
                 raise e
 
@@ -101,7 +101,7 @@ class StorageService:
             response = self._s3.get_object(Bucket=self.bucket_name,
                                            Key=object_key)
         except self._s3.exceptions.NoSuchKey:
-            raise StorageObjectNotFound
+            raise StorageObjectNotFound(object_key)
         else:
             return response['Body'].read()
 

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -29,6 +29,8 @@ from urllib.parse import (
     urlencode,
 )
 
+import botocore
+import botocore.exceptions
 from botocore.response import (
     StreamingBody,
 )
@@ -75,6 +77,10 @@ class StorageObjectNotFound(Exception):
     pass
 
 
+class StorageObjectExists(Exception):
+    pass
+
+
 class StorageService:
 
     def __init__(self, bucket_name: str | None = None):
@@ -110,12 +116,19 @@ class StorageService:
             data: bytes,
             content_type: str | None = None,
             tagging: Tagging | None = None,
+            *,
+            overwrite: bool = True,
             **kwargs):
-        self._s3.put_object(Bucket=self.bucket_name,
-                            Key=object_key,
-                            Body=data,
-                            **self._object_creation_kwargs(content_type=content_type, tagging=tagging),
-                            **kwargs)
+        try:
+            self._s3.put_object(Bucket=self.bucket_name,
+                                Key=object_key,
+                                Body=data,
+                                **self._object_creation_kwargs(content_type=content_type,
+                                                               tagging=tagging,
+                                                               overwrite=overwrite),
+                                **kwargs)
+        except botocore.exceptions.ClientError as e:
+            self._handle_overwrite(e, object_key)
 
     def list(self, prefix: str) -> OrderedSet[str]:
         keys, num_keys = OrderedSet(), 0
@@ -155,7 +168,10 @@ class StorageService:
 
     def complete_multipart_upload(self,
                                   upload: MultipartUpload,
-                                  etags: Sequence[str]) -> None:
+                                  etags: Sequence[str],
+                                  *,
+                                  overwrite: bool = True,
+                                  ) -> None:
         parts = [
             {
                 'PartNumber': index + 1,
@@ -163,7 +179,11 @@ class StorageService:
             }
             for index, etag in enumerate(etags)
         ]
-        upload.complete(MultipartUpload={'Parts': parts})
+        try:
+            upload.complete(MultipartUpload={'Parts': parts},
+                            **self._object_creation_kwargs(overwrite=overwrite))
+        except botocore.exceptions.ClientError as e:
+            self._handle_overwrite(e, upload.object_key)
 
     def upload(self,
                file_path: str,
@@ -182,13 +202,16 @@ class StorageService:
     def _object_creation_kwargs(self,
                                 *,
                                 content_type: str | None = None,
-                                tagging: Tagging | None = None
+                                tagging: Tagging | None = None,
+                                overwrite: bool = True
                                 ) -> Mapping[str, str]:
         kwargs = {}
         if content_type is not None:
             kwargs['ContentType'] = content_type
         if tagging is not None:
             kwargs['Tagging'] = urlencode(tagging)
+        if overwrite is False:
+            kwargs['IfNoneMatch'] = '*'
         return kwargs
 
     def get_presigned_url(self, key: str, file_name: str | None = None) -> str:
@@ -282,6 +305,17 @@ class StorageService:
             log.error('Actual object expiration (%s) does not match expected value (%s)',
                       expiration_header, expected_expiry)
         return time_left
+
+    def _handle_overwrite(self,
+                          exception: botocore.exceptions.ClientError,
+                          object_key: str
+                          ):
+        error = exception.response['Error']
+        code, condition = error['Code'], error['Condition']
+        if code == 'PreconditionFailed' and condition == 'If-None-Match':
+            raise StorageObjectExists(object_key)
+        else:
+            raise exception
 
 
 @dataclass

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -75,7 +75,7 @@ class TestMirrorController(DCP2TestCase,
                 with self.subTest('mirror_partition'):
                     file, file_message = self._test_mirror_partition(partition_message)
 
-                    with self.subTest('mirror_file', corrupted=False):
+                    with self.subTest('mirror_file', corrupted=False, exists=False):
                         self._test_mirror_file(file, file_message)
 
                     self._s3.delete_object(Bucket=self.mirror_bucket,
@@ -83,6 +83,9 @@ class TestMirrorController(DCP2TestCase,
 
                     with self.subTest('mirror_file', corrupted=True):
                         self._test_corrupted_download(file_message)
+
+                    with self.subTest('mirror_file', corrupted=False, exists=True):
+                        self._test_reuploaded_file(file_message)
 
     _file_contents = b'lorem ipsum dolor sit\n'
 
@@ -150,6 +153,14 @@ class TestMirrorController(DCP2TestCase,
             with self.assertRaises(AssertionError) as e:
                 self.mirror_controller.mirror(event)
             self.assertTrue(R.caused(e.exception))
+
+    def _test_reuploaded_file(self, file_message):
+        event = [self._mock_sqs_record(file_message)]
+        with patch.object(MirrorService, '_download', return_value=self._file_contents):
+            with self.assertRaises(AssertionError) as e:
+                self.mirror_controller.mirror(event)
+        self.assertTrue(R.caused(e.exception))
+        self.assertEqual(e.exception.args[0].args[0], 'File object is already present')
 
     def test_info_schema(self):
         client = http_client(log)

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -75,8 +75,14 @@ class TestMirrorController(DCP2TestCase,
                 with self.subTest('mirror_partition'):
                     file, file_message = self._test_mirror_partition(partition_message)
 
-                    with self.subTest('mirror_file'):
+                    with self.subTest('mirror_file', corrupted=False):
                         self._test_mirror_file(file, file_message)
+
+                    self._s3.delete_object(Bucket=self.mirror_bucket,
+                                           Key=self.mirror_controller.service.info_object_key(file))
+
+                    with self.subTest('mirror_file', corrupted=True):
+                        self._test_corrupted_download(file_message)
 
     _file_contents = b'lorem ipsum dolor sit\n'
 
@@ -136,12 +142,13 @@ class TestMirrorController(DCP2TestCase,
                                        Key=self.mirror_controller.service.mirror_object_key(file))
         mirrored_file_contents = response['Body'].read()
         self.assertEqual(mirrored_file_contents, self._file_contents)
+
+    def _test_corrupted_download(self, file_message):
+        event = [self._mock_sqs_record(file_message)]
         corrupted_contents = self._file_contents[:-1] + b'Q'
         with patch.object(MirrorService, '_download', return_value=corrupted_contents):
-            # Force reupload attempt in spite of info object being present
-            with patch.object(MirrorService, 'is_mirrored', return_value=False):
-                with self.assertRaises(AssertionError) as e:
-                    self.mirror_controller.mirror(event)
+            with self.assertRaises(AssertionError) as e:
+                self.mirror_controller.mirror(event)
             self.assertTrue(R.caused(e.exception))
 
     def test_info_schema(self):

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -117,7 +117,7 @@ class RepositoryFilesTestCase(LocalAppTestCase, metaclass=ABCMeta):
 @mock.patch.object(SourceService, '_put', new=MagicMock())
 @mock.patch.object(SourceService, '_get')
 @mock.patch.object(BaseMirrorService,
-                   'is_mirrored',
+                   'info_exists',
                    new=MagicMock(return_value=False))
 class TestRepositoryFilesWithTDR(DCP2TestCase, RepositoryFilesTestCase):
 
@@ -250,7 +250,7 @@ class TestRepositoryFilesWithTDR(DCP2TestCase, RepositoryFilesTestCase):
 
 
 @mock.patch.object(BaseMirrorService,
-                   'is_mirrored',
+                   'info_exists',
                    new=MagicMock(return_value=False))
 class TestRepositoryFilesWithDSS(DCP1TestCase,
                                  RepositoryFilesTestCase,
@@ -424,7 +424,7 @@ class TestRepositoryFilesWithMirroring(DCP2TestCase,
         mirror_service = MirrorService(schema_url_func=MagicMock())
         with mock.patch.object(MirrorService, '_download', return_value=file_content):
             mirror_service.mirror_file(self.catalog, file)
-        self.assertTrue(mirror_service.is_mirrored(self.catalog, file))
+        self.assertTrue(mirror_service.info_exists(self.catalog, file))
 
         client = http_client(log)
         args = dict(catalog=self.catalog, version=file_version)


### PR DESCRIPTION
Connected issues: #7134


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] PR is marked as approved
- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved connected issues to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Confirmed all checks in PR are OK and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
