### PR TITLE
Fix: Various mirror issues (#7148, #7153)

### DIFF
--- a/lambdas/indexer/.chalice/config.json.template.py
+++ b/lambdas/indexer/.chalice/config.json.template.py
@@ -56,8 +56,14 @@ emit({
                     'lambda_timeout': config.aggregation_lambda_timeout(retry=True),
                     **chalice.vpc_lambda_config(app_name)
                 },
-                indexer.forward_alb_logs.name: chalice.vpc_lambda_config(app_name),
-                indexer.forward_s3_logs.name: chalice.vpc_lambda_config(app_name),
+                **(
+                    {
+                        indexer.forward_alb_logs.name: chalice.vpc_lambda_config(app_name),
+                        indexer.forward_s3_logs.name: chalice.vpc_lambda_config(app_name),
+                    }
+                    if config.enable_log_forwarding else
+                    {}
+                ),
                 **(
                     {
                         indexer.mirror.name: {

--- a/src/azul/service/repository_controller.py
+++ b/src/azul/service/repository_controller.py
@@ -265,7 +265,8 @@ class RepositoryController(SourceController):
 
         plugin = self.repository_plugin(catalog)
 
-        is_mirrored = self.mirror_service.is_mirrored(catalog, file)
+        is_mirrored = (config.enable_mirroring
+                       and self.mirror_service.is_mirrored(catalog, file))
         if is_mirrored:
             download = MirrorFileDownload(
                 file=file,

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -2,16 +2,12 @@ import hashlib
 import json
 from unittest.mock import (
     MagicMock,
-    PropertyMock,
     patch,
 )
 
 import jsonschema
 from more_itertools import (
     one,
-)
-from moto import (
-    mock_aws,
 )
 
 from app_test_case import (
@@ -20,9 +16,6 @@ from app_test_case import (
 from azul import (
     R,
     config,
-)
-from azul.deployment import (
-    aws,
 )
 from azul.http import (
     http_client,
@@ -47,7 +40,7 @@ from azul_test_case import (
     DCP2TestCase,
 )
 from service import (
-    S3TestCase,
+    MirrorTestCase,
 )
 from sqs_test_case import (
     WorkQueueTestCase,
@@ -61,35 +54,18 @@ def setUpModule():
     configure_test_logging(log)
 
 
-@mock_aws
 class TestMirrorController(DCP2TestCase,
                            LocalAppTestCase,
                            WorkQueueTestCase,
-                           S3TestCase):
+                           MirrorTestCase):
 
     @classmethod
     def lambda_name(cls) -> str:
         return 'indexer'
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.addClassPatch(patch.object(type(config),
-                                       'enable_mirroring',
-                                       new=PropertyMock(return_value=True)))
-        cls.addClassPatch(patch.object(type(config),
-                                       'mirror_bucket',
-                                       new=PropertyMock(return_value=None)))
-
-    @property
-    def bucket(self) -> str:
-        return aws.mirror_bucket
-
     def test_mirroring(self):
         self._create_mock_queues(config.mirror_queue.name,
                                  config.mirror_queue.to_fail.name)
-        self._create_test_bucket(self.bucket)
-
         with self.subTest('remote_mirror'):
             source_message = self._test_remote_mirror()
 
@@ -156,7 +132,7 @@ class TestMirrorController(DCP2TestCase,
         event = [self._mock_sqs_record(file_message)]
         with patch.object(MirrorService, '_download', return_value=self._file_contents):
             self.mirror_controller.mirror(event)
-        response = self._s3.get_object(Bucket=self.bucket,
+        response = self._s3.get_object(Bucket=self.mirror_bucket,
                                        Key=self.mirror_controller.service.mirror_object_key(file))
         mirrored_file_contents = response['Body'].read()
         self.assertEqual(mirrored_file_contents, self._file_contents)

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -62,7 +62,10 @@ def setUpModule():
 
 
 @mock_aws
-class TestMirrorController(DCP2TestCase, LocalAppTestCase, WorkQueueTestCase, S3TestCase):
+class TestMirrorController(DCP2TestCase,
+                           LocalAppTestCase,
+                           WorkQueueTestCase,
+                           S3TestCase):
 
     @classmethod
     def lambda_name(cls) -> str:
@@ -151,7 +154,7 @@ class TestMirrorController(DCP2TestCase, LocalAppTestCase, WorkQueueTestCase, S3
 
     def _test_mirror_file(self, file, file_message):
         event = [self._mock_sqs_record(file_message)]
-        with patch.object(MirrorService, '_download', return_value=(self._file_contents)):
+        with patch.object(MirrorService, '_download', return_value=self._file_contents):
             self.mirror_controller.mirror(event)
         response = self._s3.get_object(Bucket=self.bucket,
                                        Key=self.mirror_controller.service.mirror_object_key(file))

--- a/test/service/__init__.py
+++ b/test/service/__init__.py
@@ -17,6 +17,7 @@ from typing import (
 )
 from unittest.mock import (
     MagicMock,
+    PropertyMock,
     patch,
 )
 import uuid
@@ -236,6 +237,20 @@ class StorageServiceTestCase(S3TestCase):
     def setUp(self) -> None:
         super().setUp()
         self._create_test_bucket(self.storage_service.bucket_name)
+
+
+class MirrorTestCase(S3TestCase):
+    mirror_bucket = 'test-mirror-bucket'
+
+    def setUp(self):
+        super().setUp()
+        self.addPatch(patch.object(type(config),
+                                   'enable_mirroring',
+                                   new=PropertyMock(return_value=True)))
+        self.addPatch(patch.object(type(config),
+                                   'mirror_bucket',
+                                   new=PropertyMock(return_value=self.mirror_bucket)))
+        self._create_test_bucket(self.mirror_bucket)
 
 
 @deprecated('Instead of decorating your test case, or its test methods in it, '

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -14,6 +14,7 @@ from unittest import (
 )
 from unittest.mock import (
     MagicMock,
+    PropertyMock,
 )
 
 import attr
@@ -417,6 +418,9 @@ class TestRepositoryFilesWithMirroring(DCP2TestCase,
         cls.addClassPatch(mock.patch.object(BaseMirrorService,
                                             '_bucket_name',
                                             return_value=cls.bucket_name))
+        cls.addClassPatch(mock.patch.object(type(config),
+                                            'enable_mirroring',
+                                            new=PropertyMock(return_value=True)))
 
     def test_repository_files(self):
         file_content = b'Contents of foo'

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -14,7 +14,6 @@ from unittest import (
 )
 from unittest.mock import (
     MagicMock,
-    PropertyMock,
 )
 
 import attr
@@ -27,9 +26,6 @@ from furl import (
 )
 from google.auth.transport.urllib3 import (
     AuthorizedHttp,
-)
-from moto import (
-    mock_aws,
 )
 import requests
 import responses
@@ -83,6 +79,7 @@ from azul_test_case import (
     DCP2TestCase,
 )
 from service import (
+    MirrorTestCase,
     S3TestCase,
 )
 
@@ -406,21 +403,9 @@ class TestRepositoryFilesWithDSS(DCP1TestCase,
                                 self.assertUrlEqual(re_pre_signed_s3_url, location)
 
 
-@mock_aws
 class TestRepositoryFilesWithMirroring(DCP2TestCase,
                                        RepositoryFilesTestCase,
-                                       S3TestCase):
-    bucket_name = 'test-bucket'
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.addClassPatch(mock.patch.object(BaseMirrorService,
-                                            '_bucket_name',
-                                            return_value=cls.bucket_name))
-        cls.addClassPatch(mock.patch.object(type(config),
-                                            'enable_mirroring',
-                                            new=PropertyMock(return_value=True)))
+                                       MirrorTestCase):
 
     def test_repository_files(self):
         file_content = b'Contents of foo'
@@ -437,7 +422,6 @@ class TestRepositoryFilesWithMirroring(DCP2TestCase,
                        crc32c=None)
 
         mirror_service = MirrorService(schema_url_func=MagicMock())
-        self._create_test_bucket(self.bucket_name)
         with mock.patch.object(MirrorService, '_download', return_value=file_content):
             mirror_service.mirror_file(self.catalog, file)
         self.assertTrue(mirror_service.is_mirrored(self.catalog, file))
@@ -451,7 +435,7 @@ class TestRepositoryFilesWithMirroring(DCP2TestCase,
 
         signed_url = furl(response.headers['Location'])
         self.assertEqual('https', signed_url.scheme)
-        self.assertEqual(f'{self.bucket_name}.s3.{self._aws_test_region}.amazonaws.com',
+        self.assertEqual(f'{self.mirror_bucket}.s3.{config.region}.amazonaws.com',
                          signed_url.netloc)
         self.assertEqual('/' + mirror_service.mirror_object_key(file),
                          str(signed_url.path))


### PR DESCRIPTION
Supersedes PRs #7156 and #7157

Connected issues: #7148, #7153


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [ ] ~Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`~
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or [comment ](https://github.com/DataBiosphere/azul/pull/7158#issuecomment-2900161045)in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed old fixups
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [ ] ~PR is marked as approved~
- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved connected issues to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Confirmed all checks in PR are OK and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
