### PR TITLE
Fix: Race between layer and Lambda update (#5927)

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -68,6 +68,7 @@ modules =
     scripts.post_deploy_tdr,
     scripts.find_in_snapshots,
     scripts.can_bundle,
+    scripts.delete_older_function_versions,
     scripts.zenhub_to_github,
     azul.plugins.metadata.anvil.bundle,
     azul.plugins.metadata.anvil.schema,

--- a/scripts/delete_older_function_versions.py
+++ b/scripts/delete_older_function_versions.py
@@ -39,8 +39,9 @@ def main(argv: list[str]):
     args = parser.parse_args(argv)
     log.info('Deleting function %r versions older than %r',
              args.function_name, args.function_version)
-    LambdaFunctions().delete_older_function_versions(args.function_name,
-                                                     args.function_version)
+    functions = LambdaFunctions()
+    functions.delete_older_function_versions(args.function_name,
+                                             args.function_version)
 
 
 if __name__ == '__main__':

--- a/scripts/delete_older_function_versions.py
+++ b/scripts/delete_older_function_versions.py
@@ -1,0 +1,48 @@
+"""
+Delete all versions of a Lambda function prior to the specified one.
+"""
+import argparse
+import logging
+import sys
+
+from azul import (
+    R,
+    config,
+)
+from azul.args import (
+    AzulArgumentHelpFormatter,
+)
+from azul.lambdas import (
+    Lambdas,
+)
+from azul.logging import (
+    configure_script_logging,
+)
+
+log = logging.getLogger(__name__)
+
+
+def main(argv: list[str]):
+    assert config.terraform_component == '', R(
+        'This script cannot be run with a Terraform component selected',
+        config.terraform_component)
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=AzulArgumentHelpFormatter)
+    parser.add_argument('--function-name', '-f',
+                        required=True,
+                        help='The name of the Lambda function.')
+    parser.add_argument('--function-version', '-v',
+                        type=int,
+                        required=True,
+                        help='The Lambda function version to keep. Must be an '
+                             'integer.')
+    args = parser.parse_args(argv)
+    log.info('Deleting function %r versions older than %r',
+             args.function_name, args.function_version)
+    Lambdas().delete_older_function_versions(args.function_name,
+                                             args.function_version)
+
+
+if __name__ == '__main__':
+    configure_script_logging(log)
+    main(sys.argv[1:])

--- a/scripts/delete_older_function_versions.py
+++ b/scripts/delete_older_function_versions.py
@@ -13,7 +13,7 @@ from azul.args import (
     AzulArgumentHelpFormatter,
 )
 from azul.lambdas import (
-    Lambdas,
+    LambdaFunctions,
 )
 from azul.logging import (
     configure_script_logging,
@@ -39,8 +39,8 @@ def main(argv: list[str]):
     args = parser.parse_args(argv)
     log.info('Deleting function %r versions older than %r',
              args.function_name, args.function_version)
-    Lambdas().delete_older_function_versions(args.function_name,
-                                             args.function_version)
+    LambdaFunctions().delete_older_function_versions(args.function_name,
+                                                     args.function_version)
 
 
 if __name__ == '__main__':

--- a/scripts/delete_older_function_versions.py
+++ b/scripts/delete_older_function_versions.py
@@ -40,8 +40,7 @@ def main(argv: list[str]):
     log.info('Deleting function %r versions older than %r',
              args.function_name, args.function_version)
     functions = LambdaFunctions()
-    functions.delete_older_function_versions(args.function_name,
-                                             args.function_version)
+    functions.delete_older_versions(args.function_name, args.function_version)
 
 
 if __name__ == '__main__':

--- a/scripts/generate_openapi_document.py
+++ b/scripts/generate_openapi_document.py
@@ -42,14 +42,14 @@ def main():
                                sources=set())
     }
 
-    lambda_name = Path.cwd().name
-    assert lambda_name in config.app_names(), lambda_name
+    app_name = Path.cwd().name
+    assert app_name in config.app_names(), app_name
 
     # To create a normalized OpenAPI document, we patch any
     # deployment-specific variables that affect the document.
     with (
         patch_config('catalogs', catalogs),
-        patch_config(f'{lambda_name}_function_name', f'azul-{lambda_name}-dev'),
+        patch_config(f'{app_name}_function_name', f'azul-{app_name}-dev'),
         patch_config('enable_log_forwarding', False),
         patch_config('enable_replicas', True),
         patch_config('monitoring_email', 'azul-group@ucsc.edu')
@@ -58,10 +58,10 @@ def main():
         with patch.object(target=AzulChaliceApp,
                           attribute='base_url',
                           new=lambda_endpoint):
-            app_module = load_app_module(lambda_name)
+            app_module = load_app_module(app_name)
             assert app_module.app.base_url == lambda_endpoint
             app_spec = app_module.app.spec()
-            doc_path = Path(config.project_root) / 'lambdas' / lambda_name / 'openapi.json'
+            doc_path = Path(config.project_root) / 'lambdas' / app_name / 'openapi.json'
             with write_file_atomically(doc_path) as file:
                 json.dump(app_spec, file, indent=4)
 

--- a/scripts/generate_openapi_document.py
+++ b/scripts/generate_openapi_document.py
@@ -43,7 +43,7 @@ def main():
     }
 
     lambda_name = Path.cwd().name
-    assert lambda_name in config.lambda_names(), lambda_name
+    assert lambda_name in config.app_names(), lambda_name
 
     # To create a normalized OpenAPI document, we patch any
     # deployment-specific variables that affect the document.

--- a/scripts/manage_lambdas.py
+++ b/scripts/manage_lambdas.py
@@ -18,4 +18,5 @@ if __name__ == '__main__':
     group.add_argument('--disable', dest='enabled', action='store_false')
     args = parser.parse_args()
     assert args.enabled is not None
-    LambdaFunctions().manage_lambdas(args.enabled)
+    functions = LambdaFunctions()
+    functions.manage_lambdas(args.enabled)

--- a/scripts/manage_lambdas.py
+++ b/scripts/manage_lambdas.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 
 from azul.lambdas import (
-    Lambdas,
+    LambdaFunctions,
 )
 from azul.logging import (
     configure_script_logging,
@@ -18,4 +18,4 @@ if __name__ == '__main__':
     group.add_argument('--disable', dest='enabled', action='store_false')
     args = parser.parse_args()
     assert args.enabled is not None
-    Lambdas().manage_lambdas(args.enabled)
+    LambdaFunctions().manage_lambdas(args.enabled)

--- a/scripts/reset_lambda_role.py
+++ b/scripts/reset_lambda_role.py
@@ -1,10 +1,10 @@
 from azul.lambdas import (
-    Lambdas,
+    LambdaFunctions,
 )
 
 
 def main():
-    Lambdas().reset_lambda_roles()
+    LambdaFunctions().reset_lambda_roles()
 
 
 if __name__ == '__main__':

--- a/scripts/reset_lambda_role.py
+++ b/scripts/reset_lambda_role.py
@@ -4,7 +4,8 @@ from azul.lambdas import (
 
 
 def main():
-    LambdaFunctions().reset_lambda_roles()
+    functions = LambdaFunctions()
+    functions.reset_lambda_roles()
 
 
 if __name__ == '__main__':

--- a/scripts/reset_lambda_role.py
+++ b/scripts/reset_lambda_role.py
@@ -1,3 +1,8 @@
+"""
+Attempt to fix KMSAccessDeniedException when invoking a function.
+
+See Troubleshooting section in README.md for details.
+"""
 from azul.lambdas import (
     LambdaFunctions,
 )

--- a/scripts/sell_unused_slots.py
+++ b/scripts/sell_unused_slots.py
@@ -27,7 +27,7 @@ from azul.deployment import (
     aws,
 )
 from azul.lambdas import (
-    Lambda,
+    LambdaFunction,
     Lambdas,
 )
 from azul.logging import (
@@ -65,7 +65,7 @@ class ReindexDetector:
 
     @classmethod
     @cache
-    def _list_contribution_lambda_functions(cls) -> list[Lambda]:
+    def _list_contribution_lambda_functions(cls) -> list[LambdaFunction]:
         """
         Search Lambda functions for the names of contribution Lambdas.
         """
@@ -75,7 +75,7 @@ class ReindexDetector:
             if lambda_.is_contribution_lambda
         ]
 
-    def _lambda_invocation_counts(self) -> dict[Lambda, int]:
+    def _lambda_invocation_counts(self) -> dict[LambdaFunction, int]:
         # FIXME: DeprecationWarning for datetime methods in Python 3.12
         #        https://github.com/DataBiosphere/azul/issues/5953
         end = datetime.utcnow()

--- a/scripts/sell_unused_slots.py
+++ b/scripts/sell_unused_slots.py
@@ -28,7 +28,7 @@ from azul.deployment import (
 )
 from azul.lambdas import (
     LambdaFunction,
-    Lambdas,
+    LambdaFunctions,
 )
 from azul.logging import (
     configure_script_logging,
@@ -71,7 +71,7 @@ class ReindexDetector:
         """
         return [
             lambda_
-            for lambda_ in Lambdas().list_lambdas()
+            for lambda_ in LambdaFunctions().list_lambdas()
             if lambda_.is_contribution_lambda
         ]
 

--- a/scripts/sell_unused_slots.py
+++ b/scripts/sell_unused_slots.py
@@ -71,9 +71,9 @@ class ReindexDetector:
         """
         functions = LambdaFunctions()
         return [
-            lambda_
-            for lambda_ in functions.list_lambdas()
-            if lambda_.contributes
+            function
+            for function in functions.list_lambdas()
+            if function.contributes
         ]
 
     def _lambda_invocation_counts(self) -> dict[LambdaFunction, int]:

--- a/scripts/sell_unused_slots.py
+++ b/scripts/sell_unused_slots.py
@@ -95,6 +95,9 @@ class ReindexDetector:
                                 'Namespace': 'AWS/Lambda',
                                 'MetricName': 'Invocations',
                                 'Dimensions': [{
+                                    # The 'FunctionName' dimension returns
+                                    # aggregate metrics for all versions and
+                                    # aliases of the function.
                                     'Name': 'FunctionName',
                                     'Value': lambda_.name
                                 }]

--- a/scripts/sell_unused_slots.py
+++ b/scripts/sell_unused_slots.py
@@ -69,9 +69,10 @@ class ReindexDetector:
         """
         Search Lambda functions for the names of contribution Lambdas.
         """
+        functions = LambdaFunctions()
         return [
             lambda_
-            for lambda_ in LambdaFunctions().list_lambdas()
+            for lambda_ in functions.list_lambdas()
             if lambda_.is_contribution_lambda
         ]
 

--- a/scripts/sell_unused_slots.py
+++ b/scripts/sell_unused_slots.py
@@ -73,7 +73,7 @@ class ReindexDetector:
         return [
             lambda_
             for lambda_ in functions.list_lambdas()
-            if lambda_.is_contribution_lambda
+            if lambda_.contributes
         ]
 
     def _lambda_invocation_counts(self) -> dict[LambdaFunction, int]:

--- a/scripts/sell_unused_slots.py
+++ b/scripts/sell_unused_slots.py
@@ -72,7 +72,7 @@ class ReindexDetector:
         functions = LambdaFunctions()
         return [
             function
-            for function in functions.list_lambdas()
+            for function in functions.list_functions()
             if function.contributes
         ]
 

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -743,7 +743,7 @@ class Config:
         else:
             return self.service_endpoint
 
-    def lambda_names(self) -> list[str]:
+    def app_names(self) -> list[str]:
         return ['indexer', 'service']
 
     @property

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -760,13 +760,13 @@ class Config:
     def service_function_name(self, handler_name: str | None = None):
         return self._function_name('service', handler_name)
 
-    def _function_name(self, lambda_name: str, handler_name: str | None):
+    def _function_name(self, app_name: str, handler_name: str | None):
         if handler_name is None:
-            return self.qualified_resource_name(lambda_name)
+            return self.qualified_resource_name(app_name)
         else:
             # FIXME: Eliminate hardcoded separator
             #        https://github.com/databiosphere/azul/issues/2964
-            return self.qualified_resource_name(lambda_name, suffix='-' + handler_name)
+            return self.qualified_resource_name(app_name, suffix='-' + handler_name)
 
     active_function_alias_name = 'active'
 

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -768,6 +768,8 @@ class Config:
             #        https://github.com/databiosphere/azul/issues/2964
             return self.qualified_resource_name(lambda_name, suffix='-' + handler_name)
 
+    active_function_alias_name = 'active'
+
     qualifier_re = re.compile(r'[a-z][a-z0-9]{1,16}')
 
     @classmethod

--- a/src/azul/chalice.py
+++ b/src/azul/chalice.py
@@ -669,6 +669,12 @@ class AzulChaliceApp(Chalice):
             else:
                 yield retry.bind(self, handler_name)
 
+    @property
+    def tf_function_resource_names(self) -> Iterator[str]:
+        yield self.unqualified_app_name
+        for handler_name in self.event_source_handlers:
+            yield f'{self.unqualified_app_name}_{handler_name}'
+
     def default_routes(self):
 
         @self.route(

--- a/src/azul/chalice.py
+++ b/src/azul/chalice.py
@@ -26,7 +26,6 @@ from urllib.parse import (
 )
 
 import attrs
-import chalice
 from chalice import (
     Chalice,
     ChaliceViewError,
@@ -34,6 +33,7 @@ from chalice import (
 from chalice.app import (
     BadRequestError,
     CaseInsensitiveMapping,
+    EventSourceHandler,
     HeadersType,
     MultiDict,
     NotFoundError,
@@ -598,7 +598,7 @@ class AzulChaliceApp(Chalice):
         period: int
 
         def __call__(self, f):
-            assert isinstance(f, chalice.app.EventSourceHandler), f
+            assert isinstance(f, EventSourceHandler), f
             try:
                 metric_alarms = getattr(f, 'metric_alarms')
             except AttributeError:
@@ -612,6 +612,14 @@ class AzulChaliceApp(Chalice):
             return f'{self.tf_function_resource_name}_{self.metric.name}'
 
     @property
+    def event_source_handlers(self) -> dict[str, EventSourceHandler]:
+        return {
+            handler_name: handler
+            for handler_name, handler in self.handler_map.items()
+            if isinstance(handler, EventSourceHandler)
+        }
+
+    @property
     def metric_alarms(self) -> Iterator[metric_alarm]:
         for metric in LambdaMetric:
             # The api_handler lambda functions (indexer & service) aren't
@@ -622,19 +630,16 @@ class AzulChaliceApp(Chalice):
                                       threshold=0,
                                       period=60 * 60 if for_errors else 5 * 60)
             yield alarm.bind(self)
-        for handler_name, handler in self.handler_map.items():
-            if isinstance(handler, chalice.app.EventSourceHandler):
-                try:
-                    metric_alarms = getattr(handler, 'metric_alarms')
-                except AttributeError:
-                    metric_alarms = (
-                        self.metric_alarm(metric=metric,
-                                          threshold=0,
-                                          period=5 * 60)
-                        for metric in LambdaMetric
-                    )
-                for metric_alarm in metric_alarms:
-                    yield metric_alarm.bind(self, handler_name)
+        for handler_name, handler in self.event_source_handlers.items():
+            try:
+                metric_alarms = getattr(handler, 'metric_alarms')
+            except AttributeError:
+                metric_alarms = (
+                    self.metric_alarm(metric=metric, threshold=0, period=5 * 60)
+                    for metric in LambdaMetric
+                )
+            for metric_alarm in metric_alarms:
+                yield metric_alarm.bind(self, handler_name)
 
     # noinspection PyPep8Naming
     @attrs.frozen
@@ -650,20 +655,19 @@ class AzulChaliceApp(Chalice):
         num_retries: int
 
         def __call__(self, f):
-            assert isinstance(f, chalice.app.EventSourceHandler), f
+            assert isinstance(f, EventSourceHandler), f
             setattr(f, 'retry', self)
             return f
 
     @property
     def retries(self) -> Iterator[retry]:
-        for handler_name, handler in self.handler_map.items():
-            if isinstance(handler, chalice.app.EventSourceHandler):
-                try:
-                    retry = getattr(handler, 'retry')
-                except AttributeError:
-                    pass
-                else:
-                    yield retry.bind(self, handler_name)
+        for handler_name, handler in self.event_source_handlers.items():
+            try:
+                retry = getattr(handler, 'retry')
+            except AttributeError:
+                pass
+            else:
+                yield retry.bind(self, handler_name)
 
     def default_routes(self):
 

--- a/src/azul/health.py
+++ b/src/azul/health.py
@@ -200,9 +200,9 @@ class Health:
         Indicates whether the companion REST API responds to HTTP requests.
         """
         response = {
-            lambda_name: self._lambda(lambda_name)
-            for lambda_name in config.app_names()
-            if lambda_name != self.lambda_name
+            app_name: self._lambda(app_name)
+            for app_name in config.app_names()
+            if app_name != self.lambda_name
         }
         return {
             'up': all(json_bool(v['up']) for v in response.values()),

--- a/src/azul/health.py
+++ b/src/azul/health.py
@@ -201,7 +201,7 @@ class Health:
         """
         response = {
             lambda_name: self._lambda(lambda_name)
-            for lambda_name in config.lambda_names()
+            for lambda_name in config.app_names()
             if lambda_name != self.lambda_name
         }
         return {

--- a/src/azul/health.py
+++ b/src/azul/health.py
@@ -93,7 +93,7 @@ class health_property(cached_property):
 
 @attr.s(frozen=True, kw_only=True, auto_attribs=True)
 class HealthController(AppController):
-    lambda_name: str
+    app_name: str
 
     @cached_property
     def storage_service(self):
@@ -134,7 +134,7 @@ class HealthController(AppController):
                                 self.app.catalog, config.default_catalog)
         else:
             try:
-                cache = json.loads(self.storage_service.get(f'health/{self.lambda_name}'))
+                cache = json.loads(self.storage_service.get(f'health/{self.app_name}'))
             except StorageObjectNotFound:
                 raise NotFoundError('Cached health object does not exist')
             else:
@@ -148,7 +148,7 @@ class HealthController(AppController):
     def update_cache(self) -> None:
         assert self.app.catalog == config.default_catalog
         health_object = dict(time=time.time(), health=self._health.as_json_fast())
-        self.storage_service.put(object_key=f'health/{self.lambda_name}',
+        self.storage_service.put(object_key=f'health/{self.app_name}',
                                  data=json.dumps(health_object).encode())
 
     @property
@@ -182,7 +182,7 @@ class Health:
 
     @property
     def lambda_name(self):
-        return self.controller.lambda_name
+        return self.controller.app_name
 
     def as_json(self, keys: Iterable[str]) -> JSON:
         keys = frozenset(keys)
@@ -333,7 +333,7 @@ class HealthApp(AzulChaliceApp):
 
     @cached_property
     def health_controller(self) -> HealthController:
-        return HealthController(app=self, lambda_name=self.unqualified_app_name)
+        return HealthController(app=self, app_name=self.unqualified_app_name)
 
     def default_routes(self):
         _routes = super().default_routes()

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -197,10 +197,10 @@ class LambdaFunctions:
         for function in self.list_functions():
             for app_name in app_names:
                 if function.name.startswith(config.qualified_resource_name(app_name)):
-                    other_lambda_name = one(app_names - {app_name})
+                    other_app_name = one(app_names - {app_name})
                     temporary_role = function.role.replace(
                         config.qualified_resource_name(app_name),
-                        config.qualified_resource_name(other_lambda_name)
+                        config.qualified_resource_name(other_app_name)
                     )
                     log.info('Temporarily updating %r to role %r', function.name, temporary_role)
                     client.update_function_configuration(FunctionName=function.name,

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -172,7 +172,9 @@ class LambdaFunctions:
             else:
                 log.warning('Function %r is already enabled.', function_name)
         else:
-            if self.tag_name not in tags.keys():
+            if self.tag_name in tags.keys():
+                log.warning('Function %r is already disabled.', function_name)
+            else:
                 try:
                     concurrency = function['Concurrency']
                 except KeyError:
@@ -184,8 +186,6 @@ class LambdaFunctions:
                 new_tag = {self.tag_name: repr(concurrency_limit)}
                 self._lambda.tag_resource(Resource=function_arn, Tags=new_tag)
                 self._lambda.put_function_concurrency(FunctionName=function_name, ReservedConcurrentExecutions=0)
-            else:
-                log.warning('Function %r is already disabled.', function_name)
 
     def reset_lambda_roles(self):
         client = self._lambda

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -39,7 +39,7 @@ class LambdaFunction:
     slot_location: Optional[str]
 
     @property
-    def is_contribution_lambda(self) -> bool:
+    def contributes(self) -> bool:
         unqualify = config.unqualified_resource_name
         for handler_name in self._contribution_handler_names():
             try:
@@ -92,7 +92,7 @@ class LambdaFunction:
 
     def __attrs_post_init__(self):
         if self.slot_location is None:
-            assert not self.is_contribution_lambda, self
+            assert not self.contributes, self
         else:
             allowed_locations = config.tdr_allowed_source_locations
             assert self.slot_location in allowed_locations, self.slot_location

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -114,9 +114,7 @@ class LambdaFunctions:
             for function in response['Functions']
         ]
 
-    def delete_older_function_versions(self,
-                                       function_name: str,
-                                       keep_version: int) -> None:
+    def delete_older_versions(self, function_name: str, keep_version: int) -> None:
         """
         Delete all versions of a Lambda function prior to the specified one.
 

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -105,7 +105,7 @@ class LambdaFunctions:
     def _lambda(self):
         return aws.lambda_
 
-    def list_lambdas(self) -> list[LambdaFunction]:
+    def list_functions(self) -> list[LambdaFunction]:
         # Note that this method returns the $LATEST version, which is what
         # Amazon also refers to as the "unpublished" version.
         return [
@@ -196,7 +196,7 @@ class LambdaFunctions:
         client = self._lambda
         app_names = set(config.app_names())
 
-        for lambda_ in self.list_lambdas():
+        for lambda_ in self.list_functions():
             for lambda_name in app_names:
                 if lambda_.name.startswith(config.qualified_resource_name(lambda_name)):
                     other_lambda_name = one(app_names - {lambda_name})

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -33,7 +33,7 @@ log = logging.getLogger(__name__)
 
 
 @attr.s(auto_attribs=True, kw_only=True, frozen=True)
-class Lambda:
+class LambdaFunction:
     name: str
     role: str
     slot_location: Optional[str]
@@ -105,11 +105,11 @@ class Lambdas:
     def _lambda(self):
         return aws.lambda_
 
-    def list_lambdas(self) -> list[Lambda]:
+    def list_lambdas(self) -> list[LambdaFunction]:
         # Note that this method returns the $LATEST version, which is what
         # Amazon also refers to as the "unpublished" version.
         return [
-            Lambda.from_response(function)
+            LambdaFunction.from_response(function)
             for response in self._lambda.get_paginator('list_functions').paginate()
             for function in response['Functions']
         ]

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -196,24 +196,24 @@ class LambdaFunctions:
         client = self._lambda
         app_names = set(config.app_names())
 
-        for lambda_ in self.list_functions():
+        for function in self.list_functions():
             for lambda_name in app_names:
-                if lambda_.name.startswith(config.qualified_resource_name(lambda_name)):
+                if function.name.startswith(config.qualified_resource_name(lambda_name)):
                     other_lambda_name = one(app_names - {lambda_name})
-                    temporary_role = lambda_.role.replace(
+                    temporary_role = function.role.replace(
                         config.qualified_resource_name(lambda_name),
                         config.qualified_resource_name(other_lambda_name)
                     )
-                    log.info('Temporarily updating %r to role %r', lambda_.name, temporary_role)
-                    client.update_function_configuration(FunctionName=lambda_.name,
+                    log.info('Temporarily updating %r to role %r', function.name, temporary_role)
+                    client.update_function_configuration(FunctionName=function.name,
                                                          Role=temporary_role)
-                    log.info('Updating %r to role %r', lambda_.name, lambda_.role)
+                    log.info('Updating %r to role %r', function.name, function.role)
                     while True:
                         try:
-                            client.update_function_configuration(FunctionName=lambda_.name,
-                                                                 Role=lambda_.role)
+                            client.update_function_configuration(FunctionName=function.name,
+                                                                 Role=function.role)
                         except client.exceptions.ResourceConflictException:
-                            log.info('Function %r is being updated. Retrying ...', lambda_.name)
+                            log.info('Function %r is being updated. Retrying ...', function.name)
                             time.sleep(1)
                         else:
                             break

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -40,12 +40,12 @@ class LambdaFunction:
 
     @property
     def is_contribution_lambda(self) -> bool:
-        for lambda_name in self._contribution_handler_names():
+        for handler_name in self._contribution_handler_names():
             try:
                 # FIXME: Eliminate hardcoded separator
                 #        https://github.com/databiosphere/azul/issues/2964
                 resource_name, _ = config.unqualified_resource_name(self.name,
-                                                                    suffix='-' + lambda_name)
+                                                                    suffix='-' + handler_name)
             except AssertionError as e:
                 if not R.caused(e):
                     raise

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -159,36 +159,33 @@ class LambdaFunctions:
         if enable:
             if self.tag_name in tags.keys():
                 original_concurrency_limit = ast.literal_eval(tags[self.tag_name])
-
                 if original_concurrency_limit is not None:
-                    log.info(f'Setting concurrency limit for {function_name} back to {original_concurrency_limit}.')
+                    log.info('Setting concurrency limit on %r back to %r.',
+                             function_name, original_concurrency_limit)
                     self._lambda.put_function_concurrency(FunctionName=function_name,
                                                           ReservedConcurrentExecutions=original_concurrency_limit)
                 else:
-                    log.info(f'Removed concurrency limit for {function_name}.')
+                    log.info('Removed concurrency limit on %r.', function_name)
                     self._lambda.delete_function_concurrency(FunctionName=function_name)
 
                 self._lambda.untag_resource(Resource=function_arn, TagKeys=[self.tag_name])
             else:
-                log.warning(f'{function_name} is already enabled.')
+                log.warning('Function %r is already enabled.', function_name)
         else:
             if self.tag_name not in tags.keys():
                 try:
                     concurrency = function['Concurrency']
                 except KeyError:
-                    # If a lambda doesn't have a limit for concurrency
-                    # executions, Lambda.Client.get_function()
-                    # doesn't return a response with the key, `Concurrency`.
+                    # Function doesn't have a concurrency limit
                     concurrency_limit = None
                 else:
                     concurrency_limit = concurrency['ReservedConcurrentExecutions']
-
-                log.info(f'Setting concurrency limit for {function_name} to zero.')
+                log.info('Setting concurrency limit on %r to zero.', function_name)
                 new_tag = {self.tag_name: repr(concurrency_limit)}
                 self._lambda.tag_resource(Resource=function_arn, Tags=new_tag)
                 self._lambda.put_function_concurrency(FunctionName=function_name, ReservedConcurrentExecutions=0)
             else:
-                log.warning(f'{function_name} is already disabled.')
+                log.warning('Function %r is already disabled.', function_name)
 
     def reset_lambda_roles(self):
         client = self._lambda

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -107,7 +107,7 @@ class Lambdas:
 
     def list_lambdas(self) -> list[Lambda]:
         # Note that this method returns the $LATEST version, which is what
-        # Amazon calls the "unpublished" version.
+        # Amazon also refers to as the "unpublished" version.
         return [
             Lambda.from_response(function)
             for response in self._lambda.get_paginator('list_functions').paginate()

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -151,9 +151,9 @@ class LambdaFunctions:
             for function in response['Functions']:
                 function_name = function['FunctionName']
                 if any(function_name.startswith(prefix) for prefix in prefixes):
-                    self.manage_lambda(function_name, enabled)
+                    self.manage_function(function_name, enabled)
 
-    def manage_lambda(self, lambda_name: str, enable: bool):
+    def manage_function(self, lambda_name: str, enable: bool):
         lambda_settings = self._lambda.get_function(FunctionName=lambda_name)
         lambda_arn = lambda_settings['Configuration']['FunctionArn']
         lambda_tags = self._lambda.list_tags(Resource=lambda_arn)['Tags']
@@ -197,11 +197,11 @@ class LambdaFunctions:
         app_names = set(config.app_names())
 
         for function in self.list_functions():
-            for lambda_name in app_names:
-                if function.name.startswith(config.qualified_resource_name(lambda_name)):
-                    other_lambda_name = one(app_names - {lambda_name})
+            for app_name in app_names:
+                if function.name.startswith(config.qualified_resource_name(app_name)):
+                    other_lambda_name = one(app_names - {app_name})
                     temporary_role = function.role.replace(
-                        config.qualified_resource_name(lambda_name),
+                        config.qualified_resource_name(app_name),
                         config.qualified_resource_name(other_lambda_name)
                     )
                     log.info('Temporarily updating %r to role %r', function.name, temporary_role)

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -153,26 +153,26 @@ class LambdaFunctions:
                 if any(function_name.startswith(prefix) for prefix in prefixes):
                     self.manage_function(function_name, enabled)
 
-    def manage_function(self, lambda_name: str, enable: bool):
-        lambda_settings = self._lambda.get_function(FunctionName=lambda_name)
+    def manage_function(self, function_name: str, enable: bool):
+        lambda_settings = self._lambda.get_function(FunctionName=function_name)
         lambda_arn = lambda_settings['Configuration']['FunctionArn']
         lambda_tags = self._lambda.list_tags(Resource=lambda_arn)['Tags']
-        lambda_name = lambda_settings['Configuration']['FunctionName']
+        function_name = lambda_settings['Configuration']['FunctionName']
         if enable:
             if self.tag_name in lambda_tags.keys():
                 original_concurrency_limit = ast.literal_eval(lambda_tags[self.tag_name])
 
                 if original_concurrency_limit is not None:
-                    log.info(f'Setting concurrency limit for {lambda_name} back to {original_concurrency_limit}.')
-                    self._lambda.put_function_concurrency(FunctionName=lambda_name,
+                    log.info(f'Setting concurrency limit for {function_name} back to {original_concurrency_limit}.')
+                    self._lambda.put_function_concurrency(FunctionName=function_name,
                                                           ReservedConcurrentExecutions=original_concurrency_limit)
                 else:
-                    log.info(f'Removed concurrency limit for {lambda_name}.')
-                    self._lambda.delete_function_concurrency(FunctionName=lambda_name)
+                    log.info(f'Removed concurrency limit for {function_name}.')
+                    self._lambda.delete_function_concurrency(FunctionName=function_name)
 
                 self._lambda.untag_resource(Resource=lambda_arn, TagKeys=[self.tag_name])
             else:
-                log.warning(f'{lambda_name} is already enabled.')
+                log.warning(f'{function_name} is already enabled.')
         else:
             if self.tag_name not in lambda_tags.keys():
                 try:
@@ -185,12 +185,12 @@ class LambdaFunctions:
                 else:
                     concurrency_limit = concurrency['ReservedConcurrentExecutions']
 
-                log.info(f'Setting concurrency limit for {lambda_name} to zero.')
+                log.info(f'Setting concurrency limit for {function_name} to zero.')
                 new_tag = {self.tag_name: repr(concurrency_limit)}
                 self._lambda.tag_resource(Resource=lambda_arn, Tags=new_tag)
-                self._lambda.put_function_concurrency(FunctionName=lambda_name, ReservedConcurrentExecutions=0)
+                self._lambda.put_function_concurrency(FunctionName=function_name, ReservedConcurrentExecutions=0)
             else:
-                log.warning(f'{lambda_name} is already disabled.')
+                log.warning(f'{function_name} is already disabled.')
 
     def reset_lambda_roles(self):
         client = self._lambda

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -45,12 +45,12 @@ class LambdaFunction:
             try:
                 # FIXME: Eliminate hardcoded separator
                 #        https://github.com/databiosphere/azul/issues/2964
-                resource_name, _ = unqualify(self.name, suffix='-' + handler_name)
+                app_name, _ = unqualify(self.name, suffix='-' + handler_name)
             except AssertionError as e:
                 if not R.caused(e):
                     raise
             else:
-                if resource_name == 'indexer':
+                if app_name == 'indexer':
                     return True
         return False
 

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -57,7 +57,6 @@ class LambdaFunction:
     @classmethod
     @cache
     def _contribution_handler_names(cls) -> frozenset[str]:
-        indexer = load_app_module('indexer')
         notification_queue_names = {
             config.notifications_queue.derive(retry=retry).unqual_name
             for retry in (False, True)
@@ -72,6 +71,7 @@ class LambdaFunction:
                 resource_name, _, _ = config.unqualified_resource_name_and_suffix(queue)
                 return resource_name in notification_queue_names
 
+        indexer = load_app_module('indexer')
         return frozenset(
             handler.name
             for handler in vars(indexer).values()

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -98,7 +98,7 @@ class LambdaFunction:
             assert self.slot_location in allowed_locations, self.slot_location
 
 
-class Lambdas:
+class LambdaFunctions:
     tag_name = 'azul-original-concurrency-limit'
 
     @property

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -194,12 +194,12 @@ class Lambdas:
 
     def reset_lambda_roles(self):
         client = self._lambda
-        lambda_names = set(config.app_names())
+        app_names = set(config.app_names())
 
         for lambda_ in self.list_lambdas():
-            for lambda_name in lambda_names:
+            for lambda_name in app_names:
                 if lambda_.name.startswith(config.qualified_resource_name(lambda_name)):
-                    other_lambda_name = one(lambda_names - {lambda_name})
+                    other_lambda_name = one(app_names - {lambda_name})
                     temporary_role = lambda_.role.replace(
                         config.qualified_resource_name(lambda_name),
                         config.qualified_resource_name(other_lambda_name)

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -40,7 +40,7 @@ class LambdaFunction:
 
     @property
     def is_contribution_lambda(self) -> bool:
-        for lambda_name in self._contribution_lambda_names():
+        for lambda_name in self._contribution_handler_names():
             try:
                 # FIXME: Eliminate hardcoded separator
                 #        https://github.com/databiosphere/azul/issues/2964
@@ -56,7 +56,7 @@ class LambdaFunction:
 
     @classmethod
     @cache
-    def _contribution_lambda_names(cls) -> frozenset[str]:
+    def _contribution_handler_names(cls) -> frozenset[str]:
         indexer = load_app_module('indexer')
         notification_queue_names = {
             config.notifications_queue.derive(retry=retry).unqual_name

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -154,11 +154,11 @@ class LambdaFunctions:
     def manage_function(self, function_name: str, enable: bool):
         function = self._lambda.get_function(FunctionName=function_name)
         function_arn = function['Configuration']['FunctionArn']
-        lambda_tags = self._lambda.list_tags(Resource=function_arn)['Tags']
+        tags = self._lambda.list_tags(Resource=function_arn)['Tags']
         function_name = function['Configuration']['FunctionName']
         if enable:
-            if self.tag_name in lambda_tags.keys():
-                original_concurrency_limit = ast.literal_eval(lambda_tags[self.tag_name])
+            if self.tag_name in tags.keys():
+                original_concurrency_limit = ast.literal_eval(tags[self.tag_name])
 
                 if original_concurrency_limit is not None:
                     log.info(f'Setting concurrency limit for {function_name} back to {original_concurrency_limit}.')
@@ -172,7 +172,7 @@ class LambdaFunctions:
             else:
                 log.warning(f'{function_name} is already enabled.')
         else:
-            if self.tag_name not in lambda_tags.keys():
+            if self.tag_name not in tags.keys():
                 try:
                     concurrency = function['Concurrency']
                 except KeyError:

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -72,11 +72,11 @@ class Lambda:
                 resource_name, _, _ = config.unqualified_resource_name_and_suffix(queue)
                 return resource_name in notification_queue_names
 
-        return frozenset((
+        return frozenset(
             handler.name
             for handler in vars(indexer).values()
             if has_notification_queue(handler)
-        ))
+        )
 
     @classmethod
     def from_response(cls, response: 'FunctionConfigurationTypeDef') -> Self:

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -143,8 +143,8 @@ class Lambdas:
     def manage_lambdas(self, enabled: bool):
         paginator = self._lambda.get_paginator('list_functions')
         prefixes = [
-            config.qualified_resource_name(infix)
-            for infix in config.app_names()
+            config.qualified_resource_name(app_name)
+            for app_name in config.app_names()
         ]
         assert all(prefixes)
         for response in paginator.paginate(MaxItems=500):

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -153,8 +153,8 @@ class LambdaFunctions:
 
     def manage_function(self, function_name: str, enable: bool):
         function = self._lambda.get_function(FunctionName=function_name)
-        lambda_arn = function['Configuration']['FunctionArn']
-        lambda_tags = self._lambda.list_tags(Resource=lambda_arn)['Tags']
+        function_arn = function['Configuration']['FunctionArn']
+        lambda_tags = self._lambda.list_tags(Resource=function_arn)['Tags']
         function_name = function['Configuration']['FunctionName']
         if enable:
             if self.tag_name in lambda_tags.keys():
@@ -168,7 +168,7 @@ class LambdaFunctions:
                     log.info(f'Removed concurrency limit for {function_name}.')
                     self._lambda.delete_function_concurrency(FunctionName=function_name)
 
-                self._lambda.untag_resource(Resource=lambda_arn, TagKeys=[self.tag_name])
+                self._lambda.untag_resource(Resource=function_arn, TagKeys=[self.tag_name])
             else:
                 log.warning(f'{function_name} is already enabled.')
         else:
@@ -185,7 +185,7 @@ class LambdaFunctions:
 
                 log.info(f'Setting concurrency limit for {function_name} to zero.')
                 new_tag = {self.tag_name: repr(concurrency_limit)}
-                self._lambda.tag_resource(Resource=lambda_arn, Tags=new_tag)
+                self._lambda.tag_resource(Resource=function_arn, Tags=new_tag)
                 self._lambda.put_function_concurrency(FunctionName=function_name, ReservedConcurrentExecutions=0)
             else:
                 log.warning(f'{function_name} is already disabled.')

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -142,12 +142,16 @@ class Lambdas:
 
     def manage_lambdas(self, enabled: bool):
         paginator = self._lambda.get_paginator('list_functions')
-        lambda_prefixes = [config.qualified_resource_name(lambda_infix) for lambda_infix in config.lambda_names()]
-        assert all(lambda_prefixes)
-        for lambda_page in paginator.paginate(MaxItems=500):
-            for lambda_name in [metadata['FunctionName'] for metadata in lambda_page['Functions']]:
-                if any(lambda_name.startswith(prefix) for prefix in lambda_prefixes):
-                    self.manage_lambda(lambda_name, enabled)
+        prefixes = [
+            config.qualified_resource_name(infix)
+            for infix in config.lambda_names()
+        ]
+        assert all(prefixes)
+        for response in paginator.paginate(MaxItems=500):
+            for function in response['Functions']:
+                function_name = function['FunctionName']
+                if any(function_name.startswith(prefix) for prefix in prefixes):
+                    self.manage_lambda(function_name, enabled)
 
     def manage_lambda(self, lambda_name: str, enable: bool):
         lambda_settings = self._lambda.get_function(FunctionName=lambda_name)

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -144,7 +144,7 @@ class Lambdas:
         paginator = self._lambda.get_paginator('list_functions')
         prefixes = [
             config.qualified_resource_name(infix)
-            for infix in config.lambda_names()
+            for infix in config.app_names()
         ]
         assert all(prefixes)
         for response in paginator.paginate(MaxItems=500):
@@ -194,7 +194,7 @@ class Lambdas:
 
     def reset_lambda_roles(self):
         client = self._lambda
-        lambda_names = set(config.lambda_names())
+        lambda_names = set(config.app_names())
 
         for lambda_ in self.list_lambdas():
             for lambda_name in lambda_names:

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -153,9 +153,9 @@ class LambdaFunctions:
 
     def manage_function(self, function_name: str, enable: bool):
         function = self._lambda.get_function(FunctionName=function_name)
+        assert function_name == function['Configuration']['FunctionName']
         function_arn = function['Configuration']['FunctionArn']
         tags = self._lambda.list_tags(Resource=function_arn)['Tags']
-        function_name = function['Configuration']['FunctionName']
         if enable:
             if self.tag_name in tags.keys():
                 original_concurrency_limit = ast.literal_eval(tags[self.tag_name])

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -106,6 +106,8 @@ class Lambdas:
         return aws.lambda_
 
     def list_lambdas(self) -> list[Lambda]:
+        # Note that this method returns the $LATEST version, which is what
+        # Amazon calls the "unpublished" version.
         return [
             Lambda.from_response(function)
             for response in self._lambda.get_paginator('list_functions').paginate()
@@ -116,7 +118,7 @@ class Lambdas:
         paginator = self._lambda.get_paginator('list_functions')
         lambda_prefixes = [config.qualified_resource_name(lambda_infix) for lambda_infix in config.lambda_names()]
         assert all(lambda_prefixes)
-        for lambda_page in paginator.paginate(FunctionVersion='ALL', MaxItems=500):
+        for lambda_page in paginator.paginate(MaxItems=500):
             for lambda_name in [metadata['FunctionName'] for metadata in lambda_page['Functions']]:
                 if any(lambda_name.startswith(prefix) for prefix in lambda_prefixes):
                     self.manage_lambda(lambda_name, enabled)
@@ -138,7 +140,6 @@ class Lambdas:
                     log.info(f'Removed concurrency limit for {lambda_name}.')
                     self._lambda.delete_function_concurrency(FunctionName=lambda_name)
 
-                lambda_arn = lambda_settings['Configuration']['FunctionArn']
                 self._lambda.untag_resource(Resource=lambda_arn, TagKeys=[self.tag_name])
             else:
                 log.warning(f'{lambda_name} is already enabled.')
@@ -156,7 +157,7 @@ class Lambdas:
 
                 log.info(f'Setting concurrency limit for {lambda_name} to zero.')
                 new_tag = {self.tag_name: repr(concurrency_limit)}
-                self._lambda.tag_resource(Resource=lambda_settings['Configuration']['FunctionArn'], Tags=new_tag)
+                self._lambda.tag_resource(Resource=lambda_arn, Tags=new_tag)
                 self._lambda.put_function_concurrency(FunctionName=lambda_name, ReservedConcurrentExecutions=0)
             else:
                 log.warning(f'{lambda_name} is already disabled.')

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -40,12 +40,12 @@ class LambdaFunction:
 
     @property
     def is_contribution_lambda(self) -> bool:
+        unqualify = config.unqualified_resource_name
         for handler_name in self._contribution_handler_names():
             try:
                 # FIXME: Eliminate hardcoded separator
                 #        https://github.com/databiosphere/azul/issues/2964
-                resource_name, _ = config.unqualified_resource_name(self.name,
-                                                                    suffix='-' + handler_name)
+                resource_name, _ = unqualify(self.name, suffix='-' + handler_name)
             except AssertionError as e:
                 if not R.caused(e):
                     raise

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -188,6 +188,11 @@ class LambdaFunctions:
                 self._lambda.put_function_concurrency(FunctionName=function_name, ReservedConcurrentExecutions=0)
 
     def reset_lambda_roles(self):
+        """
+        Attempt to fix KMSAccessDeniedException when invoking a function.
+
+        See Troubleshooting section in README.md for details.
+        """
         client = self._lambda
         app_names = set(config.app_names())
 

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -114,6 +114,32 @@ class Lambdas:
             for function in response['Functions']
         ]
 
+    def delete_older_function_versions(self,
+                                       function_name: str,
+                                       keep_version: int) -> None:
+        """
+        Delete all versions of a Lambda function prior to the specified one.
+
+        :param function_name: The fully qualified name of the function
+                              e.g. 'azul-service-dev'
+
+        :param keep_version: The version of the function to not delete.
+        """
+        paginator = self._lambda.get_paginator('list_versions_by_function')
+        versions = [
+            function['Version']
+            for page in paginator.paginate(FunctionName=function_name)
+            for function in page['Versions']
+            if (
+                function['Version'] != '$LATEST'  # The so-called "unpublished" version
+                and int(function['Version']) < keep_version
+            )
+        ]
+        for version in versions:
+            log.info('Deleting version %r of %r', version, function_name)
+            self._lambda.delete_function(FunctionName=function_name,
+                                         Qualifier=version)
+
     def manage_lambdas(self, enabled: bool):
         paginator = self._lambda.get_paginator('list_functions')
         lambda_prefixes = [config.qualified_resource_name(lambda_infix) for lambda_infix in config.lambda_names()]

--- a/src/azul/lambdas.py
+++ b/src/azul/lambdas.py
@@ -152,10 +152,10 @@ class LambdaFunctions:
                     self.manage_function(function_name, enabled)
 
     def manage_function(self, function_name: str, enable: bool):
-        lambda_settings = self._lambda.get_function(FunctionName=function_name)
-        lambda_arn = lambda_settings['Configuration']['FunctionArn']
+        function = self._lambda.get_function(FunctionName=function_name)
+        lambda_arn = function['Configuration']['FunctionArn']
         lambda_tags = self._lambda.list_tags(Resource=lambda_arn)['Tags']
-        function_name = lambda_settings['Configuration']['FunctionName']
+        function_name = function['Configuration']['FunctionName']
         if enable:
             if self.tag_name in lambda_tags.keys():
                 original_concurrency_limit = ast.literal_eval(lambda_tags[self.tag_name])
@@ -174,7 +174,7 @@ class LambdaFunctions:
         else:
             if self.tag_name not in lambda_tags.keys():
                 try:
-                    concurrency = lambda_settings['Concurrency']
+                    concurrency = function['Concurrency']
                 except KeyError:
                     # If a lambda doesn't have a limit for concurrency
                     # executions, Lambda.Client.get_function()

--- a/src/azul/queues.py
+++ b/src/azul/queues.py
@@ -60,7 +60,7 @@ from azul.json import (
     Serializable,
 )
 from azul.lambdas import (
-    Lambdas,
+    LambdaFunctions,
 )
 from azul.modules import (
     load_app_module,
@@ -589,8 +589,8 @@ class Queues:
         self._lambdas.manage_lambda(function_name, enable)
 
     @cached_property
-    def _lambdas(self) -> Lambdas:
-        return Lambdas()
+    def _lambdas(self) -> LambdaFunctions:
+        return LambdaFunctions()
 
     def _handle_futures(self, futures: Iterable[Future]):
         errors = []

--- a/src/azul/queues.py
+++ b/src/azul/queues.py
@@ -586,7 +586,7 @@ class Queues:
             self._handle_futures(futures)
 
     def _manage_lambda(self, function_name: str, enable: bool):
-        self._functions.manage_lambda(function_name, enable)
+        self._functions.manage_function(function_name, enable)
 
     @cached_property
     def _functions(self) -> LambdaFunctions:

--- a/src/azul/queues.py
+++ b/src/azul/queues.py
@@ -502,21 +502,27 @@ class Queues:
             time.sleep(3)
             queue.reload()
 
-    def _manage_sqs_push(self, function_name: str, queue: 'Queue', enable: bool):
+    def _manage_sqs_push(self,
+                         *,
+                         function: str,
+                         alias: str,
+                         queue: 'Queue',
+                         enable: bool):
         lambda_ = aws.lambda_
-        response = lambda_.list_event_source_mappings(FunctionName=function_name,
+        partial_arn = f'{function}:{alias}'
+        response = lambda_.list_event_source_mappings(FunctionName=partial_arn,
                                                       EventSourceArn=queue.attributes['QueueArn'])
         mapping_uuid = one(response['EventSourceMappings'])['UUID']
 
         def update_():
             log.info('%s push from %r to lambda function %r',
-                     'Enabling' if enable else 'Disabling', queue.url, function_name)
+                     'Enabling' if enable else 'Disabling', queue.url, function)
             lambda_.update_event_source_mapping(UUID=mapping_uuid, Enabled=enable)
 
         state = one(response['EventSourceMappings'])['State']
         while True:
             log.info('Push from %r to lambda function %r is in state %r.',
-                     queue.url, function_name, state)
+                     queue.url, function, state)
             if state in ('Disabling', 'Enabling', 'Updating'):
                 pass
             elif state == 'Enabled':
@@ -570,7 +576,11 @@ class Queues:
                     if queue_name == config.notifications_queue.name:
                         # Prevent new notifications from being added
                         submit(self._manage_lambda, config.indexer_name, enable)
-                    submit(self._manage_sqs_push, function, queue, enable)
+                    submit(self._manage_sqs_push,
+                           function=function,
+                           alias=config.active_function_alias_name,
+                           queue=queue,
+                           enable=enable)
             self._handle_futures(futures)
             futures = [tpe.submit(self._wait_for_queue_idle, queue) for queue in queues.values()]
             self._handle_futures(futures)

--- a/src/azul/queues.py
+++ b/src/azul/queues.py
@@ -586,10 +586,10 @@ class Queues:
             self._handle_futures(futures)
 
     def _manage_lambda(self, function_name: str, enable: bool):
-        self._lambdas.manage_lambda(function_name, enable)
+        self._functions.manage_lambda(function_name, enable)
 
     @cached_property
-    def _lambdas(self) -> LambdaFunctions:
+    def _functions(self) -> LambdaFunctions:
         return LambdaFunctions()
 
     def _handle_futures(self, futures: Iterable[Future]):

--- a/src/azul/terraform.py
+++ b/src/azul/terraform.py
@@ -757,10 +757,14 @@ class Chalice:
                 '${aws_vpc_endpoint.%s.id}' % app_name
             ]
 
-        functions = json_item_dicts(json_dict(resources['aws_lambda_function']))
-        for _, resource in functions:
+        functions = json_item_dicts(resources['aws_lambda_function'])
+        for resource_name, resource in functions:
             assert 'layers' not in resource
             resource['layers'] = ['${aws_lambda_layer_version.dependencies.arn}']
+            # Publishing a new Lambda function version each time lets us perform
+            # an atomic update of the function, avoiding a race condition
+            # between the update of the function's configuration and its code.
+            resource['publish'] = True
             env = config.es_endpoint_env(
                 es_endpoint=(
                     aws.es_endpoint
@@ -777,6 +781,25 @@ class Chalice:
             package_zip = str(self.package_zip_path(app_name))
             resource['source_code_hash'] = '${filebase64sha256("%s")}' % package_zip
             resource['filename'] = package_zip
+
+        # Replace any references to unqualified function ARNs emitted by Chalice
+        # with references to the alias.
+        #
+        def function_to_alias[T: AnyMutableJSON](v: T) -> T:
+            if isinstance(v, dict):
+                return type(v)((k, function_to_alias(v)) for k, v in v.items())
+            elif isinstance(v, list):
+                return type(v)(map(function_to_alias, v))
+            elif isinstance(v, str) and v.endswith(('.arn}', '.invoke_arn}')):
+                r = v.replace('${aws_lambda_function', '${aws_lambda_alias')
+                assert isinstance(r, type(v))
+                return r
+            else:
+                return v
+
+        openapi_spec = json_dict(json.loads(json_str(locals[app_name])))
+        openapi_spec = function_to_alias(openapi_spec)
+        resources = function_to_alias(resources)
 
         assert 'aws_cloudwatch_log_group' not in resources
         functions = json_item_dicts(resources['aws_lambda_function'])
@@ -869,7 +892,6 @@ class Chalice:
         # default responses for the API, so we use these extensions for that
         # purpose, too.
         #
-        openapi_spec = json.loads(json_str(locals[app_name]))
         rest_apis = json_dict(resources['aws_api_gateway_rest_api'])
         rest_api = json_dict(rest_apis[app_name])
         assert 'minimum_compression_size' not in rest_api, rest_api
@@ -883,43 +905,43 @@ class Chalice:
         #
         # https://docs.aws.amazon.com/apigateway/latest/developerguide/request-response-data-mappings.html#mapping-response-parameters
         #
-        security_headers = {
+        security_headers: MutableJSON = {
             f'gatewayresponse.header.{k}': f"'{v}'"
             for k, v in AzulChaliceApp.security_headers().items()
         }
-        assert 'aws_api_gateway_gateway_response' not in resources, resources
-        openapi_spec['x-amazon-apigateway-gateway-responses'] = (
-            {
-                f'DEFAULT_{response_type}': {
-                    'responseParameters': security_headers
-                } for response_type in ['4XX', '5XX']
-            } | {
-                'INTEGRATION_FAILURE': {
-                    'statusCode': '502',
-                    'responseParameters': security_headers,
-                    'responseTemplates': {
-                        "application/json": json.dumps({
-                            'message': '502 Bad Gateway. The server was unable '
-                                       'to complete your request.'
-                        })
-                    }
+        default_responses: MutableJSON = {
+            f'DEFAULT_{response_type}': {'responseParameters': security_headers}
+            for response_type in ['4XX', '5XX']
+        }
+        error_responses: MutableJSON = {
+            'INTEGRATION_FAILURE': {
+                'statusCode': '502',
+                'responseParameters': security_headers,
+                'responseTemplates': {
+                    "application/json": json.dumps({
+                        'message': '502 Bad Gateway. The server was unable '
+                                   'to complete your request.'
+                    })
+                }
+            },
+            'INTEGRATION_TIMEOUT': {
+                'statusCode': '504',
+                'responseParameters': {
+                    **security_headers,
+                    'gatewayresponse.header.Retry-After': "'10'"
                 },
-                'INTEGRATION_TIMEOUT': {
-                    'statusCode': '504',
-                    'responseParameters': {
-                        **security_headers,
-                        'gatewayresponse.header.Retry-After': "'10'"
-                    },
-                    'responseTemplates': {
-                        "application/json": json.dumps({
-                            'message': '504 Gateway Timeout. Wait the number of '
-                                       'seconds specified in the `Retry-After` '
-                                       'header before retrying the request.'
-                        })
-                    }
+                'responseTemplates': {
+                    "application/json": json.dumps({
+                        'message': '504 Gateway Timeout. Wait the number of '
+                                   'seconds specified in the `Retry-After` '
+                                   'header before retrying the request.'
+                    })
                 }
             }
-        )
+        }
+        gateway_responses = error_responses | default_responses
+        assert 'aws_api_gateway_gateway_response' not in resources, resources
+        openapi_spec['x-amazon-apigateway-gateway-responses'] = gateway_responses
         locals[app_name] = json.dumps(openapi_spec)
 
         # Replace the hard-coded ARN emitted by Chalice with a resource
@@ -933,6 +955,14 @@ class Chalice:
                 suffix = '.fifo' if resource_name.endswith('.fifo') else ''
                 sqs_name, _ = config.unqualified_resource_name(resource_name, suffix)
                 resource['event_source_arn'] = f'${{aws_sqs_queue.{sqs_name}.arn}}'
+
+        # Ensure that the Lambda permissions for the previous aliases aren't
+        # deleted until after the permissions for the new aliases have been
+        # created.
+        #
+        for name, resource in json_item_dicts(resources['aws_lambda_permission']):
+            assert 'lifecycle' not in resource, resource
+            resource['lifecycle'] = {'create_before_destroy': True}
 
         return {
             'resource': resources,

--- a/src/azul/terraform.py
+++ b/src/azul/terraform.py
@@ -652,15 +652,17 @@ class Chalice:
         # Sort in reverse so that keys that are prefixes of other keys go last
         rev_ref_map = sorted(ref_map.items(), reverse=True)
 
-        def patch_refs(v: AnyMutableJSON) -> AnyMutableJSON:
+        def patch_refs[T: AnyMutableJSON](v: T) -> T:
             if isinstance(v, dict):
-                return {k: patch_refs(v) for k, v in json_dict(v).items()}
+                return type(v)((k, patch_refs(v)) for k, v in json_dict(v).items())
             elif isinstance(v, list):
-                return list(map(patch_refs, v))
+                return type(v)(map(patch_refs, v))
             elif isinstance(v, str):
+                r: str = v
                 for old_ref, new_ref in rev_ref_map:
-                    v = v.replace(old_ref, new_ref)
-                return v
+                    r = r.replace(old_ref, new_ref)
+                assert isinstance(r, type(v))
+                return r
             else:
                 return v
 

--- a/terraform/api_gateway.tf.json.template.py
+++ b/terraform/api_gateway.tf.json.template.py
@@ -763,10 +763,21 @@ emit_tf({
                 retry.tf_function_resource_name: {
                     'function_name': '${aws_lambda_function.%s.function_name}'
                                      % retry.tf_function_resource_name,
+                    'qualifier': '${aws_lambda_alias.%s.name}'
+                                 % retry.tf_function_resource_name,
                     'maximum_retry_attempts': retry.num_retries
                 }
                 for app in apps
                 for retry in app.chalice.retries
+            },
+            'aws_lambda_alias': {
+                resource_name: {
+                    'name': config.active_function_alias_name,
+                    'function_name': '${aws_lambda_function.%s.function_name}' % resource_name,
+                    'function_version': '${aws_lambda_function.%s.version}' % resource_name
+                }
+                for app in apps
+                for resource_name in app.chalice.tf_function_resource_names
             }
         }),
         *(

--- a/terraform/api_gateway.tf.json.template.py
+++ b/terraform/api_gateway.tf.json.template.py
@@ -778,6 +778,23 @@ emit_tf({
                 }
                 for app in apps
                 for resource_name in app.chalice.tf_function_resource_names
+            },
+            'terraform_data': {
+                resource_name: {
+                    'triggers_replace': ['${aws_lambda_alias.%s.function_version}' % resource_name],
+                    'provisioner': {
+                        'local-exec': {
+                            'command': ' '.join([
+                                'python',
+                                f'{config.project_root}/scripts/delete_older_function_versions.py',
+                                '--function-name ${aws_lambda_alias.%s.function_name}' % resource_name,
+                                '--function-version ${aws_lambda_alias.%s.function_version}' % resource_name
+                            ])
+                        }
+                    }
+                }
+                for app in apps
+                for resource_name in app.chalice.tf_function_resource_names
             }
         }),
         *(

--- a/terraform/cloudwatch.tf.json.template.py
+++ b/terraform/cloudwatch.tf.json.template.py
@@ -97,16 +97,16 @@ emit_tf({
                 *(
                     {
                         'aws_cloudwatch_log_metric_filter': {
-                            f'{lambda_}cachehealth': {
-                                'name': config.qualified_resource_name(f'{lambda_}cachehealth', suffix='.filter'),
+                            f'{app_name}cachehealth': {
+                                'name': config.qualified_resource_name(f'{app_name}cachehealth', suffix='.filter'),
                                 'pattern': '',
                                 'log_group_name': (
                                     '/aws/lambda/'
-                                    + config.qualified_resource_name(lambda_)
-                                    + f'-{lambda_}cachehealth'
+                                    + config.qualified_resource_name(app_name)
+                                    + f'-{app_name}cachehealth'
                                 ),
                                 'metric_transformation': {
-                                    'name': config.qualified_resource_name(f'{lambda_}cachehealth'),
+                                    'name': config.qualified_resource_name(f'{app_name}cachehealth'),
                                     'namespace': 'LogMetrics',
                                     'value': 1,
                                     'default_value': 0,
@@ -114,7 +114,7 @@ emit_tf({
                             }
                         }
                     }
-                    for lambda_ in config.app_names()
+                    for app_name in config.app_names()
                 ),
                 *(
                     {

--- a/terraform/cloudwatch.tf.json.template.py
+++ b/terraform/cloudwatch.tf.json.template.py
@@ -72,12 +72,12 @@ emit_tf({
                 *(
                     {
                         'aws_cloudwatch_metric_alarm': {
-                            f'{lambda_}_5xx': {
-                                'alarm_name': config.qualified_resource_name(lambda_ + '_5xx'),
+                            f'{app_name}_5xx': {
+                                'alarm_name': config.qualified_resource_name(app_name + '_5xx'),
                                 'namespace': 'AWS/ApiGateway',
                                 'metric_name': '5XXError',
                                 'dimensions': {
-                                    'ApiName': config.qualified_resource_name(lambda_),
+                                    'ApiName': config.qualified_resource_name(app_name),
                                     'Stage': config.deployment_stage,
                                 },
                                 'statistic': 'Sum',
@@ -92,7 +92,7 @@ emit_tf({
                             }
                         }
                     }
-                    for lambda_ in config.app_names()
+                    for app_name in config.app_names()
                 ),
                 *(
                     {

--- a/terraform/cloudwatch.tf.json.template.py
+++ b/terraform/cloudwatch.tf.json.template.py
@@ -92,7 +92,7 @@ emit_tf({
                             }
                         }
                     }
-                    for lambda_ in config.lambda_names()
+                    for lambda_ in config.app_names()
                 ),
                 *(
                     {
@@ -114,7 +114,7 @@ emit_tf({
                             }
                         }
                     }
-                    for lambda_ in config.lambda_names()
+                    for lambda_ in config.app_names()
                 ),
                 *(
                     {
@@ -154,7 +154,7 @@ emit_tf({
                             }
                         }
                     }
-                    for lambda_ in config.lambda_names()
+                    for lambda_ in config.app_names()
                 ),
                 {
                     'aws_cloudwatch_metric_alarm': {
@@ -254,7 +254,7 @@ emit_tf({
                                 'ok_actions': ['${data.aws_sns_topic.monitoring.arn}'],
                                 'treat_missing_data': 'notBreaching',
                             }
-                            for lambda_name in config.lambda_names()
+                            for lambda_name in config.app_names()
                             for metric_alarm in load_app_module(lambda_name).app.metric_alarms
                         },
                         'waf_rate_blocked': {

--- a/terraform/cloudwatch.tf.json.template.py
+++ b/terraform/cloudwatch.tf.json.template.py
@@ -119,8 +119,8 @@ emit_tf({
                 *(
                     {
                         'aws_cloudwatch_metric_alarm': {
-                            f'{lambda_}cachehealth': {
-                                'alarm_name': config.qualified_resource_name(f'{lambda_}cachehealth', suffix='.alarm'),
+                            f'{app_name}cachehealth': {
+                                'alarm_name': config.qualified_resource_name(f'{app_name}cachehealth', suffix='.alarm'),
                                 # CloudWatch uses an unconfigurable "evaluation range" when missing
                                 # data is involved. In practice this means that an alarm on the
                                 # absence of logs with an evaluation window of ten minutes would
@@ -133,7 +133,7 @@ emit_tf({
                                         'metric': {
                                             'namespace': 'LogMetrics',
                                             'metric_name': '${aws_cloudwatch_log_metric_filter.'
-                                                           '%scachehealth.metric_transformation[0].name}' % lambda_,
+                                                           '%scachehealth.metric_transformation[0].name}' % app_name,
                                             'stat': 'Sum',
                                             'period': 10 * 60,
                                         }
@@ -154,7 +154,7 @@ emit_tf({
                             }
                         }
                     }
-                    for lambda_ in config.app_names()
+                    for app_name in config.app_names()
                 ),
                 {
                     'aws_cloudwatch_metric_alarm': {

--- a/terraform/cloudwatch.tf.json.template.py
+++ b/terraform/cloudwatch.tf.json.template.py
@@ -254,8 +254,8 @@ emit_tf({
                                 'ok_actions': ['${data.aws_sns_topic.monitoring.arn}'],
                                 'treat_missing_data': 'notBreaching',
                             }
-                            for lambda_name in config.app_names()
-                            for metric_alarm in load_app_module(lambda_name).app.metric_alarms
+                            for app_name in config.app_names()
+                            for metric_alarm in load_app_module(app_name).app.metric_alarms
                         },
                         'waf_rate_blocked': {
                             'alarm_name': config.qualified_resource_name('waf_rate_blocked'),

--- a/test/app_test_case.py
+++ b/test/app_test_case.py
@@ -75,11 +75,11 @@ class LocalAppTestCase(CatalogTestCase, metaclass=ABCMeta):
 
     @classmethod
     @abstractmethod
-    def lambda_name(cls) -> str:
+    def app_name(cls) -> str:
         """
-        Return the name of the AWS Lambda function to start locally. Must match
-        the name of a subdirectory of ${project_root}/lambdas. Subclasses must
-        override this to select which AWS Lambda function to start locally.
+        Return the name of the application to start locally. Must match the name
+        of a directory in ${project_root}/lambdas. Subclasses must override this
+        method.
         """
         raise NotImplementedError
 
@@ -100,7 +100,7 @@ class LocalAppTestCase(CatalogTestCase, metaclass=ABCMeta):
         # app modules from different lambdas loaded by different concrete
         # subclasses. It does, however, violate this one invariant:
         # `sys.modules[module.__name__] == module`
-        cls.app_module = load_app_module(cls.lambda_name())
+        cls.app_module = load_app_module(cls.app_name())
 
     @classmethod
     def tearDownClass(cls):

--- a/test/health_check_test_case.py
+++ b/test/health_check_test_case.py
@@ -226,7 +226,7 @@ class HealthCheckTestCase(LocalAppTestCase,
     def _other_lambda_names(self) -> list[str]:
         return [
             lambda_name
-            for lambda_name in config.lambda_names()
+            for lambda_name in config.app_names()
             if lambda_name != self.lambda_name()
         ]
 

--- a/test/health_check_test_case.py
+++ b/test/health_check_test_case.py
@@ -137,7 +137,7 @@ class HealthCheckTestCase(LocalAppTestCase,
 
         # A successful response is obtained when all the systems are functional
         self._create_mock_queues()
-        app = load_app_module(self.lambda_name())
+        app = load_app_module(self.app_name())
         with self._mock():
             app.update_health_cache(MagicMock(), MagicMock())
             response = self._test('/health/cached')
@@ -227,7 +227,7 @@ class HealthCheckTestCase(LocalAppTestCase,
         return [
             app_name
             for app_name in config.app_names()
-            if app_name != self.lambda_name()
+            if app_name != self.app_name()
         ]
 
     def _expected_other_lambdas(self, *, up: bool) -> MutableJSON:

--- a/test/health_check_test_case.py
+++ b/test/health_check_test_case.py
@@ -225,9 +225,9 @@ class HealthCheckTestCase(LocalAppTestCase,
 
     def _other_lambda_names(self) -> list[str]:
         return [
-            lambda_name
-            for lambda_name in config.app_names()
-            if lambda_name != self.lambda_name()
+            app_name
+            for app_name in config.app_names()
+            if app_name != self.lambda_name()
         ]
 
     def _expected_other_lambdas(self, *, up: bool) -> MutableJSON:

--- a/test/indexer/test_health_check.py
+++ b/test/indexer/test_health_check.py
@@ -24,7 +24,7 @@ def setUpModule():
 class TestIndexerHealthCheck(DCP1TestCase, HealthCheckTestCase):
 
     @classmethod
-    def lambda_name(cls) -> str:
+    def app_name(cls) -> str:
         return 'indexer'
 
     def _expected_health(self,

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -66,7 +66,7 @@ class TestMirrorController(DCP2TestCase,
                            MirrorTestCase):
 
     @classmethod
-    def lambda_name(cls) -> str:
+    def app_name(cls) -> str:
         return 'indexer'
 
     def test_mirroring(self):

--- a/test/indexer/test_notifications.py
+++ b/test/indexer/test_notifications.py
@@ -35,7 +35,7 @@ class TestValidNotificationRequests(LocalAppTestCase,
                                     SqsTestCase):
 
     @classmethod
-    def lambda_name(cls) -> str:
+    def app_name(cls) -> str:
         return 'indexer'
 
     @mock_aws

--- a/test/service/__init__.py
+++ b/test/service/__init__.py
@@ -105,7 +105,7 @@ class WebServiceTestCase(IndexerTestCase, LocalAppTestCase, metaclass=ABCMeta):
         ]
 
     @classmethod
-    def lambda_name(cls) -> str:
+    def app_name(cls) -> str:
         return 'service'
 
     @classmethod

--- a/test/service/test_app_logging.py
+++ b/test/service/test_app_logging.py
@@ -52,7 +52,7 @@ class TestServiceAppLogging(DCP1CannedBundleTestCase, WebServiceTestCase):
         super().tearDownClass()
 
     @classmethod
-    def lambda_name(cls) -> str:
+    def app_name(cls) -> str:
         return 'service'
 
     def test_request_logs(self):

--- a/test/service/test_cache_poisoning.py
+++ b/test/service/test_cache_poisoning.py
@@ -45,7 +45,7 @@ class CachePoisoningTestCase(LocalAppTestCase, metaclass=ABCMeta):
         super().tearDownClass()
 
     @classmethod
-    def lambda_name(cls) -> str:
+    def app_name(cls) -> str:
         return 'service'
 
     def _test(self):

--- a/test/service/test_drs.py
+++ b/test/service/test_drs.py
@@ -146,7 +146,7 @@ class TestDRSEndpoint(DCP1CannedBundleTestCase, LocalAppTestCase):
     gs_url = 'gs://important-bucket/object/path'
 
     @classmethod
-    def lambda_name(cls) -> str:
+    def app_name(cls) -> str:
         return 'service'
 
     def test_drs(self):

--- a/test/service/test_health_check.py
+++ b/test/service/test_health_check.py
@@ -24,7 +24,7 @@ def setUpModule():
 class TestServiceHealthCheck(DCP1TestCase, HealthCheckTestCase):
 
     @classmethod
-    def lambda_name(cls) -> str:
+    def app_name(cls) -> str:
         return 'service'
 
     def _expected_health(self,

--- a/test/service/test_manifest_async.py
+++ b/test/service/test_manifest_async.py
@@ -173,7 +173,7 @@ class TestAsyncManifestService(AzulUnitTestCase):
 class TestManifestController(DCP1TestCase, LocalAppTestCase):
 
     @classmethod
-    def lambda_name(cls) -> str:
+    def app_name(cls) -> str:
         return 'service'
 
     generation_id = UUID('1ea94a54-a64d-54f1-8b41-15455fb958db')

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -94,7 +94,7 @@ def setUpModule():
 class RepositoryFilesTestCase(LocalAppTestCase, metaclass=ABCMeta):
 
     @classmethod
-    def lambda_name(cls) -> str:
+    def app_name(cls) -> str:
         return 'service'
 
     def chalice_config(self):

--- a/test/service/test_response.py
+++ b/test/service/test_response.py
@@ -3690,7 +3690,7 @@ class TestListCatalogsResponse(DCP1CannedBundleTestCase, LocalAppTestCase):
     maxDiff = None
 
     @classmethod
-    def lambda_name(cls) -> str:
+    def app_name(cls) -> str:
         return 'service'
 
     def test(self):


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #5927


## Checklist


### Author

- [x] PR is assigned to the author
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile`, `Dockerfile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer


### Peer reviewer (after approval)

Note that when requesting changes, the PR must be assigned back to the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
