### PR TITLE
Fix: Repeat manifest requests after failed generation raise InvalidGeneration (DataBiosphere/azul-private#212)

### DIFF
--- a/lambdas/service/app.py
+++ b/lambdas/service/app.py
@@ -483,21 +483,17 @@ def oauth2_redirect():
                     body=html)
 
 
-def validate_repository_search(entity_type: EntityType,
-                               params: Mapping[str, str],
-                               **validators):
-    validate_params(params, **{
-        'catalog': validate_catalog,
-        'filters': validate_filters,
-        'order': validate_order,
-        'search_after': partial(validate_json_param, 'search_after'),
-        'search_after_uid': str,
-        'search_before': partial(validate_json_param, 'search_before'),
-        'search_before_uid': str,
-        'size': partial(validate_size, entity_type),
-        'sort': validate_field,
-        **validators
-    })
+def validate_repository_search(entity_type: EntityType, params: Mapping[str, str]):
+    validate_params(params,
+                    catalog=validate_catalog,
+                    filters=validate_filters,
+                    order=validate_order,
+                    search_after=partial(validate_json_param, 'search_after'),
+                    search_after_uid=str,
+                    search_before=partial(validate_json_param, 'search_before'),
+                    search_before_uid=str,
+                    size=partial(validate_size, entity_type),
+                    sort=validate_field)
 
 
 def validate_entity_type(entity_type: str):

--- a/lambdas/service/app.py
+++ b/lambdas/service/app.py
@@ -483,19 +483,6 @@ def oauth2_redirect():
                     body=html)
 
 
-def validate_repository_search(entity_type: EntityType, params: Mapping[str, str]):
-    validate_params(params,
-                    catalog=validate_catalog,
-                    filters=validate_filters,
-                    order=validate_order,
-                    search_after=partial(validate_json_param, 'search_after'),
-                    search_after_uid=str,
-                    search_before=partial(validate_json_param, 'search_before'),
-                    search_before_uid=str,
-                    size=partial(validate_size, entity_type),
-                    sort=validate_field)
-
-
 def validate_entity_type(entity_type: str):
     entity_types = app.metadata_plugin.exposed_indices.keys()
     if entity_type not in entity_types:
@@ -990,7 +977,16 @@ def repository_search(entity_type: str, entity_id: str | None = None) -> JSON:
     request = app.current_request
     query_params = request.query_params or {}
     _hoist_parameters(query_params, request)
-    validate_repository_search(entity_type, query_params)
+    validate_params(query_params,
+                    catalog=validate_catalog,
+                    filters=validate_filters,
+                    order=validate_order,
+                    search_after=partial(validate_json_param, 'search_after'),
+                    search_after_uid=str,
+                    search_before=partial(validate_json_param, 'search_before'),
+                    search_before_uid=str,
+                    size=partial(validate_size, entity_type),
+                    sort=validate_field)
     validate_entity_type(entity_type)
     return app.repository_controller.search(catalog=app.catalog,
                                             entity_type=entity_type,

--- a/src/azul/service/__init__.py
+++ b/src/azul/service/__init__.py
@@ -1,6 +1,3 @@
-from collections.abc import (
-    Mapping,
-)
 import logging
 from typing import (
     Protocol,
@@ -44,8 +41,8 @@ type FilterRangeEnd = int | float | str
 # currently represent the mutual exclusivity of the operators. We could, as a
 # union of singleton TypeDict subclasses, but PyCharm doesn't support that.
 #
-FilterOperator = TypedDict(
-    'FilterOperator',
+FilterJSON = TypedDict(
+    'FilterJSON',
     {
         'is': list[PrimitiveJSON | FlatJSON],
         'is_not': list[PrimitiveJSON | FlatJSON],
@@ -56,7 +53,7 @@ FilterOperator = TypedDict(
     total=False
 )
 
-type FiltersJSON = Mapping[FieldName, FilterOperator]
+type FiltersJSON = dict[FieldName, FilterJSON]
 
 
 @attr.s(auto_attribs=True, kw_only=True, frozen=True)

--- a/src/azul/service/__init__.py
+++ b/src/azul/service/__init__.py
@@ -37,6 +37,7 @@ log = logging.getLogger(__name__)
 # supports serializing them by default.
 #
 type FilterRange = list[int] | list[float] | list[str]
+type FilterRangeEnd = int | float | str
 
 # `is` is a reserved keyword so we can't use the class-based syntax for
 # TypedDict, but have to use the constructor-based one instead. We don't
@@ -49,7 +50,7 @@ FilterOperator = TypedDict(
         'is': list[PrimitiveJSON | FlatJSON],
         'is_not': list[PrimitiveJSON | FlatJSON],
         'intersects': list[FilterRange],
-        'contains': list[FilterRange | int | float | str],
+        'contains': list[FilterRange | FilterRangeEnd],
         'within': list[FilterRange],
     },
     total=False

--- a/src/azul/service/__init__.py
+++ b/src/azul/service/__init__.py
@@ -1,17 +1,34 @@
+from collections import (
+    defaultdict,
+)
+from functools import (
+    partial,
+)
+from itertools import (
+    chain,
+)
+import json
 import logging
 from typing import (
     Protocol,
     Self,
     TypedDict,
+    cast,
+    get_args,
 )
 
 import attr
 from chalice import (
     ForbiddenError,
 )
+from more_itertools import (
+    one,
+    only,
+)
 
 from azul import (
     CatalogName,
+    R,
     mutable_furl,
 )
 from azul.json import (
@@ -25,6 +42,7 @@ from azul.types import (
     FlatJSON,
     JSON,
     PrimitiveJSON,
+    reify,
 )
 
 log = logging.getLogger(__name__)
@@ -54,6 +72,250 @@ FilterJSON = TypedDict(
 )
 
 type FiltersJSON = dict[FieldName, FilterJSON]
+
+_filter_operators = FilterJSON.__optional_keys__
+_simple_filter_value_types = reify(PrimitiveJSON)
+_dict_filter_value_types = reify(get_args(FlatJSON.__value__)[1])
+assert _simple_filter_value_types == _dict_filter_value_types
+_filter_range_end_types = reify(FilterRangeEnd)
+
+
+def parse_filters(raw_filters: str | None) -> FiltersJSON:
+    """
+    Deserialize, validate and normalize the given string form of the `filters`
+    request parameter. The aim of normalization is to eliminate any
+    insignificant differences so that serializing the value returned from calls
+    to this method with semantically equivalent and valid arguments yields
+    exactly the same JSON string. Two valid arguments are considered
+    semantically equivalent if they match the same subset of all possible
+    documents.
+
+    >>> parse_filters(None)
+    {}
+
+    >>> parse_filters('{}')
+    {}
+
+    >>> parse_filters('{"x":{"is":[null]}}')
+    {'x': {'is': [None]}}
+
+    Values are sorted.
+
+    >>> parse_filters('{"x":{"is":[2,1,null]}}')
+    {'x': {'is': [None, 1, 2]}}
+
+    The entries in value dictionaries are sorted by key.
+
+    >>> parse_filters('{"x":{"is":[{"b":2,"a":1}]}}')
+    {'x': {'is': [{'a': 1, 'b': 2}]}}
+
+    Value dictionaries are sorted by their values, in order of the key. If two
+    dictionaries have equal values at the first key, the value at the second key
+    is used as a tie breaker and so on.
+
+    >>> parse_filters('{"x":{"is":[{"b":2,"a":1},{"a":0,"b":3},{"b":null,"a":1}]}}')
+    {'x': {'is': [{'a': 0, 'b': 3}, {'a': 1, 'b': None}, {'a': 1, 'b': 2}]}}
+
+    Ranges are sorted by start and end value.
+
+    >>> parse_filters('{"x":{"within":[[3,4],[1,2],[1,1]]}}')
+    {'x': {'within': [[1, 1], [1, 2], [3, 4]]}}
+
+    Overall, filters are sorted by field name.
+
+    >>> parse_filters('{"y":{"within":[[1,2]]},"x":{"is":[4, 3]}}')
+    {'x': {'is': [3, 4]}, 'y': {'within': [[1, 2]]}}
+
+    >>> parse_filters('[]')
+    Traceback (most recent call last):
+        ...
+    AssertionError: R('Filters must be an object')
+
+    >>> parse_filters('{"":42}')
+    Traceback (most recent call last):
+        ...
+    AssertionError: R('Empty field name')
+
+    >>> parse_filters('{"x":42}')
+    Traceback (most recent call last):
+        ...
+    AssertionError: R('Filter must be an object', 'x')
+
+    >>> parse_filters('{"x":{}}')
+    Traceback (most recent call last):
+        ...
+    AssertionError: R('Need exactly one filter per field', 'x')
+
+    >>> parse_filters('{"x":{"is":[1],"contains":[1]}}')
+    Traceback (most recent call last):
+        ...
+    AssertionError: R('Need exactly one filter per field', 'x')
+
+    >>> parse_filters('{"x":{"foo":[2]}}')
+    Traceback (most recent call last):
+        ...
+    AssertionError: R('Invalid operator', 'x', 'foo')
+
+    >>> parse_filters('{"x":{"is":[]}}')
+    Traceback (most recent call last):
+        ...
+    AssertionError: R('Need at least one value', 'x')
+
+    >>> parse_filters('{"x":{"is":[1,1]}}')
+    Traceback (most recent call last):
+        ...
+    AssertionError: R('Duplicate values', 'x')
+
+    >>> parse_filters('{"x":{"within":[1]}}')
+    Traceback (most recent call last):
+        ...
+    AssertionError: R('Value does not match operator', 'x', <class 'int'>, 'within')
+
+    >>> parse_filters('{"x":{"is":[42,4.1]}}')
+    Traceback (most recent call last):
+        ...
+    AssertionError: R('Inconsistent value types', 'x')
+
+    >>> parse_filters('{"x":{"within":[[1]]}}')
+    Traceback (most recent call last):
+        ...
+    AssertionError: R('Range must be list of length 2', 'x')
+
+    >>> parse_filters('{"x":{"within":[[2,1]]}}')
+    Traceback (most recent call last):
+        ...
+    AssertionError: R('Range is inverted', 'x')
+
+    >>> parse_filters('{"x":{"within":[[1,2],["",""]]}}')
+    Traceback (most recent call last):
+        ...
+    AssertionError: R('Inconsistent range ends', 'x')
+
+    >>> parse_filters('{"x":{"within":[[1,1.1],[2,2.2]]}}')
+    Traceback (most recent call last):
+        ...
+    AssertionError: R('Inconsistent range ends', 'x')
+
+    >>> parse_filters('{"x":{"within":[[false,true]]}}')
+    Traceback (most recent call last):
+        ...
+    AssertionError: R('Invalid range end', 'x')
+
+    >>> parse_filters('{"x":{"within":[{}]}}')
+    Traceback (most recent call last):
+        ...
+    AssertionError: R('Value does not match operator', 'x', <class 'dict'>, 'within')
+
+    >>> parse_filters('{"x":{"within":[[1,2],[1,2]]}}')
+    Traceback (most recent call last):
+        ...
+    AssertionError: R('Duplicate ranges', 'x')
+
+    >>> parse_filters('{"x":{"is":[{}]}}')
+    Traceback (most recent call last):
+        ...
+    AssertionError: R('Empty object', 'x')
+
+    >>> parse_filters('{"x":{"is":[{"":1}]}}')
+    Traceback (most recent call last):
+        ...
+    AssertionError: R('Empty property name', 'x')
+
+    >>> parse_filters('{"x":{"is":[{"y":1},{"z":2}]}}')
+    Traceback (most recent call last):
+        ...
+    AssertionError: R('Inconsistent property names', 'x')
+
+    >>> parse_filters('{"x":{"is":[{"y":1,"z":[]}]}}')
+    Traceback (most recent call last):
+        ...
+    AssertionError: R('Invalid property value', 'x')
+
+    >>> parse_filters('{"x":{"is":[{"y":1,"z":2},{"y":"","z":3}]}}')
+    Traceback (most recent call last):
+        ...
+    AssertionError: R('Inconsistent property values', 'x')
+
+    >>> parse_filters('{"x":{"is":[{"a":1,"b":2},{"b":2,"a":1}]}}')
+    Traceback (most recent call last):
+        ...
+    AssertionError: R('Duplicate objects', 'x')
+    """
+    if raw_filters is None:
+        return {}
+    else:
+        filters = json.loads(raw_filters)
+        assert type(filters) is dict, R('Filters must be an object')
+        for field, filter in filters.items():
+            assert len(field) > 0, R('Empty field name')
+            assert type(filter) is dict, R('Filter must be an object', field)
+            assert len(filter) == 1, R('Need exactly one filter per field', field)
+            operator, values = one(filter.items())
+            assert operator in _filter_operators, R('Invalid operator', field, operator)
+            assert len(values) > 0, R('Need at least one value', field)
+            num_value_types = set(map(type, values))
+            num_value_types.discard(type(None))
+            assert len(num_value_types) < 2, R('Inconsistent value types', field)
+            value_type = only(num_value_types)
+            mismatch = R('Value does not match operator', field, value_type, operator)
+            if value_type is None:
+                assert operator in {'is'}, mismatch
+            elif value_type in _simple_filter_value_types:
+                assert operator in {'is', 'contains'}, mismatch
+                assert len(set(values)) == len(values), R('Duplicate values', field)
+            elif value_type is list:
+                assert operator in {'contains', 'within', 'intersects'}, mismatch
+                for range in values:
+                    assert len(range) == 2, R('Range must be list of length 2', field)
+                    assert range[0] <= range[1], R('Range is inverted', field)
+                assert len(set(map(tuple, values))) == len(values), R('Duplicate ranges', field)
+                end_types = set(chain.from_iterable(map(partial(map, type), values)))
+                assert len(end_types) == 1, R('Inconsistent range ends', field)
+                end_type = one(end_types)
+                assert end_type in _filter_range_end_types, R('Invalid range end', field)
+            elif value_type is dict:
+                assert operator == 'is', mismatch
+                key_sets = set(map(frozenset, map(dict.keys, values)))
+                assert len(key_sets) == 1, R('Inconsistent property names', field)
+                keys = one(key_sets)
+                assert len(keys) > 0, R('Empty object', field)
+                assert '' not in keys, R('Empty property name', field)
+                value_types_by_key = defaultdict(set)
+                for value in values:
+                    for k, v in value.items():
+                        assert type(v) in _dict_filter_value_types, R('Invalid property value', field)
+                        if v is not None:
+                            value_types_by_key[k].add(type(v))
+                num_value_types = set(map(len, value_types_by_key.values()))
+                assert num_value_types == {1}, R('Inconsistent property values', field)
+                # Sort each value dictionary in place by key (and value, but key
+                # is already unique). This makes sorting the values and checking
+                # their uniqueness easier.
+                for value in values:
+                    sorted_value = dict(sorted(value.items()))
+                    value.clear()
+                    value.update(sorted_value)
+                unique_values = set(map(tuple, map(dict.items, values)))
+                assert len(unique_values) == len(values), R('Duplicate objects', field)
+            else:
+                assert False, R('Invalid value', field)
+
+            def key(v):
+                if v is None:
+                    return False, v
+                elif type(v) is dict:
+                    # The entries in the dict are alteady sorted by key, the
+                    # values are primitive so we just need to handle None values
+                    # and "freeze" the iterable of entries.
+                    return True, tuple((k, key(v)) for k, v in v.items())
+                else:
+                    return True, v
+
+            values.sort(key=key)
+
+        filters = {k: v for k, v in sorted(filters.items())}
+
+        return cast(FiltersJSON, filters)
 
 
 @attr.s(auto_attribs=True, kw_only=True, frozen=True)

--- a/src/azul/service/__init__.py
+++ b/src/azul/service/__init__.py
@@ -1,6 +1,5 @@
 from collections.abc import (
     Mapping,
-    Sequence,
 )
 import logging
 from typing import (
@@ -32,10 +31,11 @@ from azul.types import (
 
 log = logging.getLogger(__name__)
 
-# We can't express that these are actually pairs. We could, using tuples, but
-# those are not JSON, generally speaking, even though the `json` module supports
-# serializing them by default.
-FilterRange = Sequence[int] | Sequence[float] | Sequence[str]
+# We can't express that these are actually pairs, i.e. lists of length 2. We
+# could, using tuples, but those are not JSON, even though the `json` module
+# supports serializing them by default.
+#
+FilterRange = list[int] | list[float] | list[str]
 
 # `is` is a reserved keyword so we can't use the class-based syntax for
 # TypedDict, but have to use the constructor-based one instead. We don't
@@ -47,9 +47,9 @@ FilterOperator = TypedDict(
     {
         'is': list[PrimitiveJSON | FlatJSON],
         'is_not': list[PrimitiveJSON | FlatJSON],
-        'intersects': Sequence[FilterRange],
-        'contains': Sequence[FilterRange | int | float | str],
-        'within': Sequence[FilterRange],
+        'intersects': list[FilterRange],
+        'contains': list[FilterRange | int | float | str],
+        'within': list[FilterRange],
     },
     total=False
 )

--- a/src/azul/service/__init__.py
+++ b/src/azul/service/__init__.py
@@ -21,6 +21,7 @@ from azul.json import (
     copy_json,
 )
 from azul.plugins import (
+    FieldName,
     MetadataPlugin,
 )
 from azul.types import (
@@ -54,7 +55,7 @@ FilterOperator = TypedDict(
     total=False
 )
 
-FiltersJSON = Mapping[str, FilterOperator]
+FiltersJSON = Mapping[FieldName, FilterOperator]
 
 
 @attr.s(auto_attribs=True, kw_only=True, frozen=True)

--- a/src/azul/service/__init__.py
+++ b/src/azul/service/__init__.py
@@ -36,7 +36,7 @@ log = logging.getLogger(__name__)
 # could, using tuples, but those are not JSON, even though the `json` module
 # supports serializing them by default.
 #
-FilterRange = list[int] | list[float] | list[str]
+type FilterRange = list[int] | list[float] | list[str]
 
 # `is` is a reserved keyword so we can't use the class-based syntax for
 # TypedDict, but have to use the constructor-based one instead. We don't
@@ -55,7 +55,7 @@ FilterOperator = TypedDict(
     total=False
 )
 
-FiltersJSON = Mapping[FieldName, FilterOperator]
+type FiltersJSON = Mapping[FieldName, FilterOperator]
 
 
 @attr.s(auto_attribs=True, kw_only=True, frozen=True)

--- a/src/azul/service/app_controller.py
+++ b/src/azul/service/app_controller.py
@@ -1,4 +1,3 @@
-import json
 from typing import (
     Any,
     Callable,
@@ -8,6 +7,7 @@ from typing import (
 import attr
 from chalice import (
     BadRequestError as BRE,
+    BadRequestError,
     NotFoundError,
 )
 
@@ -22,6 +22,7 @@ from azul.chalice import (
 from azul.service import (
     FileUrlFunc,
     FiltersJSON,
+    parse_filters,
 )
 from azul.strings import (
     pluralize,
@@ -33,14 +34,13 @@ class ServiceAppController(AppController):
     file_url_func: FileUrlFunc
 
     def _parse_filters(self, filters: str | None) -> FiltersJSON:
-        """
-        Parses a string with Azul filters in JSON syntax. Handles default cases
-        where filters are None or '{}'.
-        """
-        if filters is None:
-            return {}
-        else:
-            return json.loads(filters)
+        try:
+            return parse_filters(filters)
+        except AssertionError as e:
+            if R.caused(e):
+                raise R.propagate(e, BadRequestError)
+            else:
+                raise
 
 
 def validate_catalog(catalog):

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -110,10 +110,6 @@ from azul.indexer.field import (
 from azul.json import (
     copy_json,
 )
-from azul.json_freeze import (
-    freeze,
-    sort_frozen,
-)
 from azul.plugins import (
     ColumnMapping,
     DocumentSlice,
@@ -984,7 +980,9 @@ class ManifestGenerator(metaclass=ABCMeta):
         different return values.
         """
         git_commit = config.lambda_git_status['commit']
-        filter_string = repr(sort_frozen(freeze(self.filters.explicit)))
+        # The explicit filters are already normalized so we don't to do anything
+        # special to desensitize the hash to insignificat differences
+        filter_string = json.dumps(self.filters.explicit)
         content_hash = str(self.manifest_content_hash)
         catalog = self.catalog
         format = self.format()

--- a/test/service/test_filters.py
+++ b/test/service/test_filters.py
@@ -13,7 +13,7 @@ from azul.plugins import (
     SpecialFields,
 )
 from azul.service import (
-    FilterOperator,
+    FilterJSON,
     Filters,
     FiltersJSON,
 )
@@ -66,7 +66,7 @@ class TestFilterReification(AzulTestCase):
         return filters.reify(plugin=self.plugin, limit_access=limit_access)
 
     def _test_filters(self,
-                      expected_source_id_filter: Optional[FilterOperator],
+                      expected_source_id_filter: Optional[FilterJSON],
                       *,
                       limit_access: bool,
                       explicit_sources: Optional[list[str]] = None,

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -923,11 +923,11 @@ class TestManifests(DCP1ManifestTestCase):
                     # a pair of deterministically derived v5 UUIDs.
                     (
                         {'project': {'is': ['Single of human pancreas', 'Mouse Melanoma']}},
-                        'hca-manifest-20d97863-d8cf-54f3-8575-0f9593d3d7ef.4bc67e84-4873-591f-b524-a5fe4ec215eb'
+                        'hca-manifest-89bc9973-de91-5fc4-9c6a-8c1f547d45c6.4bc67e84-4873-591f-b524-a5fe4ec215eb'
                     ),
                     (
                         {},
-                        'hca-manifest-c3cf398e-1927-5aae-ba2a-81d8d1800b2d.4bc67e84-4873-591f-b524-a5fe4ec215eb'
+                        'hca-manifest-832a257c-5540-567b-bcb6-260d2e374508.4bc67e84-4873-591f-b524-a5fe4ec215eb'
                     )
                 ]:
                     with self.subTest(filters=filters, format=format):

--- a/test/service/test_manifest_async.py
+++ b/test/service/test_manifest_async.py
@@ -36,8 +36,8 @@ import requests
 from app_test_case import (
     LocalAppTestCase,
 )
-from azul.collections import (
-    deep_dict_merge,
+from azul.json import (
+    copy_json,
 )
 from azul.logging import (
     configure_test_logging,
@@ -214,7 +214,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
         for format, fetch in product([ManifestFormat.compact, ManifestFormat.curl],
                                      [True, False]):
             with self.subTest(format=format, fetch=fetch):
-                filters = {'organ': {'is': ['lymph node']}, 'fileFormat': {'is': ['txt']}}
+                filters = {'fileFormat': {'is': ['txt']}, 'organ': {'is': ['heart', 'lung']}}
                 filters = Filters(explicit=filters, source_ids={self.source.id})
                 params = {
                     'catalog': self.catalog,
@@ -471,7 +471,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                         sign_manifest_key.return_value = signed_manifest_key
                     equivalent_url = initial_url.copy()
                     equivalent_filters = json.loads(equivalent_url.args['filters'])
-                    equivalent_filters = dict(reversed(equivalent_filters.items()))
+                    equivalent_filters['organ']['is'].reverse()
                     equivalent_url.args['filters'] = json.dumps(equivalent_filters)
                     url = self._request('PUT', equivalent_url, expect=302)
                     self.assertEqual(final_url, url)
@@ -489,10 +489,8 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 def modified_put_after_expiration():
                     nonlocal url, state, token_url, equivalent_input
                     get_cached_manifest.side_effect = not_found
-                    equivalent_input = deep_dict_merge(
-                        {'filters': {'explicit': equivalent_filters}},
-                        input
-                    )
+                    equivalent_input = copy_json(input)
+                    equivalent_input['filters']['explicit'] = equivalent_filters
                     iterations.append(equivalent_input)
                     mock_start_generation()
                     url = self._request('PUT', equivalent_url, expect=301)

--- a/test/service/test_manifest_async.py
+++ b/test/service/test_manifest_async.py
@@ -36,9 +36,6 @@ import requests
 from app_test_case import (
     LocalAppTestCase,
 )
-from azul.json import (
-    copy_json,
-)
 from azul.logging import (
     configure_test_logging,
 )
@@ -313,7 +310,6 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 final_url: furl
                 equivalent_url: furl
                 equivalent_filters: FiltersJSON
-                equivalent_input: ManifestGenerationState
 
                 iterations: list[JSON] = []
 
@@ -475,7 +471,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     equivalent_url.args['filters'] = json.dumps(equivalent_filters)
                     url = self._request('PUT', equivalent_url, expect=302)
                     self.assertEqual(final_url, url)
-                    assert_get_cached_manifest(filters.update(equivalent_filters))
+                    assert_get_cached_manifest(filters)
 
                 modified_put()
 
@@ -487,11 +483,9 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                 #
                 @reset
                 def modified_put_after_expiration():
-                    nonlocal url, state, token_url, equivalent_input
+                    nonlocal url, state, token_url
                     get_cached_manifest.side_effect = not_found
-                    equivalent_input = copy_json(input)
-                    equivalent_input['filters']['explicit'] = equivalent_filters
-                    iterations.append(equivalent_input)
+                    iterations.append(input)
                     mock_start_generation()
                     url = self._request('PUT', equivalent_url, expect=301)
                     assert_get_cached_manifest()
@@ -499,7 +493,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     assert_get_cached_manifest()
                     assert_start_generation()
                     token_url = url
-                    state = equivalent_input
+                    state = input
 
                 modified_put_after_expiration()
                 get_token_while_running()
@@ -516,7 +510,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     state = self.app_module.generate_manifest(state, None)
                     get_cached_manifest_with_key.side_effect = not_found
                     previous_iteration = len(iterations)
-                    iterations.append(equivalent_input)
+                    iterations.append(input)
                     mock_start_generation(start=previous_iteration,
                                           describe=previous_iteration - 1)
                     url = self._request('GET', url, expect=301)
@@ -526,7 +520,7 @@ class TestManifestController(DCP1TestCase, LocalAppTestCase):
                     assert_start_generation(start=previous_iteration,
                                             describe=previous_iteration - 1)
                     token_url = url
-                    state = equivalent_input
+                    state = input
 
                 get_stale_token_when_done()
                 get_token_while_running()


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: https://github.com/DataBiosphere/azul-private/issues/212

## Checklist


### Author

- [x] PR is assigned to the author
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile`, `Dockerfile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer


### Peer reviewer (after approval)

Note that when requesting changes, the PR must be assigned back to the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
