### PR TITLE
Simplify priming of config properties (#7221)

### DIFF
--- a/environment
+++ b/environment
@@ -258,6 +258,13 @@ _revenv() {
 	fi
 }
 
+_cwd_is_project_root() {
+	if [ "$PWD" != "$project_root" ]; then
+		echo "Current working directory must be the project root"
+		return 1
+	fi
+}
+
 _clone() {
 	if [[ -z "$1" || -z "$2" ]]; then
 		echo "Need two arguments: the name of the deployment to select in the"
@@ -268,9 +275,10 @@ _clone() {
 		echo "Run 'deactivate' first"
 		return 2
 	fi
-	if [ "$(basename "$PWD")" != azul ]; then
-		echo "The name of the current project directory must be 'azul'"
-		return 3
+	_cwd_is_project_root || return 3
+	if [ "$(basename "$project_root")" != azul ]; then
+		echo "The name of the project root directory must be 'azul'"
+		return 4
 	fi
 	deployment="$1"
 	branch="$2"
@@ -311,6 +319,7 @@ _clone() {
 }
 
 _update_clone() {
+	_cwd_is_project_root &&
 	rsync -rvlm \
 		-f '+ */' \
 		-f '+ environment.local.py' \

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -1312,9 +1312,9 @@ class Config:
     @property
     def lambda_env(self) -> dict[str, str]:
         """
-        A dictionary with the environment variables to be used by a deployed AWS
-        Lambda function or `chalice local`. Only includes those variables that
-        don't need to be outsourced.
+        A dictionary containing the environment variables to be used by a
+        deployed AWS Lambda function, `chalice local` or tests inheriting from
+        LocalAppTestCase. Only includes variables that are not outsourced.
         """
         return (
             self._lambda_env(outsource=False)

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -1286,24 +1286,24 @@ class Config:
         }
 
     @property
-    def _aws_account_name(self) -> dict[str, str]:
+    def _aws_account_name_env(self) -> dict[str, str]:
         return {
-            'azul_aws_account_name': self.aws_account_name
+            'azul_aws_account_name': self._aws_account_name
         }
 
     @property
     def aws_account_name(self) -> str:
-        """
-        When in invoked in a Lambda context, this method will retrieve the AWS
-        account name from the Lambda environment, avoiding a round trip to IAM.
-        """
-        if self.is_in_lambda:
+        try:
             return self.environ['azul_aws_account_name']
-        else:
-            from azul.deployment import (
-                aws,
-            )
-            return aws.account_name
+        except KeyError:
+            return self._aws_account_name
+
+    @property
+    def _aws_account_name(self):
+        from azul.deployment import (
+            aws,
+        )
+        return aws.account_name
 
     @property
     def is_in_lambda(self) -> bool:
@@ -1319,7 +1319,7 @@ class Config:
         return (
             self._lambda_env(outsource=False)
             | self._git_status_env
-            | self._aws_account_name
+            | self._aws_account_name_env
             | self._deployment_env
         )
 

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -168,7 +168,7 @@ class Config:
     See `environment` for documentation of these settings.
     """
 
-    @property
+    @cached_property
     def environ(self):
         return ChainMap(os.environ, self._outsourced_environ)
 

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -1264,22 +1264,25 @@ class Config:
 
     @property
     def _git_status_env(self) -> dict[str, str]:
-        return {'azul_git_' + k: str(v) for k, v in self.git_status.items()}
+        return {'azul_git_' + k: str(v) for k, v in self._git_status.items()}
 
     @property
     def git_status(self) -> GitStatus:
+        try:
+            return {
+                'commit': self.environ['azul_git_commit'],
+                'dirty': str_to_bool(self.environ['azul_git_dirty'])
+            }
+        except KeyError:
+            return self._git_status
+
+    @property
+    def _git_status(self) -> GitStatus:
         import git
         repo = git.Repo(self.project_root)
         return {
             'commit': repo.head.object.hexsha,
             'dirty': repo.is_dirty()
-        }
-
-    @property
-    def lambda_git_status(self) -> GitStatus:
-        return {
-            'commit': self.environ['azul_git_commit'],
-            'dirty': str_to_bool(self.environ['azul_git_dirty'])
         }
 
     @property

--- a/src/azul/chalice.py
+++ b/src/azul/chalice.py
@@ -822,7 +822,7 @@ class AzulChaliceApp(Chalice):
         )
         def version():
             return {
-                'git': config.lambda_git_status
+                'git': config.git_status
             }
 
         @self.route(

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -979,7 +979,7 @@ class ManifestGenerator(metaclass=ABCMeta):
         Different parameters should, with a very high probability, produce
         different return values.
         """
-        git_commit = config.lambda_git_status['commit']
+        git_commit = config.git_status['commit']
         # The explicit filters are already normalized so we don't to do anything
         # special to desensitize the hash to insignificat differences
         filter_string = json.dumps(self.filters.explicit)

--- a/terraform/cloudwatch.tf.json.template.py
+++ b/terraform/cloudwatch.tf.json.template.py
@@ -33,9 +33,11 @@ emit_tf({
                         f'{config.project_root}/scripts/elasticsearch_nodes.py'
                     ],
                     'query': {},
-                    'depends_on': ([]
-                                   if config.share_es_domain else
-                                   ['aws_opensearch_domain.index'])
+                    'depends_on': (
+                        []
+                        if config.share_es_domain else
+                        ['aws_opensearch_domain.index']
+                    )
                 }
             }
         },

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -253,29 +253,17 @@ class ManifestTestCase(WebServiceTestCase,
     def setUp(self):
         super().setUp()
         self.addPatch(patch.object(PagedManifestGenerator, 'page_size', 1))
+        self.addPatch(patch.dict(os.environ,
+                                 azul_git_commit='9347432ab0da43c73409ac7fd3edfe29cf3ae678',
+                                 azul_git_dirty=str(False)))
         self._setup_indices()
-        self._setup_git_commit()
 
     def tearDown(self):
         self._teardown_indices()
-        self._teardown_git_commit()
         super().tearDown()
 
     def _filters(self, filters: FiltersJSON) -> Filters:
         return Filters(explicit=filters, source_ids={self.source.id})
-
-    def _setup_git_commit(self):
-        """
-        Set git variables required to derive the manifest object key
-        """
-        assert 'azul_git_commit' not in os.environ
-        assert 'azul_git_dirty' not in os.environ
-        os.environ['azul_git_commit'] = '9347432ab0da43c73409ac7fd3edfe29cf3ae678'
-        os.environ['azul_git_dirty'] = 'False'
-
-    def _teardown_git_commit(self):
-        os.environ.pop('azul_git_commit')
-        os.environ.pop('azul_git_dirty')
 
     @property
     def _service(self):

--- a/test/service/test_response.py
+++ b/test/service/test_response.py
@@ -2253,7 +2253,9 @@ class TestIndexResponse(IndexResponseTestCase):
         commit = 'a9eb85ea214a6cfa6882f4be041d5cce7bee3e45'
         for dirty in True, False:
             with self.subTest(is_repo_dirty=dirty):
-                with mock.patch.dict(os.environ, azul_git_commit=commit, azul_git_dirty=str(dirty)):
+                with mock.patch.dict(os.environ,
+                                     azul_git_commit=commit,
+                                     azul_git_dirty=str(dirty)):
                     url = self.base_url.set(path='/version')
                     response = requests.get(str(url))
                     response.raise_for_status()


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #7221


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer


### Peer reviewer (after approval)

Note that when requesting changes, the PR must be assigned back to the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
