### PR TITLE
Fix: WAF blocked alarm too sensitive (#7327)

### DIFF
--- a/terraform/api_gateway.tf.json.template.py
+++ b/terraform/api_gateway.tf.json.template.py
@@ -207,7 +207,7 @@ def add_waf_blocked_alarm(resources: JSON) -> JSON:
             *[('BlockedRequests', rule) for rule in rules]
         ]
         m_sum = '+'.join(f'm{i}' for i in range(1, len(metrics)))
-        expression = f'{m_sum}/(m0+{m_sum})*100'
+        expression = f'({m_sum})/(m0+{m_sum})*100'
 
         assert 'aws_cloudwatch_metric_alarm' not in resources
         return resources | {


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Connected issues: #7327


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved connected issues to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
