### PR TITLE
Fix: Cannot generate unfiltered JSONL manifest in AnVIL (#7190)

### DIFF
--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -542,7 +542,7 @@ class ManifestPartition:
 
     def next_page(self,
                   file_name: str | None,
-                  search_after: SortKey
+                  search_after: SortKey | None
                   ) -> Self:
         assert self.page_index is not None, self
         # If different pages yield different file names, use default file name
@@ -1253,7 +1253,8 @@ class PagedManifestGenerator(ClientSidePagingManifestGenerator):
 
     In some subclasses, e.g. CompactManifestGenerator and CurlManifestGenerator,
     a manifest page corresponds to a page of hits from a paginated Elasticsearch
-    request.
+    request. In others, e.g. JSONLVerbatimManifestGenerator, the relationship
+    between manifest pages and Elasticsearch pages is more complicated.
     """
 
     @abstractmethod
@@ -1760,8 +1761,7 @@ class PFBManifestGenerator(FileBasedManifestGenerator):
         return path, None
 
 
-class VerbatimManifestGenerator(FileBasedManifestGenerator,
-                                ClientSidePagingManifestGenerator,
+class VerbatimManifestGenerator(ClientSidePagingManifestGenerator,
                                 metaclass=ABCMeta):
 
     @property
@@ -1807,6 +1807,11 @@ class VerbatimManifestGenerator(FileBasedManifestGenerator,
         # sources used for indexing, and filtering by a specific project
         # or dataset entity should produce the same results as filtering by
         # that entity's source.
+        #
+        # The verbatim JSONL generator temporarily inserts a source ID condition
+        # into its provided filters in order to partition the manifest. If the
+        # source ID field were not included below, that insertion would cause
+        # orphans to be absent from the manifest, which is incorrect.
         #
         source_fields = {
             plugin.special_fields.source_id,
@@ -1921,7 +1926,8 @@ class VerbatimManifestGenerator(FileBasedManifestGenerator,
         return self._paginate_hits(request_factory)
 
 
-class JSONLVerbatimManifestGenerator(VerbatimManifestGenerator):
+class JSONLVerbatimManifestGenerator(PagedManifestGenerator,
+                                     VerbatimManifestGenerator):
 
     @property
     def content_type(self) -> str:
@@ -1935,21 +1941,65 @@ class JSONLVerbatimManifestGenerator(VerbatimManifestGenerator):
     def format(cls) -> ManifestFormat:
         return ManifestFormat.verbatim_jsonl
 
-    def create_file(self) -> tuple[str, str | None]:
-        fd, path = mkstemp(suffix=f'.{self.file_name_extension()}')
-        os.close(fd)
-        with open(path, 'w') as f:
-            for replica in self._list_replicas():
+    @property
+    def source_id_field(self) -> str:
+        return self.metadata_plugin.special_fields.source_id
+
+    def source_ids(self) -> list[str]:
+        # Currently, we process each source that might be included in the
+        # manifest. This can be very inefficient since many partitions may be
+        # empty for small manifests. A potential optimization is to use a terms
+        # aggregation to query for the set of nonempty sources before
+        # processing any hits.
+
+        # It's possible that inaccessible sources are included in the explicit
+        # sources. If they are, an exception will be raised when the filters are
+        # reified, so it's safe to skip that check here.
+        try:
+            source_filter = self.filters.explicit[self.source_id_field]
+        except KeyError:
+            sources = self.filters.source_ids
+        else:
+            sources = source_filter['is']
+        return sorted(sources)
+
+    def write_page_to(self,
+                      partition: ManifestPartition,
+                      output: IO[str]
+                      ) -> ManifestPartition:
+        # All replicas from each source must be held in memory simultaneously to
+        # avoid emitting duplicates. Therefore, each "page" of this manifest
+        # must retrieve every replica from a given source, using multiple paged
+        # requests to ElasticSearch if necessary.
+        source_ids = self.source_ids()
+        source_id = source_ids[partition.page_index]
+        log.info('Listing replicas from source %r for manifest page %d',
+                 source_id, partition.page_index)
+        partition_filter = {self.source_id_field: {'is': [source_id]}}
+        original_filters = self.filters
+        try:
+            self.filters = original_filters.update(partition_filter)
+            replicas = self._list_replicas()
+            for replica in replicas:
                 entry = {
                     'value': replica['contents'],
                     'type': replica['replica_type']
                 }
-                json.dump(entry, f)
-                f.write('\n')
-        return path, None
+                json.dump(entry, output)
+                output.write('\n')
+        finally:
+            self.filters = original_filters
+        last_page = len(source_ids) - 1
+        if partition.page_index < last_page:
+            return partition.next_page(file_name=None, search_after=None)
+        elif partition.page_index == last_page:
+            return partition.last_page()
+        else:
+            assert False, (partition, source_ids)
 
 
-class PFBVerbatimManifestGenerator(VerbatimManifestGenerator):
+class PFBVerbatimManifestGenerator(FileBasedManifestGenerator,
+                                   VerbatimManifestGenerator):
 
     @property
     def content_type(self) -> str:

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -38,6 +38,7 @@ from tempfile import (
 )
 import time
 from typing import (
+    Callable,
     ClassVar,
     IO,
     Protocol,
@@ -1759,7 +1760,9 @@ class PFBManifestGenerator(FileBasedManifestGenerator):
         return path, None
 
 
-class VerbatimManifestGenerator(FileBasedManifestGenerator, metaclass=ABCMeta):
+class VerbatimManifestGenerator(FileBasedManifestGenerator,
+                                ClientSidePagingManifestGenerator,
+                                metaclass=ABCMeta):
 
     @property
     def entity_type(self) -> str:
@@ -1825,9 +1828,36 @@ class VerbatimManifestGenerator(FileBasedManifestGenerator, metaclass=ABCMeta):
         hub_id: str
         replica_ids: list[str]
 
-    def _replica_keys(self) -> Iterable[ReplicaKeys]:
-        request = self._create_request()
-        for hit in request.scan():
+    def _paginate_hits(self,
+                       request_factory: Callable[[SortKey | None], Search]
+                       ) -> Iterable[Hit]:
+        """
+        Yield all hits in every page of Elasticsearch hits in responses to
+        requests that use client-side paging.
+
+        :param request_factory:  A callable that returns a prepared Elasticsearch
+                                 request for the given search-after key, with the
+                                 appropriate filters and sorting applied. The
+                                 returned request should yield one page worth of
+                                 hits, starting at the first page (if the argument
+                                 is None), or the hit right after the hit with
+                                 given search-after key
+        """
+        search_after = None
+        while True:
+            request = request_factory(search_after)
+            response = request.execute()
+            if response.hits:
+                hit = None
+                for hit in response.hits:
+                    yield hit
+                assert hit is not None
+                search_after = self._search_after(hit)
+            else:
+                break
+
+    def _list_replica_keys(self) -> Iterable[ReplicaKeys]:
+        for hit in self._paginate_hits(self._create_paged_request):
             document_ids = [
                 document_id
                 for entity_type in self.hot_entity_types
@@ -1840,10 +1870,10 @@ class VerbatimManifestGenerator(FileBasedManifestGenerator, metaclass=ABCMeta):
             yield self.ReplicaKeys(hub_id=hit['entity_id'],
                                    replica_ids=document_ids)
 
-    def _all_replicas(self) -> Iterable[JSON]:
+    def _list_replicas(self) -> Iterable[JSON]:
         emitted_replica_ids = set()
         page_size = 100
-        for page in chunked(self._replica_keys(), page_size):
+        for page in chunked(self._list_replica_keys(), page_size):
             num_replicas = 0
             num_new_replicas = 0
             for replica in self._join_replicas(page):
@@ -1860,18 +1890,33 @@ class VerbatimManifestGenerator(FileBasedManifestGenerator, metaclass=ABCMeta):
                      num_replicas, num_replicas - num_new_replicas, len(page))
 
     def _join_replicas(self, keys: Iterable[ReplicaKeys]) -> Iterable[Hit]:
-        request = self.service.create_request(catalog=self.catalog,
-                                              entity_type='replica',
-                                              doc_type=DocumentType.replica)
         hub_ids, replica_ids = set(), set()
         for key in keys:
             hub_ids.add(key.hub_id)
             replica_ids.update(key.replica_ids)
+
+        request = self.service.create_request(catalog=self.catalog,
+                                              entity_type='replica',
+                                              doc_type=DocumentType.replica)
         request = request.query(Q('bool', should=[
             {'terms': {'hub_ids.keyword': list(hub_ids)}},
             {'terms': {'entity_id.keyword': list(replica_ids)}}
         ]))
-        return request.scan()
+        request = request.extra(size=self.page_size)
+
+        # `_id` is currently the only index field that is unique to each replica
+        # document (and thus results in an unambiguous total ordering). However,
+        # sorting just by `_id` is unacceptably slow, an Elasticsearch quirk. To
+        # overcome the performance hit, we sort by a field that's *almost*
+        # unique to each replica, so that `_id` only needs to be loaded and
+        # compared in the infrequent event that it's needed as a tiebreaker.
+        #
+        request = request.sort('entity_id.keyword', '_id')
+
+        def request_factory(search_after: SortKey | None) -> Search:
+            return request.extra(search_after=search_after)
+
+        return self._paginate_hits(request_factory)
 
 
 class JSONLVerbatimManifestGenerator(VerbatimManifestGenerator):
@@ -1892,7 +1937,7 @@ class JSONLVerbatimManifestGenerator(VerbatimManifestGenerator):
         fd, path = mkstemp(suffix=f'.{self.file_name_extension()}')
         os.close(fd)
         with open(path, 'w') as f:
-            for replica in self._all_replicas():
+            for replica in self._list_replicas():
                 entry = {
                     'value': replica['contents'],
                     'type': replica['replica_type']
@@ -1954,7 +1999,7 @@ class PFBVerbatimManifestGenerator(VerbatimManifestGenerator):
         )
 
     def create_file(self) -> tuple[str, str | None]:
-        replicas = list(self._all_replicas())
+        replicas = list(self._list_replicas())
         plugin = self.metadata_plugin
         replica_schemas = plugin.verbatim_pfb_schema(replicas)
         # Ensure field order is consistent for unit tests

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -1779,10 +1779,12 @@ class VerbatimManifestGenerator(FileBasedManifestGenerator, metaclass=ABCMeta):
 
     @property
     def include_orphans(self) -> bool:
+
         # When filtering exclusively by properties of implicit hubs, e.g.,
         # data sets for AnVIL or projects for HCA, we include replicas of all
         # entities implicitly connected to the matching hubs, even replicas of
         # orphans, i.e., entities that aren't connected to files.
+        #
         plugin = self.metadata_plugin
         root_entity_fields = {
             field_name

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -1211,10 +1211,48 @@ class ManifestGenerator(metaclass=ABCMeta):
         return self.service.storage_service
 
 
-class PagedManifestGenerator(ManifestGenerator):
+class ClientSidePagingManifestGenerator(ManifestGenerator, metaclass=ABCMeta):
     """
-    A manifest generator whose output can be split over multiple concatenable
-    IO streams.
+    A mixin for manifest generators that use client-side paging to query
+    Elasticsearch.
+    """
+    page_size = 500
+
+    def _create_paged_request(self, search_after: SortKey | None) -> Search:
+        pagination = Pagination(sort='entryId',
+                                order='asc',
+                                size=self.page_size,
+                                search_after=search_after)
+        pipeline = self._create_pipeline()
+        # Only needs this to satisfy the type constraints
+        pipeline = ToDictStage(service=self.service,
+                               catalog=self.catalog,
+                               entity_type=self.entity_type).wrap(pipeline)
+        pipeline = PaginationStage(service=self.service,
+                                   catalog=self.catalog,
+                                   entity_type=self.entity_type,
+                                   pagination=pagination,
+                                   filters=self.filters,
+                                   peek_ahead=False).wrap(pipeline)
+        request = self.service.create_request(catalog=self.catalog,
+                                              entity_type=self.entity_type)
+        # The response is processed by the generator, not the pipeline
+        request = pipeline.prepare_request(request)
+        return request
+
+    def _search_after(self, hit: Hit) -> SortKey:
+        a, b = hit.meta.sort
+        return a, b
+
+
+class PagedManifestGenerator(ClientSidePagingManifestGenerator):
+    """
+    A manifest generator whose output is split over several concatenable
+    segments, also known as pages.
+
+    In some subclasses, e.g. CompactManifestGenerator and CurlManifestGenerator,
+    a manifest page corresponds to a page of hits from a paginated Elasticsearch
+    request.
     """
 
     @abstractmethod
@@ -1281,34 +1319,6 @@ class PagedManifestGenerator(ManifestGenerator):
                         self.storage.put_object_tagging(object_key, tagging)
                     partition = partition.last(file_name)
                 return partition
-
-    page_size = 500
-
-    def _create_paged_request(self, search_after: SortKey | None) -> Search:
-        pagination = Pagination(sort='entryId',
-                                order='asc',
-                                size=self.page_size,
-                                search_after=search_after)
-        pipeline = self._create_pipeline()
-        # Only needs this to satisfy the type constraints
-        pipeline = ToDictStage(service=self.service,
-                               catalog=self.catalog,
-                               entity_type=self.entity_type).wrap(pipeline)
-        pipeline = PaginationStage(service=self.service,
-                                   catalog=self.catalog,
-                                   entity_type=self.entity_type,
-                                   pagination=pagination,
-                                   filters=self.filters,
-                                   peek_ahead=False).wrap(pipeline)
-        request = self.service.create_request(catalog=self.catalog,
-                                              entity_type=self.entity_type)
-        # The response is processed by the generator, not the pipeline
-        request = pipeline.prepare_request(request)
-        return request
-
-    def _search_after(self, hit: Hit) -> SortKey:
-        a, b = hit.meta.sort
-        return a, b
 
 
 class FileBasedManifestGenerator(ManifestGenerator):

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -1288,11 +1288,11 @@ class PagedManifestGenerator(ManifestGenerator):
 
     page_size = 500
 
-    def _create_paged_request(self, partition: ManifestPartition) -> Search:
+    def _create_paged_request(self, search_after: SortKey | None) -> Search:
         pagination = Pagination(sort='entryId',
                                 order='asc',
                                 size=self.page_size,
-                                search_after=partition.search_after)
+                                search_after=search_after)
         pipeline = self._create_pipeline()
         # Only needs this to satisfy the type constraints
         pipeline = ToDictStage(service=self.service,
@@ -1497,7 +1497,7 @@ class CurlManifestGenerator(PagedManifestGenerator):
             output.write('\n\n'.join(curl_options))
             output.write('\n\n')
 
-        request = self._create_paged_request(partition)
+        request = self._create_paged_request(partition.search_after)
         response = request.execute()
         if response.hits:
             hit = None
@@ -1641,7 +1641,7 @@ class CompactManifestGenerator(PagedManifestGenerator):
         if partition.page_index == 0:
             writer.writeheader()
 
-        request = self._create_paged_request(partition)
+        request = self._create_paged_request(partition.search_after)
         response = request.execute()
         if response.hits:
             project_short_names = set()

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -1791,7 +1791,17 @@ class VerbatimManifestGenerator(FileBasedManifestGenerator, metaclass=ABCMeta):
             for field_name, field_path in plugin.field_mapping.items()
             if field_path[0] == 'contents' and field_path[1] == plugin.root_entity_type
         }
-        return self.filters.explicit.keys() < root_entity_fields
+
+        # For both HCA and AnVIL, these root entities are bijective with the
+        # sources used for indexing, and filtering by a specific project
+        # or dataset entity should produce the same results as filtering by
+        # that entity's source.
+        #
+        source_fields = {
+            plugin.special_fields.source_id,
+            plugin.special_fields.source_spec
+        }
+        return self.filters.explicit.keys() < (root_entity_fields | source_fields)
 
     @attrs.frozen(kw_only=True)
     class ReplicaKeys:

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -128,6 +128,7 @@ from azul.service.avro_pfb import (
     PFBRelation,
 )
 from azul.service.elasticsearch_service import (
+    ElasticsearchChain,
     ElasticsearchService,
     Pagination,
     PaginationStage,
@@ -520,10 +521,10 @@ class ManifestPartition:
                    is_last=False)
 
     @property
-    def is_first(self):
+    def is_first(self) -> bool:
         return not (self.index or self.page_index)
 
-    def with_config(self, config: AnyJSON):
+    def with_config(self, config: AnyJSON) -> Self:
         return attrs.evolve(self, config=config)
 
     def with_upload(self, multipart_upload_id) -> Self:
@@ -551,7 +552,7 @@ class ManifestPartition:
                             file_name=file_name,
                             search_after=search_after)
 
-    def last_page(self):
+    def last_page(self) -> Self:
         return attrs.evolve(self, is_last_page=True)
 
     def next(self, part_etag: str) -> Self:
@@ -1036,7 +1037,7 @@ class ManifestGenerator(metaclass=ABCMeta):
         # The response is processed by the generator, not the pipeline
         return request
 
-    def _create_pipeline(self):
+    def _create_pipeline(self) -> ElasticsearchChain:
         if self.included_fields is None:
             document_slice = DocumentSlice()
         else:

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -132,6 +132,7 @@ from azul.service.elasticsearch_service import (
     ElasticsearchService,
     Pagination,
     PaginationStage,
+    SortKey,
     ToDictStage,
 )
 from azul.service.storage_service import (
@@ -503,7 +504,7 @@ class ManifestPartition:
 
     #: The `sort` value of the first hit of the current page in this partition,
     #: or None if there is no current page.
-    search_after: tuple[str, str] | None = None
+    search_after: SortKey | None = None
 
     @classmethod
     def from_json(cls, partition: JSON) -> Self:
@@ -540,7 +541,7 @@ class ManifestPartition:
 
     def next_page(self,
                   file_name: str | None,
-                  search_after: tuple[str, str]
+                  search_after: SortKey
                   ) -> Self:
         assert self.page_index is not None, self
         # If different pages yield different file names, use default file name
@@ -1309,7 +1310,7 @@ class PagedManifestGenerator(ManifestGenerator):
         request = pipeline.prepare_request(request)
         return request
 
-    def _search_after(self, hit: Hit) -> tuple[str, str]:
+    def _search_after(self, hit: Hit) -> SortKey:
         a, b = hit.meta.sort
         return a, b
 

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -1872,8 +1872,7 @@ class VerbatimManifestGenerator(FileBasedManifestGenerator,
 
     def _list_replicas(self) -> Iterable[JSON]:
         emitted_replica_ids = set()
-        page_size = 100
-        for page in chunked(self._list_replica_keys(), page_size):
+        for page in chunked(self._list_replica_keys(), self.page_size):
             num_replicas = 0
             num_new_replicas = 0
             for replica in self._join_replicas(page):

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -1911,6 +1911,9 @@ class VerbatimManifestGenerator(FileBasedManifestGenerator,
         # unique to each replica, so that `_id` only needs to be loaded and
         # compared in the infrequent event that it's needed as a tiebreaker.
         #
+        # FIXME: ES DeprecationWarning for using _id as sort key
+        #        https://github.com/DataBiosphere/azul/issues/7290
+        #
         request = request.sort('entity_id.keyword', '_id')
 
         def request_factory(search_after: SortKey | None) -> Search:

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -1269,22 +1269,18 @@ class PagedManifestGenerator(ManifestGenerator):
                     partition = self.write_page_to(partition, output=text_buffer)
                     if partition.is_last_page or buffer.tell() > self.part_size:
                         break
-
-                def upload_part():
+                if buffer.tell() > 0:
                     buffer.seek(0)
-                    return self.storage.upload_multipart_part(buffer, partition.index + 1, upload)
-
+                    part_etag = self.storage.upload_multipart_part(buffer, partition.index + 1, upload)
+                    partition = partition.next(part_etag=part_etag)
                 if partition.is_last_page:
-                    if buffer.tell() > 0:
-                        partition = partition.next(part_etag=upload_part())
                     self.storage.complete_multipart_upload(upload, partition.part_etags)
                     file_name = self.file_name(manifest_key, base_name=partition.file_name)
                     tagging = self.tagging(file_name)
                     if tagging is not None:
                         self.storage.put_object_tagging(object_key, tagging)
-                    return partition.last(file_name)
-                else:
-                    return partition.next(part_etag=upload_part())
+                    partition = partition.last(file_name)
+                return partition
 
     page_size = 500
 

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -1307,6 +1307,8 @@ class PagedManifestGenerator(ClientSidePagingManifestGenerator):
             with TextIOWrapper(buffer, encoding='utf-8', write_through=True) as text_buffer:
                 while True:
                     partition = self.write_page_to(partition, output=text_buffer)
+                    # Manifest lambda has 2 GB of memory
+                    assert buffer.tell() < 1.5 * 1024 ** 3
                     if partition.is_last_page or buffer.tell() > self.part_size:
                         break
                 if buffer.tell() > 0:

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -344,7 +344,8 @@ class StorageService:
                           object_key: str
                           ):
         error = exception.response['Error']
-        code, condition = error['Code'], error['Condition']
+        # `Condition` is only present when using conditional writes
+        code, condition = error['Code'], error.get('Condition')
         if code == 'PreconditionFailed' and condition == 'If-None-Match':
             raise StorageObjectExists(object_key)
         else:

--- a/test/azul_test_case.py
+++ b/test/azul_test_case.py
@@ -141,6 +141,8 @@ class AzulTestCase(TestCase):
                 'datetime.datetime.utcnow() is deprecated',
             },
             ElasticsearchWarning: {
+                # FIXME: ES DeprecationWarning for using _id as sort key
+                #        https://github.com/DataBiosphere/azul/issues/7290
                 RE('.*Loading the fielddata on the _id field is deprecated and will be removed in future versions.*'),
             }
         }

--- a/test/azul_test_case.py
+++ b/test/azul_test_case.py
@@ -123,23 +123,6 @@ class AzulTestCase(TestCase):
                 RE(r'.+humancellatlas\.data\.metadata\.api\.LibraryPreparationProcess'),
                 RE(r'.*humancellatlas\.data\.metadata\.api\.SequencingProcess'),
 
-                # FIXME: https://github.com/DataBiosphere/azul/issues/2758
-                'OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated',
-
-                RE(r'.*Fielddata access on the _uid field is deprecated, use _id instead'),
-                RE(r'.*Accessing variable \[_aggs\]'),
-                RE(r'.*Accessing variable \[_agg\]'),
-
-                # FIXME: furl.fragmentstr raises deprecation warning
-                #        https://github.com/DataBiosphere/azul/issues/2848
-                'furl.fragmentstr is deprecated',
-
-                (
-                    "Using or importing the ABCs from 'collections' instead of from "
-                    "'collections.abc' is deprecated since Python 3.3, and in 3.9 "
-                    "it will stop working"
-                ),
-
                 'Call to deprecated function (or staticmethod) patch_source_cache',
 
                 # FIXME: DeprecationWarning for ES body parameter
@@ -153,10 +136,6 @@ class AzulTestCase(TestCase):
                 # FIXME: DeprecationWarning for datetime methods in Python 3.12
                 #        https://github.com/DataBiosphere/azul/issues/5953
                 'datetime.datetime.utcnow() is deprecated',
-                'datetime.datetime.utcfromtimestamp() is deprecated',
-            },
-            UserWarning: {
-                'https://github.com/DataBiosphere/azul/issues/2114',
             }
         }
         for warning_class, message_patterns in permitted_warnings_.items():

--- a/test/azul_test_case.py
+++ b/test/azul_test_case.py
@@ -34,6 +34,9 @@ from botocore.credentials import (
     Credentials,
 )
 import botocore.session
+from elasticsearch.exceptions import (
+    ElasticsearchWarning,
+)
 from furl import (
     furl,
 )
@@ -136,6 +139,9 @@ class AzulTestCase(TestCase):
                 # FIXME: DeprecationWarning for datetime methods in Python 3.12
                 #        https://github.com/DataBiosphere/azul/issues/5953
                 'datetime.datetime.utcnow() is deprecated',
+            },
+            ElasticsearchWarning: {
+                RE('.*Loading the fielddata on the _id field is deprecated and will be removed in future versions.*'),
             }
         }
         for warning_class, message_patterns in permitted_warnings_.items():

--- a/test/docker_container_test_case.py
+++ b/test/docker_container_test_case.py
@@ -11,7 +11,6 @@ from typing import (
     ClassVar,
     Optional,
 )
-import warnings
 
 import docker
 from docker import (
@@ -177,9 +176,5 @@ class DockerContainerTestCase(AzulUnitTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        for cached, containers in cls._containers.values():
-            for line in containers.logs().decode().split('\n'):
-                if 'deprecated' in line.lower():
-                    warnings.warn(line, DeprecationWarning)
         cls._kill_containers()
         super().tearDownClass()

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -18,6 +18,10 @@ from datetime import (
 from io import (
     BytesIO,
 )
+from itertools import (
+    combinations,
+    starmap,
+)
 import json
 import os
 from pathlib import (
@@ -38,6 +42,9 @@ from uuid import (
 )
 
 import attrs
+from chalice import (
+    ForbiddenError,
+)
 import fastavro
 from furl import (
     furl,
@@ -63,10 +70,13 @@ from azul.collections import (
 )
 from azul.indexer import (
     Prefix,
+    SimpleSourceSpec,
     SourcedBundleFQID,
 )
 from azul.indexer.document import (
+    EntityID,
     EntityReference,
+    EntityType,
 )
 from azul.json import (
     copy_json,
@@ -84,6 +94,8 @@ from azul.plugins.metadata.hca import (
 )
 from azul.plugins.repository.dss import (
     DSSBundle,
+    DSSBundleFQID,
+    DSSSourceRef,
 )
 from azul.service import (
     Filters,
@@ -1808,6 +1820,123 @@ class TestAnvilManifestsWithCommonPrefix(AnvilManifestTestCase):
 
     def test(self):
         self._test_verbatim_pfb_manifest(enable_relations=True)
+
+
+class TestVerbatimJSONLManifestPartitioningBySource(DCP1ManifestTestCase):
+    """
+    This test covers two important cases not covered by
+    test_verbatim_jsonl_manifest: the interaction between implicit and explicit
+    source filters, and partitioning across multiple sources.
+    """
+
+    sources_by_bundle_uuid = {
+        '3ac62c33-93e1-56b4-b857-59497f5d942d':
+            DSSSourceRef(id='706cc417-9ed1-4c09-8341-0df38e374423',
+                         spec=SimpleSourceSpec.parse('eggs:/1')),
+        '97f0cc83-f0ac-417a-8a29-221c77debde8':
+            DSSSourceRef(id='d0024443-bddf-4d3e-b4c8-6a3a1b23e8cf',
+                         spec=SimpleSourceSpec.parse('bacon:/2')),
+        '4b03c1ce-9df1-5cd5-a8e4-48a2fe095081':
+            DSSSourceRef(id='22213a35-5c8e-4bad-bcb9-d4b7740c7165',
+                         spec=SimpleSourceSpec.parse('sausage:/3')),
+    }
+
+    @classmethod
+    def bundle_fqid(cls, *, uuid: str, version: str) -> DSSBundleFQID:
+        return DSSBundleFQID(uuid=uuid,
+                             version=version,
+                             source=cls.sources_by_bundle_uuid[uuid])
+
+    @classmethod
+    def bundles(cls) -> list[SourcedBundleFQID]:
+        return [
+            cls.bundle_fqid(uuid=uuid,
+                            version='2022-06-01T00:00:00.000000Z')
+            for uuid in cls.sources_by_bundle_uuid.keys()
+        ]
+
+    def _filters(self, filters: FiltersJSON) -> Filters:
+        return Filters(explicit=filters,
+                       source_ids={
+                           source.id
+                           for source in self.sources_by_bundle_uuid.values()
+                       })
+
+    def test_manifest_partitioning_by_source(self):
+
+        # We can't assert the presence of every entity from the indexed bundles
+        # because some HCA entities still lack replicas.
+        #
+        def replicas_exist_for(entity_type: EntityType) -> bool:
+            return entity_type in (
+                'project',
+                'links',
+                'donor_organism',
+                'specimen_from_organism'
+            ) or entity_type.endswith('_file')
+
+        bundles_by_fqid = {
+            fqid: self._load_canned_bundle(fqid)
+            for fqid in self.bundles()
+        }
+        entity_ids_by_source_id: dict[str, set[EntityID]] = {
+            bundle_fqid.source.id: {bundle_fqid.uuid} | {
+                ref.entity_id
+                for ref in map(EntityReference.parse, bundle.metadata)
+                if replicas_exist_for(ref.entity_type)
+            }
+            for bundle_fqid, bundle in bundles_by_fqid.items()
+        }
+
+        # The manifest partitioning depends on the invariant that sources are
+        # disjunctive. It's very easy to accidentally violate this invariant
+        # while setting up this test, for example by choosing canned bundles
+        # that came from the same source.
+        #
+        assert all(starmap(
+            set.isdisjoint,
+            combinations(entity_ids_by_source_id.values(), 2)
+        ))
+
+        for num_sources in range(1, len(entity_ids_by_source_id) + 1):
+            for source_ids in combinations(entity_ids_by_source_id, r=num_sources):
+                with self.subTest(sources=source_ids):
+                    filters = {'sourceId': {'is': list(source_ids)}}
+                    response = self._get_manifest(ManifestFormat.verbatim_jsonl, filters)
+                    manifest_rows = list(map(json.loads, response.content.decode().splitlines()))
+
+                    def entity_id(row: JSON) -> EntityID:
+                        if row['type'] == 'links':
+                            return one(
+                                bundle_fqid.uuid
+                                for bundle_fqid, bundle in bundles_by_fqid.items()
+                                if row['value']['links'] == bundle.links['links']
+                            )
+                        else:
+                            return row['value']['provenance']['document_id']
+
+                    actual_entity_ids = {
+                        entity_id(row)
+                        for row in manifest_rows
+                        if replicas_exist_for(row['type'])
+                    }
+                    expected_entity_ids = set.union(*(
+                        entity_ids_by_source_id[source_id]
+                        for source_id in source_ids
+                    ))
+                    self.assertEqual(expected_entity_ids, actual_entity_ids)
+
+    def test_inaccessible_source(self):
+        accessible_source = list(self.sources_by_bundle_uuid.values())[0].id
+        inaccessible_source = 'cafebabe-5b46-40e9-81c5-aaa7ebadf00d'
+        with self.assertRaises(ForbiddenError) as e:
+            filters = {'sourceId': {'is': [accessible_source, inaccessible_source]}}
+            self._get_manifest(ManifestFormat.verbatim_jsonl, filters)
+        expected_args = (
+            'Cannot filter by inaccessible sources',
+            {inaccessible_source}
+        )
+        self.assertEqual(expected_args, e.exception.args)
 
 
 class TestPFB(CannedManifestTestCase):

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -1277,6 +1277,10 @@ class AnvilManifestTestCase(ManifestTestCase, AnvilCannedBundleTestCase):
             cls.bundle_fqid(uuid='6b35f59c-d33d-abf7-9ba0-c7b3a0ca82f3')
         ]
 
+    source_id_filters: FiltersJSON = {
+        'source_id': {'is': ['6c87f0e1-509d-46a4-b845-7584df39263b']}
+    }
+
     dataset_id_filters: FiltersJSON = {
         'datasets.dataset_id': {'is': ['52ee7665-7033-63f2-a8d9-ce8e32666739']}
     }
@@ -1293,6 +1297,7 @@ class AnvilManifestTestCase(ManifestTestCase, AnvilCannedBundleTestCase):
     # the given filters.
     expect_orphans_by_filters = [
         ({}, True),
+        (source_id_filters, True),
         (dataset_title_filters, True),
         (dataset_id_filters, True),
         (neutral_file_filters, False),

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -1867,6 +1867,9 @@ class TestVerbatimJSONLManifestPartitioningBySource(DCP1ManifestTestCase):
         # We can't assert the presence of every entity from the indexed bundles
         # because some HCA entities still lack replicas.
         #
+        # FIXME: Some replicas are still missing for HCA
+        #        https://github.com/DataBiosphere/azul/issues/6597
+        #
         def replicas_exist_for(entity_type: EntityType) -> bool:
             return entity_type in (
                 'project',


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Connected issues: #7190


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved connected issues to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
