### PR TITLE
Issue and PR template improvements (#7391, #7437, #6779)

### DIFF
--- a/.github/ISSUE_TEMPLATE/audited_events_rule_set_review.md
+++ b/.github/ISSUE_TEMPLATE/audited_events_rule_set_review.md
@@ -1,5 +1,5 @@
 ---
-name: Annual review of the rule set for audited events
+name: Review rule set for audited events
 about: Issue template for annual review of the rule set for audited events
 title: Review rule set for audited events
 labels: -,compliance,doc,no demo,orange

--- a/.github/ISSUE_TEMPLATE/audited_events_rule_set_review.md
+++ b/.github/ISSUE_TEMPLATE/audited_events_rule_set_review.md
@@ -4,7 +4,7 @@ about: Issue template for annual review of the rule set for audited events
 title: Review rule set for audited events
 labels: -,compliance,doc,no demo,orange
 assignees: nolunwa-ucsc,bvizzier-ucsc
-type: Task
+type: Chore
 _start: 2025-01-10T10:00
 _period: 1 year
 ---

--- a/.github/ISSUE_TEMPLATE/blank.md
+++ b/.github/ISSUE_TEMPLATE/blank.md
@@ -1,5 +1,5 @@
 ---
-name: A New Issue
+name: A new blank issue
 about: Template for new issues
 title: ''
 labels: orange

--- a/.github/ISSUE_TEMPLATE/fedramp_inventory_review.md
+++ b/.github/ISSUE_TEMPLATE/fedramp_inventory_review.md
@@ -2,9 +2,9 @@
 name: Monthly FedRAMP inventory review
 about: Issue template for the monthly creation and review of the FedRAMP cloud infrastructure inventory   
 title: Monthly FedRAMP inventory review
-labels: +,compliance,infra,no demo,operator,orange
+labels: -,compliance,infra,no demo,operator,orange
 assignees: hannes-ucsc
-type: Task
+type: Chore
 _repository: DataBiosphere/azul-private
 _start: 2024-03-01T09:00
 _period: 1 month

--- a/.github/ISSUE_TEMPLATE/fedramp_inventory_review.md
+++ b/.github/ISSUE_TEMPLATE/fedramp_inventory_review.md
@@ -1,7 +1,7 @@
 ---
-name: Review FedRAMP inventory
-about: Issue template for the current operator to perform a Port and Protocol review with system administrator
-title: Monthly inventory review
+name: Monthly FedRAMP inventory review
+about: Issue template for the monthly creation and review of the FedRAMP cloud infrastructure inventory   
+title: Monthly FedRAMP inventory review
 labels: +,compliance,infra,no demo,operator,orange
 assignees: hannes-ucsc
 type: Task

--- a/.github/ISSUE_TEMPLATE/opensearch_updates.md
+++ b/.github/ISSUE_TEMPLATE/opensearch_updates.md
@@ -1,7 +1,7 @@
 ---
 name: OpenSearch service software update
 about: Issue template for operator tasks to update OpenSearch instances software
-title: Apply Amazon OpenSearch (ES) Software Update
+title: Apply Amazon OpenSearch software updates
 labels: -,infra,no demo,operator,orange
 type: Task
 _start: 2024-02-26T09:00

--- a/.github/ISSUE_TEMPLATE/opensearch_updates.md
+++ b/.github/ISSUE_TEMPLATE/opensearch_updates.md
@@ -1,6 +1,6 @@
 ---
-name: OpenSearch service software update
-about: Issue template for operator tasks to update OpenSearch instances software
+name: Apply Amazon OpenSearch software updates
+about: Issue template for operator to update the service software version on all OpenSearch domains 
 title: Apply Amazon OpenSearch software updates
 labels: -,infra,no demo,operator,orange
 type: Task

--- a/.github/ISSUE_TEMPLATE/opensearch_updates.md
+++ b/.github/ISSUE_TEMPLATE/opensearch_updates.md
@@ -3,7 +3,7 @@ name: Apply Amazon OpenSearch software updates
 about: Issue template for operator to update the service software version on all OpenSearch domains 
 title: Apply Amazon OpenSearch software updates
 labels: -,infra,no demo,operator,orange
-type: Task
+type: Chore
 _start: 2024-02-26T09:00
 _period: 14 days
 ---

--- a/.github/ISSUE_TEMPLATE/promotion.md
+++ b/.github/ISSUE_TEMPLATE/promotion.md
@@ -3,7 +3,7 @@ name: Promotion
 about: Issue template for promoting changes to stable deployments on a weekly basis
 title: Promotion
 labels: -,infra,no demo,operator,orange
-type: Feature
+type: Chore
 _start: 2024-02-27T09:00
 _period: 7 days
 ---

--- a/.github/ISSUE_TEMPLATE/promotion.md
+++ b/.github/ISSUE_TEMPLATE/promotion.md
@@ -1,6 +1,6 @@
 ---
-name: Promotion pull request
-about: Issue template for promoting changes to stable deployments
+name: Promotion
+about: Issue template for promoting changes to stable deployments on a weekly basis
 title: Promotion
 labels: -,infra,no demo,operator,orange
 type: Feature

--- a/.github/ISSUE_TEMPLATE/prune_gitlab_backups.md
+++ b/.github/ISSUE_TEMPLATE/prune_gitlab_backups.md
@@ -3,7 +3,7 @@ name: Prune GitLab data volume backups
 about: Issue template for the quarterly pruning of GitLab data volume snapshots
 title: Prune GitLab data volume backups
 labels: -,infra,operator,orange
-type: Task
+type: Chore
 _start: 2025-04-01T09:00
 _period: 3 months
 ---

--- a/.github/ISSUE_TEMPLATE/public_access_content_review.md
+++ b/.github/ISSUE_TEMPLATE/public_access_content_review.md
@@ -4,7 +4,7 @@ about: Issue template for the system administrator to perform a review of public
 title: Monthly review of publicly accessible content
 labels: -,compliance,infra,doc,orange
 assignees: hannes-ucsc
-type: Task
+type: Chore
 _repository: DataBiosphere/azul-private
 _start: 2024-08-01T09:00
 _period: 1 month

--- a/.github/ISSUE_TEMPLATE/public_access_content_review.md
+++ b/.github/ISSUE_TEMPLATE/public_access_content_review.md
@@ -1,6 +1,6 @@
 ---
-name: Review publicly accessible content
-about: Issue template for the system administrator to perform a review of publicly accessible content.
+name: Monthly review of publicly accessible content
+about: Issue template for the system administrator to perform a review of publicly accessible content on a monthly basis
 title: Monthly review of publicly accessible content
 labels: -,compliance,infra,doc,orange
 assignees: hannes-ucsc

--- a/.github/ISSUE_TEMPLATE/upgrade.md
+++ b/.github/ISSUE_TEMPLATE/upgrade.md
@@ -21,7 +21,7 @@ _period: 14 days
   - [ ] Push commit to GitHub (directly to `azul` branch, no PR needed)
   - [ ] GH Action workflow succeeded
   - [ ] Image is available on [DockerHub](https://hub.docker.com/repository/docker/ucscgi/azul-bigquery-emulator/tags) 
-- [ ] Create Azul PR, connected to this issue, with … 
+- [ ] Create Azul PR, linked to this issue, with … 
     - [ ] … changes to `requirements*.txt` from open Dependabot PRs, one commit per PR
     - [ ] … upgrade direct Python dependencies, [reference the operator manual](https://github.com/DataBiosphere/azul/blob/develop/OPERATOR.rst#upgrade-direct-python-dependencies) for instructions <sub>or not applicable</sub>
     - [ ] … update to [Python](https://hub.docker.com/_/python/tags) (only patch versions) <sub>or no update available</sub>

--- a/.github/ISSUE_TEMPLATE/upgrade.md
+++ b/.github/ISSUE_TEMPLATE/upgrade.md
@@ -34,8 +34,8 @@ _period: 14 days
     - [ ] … update to [ClamAV image](https://hub.docker.com/r/clamav/clamav/tags) <sub>or no update available</sub>
     - [ ] … update to [GitLab AMI](https://github.com/DataBiosphere/azul/blob/develop/OPERATOR.rst#updating-the-ami-for-gitlab-instances) <sub>or no update available</sub>
     - [ ] … update to [Swagger UI](https://github.com/DataBiosphere/azul/blob/develop/OPERATOR.rst#updating-the-swagger-ui) <sub>or no update available</sub>
-- [ ] Created tickets for any deferred updates to …
-  - [ ] … to next major or minor Python version <sub>or such ticket already exists</sub>
-  - [ ] … to next major Docker version <sub>or such ticket already exists</sub>
-  - [ ] … to next major or minor Terraform version <sub>or such ticket already exists</sub>
-  - [ ] … to next major OpenSearch version <sub>or such ticket already exists</sub>
+- [ ] Created issues for any deferred updates to …
+  - [ ] … the next major or minor Python version <sub>or such an issue already exists</sub>
+  - [ ] … the next major Docker version <sub>or such an issue already exists</sub>
+  - [ ] … the next major or minor Terraform version <sub>or such an issue already exists</sub>
+  - [ ] … the next major OpenSearch version <sub>or such an issue already exists</sub>

--- a/.github/ISSUE_TEMPLATE/upgrade.md
+++ b/.github/ISSUE_TEMPLATE/upgrade.md
@@ -1,7 +1,7 @@
 ---
-name: Dependency upgrades
-about: Issue template for bi-weekly dependency upgrades
-title: Upgrade dependencies
+name: Upgrade software dependencies
+about: Issue template for the bi-weekly upgrade of Azul's software dependencies
+title: Upgrade software dependencies
 labels: orange,operator,infra,debt
 type: Feature
 _start: 2023-11-27T09:00

--- a/.github/ISSUE_TEMPLATE/upgrade.md
+++ b/.github/ISSUE_TEMPLATE/upgrade.md
@@ -2,8 +2,8 @@
 name: Upgrade software dependencies
 about: Issue template for the bi-weekly upgrade of Azul's software dependencies
 title: Upgrade software dependencies
-labels: orange,operator,infra,debt
-type: Feature
+labels: -,orange,operator,infra,debt
+type: Chore
 _start: 2023-11-27T09:00
 _period: 14 days
 ---

--- a/.github/ISSUE_TEMPLATE/vpn_certificate_renewals.md
+++ b/.github/ISSUE_TEMPLATE/vpn_certificate_renewals.md
@@ -9,7 +9,7 @@ _period: 3 months
 ---
 
 - [ ] Deploy `tempdev.gitlab`
-- [ ] Assign this ticket to the system administrator
+- [ ] Assign this issue to the system administrator
 - [ ] Renew server certificate on `tempdev`
 - [ ] Renew client certificates on `tempdev`
 - [ ] Hibernate `tempdev`

--- a/.github/ISSUE_TEMPLATE/vpn_certificate_renewals.md
+++ b/.github/ISSUE_TEMPLATE/vpn_certificate_renewals.md
@@ -1,6 +1,6 @@
 ---
 name: Renew server and client VPN certificates 
-about: Issue template for the quarterly renewals of VPN certificates
+about: Issue template for the quarterly renewal of all VPN certificates
 title: Renew VPN server and client certificates 
 labels: -,infra,orange
 type: Task

--- a/.github/ISSUE_TEMPLATE/vpn_certificate_renewals.md
+++ b/.github/ISSUE_TEMPLATE/vpn_certificate_renewals.md
@@ -3,7 +3,7 @@ name: Renew server and client VPN certificates
 about: Issue template for the quarterly renewal of all VPN certificates
 title: Renew VPN server and client certificates 
 labels: -,infra,orange
-type: Task
+type: Chore
 _start: 2025-08-01T09:00
 _period: 3 months
 ---

--- a/.github/ISSUE_TEMPLATE/web_app_vulnerability_scan.md
+++ b/.github/ISSUE_TEMPLATE/web_app_vulnerability_scan.md
@@ -1,6 +1,6 @@
 ---
-name: Run the web app vulnerability scans
-about: Issue template for the monthly scanning and triaging of web app vulnerabilities
+name: Monthly web app vulnerability scans
+about: Issue template for the monthly scanning and triaging of web application vulnerabilities
 title: Monthly web app vulnerability scans
 labels: +,compliance,infra,no demo,orange
 type: Task

--- a/.github/ISSUE_TEMPLATE/web_app_vulnerability_scan.md
+++ b/.github/ISSUE_TEMPLATE/web_app_vulnerability_scan.md
@@ -2,8 +2,8 @@
 name: Monthly web app vulnerability scans
 about: Issue template for the monthly scanning and triaging of web application vulnerabilities
 title: Monthly web app vulnerability scans
-labels: +,compliance,infra,no demo,orange
-type: Task
+labels: -,compliance,infra,no demo,orange
+type: Chore
 _repository: DataBiosphere/azul-private
 _start: 2025-06-01T09:00
 _period: 1 month

--- a/.github/PULL_REQUEST_TEMPLATE/anvilprod-hotfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/anvilprod-hotfix.md
@@ -32,6 +32,10 @@ Linked issue: #0000
 - [ ] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile`, `Dockerfile` or `environment.boot`</sub>
 - [ ] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
 - [ ] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
+- [ ] PR is not a draft
+- [ ] PR is awaiting requested review from system administrator
+- [ ] Status of PR is *Review requested*
+- [ ] PR is assigned to only the system administrator
 
 
 ### System administrator (after approval)
@@ -40,7 +44,7 @@ Linked issue: #0000
 - [ ] Decided if PR can be labeled `no sandbox`
 - [ ] A comment to this PR details the completed security design review
 - [ ] PR title is appropriate as title of merge commit
-- [ ] Moved linked issue to *Approved*
+- [ ] Status of PR is *Approved*
 - [ ] PR is assigned to only the operator
 
 
@@ -57,8 +61,8 @@ Linked issue: #0000
 - [ ] The title of the merge commit starts with the title of this PR
 - [ ] Added PR # reference to merge commit title
 - [ ] Collected commit title tags in merge commit title <sub>but excluded any `p` tags</sub>
-- [ ] Moved linked issue to *Merged stable*
 - [ ] Pushed merge commit to GitHub
+- [ ] Status of PR is *Merged stable*
 
 
 ### Operator (after pushing the merge commit)
@@ -68,6 +72,7 @@ Linked issue: #0000
 - [ ] Reviewed build logs for anomalies on GitLab `anvilprod`
 - [ ] Deleted PR branch from GitHub
 - [ ] Deleted PR branch from GitLab `anvilprod`
+- [ ] Status of linked issue is *Stable*
 
 
 ### Operator (reindex)

--- a/.github/PULL_REQUEST_TEMPLATE/anvilprod-hotfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/anvilprod-hotfix.md
@@ -2,7 +2,7 @@
 This is the PR template for hotfix PRs against `anvilprod`.
 -->
 
-Connected issue: #0000
+Linked issue: #0000
 
 
 ## Checklist
@@ -12,10 +12,10 @@ Connected issue: #0000
 
 - [ ] Target branch is `anvilprod`
 - [ ] Name of PR branch matches `hotfixes/<GitHub handle of author>/<issue#>-<slug>-anvilprod`
-- [ ] On ZenHub, PR is connected to the issue it hotfixes
+- [ ] PR is linked to the issue it hotfixes
 - [ ] PR description links to connected issue
-- [ ] PR title is `Hotfix anvilprod: ` followed by title of connected issue
-- [ ] PR title references the connected issue
+- [ ] PR title is `Hotfix anvilprod: ` followed by title of linked issue
+- [ ] PR title references the linked issue
 
 
 ### Author (hotfixes)
@@ -40,7 +40,7 @@ Connected issue: #0000
 - [ ] Decided if PR can be labeled `no sandbox`
 - [ ] A comment to this PR details the completed security design review
 - [ ] PR title is appropriate as title of merge commit
-- [ ] Moved connected issue to *Approved* column
+- [ ] Moved linked issue to *Approved* column
 - [ ] PR is assigned to only the operator
 
 
@@ -57,7 +57,7 @@ Connected issue: #0000
 - [ ] The title of the merge commit starts with the title of this PR
 - [ ] Added PR # reference to merge commit title
 - [ ] Collected commit title tags in merge commit title <sub>but excluded any `p` tags</sub>
-- [ ] Moved connected issue to *Merged stable* column in ZenHub
+- [ ] Moved linked issue to *Merged stable* column in ZenHub
 - [ ] Pushed merge commit to GitHub
 
 

--- a/.github/PULL_REQUEST_TEMPLATE/anvilprod-hotfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/anvilprod-hotfix.md
@@ -29,7 +29,7 @@ Connected issue: #0000
 ### Author (before every review)
 
 - [ ] Rebased PR branch on `anvilprod`, squashed fixups from prior reviews
-- [ ] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
+- [ ] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile`, `Dockerfile` or `environment.boot`</sub>
 - [ ] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
 - [ ] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
 

--- a/.github/PULL_REQUEST_TEMPLATE/anvilprod-hotfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/anvilprod-hotfix.md
@@ -40,7 +40,7 @@ Linked issue: #0000
 - [ ] Decided if PR can be labeled `no sandbox`
 - [ ] A comment to this PR details the completed security design review
 - [ ] PR title is appropriate as title of merge commit
-- [ ] Moved linked issue to *Approved* column
+- [ ] Moved linked issue to *Approved*
 - [ ] PR is assigned to only the operator
 
 
@@ -57,7 +57,7 @@ Linked issue: #0000
 - [ ] The title of the merge commit starts with the title of this PR
 - [ ] Added PR # reference to merge commit title
 - [ ] Collected commit title tags in merge commit title <sub>but excluded any `p` tags</sub>
-- [ ] Moved linked issue to *Merged stable* column in ZenHub
+- [ ] Moved linked issue to *Merged stable*
 - [ ] Pushed merge commit to GitHub
 
 

--- a/.github/PULL_REQUEST_TEMPLATE/anvilprod-promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/anvilprod-promotion.md
@@ -36,13 +36,17 @@ Linked issue: #0000
 ### Author (before every review)
 
 - [ ] PR branch is up to date (if not, merge `anvilprod` into PR branch to integrate upstream changes)
+- [ ] PR is not a draft
+- [ ] PR is awaiting requested review from system administrator
+- [ ] Status of PR is *Review requested*
+- [ ] PR is assigned to only the system administrator
 
 
 ### System administrator (after approval)
 
 - [ ] Actually approved the PR
 - [ ] Decided if PR can be labeled `no sandbox`
-- [ ] Moved linked issue to *Approved*
+- [ ] Status of PR is *Approved*
 - [ ] PR is assigned to only the operator
 
 
@@ -74,6 +78,7 @@ Linked issue: #0000
 - [ ] Added PR # reference to merge commit title
 - [ ] Collected commit title tags in merge commit title <sub>but excluded any `p` tags</sub>
 - [ ] Pushed merge commit to GitHub
+- [ ] Status of PR is *Merged stable*
 
 
 ### Operator (after pushing the merge commit)
@@ -84,9 +89,14 @@ Linked issue: #0000
 - [ ] Ran `_select anvilprod.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
 - [ ] Deleted PR branch from GitHub
 - [ ] Deleted PR branch from GitLab `anvilprod`
-- [ ] Moved linked issue to *Merged stable*
-- [ ] Moved promoted issues in status *Merged lower* to *Merged stable*
-- [ ] Moved promoted issues in status *Lower* to *Stable*
+- [ ] Status of linked issue is *Stable*
+- [ ] Status of promoted<sup>1</sup> PRs is *Merged stable*
+- [ ] Status of promoted<sup>1</sup> issues is *Stable*
+
+<sup>1</sup> Promoted issues and PRs are referenced in the titles of the commits
+that the promotion branch introduces to the stable branch. Prior to the
+promotion, the status of promoted issues (PRs) is *Lower* (*Merged lower*).
+Promoted PRs in status *Done* do not need to be moved.
 
 
 ### Operator (reindex)

--- a/.github/PULL_REQUEST_TEMPLATE/anvilprod-promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/anvilprod-promotion.md
@@ -2,7 +2,7 @@
 This is the PR template for a promotion PR against `anvilprod`.
 -->
 
-Connected issue: #0000
+Linked issue: #0000
 
 
 ## Checklist
@@ -12,12 +12,11 @@ Connected issue: #0000
 
 - [ ] Target branch is `anvilprod`
 - [ ] Name of PR branch matches `promotions/yyyy-mm-dd-anvilprod`
-- [ ] On ZenHub, PR is connected to the promotion issue it resolves
+- [ ] PR is linked to the promotion issue it resolves
 - [ ] PR description links to connected issue
-- [ ] Title of connected issue matches `Promotion yyyy-mm-dd`
-- [ ] PR title starts with title of connected issue followed by ` anvilprod`
-- [ ] PR title references the connected issue
-- [ ] The promoted issues are part of the same sprint as the connected issue
+- [ ] Title of linked issue matches `Promotion yyyy-mm-dd`
+- [ ] PR title starts with title of linked issue followed by ` anvilprod`
+- [ ] PR title references the linked issue
 
 
 ### Author (reindex, API changes)
@@ -43,7 +42,7 @@ Connected issue: #0000
 
 - [ ] Actually approved the PR
 - [ ] Decided if PR can be labeled `no sandbox`
-- [ ] Moved connected issue to *Approved* column
+- [ ] Moved linked issue to *Approved* column
 - [ ] PR is assigned to only the operator
 
 
@@ -85,7 +84,7 @@ Connected issue: #0000
 - [ ] Ran `_select anvilprod.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
 - [ ] Deleted PR branch from GitHub
 - [ ] Deleted PR branch from GitLab `anvilprod`
-- [ ] Moved connected issue to *Merged stable* column on ZenHub
+- [ ] Moved linked issue to *Merged stable* column on ZenHub
 - [ ] Moved promoted issues from *Merged lower* to *Merged stable* column on ZenHub
 - [ ] Moved promoted issues from *Lower* to *Stable* column on ZenHub
 

--- a/.github/PULL_REQUEST_TEMPLATE/anvilprod-promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/anvilprod-promotion.md
@@ -19,7 +19,7 @@ Linked issue: #0000
 - [ ] PR title references the linked issue
 
 
-### Author (reindex, API changes)
+### Author (reindex)
 
 - [ ] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
 - [ ] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `anvilprod` <sub>or requires a full reindex or is not labeled`reindex:anvilprod`</sub>

--- a/.github/PULL_REQUEST_TEMPLATE/anvilprod-promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/anvilprod-promotion.md
@@ -42,7 +42,7 @@ Linked issue: #0000
 
 - [ ] Actually approved the PR
 - [ ] Decided if PR can be labeled `no sandbox`
-- [ ] Moved linked issue to *Approved* column
+- [ ] Moved linked issue to *Approved*
 - [ ] PR is assigned to only the operator
 
 
@@ -84,9 +84,9 @@ Linked issue: #0000
 - [ ] Ran `_select anvilprod.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
 - [ ] Deleted PR branch from GitHub
 - [ ] Deleted PR branch from GitLab `anvilprod`
-- [ ] Moved linked issue to *Merged stable* column on ZenHub
-- [ ] Moved promoted issues from *Merged lower* to *Merged stable* column on ZenHub
-- [ ] Moved promoted issues from *Lower* to *Stable* column on ZenHub
+- [ ] Moved linked issue to *Merged stable*
+- [ ] Moved promoted issues in status *Merged lower* to *Merged stable*
+- [ ] Moved promoted issues in status *Lower* to *Stable*
 
 
 ### Operator (reindex)

--- a/.github/PULL_REQUEST_TEMPLATE/backport.md
+++ b/.github/PULL_REQUEST_TEMPLATE/backport.md
@@ -18,7 +18,7 @@ This is the PR template for backport PRs against `develop`.
 ### Author (before every review)
 
 - [ ] PR branch is up to date (if not, merge `develop` into PR branch to integrate upstream changes)
-- [ ] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
+- [ ] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile`, `Dockerfile` or `environment.boot`</sub>
 - [ ] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
 - [ ] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
 

--- a/.github/PULL_REQUEST_TEMPLATE/backport.md
+++ b/.github/PULL_REQUEST_TEMPLATE/backport.md
@@ -28,7 +28,7 @@ This is the PR template for backport PRs against `develop`.
 - [ ] Actually approved the PR
 - [ ] Decided if PR can be labeled `no sandbox`
 - [ ] PR title is appropriate as title of merge commit
-- [ ] Moved linked issue to *Approved* column
+- [ ] Moved linked issue to *Approved*
 - [ ] PR is assigned to only the operator
 
 

--- a/.github/PULL_REQUEST_TEMPLATE/backport.md
+++ b/.github/PULL_REQUEST_TEMPLATE/backport.md
@@ -28,7 +28,7 @@ This is the PR template for backport PRs against `develop`.
 - [ ] Actually approved the PR
 - [ ] Decided if PR can be labeled `no sandbox`
 - [ ] PR title is appropriate as title of merge commit
-- [ ] Moved connected issue to *Approved* column
+- [ ] Moved linked issue to *Approved* column
 - [ ] PR is assigned to only the operator
 
 

--- a/.github/PULL_REQUEST_TEMPLATE/backport.md
+++ b/.github/PULL_REQUEST_TEMPLATE/backport.md
@@ -21,6 +21,10 @@ This is the PR template for backport PRs against `develop`.
 - [ ] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile`, `Dockerfile` or `environment.boot`</sub>
 - [ ] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
 - [ ] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
+- [ ] PR is not a draft
+- [ ] PR is awaiting requested review from system administrator
+- [ ] Status of PR is *Review requested*
+- [ ] PR is assigned to only the system administrator
 
 
 ### System administrator (after approval)
@@ -28,7 +32,7 @@ This is the PR template for backport PRs against `develop`.
 - [ ] Actually approved the PR
 - [ ] Decided if PR can be labeled `no sandbox`
 - [ ] PR title is appropriate as title of merge commit
-- [ ] Moved linked issue to *Approved*
+- [ ] Status of PR is *Approved*
 - [ ] PR is assigned to only the operator
 
 
@@ -48,6 +52,7 @@ This is the PR template for backport PRs against `develop`.
 - [ ] Added PR # reference (to this PR) to merge commit title
 - [ ] Collected commit title tags in merge commit title <sub>but excluded any `p` tags</sub>
 - [ ] Pushed merge commit to GitHub
+- [ ] Status of PR is *Merged lower*
 
 
 ### Operator (after pushing the merge commit)
@@ -61,6 +66,7 @@ This is the PR template for backport PRs against `develop`.
 - [ ] Deleted PR branch from GitHub
 - [ ] Deleted PR branch from GitLab `dev`
 - [ ] Deleted PR branch from GitLab `anvildev`
+- [ ] Status of linked issue is *Lower*
 
 
 ### Operator

--- a/.github/PULL_REQUEST_TEMPLATE/prod-hotfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/prod-hotfix.md
@@ -40,7 +40,7 @@ Linked issue: #0000
 - [ ] Labeled PR as `no sandbox`
 - [ ] A comment to this PR details the completed security design review
 - [ ] PR title is appropriate as title of merge commit
-- [ ] Moved linked issue to *Approved* column
+- [ ] Moved linked issue to *Approved*
 - [ ] PR is assigned to only the operator
 
 
@@ -53,7 +53,7 @@ Linked issue: #0000
 - [ ] The title of the merge commit starts with the title of this PR
 - [ ] Added PR # reference to merge commit title
 - [ ] Collected commit title tags in merge commit title <sub>but excluded any `p` tags</sub>
-- [ ] Moved linked issue to *Merged stable* column in ZenHub
+- [ ] Moved linked issue to *Merged stable*
 - [ ] Pushed merge commit to GitHub
 
 

--- a/.github/PULL_REQUEST_TEMPLATE/prod-hotfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/prod-hotfix.md
@@ -29,7 +29,7 @@ Connected issue: #0000
 ### Author (before every review)
 
 - [ ] Rebased PR branch on `prod`, squashed fixups from prior reviews
-- [ ] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
+- [ ] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile`, `Dockerfile` or `environment.boot`</sub>
 - [ ] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
 - [ ] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
 

--- a/.github/PULL_REQUEST_TEMPLATE/prod-hotfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/prod-hotfix.md
@@ -32,6 +32,10 @@ Linked issue: #0000
 - [ ] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile`, `Dockerfile` or `environment.boot`</sub>
 - [ ] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
 - [ ] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
+- [ ] PR is not a draft
+- [ ] PR is awaiting requested review from system administrator
+- [ ] Status of PR is *Review requested*
+- [ ] PR is assigned to only the system administrator
 
 
 ### System administrator (after approval)
@@ -40,7 +44,7 @@ Linked issue: #0000
 - [ ] Labeled PR as `no sandbox`
 - [ ] A comment to this PR details the completed security design review
 - [ ] PR title is appropriate as title of merge commit
-- [ ] Moved linked issue to *Approved*
+- [ ] Status of PR is *Approved*
 - [ ] PR is assigned to only the operator
 
 
@@ -53,8 +57,8 @@ Linked issue: #0000
 - [ ] The title of the merge commit starts with the title of this PR
 - [ ] Added PR # reference to merge commit title
 - [ ] Collected commit title tags in merge commit title <sub>but excluded any `p` tags</sub>
-- [ ] Moved linked issue to *Merged stable*
 - [ ] Pushed merge commit to GitHub
+- [ ] Status of PR is *Merged stable*
 
 
 ### Operator (after pushing the merge commit)
@@ -63,6 +67,7 @@ Linked issue: #0000
 - [ ] Build passes on GitLab `prod`
 - [ ] Reviewed build logs for anomalies on GitLab `prod`
 - [ ] Deleted PR branch from GitHub
+- [ ] Status of linked issue is *Stable*
 
 
 ### Operator (reindex)

--- a/.github/PULL_REQUEST_TEMPLATE/prod-hotfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/prod-hotfix.md
@@ -2,7 +2,7 @@
 This is the PR template for hotfix PRs against `prod`.
 -->
 
-Connected issue: #0000
+Linked issue: #0000
 
 
 ## Checklist
@@ -12,10 +12,10 @@ Connected issue: #0000
 
 - [ ] Target branch is `prod`
 - [ ] Name of PR branch matches `hotfixes/<GitHub handle of author>/<issue#>-<slug>-prod`
-- [ ] On ZenHub, PR is connected to the issue it hotfixes
+- [ ] PR is linked to the issue it hotfixes
 - [ ] PR description links to connected issue
-- [ ] PR title is `Hotfix prod: ` followed by title of connected issue
-- [ ] PR title references the connected issue
+- [ ] PR title is `Hotfix prod: ` followed by title of linked issue
+- [ ] PR title references the linked issue
 
 
 ### Author (hotfixes)
@@ -40,7 +40,7 @@ Connected issue: #0000
 - [ ] Labeled PR as `no sandbox`
 - [ ] A comment to this PR details the completed security design review
 - [ ] PR title is appropriate as title of merge commit
-- [ ] Moved connected issue to *Approved* column
+- [ ] Moved linked issue to *Approved* column
 - [ ] PR is assigned to only the operator
 
 
@@ -53,7 +53,7 @@ Connected issue: #0000
 - [ ] The title of the merge commit starts with the title of this PR
 - [ ] Added PR # reference to merge commit title
 - [ ] Collected commit title tags in merge commit title <sub>but excluded any `p` tags</sub>
-- [ ] Moved connected issue to *Merged stable* column in ZenHub
+- [ ] Moved linked issue to *Merged stable* column in ZenHub
 - [ ] Pushed merge commit to GitHub
 
 

--- a/.github/PULL_REQUEST_TEMPLATE/prod-promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/prod-promotion.md
@@ -2,7 +2,7 @@
 This is the PR template for a promotion PR against `prod`.
 -->
 
-Connected issue: #0000
+Linked issue: #0000
 
 
 ## Checklist
@@ -12,12 +12,11 @@ Connected issue: #0000
 
 - [ ] Target branch is `prod`
 - [ ] Name of PR branch matches `promotions/yyyy-mm-dd-prod`
-- [ ] On ZenHub, PR is connected to the promotion issue it resolves
+- [ ] PR is linked to the promotion issue it resolves
 - [ ] PR description links to connected issue
-- [ ] Title of connected issue matches `Promotion yyyy-mm-dd`
-- [ ] PR title starts with title of connected issue followed by ` prod`
-- [ ] PR title references the connected issue
-- [ ] The promoted issues are part of the same sprint as the connected issue
+- [ ] Title of linked issue matches `Promotion yyyy-mm-dd`
+- [ ] PR title starts with title of linked issue followed by ` prod`
+- [ ] PR title references the linked issue
 
 
 ### Author (reindex, API changes)
@@ -43,7 +42,7 @@ Connected issue: #0000
 
 - [ ] Actually approved the PR
 - [ ] Labeled PR as `no sandbox`
-- [ ] Moved connected issue to *Approved* column
+- [ ] Moved linked issue to *Approved* column
 - [ ] PR is assigned to only the operator
 
 
@@ -80,7 +79,7 @@ Connected issue: #0000
 - [ ] Reviewed build logs for anomalies on GitLab `prod`
 - [ ] Ran `_select prod.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
 - [ ] Deleted PR branch from GitHub
-- [ ] Moved connected issue to *Merged stable* column on ZenHub
+- [ ] Moved linked issue to *Merged stable* column on ZenHub
 - [ ] Moved promoted issues from *Merged lower* to *Merged stable* column on ZenHub
 - [ ] Moved promoted issues from *Lower* to *Stable* column on ZenHub
 

--- a/.github/PULL_REQUEST_TEMPLATE/prod-promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/prod-promotion.md
@@ -19,7 +19,7 @@ Linked issue: #0000
 - [ ] PR title references the linked issue
 
 
-### Author (reindex, API changes)
+### Author (reindex)
 
 - [ ] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
 - [ ] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `prod` <sub>or requires a full reindex or is not labeled`reindex:prod`</sub>

--- a/.github/PULL_REQUEST_TEMPLATE/prod-promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/prod-promotion.md
@@ -42,7 +42,7 @@ Linked issue: #0000
 
 - [ ] Actually approved the PR
 - [ ] Labeled PR as `no sandbox`
-- [ ] Moved linked issue to *Approved* column
+- [ ] Moved linked issue to *Approved*
 - [ ] PR is assigned to only the operator
 
 
@@ -79,9 +79,9 @@ Linked issue: #0000
 - [ ] Reviewed build logs for anomalies on GitLab `prod`
 - [ ] Ran `_select prod.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
 - [ ] Deleted PR branch from GitHub
-- [ ] Moved linked issue to *Merged stable* column on ZenHub
-- [ ] Moved promoted issues from *Merged lower* to *Merged stable* column on ZenHub
-- [ ] Moved promoted issues from *Lower* to *Stable* column on ZenHub
+- [ ] Moved linked issue to *Merged stable*
+- [ ] Moved promoted issues in status *Merged lower* to *Merged stable*
+- [ ] Moved promoted issues in status *Lower* to *Stable*
 
 
 ### Operator (reindex)

--- a/.github/PULL_REQUEST_TEMPLATE/prod-promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/prod-promotion.md
@@ -36,13 +36,17 @@ Linked issue: #0000
 ### Author (before every review)
 
 - [ ] PR branch is up to date (if not, merge `prod` into PR branch to integrate upstream changes)
+- [ ] PR is not a draft
+- [ ] PR is awaiting requested review from system administrator
+- [ ] Status of PR is *Review requested*
+- [ ] PR is assigned to only the system administrator
 
 
 ### System administrator (after approval)
 
 - [ ] Actually approved the PR
 - [ ] Labeled PR as `no sandbox`
-- [ ] Moved linked issue to *Approved*
+- [ ] Status of PR is *Approved*
 - [ ] PR is assigned to only the operator
 
 
@@ -70,6 +74,7 @@ Linked issue: #0000
 - [ ] Added PR # reference to merge commit title
 - [ ] Collected commit title tags in merge commit title <sub>but excluded any `p` tags</sub>
 - [ ] Pushed merge commit to GitHub
+- [ ] Status of PR is *Merged stable*
 
 
 ### Operator (after pushing the merge commit)
@@ -79,9 +84,14 @@ Linked issue: #0000
 - [ ] Reviewed build logs for anomalies on GitLab `prod`
 - [ ] Ran `_select prod.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
 - [ ] Deleted PR branch from GitHub
-- [ ] Moved linked issue to *Merged stable*
-- [ ] Moved promoted issues in status *Merged lower* to *Merged stable*
-- [ ] Moved promoted issues in status *Lower* to *Stable*
+- [ ] Status of linked issue is *Stable*
+- [ ] Status of promoted<sup>1</sup> PRs is *Merged stable*
+- [ ] Status of promoted<sup>1</sup> issues is *Stable*
+
+<sup>1</sup> Promoted issues and PRs are referenced in the titles of the commits
+that the promotion branch introduces to the stable branch. Prior to the
+promotion, the status of promoted issues (PRs) is *Lower* (*Merged lower*).
+Promoted PRs in status *Done* do not need to be moved.
 
 
 ### Operator (reindex)

--- a/.github/PULL_REQUEST_TEMPLATE/upgrade.md
+++ b/.github/PULL_REQUEST_TEMPLATE/upgrade.md
@@ -32,7 +32,7 @@ Connected issue: #0000
 ### Author (before every review)
 
 - [ ] Rebased PR branch on `develop`, squashed fixups from prior reviews
-- [ ] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
+- [ ] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile`, `Dockerfile` or `environment.boot`</sub>
 - [ ] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
 - [ ] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
 - [ ] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>

--- a/.github/PULL_REQUEST_TEMPLATE/upgrade.md
+++ b/.github/PULL_REQUEST_TEMPLATE/upgrade.md
@@ -44,7 +44,7 @@ Linked issue: #0000
 - [ ] Labeled linked issue as `no demo`
 - [ ] A comment to this PR details the completed security design review
 - [ ] PR title is appropriate as title of merge commit
-- [ ] Moved linked issue to *Approved* column
+- [ ] Moved linked issue to *Approved*
 - [ ] PR is assigned to only the operator
 
 
@@ -85,7 +85,7 @@ Linked issue: #0000
 - [ ] The title of the merge commit starts with the title of this PR
 - [ ] Added PR # reference to merge commit title
 - [ ] Collected commit title tags in merge commit title <sub>but excluded any `p` tags</sub>
-- [ ] Moved linked issue to *Merged lower* column in ZenHub
+- [ ] Moved linked issue to *Merged lower*
 - [ ] Moved blocked issues to *Triage* <sub>or no issues are blocked on the linked issue</sub>
 - [ ] Closed related Dependabot PRs with a comment referencing the corresponding commit in this PR <sub>or this PR does not include any such commits</sub>
 - [ ] Pushed merge commit to GitHub

--- a/.github/PULL_REQUEST_TEMPLATE/upgrade.md
+++ b/.github/PULL_REQUEST_TEMPLATE/upgrade.md
@@ -36,6 +36,10 @@ Linked issue: #0000
 - [ ] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
 - [ ] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
 - [ ] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
+- [ ] PR is not a draft
+- [ ] PR is awaiting requested review from system administrator
+- [ ] Status of PR is *Review requested*
+- [ ] PR is assigned to only the system administrator
 
 
 ### System administrator (after approval)
@@ -44,7 +48,7 @@ Linked issue: #0000
 - [ ] Labeled linked issue as `no demo`
 - [ ] A comment to this PR details the completed security design review
 - [ ] PR title is appropriate as title of merge commit
-- [ ] Moved linked issue to *Approved*
+- [ ] Status of PR is *Approved*
 - [ ] PR is assigned to only the operator
 
 
@@ -85,10 +89,10 @@ Linked issue: #0000
 - [ ] The title of the merge commit starts with the title of this PR
 - [ ] Added PR # reference to merge commit title
 - [ ] Collected commit title tags in merge commit title <sub>but excluded any `p` tags</sub>
-- [ ] Moved linked issue to *Merged lower*
-- [ ] Moved blocked issues to *Triage* <sub>or no issues are blocked on the linked issue</sub>
 - [ ] Closed related Dependabot PRs with a comment referencing the corresponding commit in this PR <sub>or this PR does not include any such commits</sub>
 - [ ] Pushed merge commit to GitHub
+- [ ] Status of PR is *Merged lower*
+- [ ] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issue</sub>
 
 
 ### Operator (after pushing the merge commit)
@@ -104,6 +108,7 @@ Linked issue: #0000
 - [ ] Deleted PR branch from GitHub
 - [ ] Deleted PR branch from GitLab `dev`
 - [ ] Deleted PR branch from GitLab `anvildev`
+- [ ] Status of linked issue is *Lower*
 
 
 ### Operator

--- a/.github/PULL_REQUEST_TEMPLATE/upgrade.md
+++ b/.github/PULL_REQUEST_TEMPLATE/upgrade.md
@@ -2,7 +2,7 @@
 This is the PR template for upgrading Azul dependencies.
 -->
 
-Connected issue: #0000
+Linked issue: #0000
 
 
 ## Checklist
@@ -12,9 +12,9 @@ Connected issue: #0000
 
 - [ ] Target branch is `develop`
 - [ ] Name of PR branch matches `upgrades/yyyy-mm-dd`
-- [ ] On ZenHub, PR is connected to the upgrade issue it resolves
+- [ ] PR is linked to the upgrade issue it resolves
 - [ ] PR title matches `Upgrade dependencies yyyy-mm-dd`
-- [ ] PR title references the connected issue
+- [ ] PR title references the linked issue
 
 
 ### Author (upgrading deployments)
@@ -41,10 +41,10 @@ Connected issue: #0000
 ### System administrator (after approval)
 
 - [ ] Actually approved the PR
-- [ ] Labeled connected issue as `no demo`
+- [ ] Labeled linked issue as `no demo`
 - [ ] A comment to this PR details the completed security design review
 - [ ] PR title is appropriate as title of merge commit
-- [ ] Moved connected issue to *Approved* column
+- [ ] Moved linked issue to *Approved* column
 - [ ] PR is assigned to only the operator
 
 
@@ -85,8 +85,8 @@ Connected issue: #0000
 - [ ] The title of the merge commit starts with the title of this PR
 - [ ] Added PR # reference to merge commit title
 - [ ] Collected commit title tags in merge commit title <sub>but excluded any `p` tags</sub>
-- [ ] Moved connected issue to *Merged lower* column in ZenHub
-- [ ] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issue</sub>
+- [ ] Moved linked issue to *Merged lower* column in ZenHub
+- [ ] Moved blocked issues to *Triage* <sub>or no issues are blocked on the linked issue</sub>
 - [ ] Closed related Dependabot PRs with a comment referencing the corresponding commit in this PR <sub>or this PR does not include any such commits</sub>
 - [ ] Pushed merge commit to GitHub
 
@@ -109,7 +109,7 @@ Connected issue: #0000
 ### Operator
 
 - [ ] At least 24 hours have passed since `anvildev.shared` was last deployed
-- [ ] Ran `scripts/export_inspector_findings.py` against `anvildev`, imported results to [Google Sheet](https://docs.google.com/spreadsheets/d/1RWF7g5wRKWPGovLw4jpJGX_XMi8aWLXLOvvE5rxqgH8) and posted screenshot of relevant<sup>1</sup> findings as a comment on the connected issue.
+- [ ] Ran `scripts/export_inspector_findings.py` against `anvildev`, imported results to [Google Sheet](https://docs.google.com/spreadsheets/d/1RWF7g5wRKWPGovLw4jpJGX_XMi8aWLXLOvvE5rxqgH8) and posted screenshot of relevant<sup>1</sup> findings as a comment on the linked issue.
 - [ ] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner` and `backup:gitlab` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
 - [ ] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner` and `backup:gitlab` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
 - [ ] PR is assigned to only the system administrator

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -41,7 +41,7 @@ title is `Fix: ` followed by the issue title
 - [ ] This PR is labeled `chained` <sub>or is not chained to another PR</sub>
 
 
-### Author (reindex, API changes)
+### Author (reindex)
 
 - [ ] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
 - [ ] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
@@ -49,6 +49,10 @@ title is `Fix: ` followed by the issue title
 - [ ] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
 - [ ] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
 - [ ] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
+
+
+### Author (API changes)
+
 - [ ] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
 - [ ] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
 - [ ] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -84,7 +84,7 @@ title is `Fix: ` followed by the issue title
 
 - [ ] Actually approved the PR
 - [ ] PR is not a draft
-- [ ] Issue is in *Review requested* column
+- [ ] Issue is in *Review requested*
 - [ ] PR is awaiting requested review from system administrator
 - [ ] PR is assigned to only the system administrator
 
@@ -98,7 +98,7 @@ title is `Fix: ` followed by the issue title
 - [ ] A comment to this PR details the completed security design review
 - [ ] PR title is appropriate as title of merge commit
 - [ ] `N reviews` label is accurate
-- [ ] Moved linked issues to *Approved* column
+- [ ] Moved linked issues to *Approved*
 - [ ] PR is assigned to only the operator
 
 
@@ -145,7 +145,7 @@ title is `Fix: ` followed by the issue title
 - [ ] The title of the merge commit starts with the title of this PR
 - [ ] Added PR # reference to merge commit title
 - [ ] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
-- [ ] Moved linked issues to *Merged lower* column in ZenHub
+- [ ] Moved linked issues to *Merged lower*
 - [ ] Moved blocked issues to *Triage* <sub>or no issues are blocked on the linked issues</sub>
 - [ ] Pushed merge commit to GitHub
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -84,7 +84,7 @@ title is `Fix: ` followed by the issue title
 
 - [ ] Actually approved the PR
 - [ ] PR is not a draft
-- [ ] Ticket is in *Review requested* column
+- [ ] Issue is in *Review requested* column
 - [ ] PR is awaiting requested review from system administrator
 - [ ] PR is assigned to only the system administrator
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -74,7 +74,7 @@ title is `Fix: ` followed by the issue title
 ### Author (before every review)
 
 - [ ] Rebased PR branch on `develop`, squashed fixups from prior reviews
-- [ ] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`</sub>
+- [ ] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile`, `Dockerfile` or `environment.boot`</sub>
 - [ ] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
 - [ ] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
 - [ ] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -78,14 +78,17 @@ title is `Fix: ` followed by the issue title
 - [ ] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
 - [ ] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
 - [ ] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
+- [ ] PR is awaiting requested review from a peer
+- [ ] Status of PR is *Review requested*
+- [ ] PR is assigned to only the peer
 
 
 ### Peer reviewer (after approval)
 
 - [ ] Actually approved the PR
 - [ ] PR is not a draft
-- [ ] Issue is in *Review requested*
 - [ ] PR is awaiting requested review from system administrator
+- [ ] Status of PR is *Review requested*
 - [ ] PR is assigned to only the system administrator
 
 
@@ -98,7 +101,7 @@ title is `Fix: ` followed by the issue title
 - [ ] A comment to this PR details the completed security design review
 - [ ] PR title is appropriate as title of merge commit
 - [ ] `N reviews` label is accurate
-- [ ] Moved linked issues to *Approved*
+- [ ] Status of PR is *Approved*
 - [ ] PR is assigned to only the operator
 
 
@@ -145,9 +148,9 @@ title is `Fix: ` followed by the issue title
 - [ ] The title of the merge commit starts with the title of this PR
 - [ ] Added PR # reference to merge commit title
 - [ ] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
-- [ ] Moved linked issues to *Merged lower*
-- [ ] Moved blocked issues to *Triage* <sub>or no issues are blocked on the linked issues</sub>
 - [ ] Pushed merge commit to GitHub
+- [ ] Status of PR is *Merged lower*
+- [ ] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>
 
 
 ### Operator (chain shortening)
@@ -171,6 +174,7 @@ title is `Fix: ` followed by the issue title
 - [ ] Deleted PR branch from GitHub
 - [ ] Deleted PR branch from GitLab `dev`
 - [ ] Deleted PR branch from GitLab `anvildev`
+- [ ] Status of linked issues is *Lower*
 
 
 ### Operator (reindex)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
 template.
 -->
 
-Connected issues: #0000
+Linked issues: #0000
 
 
 ## Checklist
@@ -17,11 +17,11 @@ Connected issues: #0000
 - [ ] PR is a draft
 - [ ] Target branch is `develop`
 - [ ] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
-- [ ] On ZenHub, PR is connected to all issues it (partially) resolves
+- [ ] PR is linked to all issues it (partially) resolves
 - [ ] PR description links to connected issues
-- [ ] PR title matches<sup>1</sup> that of a connected issue <sub>or comment in PR explains why they're different</sub>
-- [ ] PR title references all connected issues
-- [ ] For each connected issue, there is at least one commit whose title references that issue
+- [ ] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
+- [ ] PR title references all linked issues
+- [ ] For each linked issue, there is at least one commit whose title references that issue
 
 <sup>1</sup> when the issue title describes a problem, the corresponding PR
 title is `Fix: ` followed by the issue title
@@ -30,8 +30,8 @@ title is `Fix: ` followed by the issue title
 ### Author (partiality)
 
 - [ ] Added `p` tag to titles of partial commits
-- [ ] This PR is labeled `partial` <sub>or completely resolves all connected issues</sub>
-- [ ] This PR partially resolves each of the connected issues <sub>or does not have the `partial` label</sub>
+- [ ] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
+- [ ] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>
 
 
 ### Author (chains)
@@ -49,7 +49,7 @@ title is `Fix: ` followed by the issue title
 - [ ] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
 - [ ] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
 - [ ] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>
-- [ ] This PR and its connected issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
+- [ ] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
 - [ ] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
 - [ ] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>
 
@@ -68,7 +68,7 @@ title is `Fix: ` followed by the issue title
 ### Author (hotfixes)
 
 - [ ] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
-- [ ] Reverted the temporary hotfixes for any connected issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues connected to this PR</sub>
+- [ ] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>
 
 
 ### Author (before every review)
@@ -92,20 +92,20 @@ title is `Fix: ` followed by the issue title
 ### System administrator (after approval)
 
 - [ ] Actually approved the PR
-- [ ] Labeled connected issues as `demo` or `no demo`
-- [ ] Commented on connected issues about demo expectations <sub>or all connected issues are labeled `no demo`</sub>
+- [ ] Labeled linked issues as `demo` or `no demo`
+- [ ] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
 - [ ] Decided if PR can be labeled `no sandbox`
 - [ ] A comment to this PR details the completed security design review
 - [ ] PR title is appropriate as title of merge commit
 - [ ] `N reviews` label is accurate
-- [ ] Moved connected issues to *Approved* column
+- [ ] Moved linked issues to *Approved* column
 - [ ] PR is assigned to only the operator
 
 
 ### Operator (before pushing merge the commit)
 
 - [ ] Checked `reindex:…` labels and `r` commit title tag
-- [ ] Checked that demo expectations are clear <sub>or all connected issues are labeled `no demo`</sub>
+- [ ] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
 - [ ] Squashed PR branch and rebased onto `develop`
 - [ ] Sanity-checked history
 - [ ] Pushed PR branch to GitHub
@@ -145,8 +145,8 @@ title is `Fix: ` followed by the issue title
 - [ ] The title of the merge commit starts with the title of this PR
 - [ ] Added PR # reference to merge commit title
 - [ ] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
-- [ ] Moved connected issues to *Merged lower* column in ZenHub
-- [ ] Moved blocked issues to *Triage* <sub>or no issues are blocked on the connected issues</sub>
+- [ ] Moved linked issues to *Merged lower* column in ZenHub
+- [ ] Moved blocked issues to *Triage* <sub>or no issues are blocked on the linked issues</sub>
 - [ ] Pushed merge commit to GitHub
 
 

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -624,7 +624,7 @@ def emit(t: T, target_branch: str):
                 },
                 {
                     'type': 'cli',
-                    'content': 'Ticket is in *Review requested* column'
+                    'content': 'Issue is in *Review requested* column'
                 },
                 {
                     'type': 'cli',

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -548,7 +548,9 @@ def emit(t: T, target_branch: str):
                                    join_grammatically(list(map(bq, T.promotion.target_branches))) +
                                    ') have temporary hotfixes for any of the issues linked to this PR'
                         }
-                    ] if t is T.default else [
+                    ]
+                    if t is T.default else
+                    [
                         {
                             'type': 'cli',
                             'content': 'Added `h` tag to commit title',
@@ -568,8 +570,10 @@ def emit(t: T, target_branch: str):
                             'content': 'This PR is labeled `partial`',
                             'alt': 'or represents a permanent hotfix'
                         },
-                    ] if t is T.hotfix else [
-                    ]),
+                    ]
+                    if t is T.hotfix else
+                    []
+                ),
             ]),
             {
                 'type': 'h2',

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -292,8 +292,7 @@ def emit(t: T, target_branch: str):
             },
             iif(t is not T.backport, {
                 'type': 'p',
-                'content': f'Connected {t.issues}: #0000'
-
+                'content': f'Linked {t.issues}: #0000'
             }),
             {
                 'type': 'h1',
@@ -324,10 +323,10 @@ def emit(t: T, target_branch: str):
             iif(t is not t.backport, {
                 'type': 'cli',
                 'content': {
-                    T.default: 'On ZenHub, PR is connected to all issues it (partially) resolves',
-                    T.upgrade: 'On ZenHub, PR is connected to the upgrade issue it resolves',
-                    T.hotfix: 'On ZenHub, PR is connected to the issue it hotfixes',
-                    T.promotion: 'On ZenHub, PR is connected to the promotion issue it resolves',
+                    T.default: 'PR is linked to all issues it (partially) resolves',
+                    T.upgrade: 'PR is linked to the upgrade issue it resolves',
+                    T.hotfix: 'PR is linked to the issue it hotfixes',
+                    T.promotion: 'PR is linked to the promotion issue it resolves',
                     T.backport: None
                 }[t]
             }),
@@ -337,16 +336,16 @@ def emit(t: T, target_branch: str):
             }),
             iif(t is T.promotion, {
                 'type': 'cli',
-                'content': 'Title of connected issue matches `Promotion yyyy-mm-dd`'
+                'content': 'Title of linked issue matches `Promotion yyyy-mm-dd`'
             }),
             {
                 'type': 'cli',
                 'content': {
-                    t.default: 'PR title matches<footnote title/> that of a connected issue',
-                    t.promotion: f'PR title starts with title of connected issue '
+                    t.default: 'PR title matches<footnote title/> that of a linked issue',
+                    t.promotion: f'PR title starts with title of linked issue '
                                  f'followed by ` {target_branch}`',
                     t.hotfix: f'PR title is `Hotfix {target_branch}: ` '
-                              f'followed by title of connected issue',
+                              f'followed by title of linked issue',
                     t.upgrade: 'PR title matches `Upgrade dependencies yyyy-mm-dd`',
                     t.backport: 'PR title contains the 7-digit SHA1 of the backported commits'
                 }[t],
@@ -354,7 +353,7 @@ def emit(t: T, target_branch: str):
             },
             iif(t is not T.backport, {
                 'type': 'cli',
-                'content': f'PR title references {t.issues('all', 'the')} connected {t.issues}'
+                'content': f'PR title references {t.issues('all', 'the')} linked {t.issues}'
             }),
             *(
                 [
@@ -373,7 +372,7 @@ def emit(t: T, target_branch: str):
             *iif(t is T.default, [
                 {
                     'type': 'cli',
-                    'content': 'For each connected issue, there is at least one commit whose title '
+                    'content': 'For each linked issue, there is at least one commit whose title '
                                'references that issue'
                 },
                 {
@@ -392,11 +391,11 @@ def emit(t: T, target_branch: str):
                 {
                     'type': 'cli',
                     'content': 'This PR is labeled `partial`',
-                    'alt': 'or completely resolves all connected issues'
+                    'alt': 'or completely resolves all linked issues'
                 },
                 {
                     'type': 'cli',
-                    'content': 'This PR partially resolves each of the connected issues',
+                    'content': 'This PR partially resolves each of the linked issues',
                     'alt': 'or does not have the `partial` label'
                 }
             ]),
@@ -462,7 +461,7 @@ def emit(t: T, target_branch: str):
                 *iif(t is T.default, [
                     {
                         'type': 'cli',
-                        'content': 'This PR and its connected issues are labeled `API`',
+                        'content': 'This PR and its linked issues are labeled `API`',
                         'alt': 'or this PR does not modify a REST API'
                     },
                     {
@@ -540,10 +539,10 @@ def emit(t: T, target_branch: str):
                         },
                         {
                             'type': 'cli',
-                            'content': 'Reverted the temporary hotfixes for any connected issues',
+                            'content': 'Reverted the temporary hotfixes for any linked issues',
                             'alt': 'or the none of the stable branches (' +
                                    join_grammatically(list(map(bq, T.promotion.target_branches))) +
-                                   ') have temporary hotfixes for any of the issues connected to this PR'
+                                   ') have temporary hotfixes for any of the issues linked to this PR'
                         }
                     ] if t is T.default else [
                         {
@@ -640,16 +639,16 @@ def emit(t: T, target_branch: str):
             },
             iif(t is T.default, {
                 'type': 'cli',
-                'content': 'Labeled connected issues as `demo` or `no demo`'
+                'content': 'Labeled linked issues as `demo` or `no demo`'
             }),
             iif(t is T.upgrade, {
                 'type': 'cli',
-                'content': 'Labeled connected issue as `no demo`'
+                'content': 'Labeled linked issue as `no demo`'
             }),
             iif(t is T.default, {
                 'type': 'cli',
-                'content': 'Commented on connected issues about demo expectations',
-                'alt': 'or all connected issues are labeled `no demo`'
+                'content': 'Commented on linked issues about demo expectations',
+                'alt': 'or all linked issues are labeled `no demo`'
             }),
             iif(t is not T.upgrade, {
                 'type': 'cli',
@@ -673,7 +672,7 @@ def emit(t: T, target_branch: str):
             }),
             {
                 'type': 'cli',
-                'content': f'Moved connected {t.issues} to *Approved* column'
+                'content': f'Moved linked {t.issues} to *Approved* column'
             },
             {
                 'type': 'cli',
@@ -691,7 +690,7 @@ def emit(t: T, target_branch: str):
                 {
                     'type': 'cli',
                     'content': 'Checked that demo expectations are clear',
-                    'alt': 'or all connected issues are labeled `no demo`'
+                    'alt': 'or all linked issues are labeled `no demo`'
                 }
             ]),
             iif(t not in (T.promotion, T.backport), {
@@ -854,13 +853,13 @@ def emit(t: T, target_branch: str):
             iif(t in (T.default, T.upgrade, T.hotfix), {
                 'type': 'cli',
                 'content': iif(t is t.hotfix,
-                               'Moved connected issue to *Merged stable* column in ZenHub',
-                               f'Moved connected {t.issues} to *Merged lower* column in ZenHub')
+                               'Moved linked issue to *Merged stable* column in ZenHub',
+                               f'Moved linked {t.issues} to *Merged lower* column in ZenHub')
             }),
             iif(target_branch == 'develop' and t is not T.backport, {
                 'type': 'cli',
                 'content': 'Moved blocked issues to *Triage*',
-                'alt': f'or no issues are blocked on the connected {t.issues}'
+                'alt': f'or no issues are blocked on the linked {t.issues}'
             }),
             iif(t is T.upgrade,
                 {
@@ -943,7 +942,7 @@ def emit(t: T, target_branch: str):
             *iif(t is T.promotion, [
                 {
                     'type': 'cli',
-                    'content': 'Moved connected issue to *Merged stable* column on ZenHub'
+                    'content': 'Moved linked issue to *Merged stable* column on ZenHub'
                 },
                 {
                     'type': 'cli',
@@ -1068,7 +1067,7 @@ def emit(t: T, target_branch: str):
                     'content': 'Ran `scripts/export_inspector_findings.py` against `anvildev`, imported results '
                                'to [Google Sheet](https://docs.google.com/spreadsheets/d/'
                                '1RWF7g5wRKWPGovLw4jpJGX_XMi8aWLXLOvvE5rxqgH8) and posted screenshot of '
-                               'relevant<footnote relevant/> findings as a comment on the connected issue.'
+                               'relevant<footnote relevant/> findings as a comment on the linked issue.'
                 }
             ]),
             *iif(target_branch == 'develop' and t is not T.backport, [

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -605,6 +605,18 @@ def emit(t: T, target_branch: str):
             ]),
             *iif(t is T.default, [
                 {
+                    'type': 'cli',
+                    'content': 'PR is awaiting requested review from a peer'
+                },
+                {
+                    'type': 'cli',
+                    'content': 'Status of PR is *Review requested*'
+                },
+                {
+                    'type': 'cli',
+                    'content': 'PR is assigned to only the peer'
+                },
+                {
                     'type': 'h2',
                     'content': 'Peer reviewer (after approval)'
                 },
@@ -612,23 +624,23 @@ def emit(t: T, target_branch: str):
                     'type': 'cli',
                     'content': 'Actually approved the PR'
                 },
-                {
-                    'type': 'cli',
-                    'content': 'PR is not a draft'
-                },
-                {
-                    'type': 'cli',
-                    'content': 'Issue is in *Review requested*'
-                },
-                {
-                    'type': 'cli',
-                    'content': 'PR is awaiting requested review from system administrator'
-                },
-                {
-                    'type': 'cli',
-                    'content': 'PR is assigned to only the system administrator'
-                }
             ]),
+            {
+                'type': 'cli',
+                'content': 'PR is not a draft'
+            },
+            {
+                'type': 'cli',
+                'content': 'PR is awaiting requested review from system administrator'
+            },
+            {
+                'type': 'cli',
+                'content': 'Status of PR is *Review requested*'
+            },
+            {
+                'type': 'cli',
+                'content': 'PR is assigned to only the system administrator'
+            },
             {
                 'type': 'h2',
                 'content': 'System administrator (after approval)'
@@ -672,7 +684,7 @@ def emit(t: T, target_branch: str):
             }),
             {
                 'type': 'cli',
-                'content': f'Moved linked {t.issues} to *Approved*'
+                'content': 'Status of PR is *Approved*'
             },
             {
                 'type': 'cli',
@@ -850,17 +862,6 @@ def emit(t: T, target_branch: str):
                            'but only included `p` if the PR is also labeled `partial`',
                            'but excluded any `p` tags')
             },
-            iif(t in (T.default, T.upgrade, T.hotfix), {
-                'type': 'cli',
-                'content': iif(t is t.hotfix,
-                               'Moved linked issue to *Merged stable*',
-                               f'Moved linked {t.issues} to *Merged lower*')
-            }),
-            iif(target_branch == 'develop' and t is not T.backport, {
-                'type': 'cli',
-                'content': 'Moved blocked issues to *Triage*',
-                'alt': f'or no issues are blocked on the linked {t.issues}'
-            }),
             iif(t is T.upgrade,
                 {
                     'type': 'cli',
@@ -873,6 +874,16 @@ def emit(t: T, target_branch: str):
                 'type': 'cli',
                 'content': 'Pushed merge commit to GitHub'
             },
+            {
+                'type': 'cli',
+                'content': f'Status of PR is '
+                           f'*Merged {'lower' if target_branch == 'develop' else 'stable'}*'
+            },
+            iif(target_branch == 'develop' and t is not T.backport, {
+                'type': 'cli',
+                'content': 'Status of blocked issues is *Triage*',
+                'alt': f'or no issues are blocked on the linked {t.issues}'
+            }),
             *iif(t is T.default, [
                 {
                     'type': 'h2',
@@ -939,20 +950,38 @@ def emit(t: T, target_branch: str):
                 for d, s in t.target_deployments(target_branch).items()
                 if s is not None
             ),
-            *iif(t is T.promotion, [
-                {
-                    'type': 'cli',
-                    'content': 'Moved linked issue to *Merged stable*'
-                },
-                {
-                    'type': 'cli',
-                    'content': 'Moved promoted issues in status *Merged lower* to *Merged stable*'
-                },
-                {
-                    'type': 'cli',
-                    'content': 'Moved promoted issues in status *Lower* to *Stable*'
-                }
-            ]),
+            *(
+                [
+                    {
+                        'type': 'cli',
+                        'content': f'Status of linked {t.issues} is '
+                                   f'*{'Lower' if target_branch == 'develop' else 'Stable'}*'
+                    }
+                ]
+                if t is not T.promotion else
+                [
+                    {
+                        'type': 'cli',
+                        'content': 'Status of linked issue is *Stable*'
+                    },
+                    {
+                        'type': 'cli',
+                        'content': 'Status of promoted<footnote promoted/> PRs is *Merged stable*'
+                    },
+                    {
+                        'type': 'cli',
+                        'content': 'Status of promoted<footnote promoted/> issues is *Stable*'
+                    },
+                    {
+                        'type': 'p',
+                        'content': '<footnote promoted/> Promoted issues and PRs are referenced in '
+                                   'the titles of the commits that the promotion branch introduces to '
+                                   'the stable branch. Prior to the promotion, the status of promoted '
+                                   'issues (PRs) is *Lower* (*Merged lower*). Promoted PRs in status '
+                                   '*Done* do not need to be moved.'
+                    }
+                ]
+            ),
             *iif(t in (T.default, T.hotfix, T.promotion), [
                 {
                     'type': 'h2',

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -423,7 +423,7 @@ def emit(t: T, target_branch: str):
             *iif(t in (T.default, T.promotion), [
                 {
                     'type': 'h2',
-                    'content': 'Author (reindex, API changes)'
+                    'content': 'Author (reindex)'
                 },
                 iif(t is T.default, {
                     'type': 'cli',
@@ -459,6 +459,10 @@ def emit(t: T, target_branch: str):
                     )
                 },
                 *iif(t is T.default, [
+                    {
+                        'type': 'h2',
+                        'content': 'Author (API changes)'
+                    },
                     {
                         'type': 'cli',
                         'content': 'This PR and its linked issues are labeled `API`',

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -618,7 +618,7 @@ def emit(t: T, target_branch: str):
                 },
                 {
                     'type': 'cli',
-                    'content': 'Issue is in *Review requested* column'
+                    'content': 'Issue is in *Review requested*'
                 },
                 {
                     'type': 'cli',
@@ -672,7 +672,7 @@ def emit(t: T, target_branch: str):
             }),
             {
                 'type': 'cli',
-                'content': f'Moved linked {t.issues} to *Approved* column'
+                'content': f'Moved linked {t.issues} to *Approved*'
             },
             {
                 'type': 'cli',
@@ -853,8 +853,8 @@ def emit(t: T, target_branch: str):
             iif(t in (T.default, T.upgrade, T.hotfix), {
                 'type': 'cli',
                 'content': iif(t is t.hotfix,
-                               'Moved linked issue to *Merged stable* column in ZenHub',
-                               f'Moved linked {t.issues} to *Merged lower* column in ZenHub')
+                               'Moved linked issue to *Merged stable*',
+                               f'Moved linked {t.issues} to *Merged lower*')
             }),
             iif(target_branch == 'develop' and t is not T.backport, {
                 'type': 'cli',
@@ -942,15 +942,15 @@ def emit(t: T, target_branch: str):
             *iif(t is T.promotion, [
                 {
                     'type': 'cli',
-                    'content': 'Moved linked issue to *Merged stable* column on ZenHub'
+                    'content': 'Moved linked issue to *Merged stable*'
                 },
                 {
                     'type': 'cli',
-                    'content': 'Moved promoted issues from *Merged lower* to *Merged stable* column on ZenHub'
+                    'content': 'Moved promoted issues in status *Merged lower* to *Merged stable*'
                 },
                 {
                     'type': 'cli',
-                    'content': 'Moved promoted issues from *Lower* to *Stable* column on ZenHub'
+                    'content': 'Moved promoted issues in status *Lower* to *Stable*'
                 }
             ]),
             *iif(t in (T.default, T.hotfix, T.promotion), [

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -588,7 +588,7 @@ def emit(t: T, target_branch: str):
                                ),
                                f'Rebased PR branch on `{target_branch}`, squashed fixups from prior reviews')
             },
-            *iif(t is not T.promotion, [
+            *iif(target_branch == 'develop' or t is T.hotfix, [
                 {
                     'type': 'cli',
                     'content': 'Ran `make requirements_update`',
@@ -605,7 +605,7 @@ def emit(t: T, target_branch: str):
                     'content': 'This PR is labeled `reqs`',
                     'alt': 'or does not modify `requirements*.txt`'
                 },
-                iif(t in (T.default, T.upgrade), {
+                iif(t not in (T.backport, T.hotfix), {
                     'type': 'cli',
                     'content': '`make integration_test` passes in personal deployment',
                     'alt': 'or this PR does not modify functionality that could affect the IT outcome'

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -590,7 +590,8 @@ def emit(t: T, target_branch: str):
                 {
                     'type': 'cli',
                     'content': 'Ran `make requirements_update`',
-                    'alt': 'or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile` and `Dockerfile`'
+                    'alt': 'or this PR does not modify `requirements*.txt`, '
+                           '`common.mk`, `Makefile`, `Dockerfile` or `environment.boot`'
                 },
                 {
                     'type': 'cli',

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -356,11 +356,6 @@ def emit(t: T, target_branch: str):
                 'type': 'cli',
                 'content': f'PR title references {t.issues('all', 'the')} connected {t.issues}'
             }),
-            iif(t is T.promotion, {
-                'type': 'cli',
-                'content': 'The promoted issues are part of the same sprint as the connected '
-                           'issue'
-            }),
             *(
                 [
                     {

--- a/scripts/zenhub_to_github.py
+++ b/scripts/zenhub_to_github.py
@@ -80,7 +80,7 @@ class Main:
         'Epics': 'Backlog',
         'Parked': 'Parked',
         'Debt': 'Backlog',
-        'Compliance controls': 'Backlog',  # add label
+        'Compliance controls': 'Backlog',
         'Compliance': 'Backlog',
         'Backlog': 'Backlog',
         'Up next': 'Up next',

--- a/scripts/zenhub_to_github.py
+++ b/scripts/zenhub_to_github.py
@@ -248,7 +248,8 @@ class Main:
                 zh_blockees = {}
                 for blockee in nodes(zh_issue, 'blockedIssues'):
                     if json_str(blockee['ghNodeId']).startswith('PR_'):
-                        log.warning('GitHub cannot block PRs on issues, ignoring blockee %s')
+                        log.warning('GitHub cannot block PRs on issues. '
+                                    'Ignoring blockee %s', blockee['htmlUrl'])
                     elif any(json_str(blockee['htmlUrl']).startswith(repo) for repo in self.archived_repos):
                         log.warning('GitHub cannot block issues in archived repositories. '
                                     'Ignoring blockee %s', blockee['htmlUrl'])

--- a/scripts/zenhub_to_github.py
+++ b/scripts/zenhub_to_github.py
@@ -66,6 +66,9 @@ log = logging.getLogger(__name__)
 class Main:
     owner = 'DataBiosphere'
 
+    #: Only issues with this label will be migrated
+    label = 'orange'
+
     project_title = 'Azul'
 
     status_field_name = 'Status'
@@ -405,7 +408,7 @@ class Main:
         while True:
             response = self._zenhub(self._body(
                 container_id=container_id,
-                label='orange',
+                label=self.label,
                 cursor=cursor,
                 query=query
             ))


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->


Linked issues: #7391, #7437, #6779


## Checklist


### Author

- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [ ] ~PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>~
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (chains)

- [x] This PR is blocked by previous PR in the chain <sub>or is not chained to another PR</sub>
- [x] The blocking PR is labeled `base` <sub>or this PR is not chained to another PR</sub>
- [x] This PR is labeled `chained` <sub>or is not chained to another PR</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile`, `Dockerfile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer


### Peer reviewer (after approval)

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub
- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (before pushing merge the commit)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (chain shortening)

- [x] Changed the target branch of the blocked PR to `develop` <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `chained` label from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the blocking relationship from the blocked PR <sub>or this PR is not labeled `base`</sub>
- [x] Removed the `base` label from this PR <sub>or this PR is not labeled `base`</sub>


### Operator (after pushing the merge commit)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
