### PR TITLE
Make metric alarms more sensitive (DataBiosphere/azul-private#280, DataBiosphere/azul-private#281, DataBiosphere/azul-private#282)

### DIFF
--- a/src/azul/chalice.py
+++ b/src/azul/chalice.py
@@ -619,8 +619,8 @@ class AzulChaliceApp(Chalice):
             # first.
             for_errors = metric is LambdaMetric.errors
             alarm = self.metric_alarm(metric=metric,
-                                      threshold=1 if for_errors else 0,
-                                      period=24 * 60 * 60 if for_errors else 5 * 60)
+                                      threshold=0,
+                                      period=60 * 60 if for_errors else 5 * 60)
             yield alarm.bind(self)
         for handler_name, handler in self.handler_map.items():
             if isinstance(handler, chalice.app.EventSourceHandler):

--- a/terraform/api_gateway.tf.json.template.py
+++ b/terraform/api_gateway.tf.json.template.py
@@ -214,38 +214,38 @@ def add_waf_blocked_alarm(resources: JSON) -> JSON:
             'aws_cloudwatch_metric_alarm': {
                 'waf_blocked': {
                     'alarm_name': config.qualified_resource_name('waf_blocked'),
-                    'comparison_operator': 'GreaterThanThreshold',
-                    'threshold': 25,  # percent blocked of total requests in a period
-                    'evaluation_periods': 4,
-                    'datapoints_to_alarm': 4,
-                    'treat_missing_data': 'notBreaching',
-                    'alarm_actions': ['${data.aws_sns_topic.monitoring.arn}'],
-                    'ok_actions': ['${data.aws_sns_topic.monitoring.arn}'],
                     'metric_query': [
-                        {
-                            'id': 'waf',
-                            'label': 'Percentage of blocked requests',
-                            'expression': expression,
-                            'return_data': 'true',
-                        },
                         *(
                             {
                                 'id': f'm{i}',
                                 'metric': {
                                     'namespace': 'AWS/WAFV2',
                                     'metric_name': metric,
-                                    'period': 15 * 60,
-                                    'stat': 'Sum',
                                     'dimensions': {
                                         'WebACL': '${aws_wafv2_web_acl.api_gateway.name}',
                                         'Region': config.region,
                                         'Rule': rule
-                                    }
+                                    },
+                                    'stat': 'Sum',
+                                    'period': 15 * 60,
                                 }
                             }
                             for i, (metric, rule) in enumerate(metrics)
-                        )
-                    ]
+                        ),
+                        {
+                            'id': 'waf',
+                            'label': 'Percentage of blocked requests',
+                            'expression': expression,
+                            'return_data': 'true',
+                        }
+                    ],
+                    'comparison_operator': 'GreaterThanThreshold',
+                    'threshold': 25,  # percent blocked of total requests in a period
+                    'evaluation_periods': 4,
+                    'datapoints_to_alarm': 4,
+                    'alarm_actions': ['${data.aws_sns_topic.monitoring.arn}'],
+                    'ok_actions': ['${data.aws_sns_topic.monitoring.arn}'],
+                    'treat_missing_data': 'notBreaching',
                 }
             }
         }

--- a/terraform/api_gateway.tf.json.template.py
+++ b/terraform/api_gateway.tf.json.template.py
@@ -227,7 +227,7 @@ def add_waf_blocked_alarm(resources: JSON) -> JSON:
                                         'Rule': rule
                                     },
                                     'stat': 'Sum',
-                                    'period': 15 * 60,
+                                    'period': 60 * 60,  # one hour
                                 }
                             }
                             for i, (metric, rule) in enumerate(metrics)
@@ -241,8 +241,8 @@ def add_waf_blocked_alarm(resources: JSON) -> JSON:
                     ],
                     'comparison_operator': 'GreaterThanThreshold',
                     'threshold': 25,  # percent blocked of total requests in a period
-                    'evaluation_periods': 4,
-                    'datapoints_to_alarm': 4,
+                    'evaluation_periods': 1,
+                    'datapoints_to_alarm': 1,
                     'alarm_actions': ['${data.aws_sns_topic.monitoring.arn}'],
                     'ok_actions': ['${data.aws_sns_topic.monitoring.arn}'],
                     'treat_missing_data': 'notBreaching',

--- a/terraform/cloudwatch.tf.json.template.py
+++ b/terraform/cloudwatch.tf.json.template.py
@@ -80,13 +80,10 @@ emit_tf({
                                 },
                                 'statistic': 'Sum',
                                 'comparison_operator': 'GreaterThanThreshold',
-                                'threshold': 1,
-                                # This alarm catches persistent 5XX errors occurring over
-                                # one hour, specifically when more than one occurrence is
-                                # sampled in a ten-minute period for six consecutive periods.
-                                'evaluation_periods': 6,
-                                'period': 60 * 10,
-                                'datapoints_to_alarm': 6,
+                                'threshold': 0,
+                                'evaluation_periods': 1,
+                                'period': 60 * 60,  # one hour
+                                'datapoints_to_alarm': 1,
                                 'alarm_actions': ['${data.aws_sns_topic.monitoring.arn}'],
                                 'ok_actions': ['${data.aws_sns_topic.monitoring.arn}'],
                                 'treat_missing_data': 'notBreaching',

--- a/terraform/cloudwatch.tf.json.template.py
+++ b/terraform/cloudwatch.tf.json.template.py
@@ -72,23 +72,24 @@ emit_tf({
                         'aws_cloudwatch_metric_alarm': {
                             f'{lambda_}_5xx': {
                                 'alarm_name': config.qualified_resource_name(lambda_ + '_5xx'),
+                                'namespace': 'AWS/ApiGateway',
+                                'metric_name': '5XXError',
+                                'dimensions': {
+                                    'ApiName': config.qualified_resource_name(lambda_),
+                                    'Stage': config.deployment_stage,
+                                },
+                                'statistic': 'Sum',
                                 'comparison_operator': 'GreaterThanThreshold',
+                                'threshold': 1,
                                 # This alarm catches persistent 5XX errors occurring over
                                 # one hour, specifically when more than one occurrence is
                                 # sampled in a ten-minute period for six consecutive periods.
                                 'evaluation_periods': 6,
                                 'period': 60 * 10,
-                                'metric_name': '5XXError',
-                                'namespace': 'AWS/ApiGateway',
-                                'statistic': 'Sum',
-                                'threshold': 1,
-                                'treat_missing_data': 'notBreaching',
-                                'dimensions': {
-                                    'ApiName': config.qualified_resource_name(lambda_),
-                                    'Stage': config.deployment_stage,
-                                },
+                                'datapoints_to_alarm': 6,
                                 'alarm_actions': ['${data.aws_sns_topic.monitoring.arn}'],
                                 'ok_actions': ['${data.aws_sns_topic.monitoring.arn}'],
+                                'treat_missing_data': 'notBreaching',
                             }
                         }
                     }
@@ -121,13 +122,6 @@ emit_tf({
                         'aws_cloudwatch_metric_alarm': {
                             f'{lambda_}cachehealth': {
                                 'alarm_name': config.qualified_resource_name(f'{lambda_}cachehealth', suffix='.alarm'),
-                                'comparison_operator': 'LessThanThreshold',
-                                'threshold': 1,
-                                'datapoints_to_alarm': 1,
-                                'evaluation_periods': 1,
-                                'treat_missing_data': 'breaching',
-                                'alarm_actions': ['${data.aws_sns_topic.monitoring.arn}'],
-                                'ok_actions': ['${data.aws_sns_topic.monitoring.arn}'],
                                 # CloudWatch uses an unconfigurable "evaluation range" when missing
                                 # data is involved. In practice this means that an alarm on the
                                 # absence of logs with an evaluation window of ten minutes would
@@ -136,21 +130,28 @@ emit_tf({
                                 # value of zero and avoid the need for the evaluation range.
                                 'metric_query': [
                                     {
+                                        'id': 'log_count_raw',
+                                        'metric': {
+                                            'namespace': 'LogMetrics',
+                                            'metric_name': '${aws_cloudwatch_log_metric_filter.'
+                                                           '%scachehealth.metric_transformation[0].name}' % lambda_,
+                                            'stat': 'Sum',
+                                            'period': 10 * 60,
+                                        }
+                                    },
+                                    {
                                         'id': 'log_count_filled',
                                         'expression': 'FILL(log_count_raw, 0)',
                                         'return_data': True,
-                                    },
-                                    {
-                                        'id': 'log_count_raw',
-                                        'metric': {
-                                            'metric_name': '${aws_cloudwatch_log_metric_filter.'
-                                                           '%scachehealth.metric_transformation[0].name}' % lambda_,
-                                            'namespace': 'LogMetrics',
-                                            'period': 10 * 60,
-                                            'stat': 'Sum',
-                                        }
                                     }
-                                ]
+                                ],
+                                'comparison_operator': 'LessThanThreshold',
+                                'threshold': 1,
+                                'evaluation_periods': 1,
+                                'datapoints_to_alarm': 1,
+                                'alarm_actions': ['${data.aws_sns_topic.monitoring.arn}'],
+                                'ok_actions': ['${data.aws_sns_topic.monitoring.arn}'],
+                                'treat_missing_data': 'breaching',
                             }
                         }
                     }
@@ -161,37 +162,37 @@ emit_tf({
                         **{
                             f'internet_{direction}': {
                                 'alarm_name': config.qualified_resource_name(f'internet_{direction}'),
-                                'comparison_operator': 'GreaterThanThreshold',
-                                'threshold': threshold,
-                                'evaluation_periods': 1,
-                                'datapoints_to_alarm': 1,
-                                'treat_missing_data': 'notBreaching',
                                 'metric_query': [
+                                    *(
+                                        {
+                                            'id': f'm{zone}',
+                                            'metric': {
+                                                'namespace': 'AWS/NATGateway',
+                                                'metric_name': metric_name,
+                                                'dimensions': {
+                                                    # Data source defined in data_sources.tf.json
+                                                    'NatGatewayId': f'${{data.aws_nat_gateway.gitlab_{zone}.id}}'
+                                                },
+                                                'stat': 'Sum',
+                                                'period': 1 * 60 * 60,
+                                            }
+                                        }
+                                        for zone in range(vpc.num_zones)
+                                    ),
                                     {
                                         'id': f'internet_{direction}',
                                         'label': f'Internet {direction} bytes/h',
                                         'expression': ' + '.join(f'm{zone}' for zone in range(vpc.num_zones)),
                                         'return_data': True,
-                                    },
-                                    *(
-                                        {
-                                            'id': f'm{zone}',
-                                            'metric': {
-                                                'dimensions': {
-                                                    # Data source defined in data_sources.tf.json
-                                                    'NatGatewayId': f'${{data.aws_nat_gateway.gitlab_{zone}.id}}'
-                                                },
-                                                'namespace': 'AWS/NATGateway',
-                                                'metric_name': metric_name,
-                                                'period': 1 * 60 * 60,
-                                                'stat': 'Sum',
-                                            }
-                                        }
-                                        for zone in range(vpc.num_zones)
-                                    )
+                                    }
                                 ],
+                                'comparison_operator': 'GreaterThanThreshold',
+                                'threshold': threshold,
+                                'evaluation_periods': 1,
+                                'datapoints_to_alarm': 1,
                                 'alarm_actions': ['${data.aws_sns_topic.monitoring.arn}'],
                                 'ok_actions': ['${data.aws_sns_topic.monitoring.arn}'],
+                                'treat_missing_data': 'notBreaching',
                             }
                             for direction, metric_name, threshold in [
                                 ('ingress', 'BytesInFromDestination', 50 * 1024 * 1024 * 1024),
@@ -201,29 +202,29 @@ emit_tf({
                         **{
                             f'vpn_{direction}': {
                                 'alarm_name': config.qualified_resource_name(f'vpn_{direction}'),
-                                'comparison_operator': 'GreaterThanThreshold',
-                                'threshold': threshold,
-                                'evaluation_periods': 1,
-                                'datapoints_to_alarm': 1,
-                                'treat_missing_data': 'notBreaching',
                                 'metric_query': [
                                     {
                                         'id': f'vpn_{direction}',
                                         'label': f'VPN {direction} bytes/h',
                                         'metric': {
+                                            'namespace': 'AWS/ClientVPN',
+                                            'metric_name': metric_name,
                                             'dimensions': {
                                                 'Endpoint': '${data.aws_ec2_client_vpn_endpoint.gitlab.id}'
                                             },
-                                            'namespace': 'AWS/ClientVPN',
-                                            'metric_name': metric_name,
-                                            'period': 1 * 60 * 60,
                                             'stat': 'Sum',
+                                            'period': 1 * 60 * 60,
                                         },
                                         'return_data': True,
                                     }
                                 ],
+                                'comparison_operator': 'GreaterThanThreshold',
+                                'threshold': threshold,
+                                'evaluation_periods': 1,
+                                'datapoints_to_alarm': 1,
                                 'alarm_actions': ['${data.aws_sns_topic.monitoring.arn}'],
                                 'ok_actions': ['${data.aws_sns_topic.monitoring.arn}'],
+                                'treat_missing_data': 'notBreaching',
                             }
                             for direction, metric_name, threshold in [
                                 ('ingress', 'IngressBytes', 100 * 1024 * 1024 * 1024),
@@ -237,44 +238,44 @@ emit_tf({
                                     suffix='.alarm'
                                 ),
                                 'namespace': 'AWS/Lambda',
+                                'metric_name': metric_alarm.metric.aws_name,
                                 'dimensions': {
                                     'FunctionName': '${' + '.'.join((
                                         'aws_lambda_function', metric_alarm.tf_function_resource_name,
                                         'function_name'
                                     )) + '}'
                                 },
-                                'metric_name': metric_alarm.metric.aws_name,
-                                'comparison_operator': 'GreaterThanThreshold',
                                 'statistic': 'Sum',
+                                'comparison_operator': 'GreaterThanThreshold',
                                 'threshold': metric_alarm.threshold,
+                                'evaluation_periods': 1,
                                 'period': metric_alarm.period,
                                 'datapoints_to_alarm': 1,
-                                'evaluation_periods': 1,
-                                'treat_missing_data': 'notBreaching',
                                 'alarm_actions': ['${data.aws_sns_topic.monitoring.arn}'],
                                 'ok_actions': ['${data.aws_sns_topic.monitoring.arn}'],
+                                'treat_missing_data': 'notBreaching',
                             }
                             for lambda_name in config.lambda_names()
                             for metric_alarm in load_app_module(lambda_name).app.metric_alarms
                         },
                         'waf_rate_blocked': {
                             'alarm_name': config.qualified_resource_name('waf_rate_blocked'),
-                            'comparison_operator': 'GreaterThanThreshold',
-                            'threshold': 0,
-                            'datapoints_to_alarm': 1,
-                            'evaluation_periods': 1,
-                            'period': 5 * 60,
-                            'metric_name': 'BlockedRequests',
                             'namespace': 'AWS/WAFV2',
-                            'statistic': 'Sum',
-                            'treat_missing_data': 'notBreaching',
+                            'metric_name': 'BlockedRequests',
                             'dimensions': {
                                 'WebACL': '${aws_wafv2_web_acl.api_gateway.name}',
                                 'Region': config.region,
                                 'Rule': config.waf_rate_limit_alarm.name
                             },
+                            'statistic': 'Sum',
+                            'comparison_operator': 'GreaterThanThreshold',
+                            'threshold': 0,
+                            'evaluation_periods': 1,
+                            'period': 5 * 60,
+                            'datapoints_to_alarm': 1,
                             'alarm_actions': ['${data.aws_sns_topic.monitoring.arn}'],
                             'ok_actions': ['${data.aws_sns_topic.monitoring.arn}'],
+                            'treat_missing_data': 'notBreaching',
                         }
                     }
                 }

--- a/terraform/gitlab/gitlab.tf.json.template.py
+++ b/terraform/gitlab/gitlab.tf.json.template.py
@@ -2242,12 +2242,8 @@ emit_tf({} if config.terraform_component != 'gitlab' else {
             **{
                 'gitlab_' + resource: {
                     'alarm_name': config.qualified_resource_name('gitlab_' + resource),
-                    'comparison_operator': 'GreaterThanOrEqualToThreshold',
-                    'datapoints_to_alarm': periods,
-                    'evaluation_periods': periods,
-                    'period': 60 * 10,
-                    'metric_name': metric,
                     'namespace': 'CWAgent',
+                    'metric_name': metric,
                     'dimensions': dimensions | {
                         # Instead of using 'InstanceId' here, we use a custom
                         # dimension that has been appended to each metric. This
@@ -2258,12 +2254,16 @@ emit_tf({} if config.terraform_component != 'gitlab' else {
                         'InstanceName': 'azul-gitlab'
                     },
                     'statistic': stat,
+                    'comparison_operator': 'GreaterThanOrEqualToThreshold',
                     'threshold': threshold,
-                    'treat_missing_data': 'missing',
+                    'evaluation_periods': periods,
+                    'period': 60 * 10,
+                    'datapoints_to_alarm': periods,
                     **{
                         state + '_actions': ['${data.aws_sns_topic.monitoring.arn}']
                         for state in ('insufficient_data', 'alarm', 'ok')
                     },
+                    'treat_missing_data': 'missing',
                 } for resource, metric, periods, stat, threshold, dimensions in
                 [
                     # FIXME: Add `mem_used_percent` alarm

--- a/terraform/shared/shared.tf.json.template.py
+++ b/terraform/shared/shared.tf.json.template.py
@@ -538,46 +538,41 @@ tf_config = {
             **{
                 a.name: {
                     'alarm_name': config.qualified_resource_name(a.name, suffix='.alarm'),
-                    'comparison_operator': 'GreaterThanThreshold',
-                    'evaluation_periods': 1,
+                    'namespace': 'LogMetrics',
                     'metric_name': '${aws_cloudwatch_log_metric_filter.'
                                    '%s.metric_transformation[0].name}' % a.name,
-                    'namespace': 'LogMetrics',
                     'statistic': a.statistic,
-                    'treat_missing_data': 'notBreaching',
+                    'comparison_operator': 'GreaterThanThreshold',
                     'threshold': a.threshold,
+                    'evaluation_periods': 1,
                     # The CIS documentation does not specify a period. 5 minutes is
                     # the default value when creating the alarm via the console UI.
                     'period': a.period,
+                    'datapoints_to_alarm': 1,
                     'alarm_actions': ['${aws_sns_topic.monitoring.arn}'],
-                    'ok_actions': ['${aws_sns_topic.monitoring.arn}']
+                    'ok_actions': ['${aws_sns_topic.monitoring.arn}'],
+                    'treat_missing_data': 'notBreaching',
                 }
                 for a in trail_alarms
             },
             'clam_fail': {
                 'alarm_name': config.qualified_resource_name('clam_fail', suffix='.alarm'),
-                'comparison_operator': 'GreaterThanThreshold',
-                'evaluation_periods': 1,
+                'namespace': 'LogMetrics',
                 'metric_name': '${aws_cloudwatch_log_metric_filter.'
                                '%s.metric_transformation[0].name}' % 'clam_fail',
-                'namespace': 'LogMetrics',
                 'statistic': 'Sum',
-                'treat_missing_data': 'notBreaching',
+                'comparison_operator': 'GreaterThanThreshold',
                 'threshold': 0,
+                'evaluation_periods': 1,
                 'period': clam_alarm_period,
+                'datapoints_to_alarm': 1,
                 'alarm_actions': ['${aws_sns_topic.monitoring.arn}'],
-                'ok_actions': ['${aws_sns_topic.monitoring.arn}']
+                'ok_actions': ['${aws_sns_topic.monitoring.arn}'],
+                'treat_missing_data': 'notBreaching',
             },
             **{
                 resource_name: {
                     'alarm_name': config.qualified_resource_name(resource_name, suffix='.alarm'),
-                    'comparison_operator': 'LessThanThreshold',
-                    'threshold': 1,
-                    'datapoints_to_alarm': 1,
-                    'evaluation_periods': 1,
-                    'treat_missing_data': 'breaching',
-                    'alarm_actions': ['${aws_sns_topic.monitoring.arn}'],
-                    'ok_actions': ['${aws_sns_topic.monitoring.arn}'],
                     # CloudWatch uses an unconfigurable "evaluation range" when missing
                     # data is involved. In practice this means that an alarm on the
                     # absence of logs with an evaluation window of ten minutes would
@@ -586,21 +581,28 @@ tf_config = {
                     # value of zero and avoid the need for the evaluation range.
                     'metric_query': [
                         {
+                            'id': 'log_count_raw',
+                            'metric': {
+                                'namespace': 'LogMetrics',
+                                'metric_name': '${aws_cloudwatch_log_metric_filter.'
+                                               '%s.metric_transformation[0].name}' % resource_name,
+                                'stat': 'Sum',
+                                'period': period,
+                            }
+                        },
+                        {
                             'id': 'log_count_filled',
                             'expression': 'FILL(log_count_raw, 0)',
                             'return_data': True
-                        },
-                        {
-                            'id': 'log_count_raw',
-                            'metric': {
-                                'metric_name': '${aws_cloudwatch_log_metric_filter.'
-                                               '%s.metric_transformation[0].name}' % resource_name,
-                                'namespace': 'LogMetrics',
-                                'period': period,
-                                'stat': 'Sum',
-                            }
                         }
-                    ]
+                    ],
+                    'comparison_operator': 'LessThanThreshold',
+                    'threshold': 1,
+                    'evaluation_periods': 1,
+                    'datapoints_to_alarm': 1,
+                    'alarm_actions': ['${aws_sns_topic.monitoring.arn}'],
+                    'ok_actions': ['${aws_sns_topic.monitoring.arn}'],
+                    'treat_missing_data': 'breaching',
                 } for resource_name, period in [
                     ('trail_logs', 10 * 60),
                     ('clamscan', clam_alarm_period),


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Connected issues: DataBiosphere/azul-private#280, DataBiosphere/azul-private#281, DataBiosphere/azul-private#282


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] On ZenHub, PR is connected to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a connected issue <sub>or [comment](https://github.com/DataBiosphere/azul/pull/7358#issuecomment-3201613376) in PR explains why they're different</sub>
- [x] PR title references all connected issues
- [x] For each connected issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
- [x] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex, API changes)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
- [x] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>


### Peer reviewer (after approval)

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] Ticket is in *Review requested* column
- [x] PR is awaiting requested review from system administrator
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled connected issues as `demo` or `no demo`
- [x] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Moved connected issues to *Approved* column
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Moved connected issues to *Merged lower* column in ZenHub
- [x] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
- [x] Pushed merge commit to GitHub


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
