### PR TITLE
Fix: envhook.py falsely warns about variable override (#6320)

### DIFF
--- a/scripts/envhook.py
+++ b/scripts/envhook.py
@@ -21,15 +21,9 @@ from importlib.abc import (
     Loader,
 )
 import importlib.util
-from itertools import (
-    chain,
-)
 import os
 import pathlib
 import sys
-from typing import (
-    TypeVar,
-)
 
 
 class EnvHook:
@@ -46,7 +40,7 @@ class EnvHook:
             if enabled == 0:
                 self.print('Currently disabled because the ENVHOOK environment variable is set to 0.')
             else:
-                self.set_env(self.load_env())
+                self.handle_env()
                 self.share_aws_cli_credential_cache()
         except EnvhookError as e:
             if self.pycharm_hosted:
@@ -129,36 +123,37 @@ class EnvHook:
         else:
             assert False
 
-    def load_env(self) -> Mapping[str, str]:
-        resolve_env = self.export_environment.resolve_env
-        load_env = self.export_environment.load_env
-        new, _ = load_env()
-        new = resolve_env(new)
+    def handle_env(self):
+        env = self.prepare_env()
+        azul_env_hash = self.export_environment.azul_env_hash
+        expected, actual = env[azul_env_hash], os.environ.get(azul_env_hash)
+        if self.pycharm_hosted:
+            if actual is None:
+                self.set_env(env)
+            else:
+                raise TaintedEnv()
+        else:
+            if actual is None:
+                raise EmptyEnv()
+            elif actual != expected:
+                raise StaleEnv()
+
+    def prepare_env(self) -> Mapping[str, str]:
+        prepare_env = self.export_environment.prepare_env
+        new, message = prepare_env()
         return new
 
-    def set_env(self, new: Mapping[str, str]):
+    def set_env(self, env: Mapping[str, str]):
         redact = self.export_environment.redact
-        old = os.environ
-        for k, (o, n) in sorted(zip_dict(old, new).items()):
-            if o is None:
-                if self.pycharm_hosted:
-                    self.print(f'Setting {k} to {redact(k, n)!r}')
-                    os.environ[k] = n
-                else:
-                    self.print(f'Warning: {k} is not set but should be {redact(k, n)!r}, '
-                               f'you should run `source environment`')
-            elif n is None:
-                pass
-            elif n != o:
-                if k.startswith('PYTHON'):
-                    self.print(f'Ignoring change in {k} from {redact(k, o)!r} to {redact(k, n)!r}')
-                else:
-                    if self.pycharm_hosted:
-                        self.print(f'Changing {k} from {redact(k, o)!r} to {redact(k, n)!r}')
-                        os.environ[k] = n
-                    else:
-                        self.print(f'Warning: {k} is {redact(k, o)!r} but should be {redact(k, n)!r}, '
-                                   f'you must run `source environment`')
+        for k, v in env.items():
+            try:
+                v_ = os.environ[k]
+            except KeyError:
+                self.print(f'Setting {k} to {redact(k, v)!r}')
+                os.environ[k] = v
+            else:
+                self.print(f'Not setting {k} to {redact(k, v)!r} '
+                           f'because it is already set to {redact(k, v_)!r}')
 
     @property
     def pycharm_hosted(self):
@@ -232,7 +227,7 @@ class EnvHook:
                 ):
                     self.print('Looks like botocore credentials are not cached. '
                                'Skipping credential sharing with AWS CLI. '
-                               'Use _login from a shell to avoid this.')
+                               'Invoke `_login` from a shell to avoid this.')
                 else:
                     self.set_env(dict(AWS_ACCESS_KEY_ID=credentials.access_key,
                                       AWS_SECRET_ACCESS_KEY=credentials.secret_key,
@@ -246,44 +241,6 @@ class EnvHook:
                     # may therefore not strictly be necessary. We do it anyways, so
                     # as to not rely on an undocumented side effect.
                     resolver.remove('env')
-
-
-K = TypeVar('K')
-OV = TypeVar('OV')
-NV = TypeVar('NV')
-
-
-def zip_dict(old: Mapping[K, OV],
-             new: Mapping[K, NV],
-             missing=None
-             ) -> dict[K, tuple[OV, NV]]:
-    """
-    Merge two dictionaries. The resulting dictionary contains an entry for every
-    key in either `old` or `new`. Each entry in the result associates a key to
-    two values: the value from `old` for that key followed by the value from
-    `new` for that key. If the key is absent from either argument, the
-    respective tuple element will be `missing`, which defaults to None. If
-    either `old` or `new` could contain None values, some other value should be
-    passed for `missing` in order to distinguish None values from values for
-    absent entries.
-
-    >>> zip_dict({1:2}, {1:2})
-    {1: (2, 2)}
-    >>> zip_dict({1:2}, {3:4})
-    {1: (2, None), 3: (None, 4)}
-    >>> zip_dict({1:2}, {1:3})
-    {1: (2, 3)}
-    >>> zip_dict({1:2}, {})
-    {1: (2, None)}
-    >>> zip_dict({}, {1:2})
-    {1: (None, 2)}
-    >>> zip_dict({'deleted': 1, 'same': 2, 'changed': 3}, {'same': 2, 'changed': 4, 'added': 5}, missing=-1)
-    {'deleted': (1, -1), 'same': (2, 2), 'changed': (3, 4), 'added': (-1, 5)}
-    """
-    result = ((k, (old.get(k, missing), n)) for k, n in new.items())
-    removed = ((k, o) for k, o in old.items() if k not in new)
-    removed = ((k, (o, missing)) for k, o in removed)
-    return dict(chain(removed, result))
 
 
 class Path(pathlib.PosixPath):
@@ -370,6 +327,31 @@ class ThirdPartySiteCustomize(EnvhookError):
             f'Make a backup of that file, remove the original and try again. '
             f'Note that removing the file may break other, third-party site '
             f'customizations.'
+        )
+
+
+class TaintedEnv(EnvhookError):
+
+    def __init__(self):
+        super().__init__(
+            'The current process is a child of the PyCharm process but '
+            'unexpectedly already has the Azul environment loaded'
+        )
+
+
+class StaleEnv(EnvhookError):
+
+    def __init__(self):
+        super().__init__(
+            'The environment is stale. You need to run `source environment`.'
+        )
+
+
+class EmptyEnv(EnvhookError):
+
+    def __init__(self):
+        super().__init__(
+            'The environment is empty. You need to run `source environment`.'
         )
 
 

--- a/scripts/envhook.py
+++ b/scripts/envhook.py
@@ -40,7 +40,7 @@ class EnvHook:
         try:
             self._main(sys.argv[1:])
         except EnvhookError as e:
-            self._print(e.args[0])
+            self.print(e.args[0])
             sys.exit(1)
         finally:
             sys.stderr.flush()
@@ -51,7 +51,7 @@ class EnvHook:
         try:
             enabled = int(os.environ.get('ENVHOOK', '1'))
             if enabled == 0:
-                self._print('Currently disabled because the ENVHOOK environment variable is set to 0.')
+                self.print('Currently disabled because the ENVHOOK environment variable is set to 0.')
             else:
                 self.set_env(self.load_env())
                 self.share_aws_cli_credential_cache()
@@ -110,17 +110,17 @@ class EnvHook:
 
         if options.action == 'install':
             if cur_dst is None:
-                self._print(f'Installing by creating symbolic link from {link} to {dst}.')
+                self.print(f'Installing by creating symbolic link from {link} to {dst}.')
                 link.symlink_to(dst)
             elif dst == cur_dst:
-                self._print(f'Already installed. Symbolic link from {link} to {dst} exists.')
+                self.print(f'Already installed. Symbolic link from {link} to {dst} exists.')
             else:
                 raise BadSymlinkDestination(link, cur_dst, dst)
         elif options.action == 'remove':
             if cur_dst is None:
-                self._print(f'Not currently installed. Symbolic link {link} does not exist.')
+                self.print(f'Not currently installed. Symbolic link {link} does not exist.')
             elif cur_dst == dst:
-                self._print(f'Uninstalling by removing {link}.')
+                self.print(f'Uninstalling by removing {link}.')
                 link.unlink()
             else:
                 raise BadSymlinkDestination(link, cur_dst, dst)
@@ -140,23 +140,23 @@ class EnvHook:
         for k, (o, n) in sorted(zip_dict(old, new).items()):
             if o is None:
                 if self.pycharm_hosted:
-                    self._print(f'Setting {k} to {redact(k, n)!r}')
+                    self.print(f'Setting {k} to {redact(k, n)!r}')
                     os.environ[k] = n
                 else:
-                    self._print(f'Warning: {k} is not set but should be {redact(k, n)!r}, '
-                                f'you should run `source environment`')
+                    self.print(f'Warning: {k} is not set but should be {redact(k, n)!r}, '
+                               f'you should run `source environment`')
             elif n is None:
                 pass
             elif n != o:
                 if k.startswith('PYTHON'):
-                    self._print(f'Ignoring change in {k} from {redact(k, o)!r} to {redact(k, n)!r}')
+                    self.print(f'Ignoring change in {k} from {redact(k, o)!r} to {redact(k, n)!r}')
                 else:
                     if self.pycharm_hosted:
-                        self._print(f'Changing {k} from {redact(k, o)!r} to {redact(k, n)!r}')
+                        self.print(f'Changing {k} from {redact(k, o)!r} to {redact(k, n)!r}')
                         os.environ[k] = n
                     else:
-                        self._print(f'Warning: {k} is {redact(k, o)!r} but should be {redact(k, n)!r}, '
-                                    f'you must run `source environment`')
+                        self.print(f'Warning: {k} is {redact(k, o)!r} but should be {redact(k, n)!r}, '
+                                   f'you must run `source environment`')
 
     @property
     def pycharm_hosted(self):
@@ -182,7 +182,7 @@ class EnvHook:
         return self.import_sibling_script('export_environment')
 
     @classmethod
-    def _print(cls, msg):
+    def print(cls, msg):
         print(Path(__file__).resolve().name + ':', msg, file=sys.stderr)
 
     def share_aws_cli_credential_cache(self):
@@ -202,8 +202,8 @@ class EnvHook:
             import botocore.session
             import botocore.utils
         except ImportError:
-            self._print('Looks like boto3 is not installed. '
-                        'Skipping credential sharing with AWS CLI.')
+            self.print('Looks like boto3 is not installed. '
+                       'Skipping credential sharing with AWS CLI.')
         else:
             # Get the AssumeRole credential provider
             session = botocore.session.get_session()
@@ -228,9 +228,9 @@ class EnvHook:
                     isinstance(credentials, botocore.credentials.DeferredRefreshableCredentials)
                     and credentials.refresh_needed()
                 ):
-                    self._print('Looks like botocore credentials are not cached. '
-                                'Skipping credential sharing with AWS CLI. '
-                                'Use _login from a shell to avoid this.')
+                    self.print('Looks like botocore credentials are not cached. '
+                               'Skipping credential sharing with AWS CLI. '
+                               'Use _login from a shell to avoid this.')
                 else:
                     self.set_env(dict(AWS_ACCESS_KEY_ID=credentials.access_key,
                                       AWS_SECRET_ACCESS_KEY=credentials.secret_key,

--- a/scripts/envhook.py
+++ b/scripts/envhook.py
@@ -34,9 +34,7 @@ from typing import (
 
 class EnvHook:
 
-    @classmethod
-    def main(cls):
-        self = cls()
+    def main(self):
         try:
             self._main(sys.argv[1:])
         except EnvhookError as e:
@@ -45,9 +43,7 @@ class EnvHook:
         finally:
             sys.stderr.flush()
 
-    @classmethod
-    def sitecustomize(cls):
-        self = cls()
+    def sitecustomize(self):
         try:
             enabled = int(os.environ.get('ENVHOOK', '1'))
             if enabled == 0:
@@ -372,6 +368,6 @@ class ThirdPartySiteCustomize(EnvhookError):
 
 
 if __name__ == '__main__':
-    EnvHook.main()
+    EnvHook().main()
 elif __name__ == 'sitecustomize':
-    EnvHook.sitecustomize()
+    EnvHook().sitecustomize()

--- a/scripts/envhook.py
+++ b/scripts/envhook.py
@@ -358,12 +358,12 @@ class BadSymlinkDestination(EnvhookError):
 
 class ThirdPartySiteCustomize(EnvhookError):
 
-    def __init__(self, sitecustomize: Path) -> None:
+    def __init__(self, other: Path) -> None:
         super().__init__(
-            f'A different `sitecustomize` module already exists at '
-            f'{sitecustomize}. Make a backup of that file, remove the original '
-            f'and try again. Note that removing the file may break other, '
-            f'third-party site customizations.'
+            f'A different `sitecustomize` module already exists at {other}. '
+            f'Make a backup of that file, remove the original and try again. '
+            f'Note that removing the file may break other, third-party site '
+            f'customizations.'
         )
 
 

--- a/scripts/envhook.py
+++ b/scripts/envhook.py
@@ -37,9 +37,6 @@ class EnvHook:
     def main(self):
         try:
             self._main(sys.argv[1:])
-        except EnvhookError as e:
-            self.print(e.args[0])
-            sys.exit(1)
         finally:
             sys.stderr.flush()
 
@@ -51,6 +48,15 @@ class EnvHook:
             else:
                 self.set_env(self.load_env())
                 self.share_aws_cli_credential_cache()
+        except EnvhookError as e:
+            if self.pycharm_hosted:
+                # Under PyCharm, something suppresses sys.exit, probably
+                # wrongly catching BaseException instead of Exception, so we
+                # need to force the exit.
+                self.print(e.args)
+                os._exit(1)
+            else:
+                raise
         finally:
             sys.stderr.flush()
 
@@ -327,7 +333,7 @@ class Path(pathlib.PosixPath):
             return other.parts[:len(self.parts)] == self.parts
 
 
-class EnvhookError(RuntimeError):
+class EnvhookError(SystemExit):
     pass
 
 

--- a/scripts/envhook.py
+++ b/scripts/envhook.py
@@ -185,9 +185,6 @@ class EnvHook:
     def _print(cls, msg):
         print(Path(__file__).resolve().name + ':', msg, file=sys.stderr)
 
-    def _parse(self, env: str) -> dict[str, str]:
-        return {k: v for k, _, v in (line.partition('=') for line in env.splitlines())}
-
     def share_aws_cli_credential_cache(self):
         """
         By default, boto3 and botocore do not use a cache for the assume-role

--- a/scripts/export_environment.py
+++ b/scripts/export_environment.py
@@ -9,6 +9,7 @@ from collections.abc import (
     Iterator,
     Mapping,
 )
+import hashlib
 from importlib.abc import (
     Loader,
 )
@@ -389,6 +390,17 @@ def resolve_env(env: Environment) -> Environment:
     return dict(ResolvedEnvironment(env))
 
 
+azul_env_hash = 'azul_env_hash'
+
+
+def hash_env(env: Environment) -> Environment:
+    hash = hashlib.sha1()
+    encoder = json.JSONEncoder(sort_keys=True, separators=(',', ':'))
+    hash.update(encoder.encode(env).encode())
+    assert azul_env_hash not in env, env[azul_env_hash]
+    return {**env, azul_env_hash: hash.hexdigest()}
+
+
 azul_env_vars = 'azul_env_vars'
 
 
@@ -433,9 +445,8 @@ def main():
     # confusing the shell's eval. Note the  `|| echo false` in the recommended
     # usage below.
     output = None if os.isatty(sys.stdout.fileno()) else StringIO()
-    env, warning = load_env()
-    resolved_env = resolve_env(env)
-    export_env(resolved_env, output)
+    hashed_env, warning = prepare_env()
+    export_env(hashed_env, output)
     if warning:
         print(warning, file=sys.stderr)
     if output is None:
@@ -446,6 +457,13 @@ def main():
         sys.exit(1)
     else:
         print(output.getvalue(), file=sys.stdout)
+
+
+def prepare_env() -> Tuple[Environment, Optional[str]]:
+    env, warning = load_env()
+    resolved_env = resolve_env(env)
+    hashed_env = hash_env(resolved_env)
+    return hashed_env, warning
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Connected issues: #6320


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved connected issues to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
