### PR TITLE
Improve mirroring IT (#7145)

### DIFF
--- a/src/azul/indexer/mirror_controller.py
+++ b/src/azul/indexer/mirror_controller.py
@@ -143,7 +143,7 @@ class MirrorController(ActionController[MirrorAction]):
         file = self.load_file(catalog, file_json)
         assert file.size is not None, R('File size unknown', file)
 
-        file_is_large = file.size > 10 * 1024 ** 2
+        file_is_large = file.size > 1.5 * 1024 ** 3
         deployment_is_stable = (config.deployment.is_stable
                                 and not config.deployment.is_unit_test
                                 and catalog not in config.integration_test_catalogs)
@@ -155,8 +155,7 @@ class MirrorController(ActionController[MirrorAction]):
         elif self.service.file_exists(catalog, file):
             assert False, R('File object is already present', file)
         else:
-            # Ensure we test with multiple parts on lower deployments
-            part_size = FilePart.default_size if deployment_is_stable else FilePart.min_size
+            part_size = FilePart.default_size
             if file.size <= part_size:
                 log.info('Mirroring file via standard upload: %r', file)
                 self.service.mirror_file(catalog, file)

--- a/src/azul/indexer/mirror_controller.py
+++ b/src/azul/indexer/mirror_controller.py
@@ -302,5 +302,5 @@ class MirrorController(ActionController[MirrorAction]):
                 'etags': etags,
                 'hasher': hasher_to_str(hasher)
             },
-            group_id=self.service.mirror_object_key(file)
+            group_id=self.service.mirror_object_key(catalog, file)
         )

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -201,6 +201,23 @@ class BaseMirrorService:
         else:
             return True
 
+    def delete_it_files(self, catalog: CatalogName):
+        """
+        Delete all objects (both file/ and info/) with the given catalog's
+        mirror prefix. Currently, the mirror prefix is only used to distinguish
+        IT catalogs from non-IT catalogs, so if an IT catalog is specified,
+        objects from *all* IT catalogs will be deleted, not just the specified
+        catalog.
+        """
+        assert catalog in config.integration_test_catalogs, R(
+            'Not an IT catalog', catalog)
+        storage = self._storage(catalog)
+        prefix = self._mirror_prefix(catalog)
+        assert len(prefix) > 1 and prefix.endswith('/'), prefix
+        keys = storage.list(prefix)
+        assert len(keys) <= 300, R('Too many objects', len(keys))
+        storage.delete(keys, batch_size=100)
+
     def _mirror_prefix(self, catalog: CatalogName) -> str:
         return '_it/' if catalog in config.integration_test_catalogs else ''
 

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -181,11 +181,14 @@ class BaseMirrorService:
                 log.warning('Conflicting content type %r for file %r', content_type, file)
             return json_content
 
+    info_prefix = 'info'
+    file_prefix = 'file'
+
     def mirror_object_key(self, file: File) -> str:
-        return self._file_key('file', file)
+        return self._file_key(self.file_prefix, file)
 
     def info_object_key(self, file: File) -> str:
-        return self._file_key('info', file, extension='.json')
+        return self._file_key(self.info_prefix, file, extension='.json')
 
     def info_exists(self, catalog: CatalogName, file: File) -> bool:
         return self._get_info(catalog, file) is not None
@@ -200,9 +203,10 @@ class BaseMirrorService:
 
     def _file_key(self, prefix: str, file: File, *, extension: str = '') -> str:
         digest = file.digest
-        assert all(c in string.hexdigits for c in digest.value), R(
+        digest_value = digest.value.lower()
+        assert all(c in string.hexdigits for c in digest_value), R(
             'Expected a hexadecimal digest', digest)
-        return f'{prefix}/{digest.value.lower()}.{digest.type}{extension}'
+        return f'{prefix}/{digest_value}.{digest.type}{extension}'
 
 
 @attrs.frozen(kw_only=True)

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -162,12 +162,12 @@ class BaseMirrorService:
         return StorageService(bucket_name=self._bucket_name(catalog))
 
     def get_mirror_url(self, catalog: CatalogName, file: File) -> str:
-        key = self.mirror_object_key(file)
+        key = self.mirror_object_key(catalog, file)
         return self._storage(catalog).get_presigned_url(key=key,
                                                         file_name=file.name)
 
     def _get_info(self, catalog: CatalogName, file: File) -> JSON | None:
-        key = self.info_object_key(file)
+        key = self.info_object_key(catalog, file)
         try:
             content = self._storage(catalog).get(key)
         except StorageObjectNotFound:
@@ -184,29 +184,39 @@ class BaseMirrorService:
     info_prefix = 'info'
     file_prefix = 'file'
 
-    def mirror_object_key(self, file: File) -> str:
-        return self._file_key(self.file_prefix, file)
+    def mirror_object_key(self, catalog: CatalogName, file: File) -> str:
+        return self._file_key(catalog, self.file_prefix, file)
 
-    def info_object_key(self, file: File) -> str:
-        return self._file_key(self.info_prefix, file, extension='.json')
+    def info_object_key(self, catalog: CatalogName, file: File) -> str:
+        return self._file_key(catalog, self.info_prefix, file, extension='.json')
 
     def info_exists(self, catalog: CatalogName, file: File) -> bool:
         return self._get_info(catalog, file) is not None
 
     def file_exists(self, catalog: CatalogName, file: File) -> bool:
         try:
-            self._storage(catalog).head(self.mirror_object_key(file))
+            self._storage(catalog).head(self.mirror_object_key(catalog, file))
         except StorageObjectNotFound:
             return False
         else:
             return True
 
-    def _file_key(self, prefix: str, file: File, *, extension: str = '') -> str:
+    def _mirror_prefix(self, catalog: CatalogName) -> str:
+        return '_it/' if catalog in config.integration_test_catalogs else ''
+
+    def _file_key(self,
+                  catalog: CatalogName,
+                  prefix: str,
+                  file: File,
+                  *,
+                  extension: str = ''
+                  ) -> str:
         digest = file.digest
         digest_value = digest.value.lower()
         assert all(c in string.hexdigits for c in digest_value), R(
             'Expected a hexadecimal digest', digest)
-        return f'{prefix}/{digest_value}.{digest.type}{extension}'
+        mirror_prefix = self._mirror_prefix(catalog)
+        return f'{mirror_prefix}{prefix}/{digest_value}.{digest.type}{extension}'
 
 
 @attrs.frozen(kw_only=True)
@@ -223,7 +233,7 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
         :meth:`begin_mirroring_file` instead.
         """
         file_content = self._download(catalog, file)
-        self._storage(catalog).put(object_key=self.mirror_object_key(file),
+        self._storage(catalog).put(object_key=self.mirror_object_key(catalog, file),
                                    data=file_content,
                                    content_type=file.content_type,
                                    overwrite=False)
@@ -238,7 +248,7 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
         ID.
         """
         storage = self._storage(catalog)
-        key = self.mirror_object_key(file)
+        key = self.mirror_object_key(catalog, file)
         upload = storage.create_multipart_upload(object_key=key,
                                                  content_type=file.content_type)
         return upload.id
@@ -288,7 +298,7 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
         }
 
     def _put_info(self, catalog: CatalogName, file: File):
-        key = self.info_object_key(file)
+        key = self.info_object_key(catalog, file)
         content = self.info_object(file)
         self._storage(catalog).put(object_key=key,
                                    data=json.dumps(content).encode(),
@@ -337,7 +347,8 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
                     upload_id: str
                     ) -> 'MultipartUpload':
         storage = self._storage(catalog)
-        return storage.load_multipart_upload(object_key=self.mirror_object_key(file),
+        key = self.mirror_object_key(catalog, file)
+        return storage.load_multipart_upload(object_key=key,
                                              upload_id=upload_id)
 
     def _verify_digest(self, file: File, hasher: Hasher):

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -22,6 +22,7 @@ from logging import (
 )
 import time
 from typing import (
+    Collection,
     IO,
     TYPE_CHECKING,
 )
@@ -33,6 +34,9 @@ import botocore
 import botocore.exceptions
 from botocore.response import (
     StreamingBody,
+)
+from more_itertools import (
+    chunked,
 )
 from werkzeug.http import (
     parse_dict_header,
@@ -129,6 +133,20 @@ class StorageService:
                                 **kwargs)
         except botocore.exceptions.ClientError as e:
             self._handle_overwrite(e, object_key)
+
+    def delete(self, keys: Collection[str], batch_size: int = 1000) -> None:
+        assert batch_size <= 1000, R('Batch size must <= 1000', batch_size)
+        num_keys = len(keys)
+        for batch in chunked(keys, batch_size):
+            log.debug('Deleting batch of objects: %r', batch)
+            self._s3.delete_objects(Bucket=self.bucket_name,
+                                    Delete={
+                                        'Objects': [
+                                            {'Key': key}
+                                            for key in batch
+                                        ]
+                                    })
+        log.info('Deleted %d objects overall', num_keys)
 
     def list(self, prefix: str) -> OrderedSet[str]:
         keys, num_keys = OrderedSet(), 0

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -78,7 +78,7 @@ class TestMirrorController(DCP2TestCase,
                         self._test_mirror_file(file, file_message)
 
                     self._s3.delete_object(Bucket=self.mirror_bucket,
-                                           Key=self.mirror_controller.service.info_object_key(file))
+                                           Key=self.mirror_controller.service.info_object_key(self.catalog, file))
 
                     with self.subTest('mirror_file', corrupted=True):
                         self._test_corrupted_download(file_message)
@@ -141,7 +141,7 @@ class TestMirrorController(DCP2TestCase,
         with patch.object(MirrorService, '_download', return_value=self._file_contents):
             self.mirror_controller.mirror(event)
         response = self._s3.get_object(Bucket=self.mirror_bucket,
-                                       Key=self.mirror_controller.service.mirror_object_key(file))
+                                       Key=self.mirror_controller.service.mirror_object_key(self.catalog, file))
         mirrored_file_contents = response['Body'].read()
         self.assertEqual(mirrored_file_contents, self._file_contents)
 

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -132,6 +132,9 @@ from azul.indexer.index_service import (
     IndexExistsAndDiffersException,
     IndexService,
 )
+from azul.indexer.mirror_service import (
+    BaseMirrorService,
+)
 from azul.json_freeze import (
     freeze,
 )
@@ -491,7 +494,7 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
         self._test_other_endpoints()
 
         if config.enable_mirroring:
-            self._test_mirroring()
+            self._test_mirroring(delete=delete)
 
     def _reset_indexer(self):
         # While it's OK to erase the integration test catalog, the queues are
@@ -1725,14 +1728,36 @@ class IndexingIntegrationTest(IntegrationTestCase, AlwaysTearDownTestCase):
             for command_line in command_lines:
                 self.assertIn(expected_auth_header, command_line)
 
-    def _test_mirroring(self):
+    def _test_mirroring(self, *, delete: bool):
         with self.subTest('mirror_files'):
-            self._assert_queues_empty(config.mirror_queue_names)
-            for catalog in config.integration_test_catalogs:
-                source = self._select_source(catalog, public=True)
-                self.azul_client.remote_mirror(catalog, [source])
-            self.azul_client.wait_for_mirroring()
-            self._assert_queues_empty(config.mirror_fail_queue_names)
+            catalogs = [
+                c.name
+                for c in config.catalogs.values()
+                if c.is_integration_test_catalog and c.atlas == 'hca'
+            ]
+            service = BaseMirrorService()
+            sources_by_catalog = {
+                catalog: [self._select_source(catalog, public=True)]
+                for catalog in catalogs
+            }
+
+            def _delete():
+                if delete:
+                    # This potentially causes redundant ListObjects requests,
+                    # since each IT catalog currently uses the same mirror
+                    # prefix and bucket
+                    for catalog in catalogs:
+                        service.delete_it_files(catalog)
+
+            self._assert_queues_empty([config.mirror_queue.name,
+                                       config.mirror_queue.to_fail.name])
+            _delete()
+            for _ in range(2):
+                for catalog, sources in sources_by_catalog.items():
+                    self.azul_client.remote_mirror(catalog, sources)
+                self.azul_client.wait_for_mirroring()
+                self._assert_queues_empty([config.mirror_queue.to_fail.name])
+            _delete()
 
 
 class AzulClientIntegrationTest(IntegrationTestCase):

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -437,7 +437,7 @@ class TestRepositoryFilesWithMirroring(DCP2TestCase,
         self.assertEqual('https', signed_url.scheme)
         self.assertEqual(f'{self.mirror_bucket}.s3.{config.region}.amazonaws.com',
                          signed_url.netloc)
-        self.assertEqual('/' + mirror_service.mirror_object_key(file),
+        self.assertEqual('/' + mirror_service.mirror_object_key(self.catalog, file),
                          str(signed_url.path))
         self.assertEqual(f'attachment;filename="{file.name}"',
                          signed_url.args.get('response-content-disposition'))


### PR DESCRIPTION
Connected issues: #7145


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved connected issues to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
