### PR TITLE
Fix: GET request with empty JSON body causes 5xx (DataBiosphere/azul-private#289)

### DIFF
--- a/src/azul/chalice.py
+++ b/src/azul/chalice.py
@@ -467,7 +467,7 @@ class AzulChaliceApp(Chalice):
         info = json.dumps(info, cls=self._LogJSONEncoder)
         log.info('Received %s request for %r, with %s.',
                  request.context['httpMethod'], request.context['path'], info)
-        log.info(http_body_log_message('request', request.json_body))
+        log.info(http_body_log_message('request', request.raw_body))
 
     def _log_response(self, response: Response) -> None:
         info = {

--- a/src/azul/logging.py
+++ b/src/azul/logging.py
@@ -203,6 +203,8 @@ string_types = str, bytes, bytearray
 
 max_log_arg_len = 1024 * 1024
 
+empty_bodies = ('', b'', bytearray())
+
 
 def http_body_log_message(kind: Literal['request', 'response'], body: Any) -> str:
     """
@@ -218,7 +220,7 @@ def http_body_log_message(kind: Literal['request', 'response'], body: Any) -> st
     debug = azul.config.debug
     max_len = max_log_arg_len if debug > 1 else 1024
     assert debug >= 0, debug
-    if body is None:
+    if body is None or body in empty_bodies:
         return f'… without a {kind} body'
     elif isinstance(body, string_types):
         if debug == 0:

--- a/test/service/test_app_logging.py
+++ b/test/service/test_app_logging.py
@@ -65,9 +65,9 @@ class TestServiceAppLogging(DCP1CannedBundleTestCase, WebServiceTestCase):
             [None, filter_body('foo'), filter_body('foo' * int(prefix_len / 3 + 1))]
         ):
             if body_json is None:
-                body = ''
+                body = b''
             else:
-                body = json.dumps(body_json)
+                body = json.dumps(body_json).encode()
 
             with self.subTest(azul_debug=debug,
                               authenticated=authenticated,
@@ -106,6 +106,7 @@ class TestServiceAppLogging(DCP1CannedBundleTestCase, WebServiceTestCase):
                     **AzulChaliceApp.security_headers(),
                     'Cache-Control': 'no-store'
                 }
+                body_prefix = body[:prefix_len - 3] + b'...'
                 self.assertEqual(
                     [
                         (
@@ -117,17 +118,17 @@ class TestServiceAppLogging(DCP1CannedBundleTestCase, WebServiceTestCase):
                             INFO,
                             '… without a request body'
                         )
-                        if body == '' else
+                        if body == b'' else
                         (
                             INFO,
-                            "… with a request body of type (<class 'dict'>)"
+                            f"… with a request body of length {len(body)} and type <class 'bytes'>"
                         )
                         if debug == 0 else
                         (
                             INFO,
-                            f'… with a request body starting in {body[:prefix_len]}'
+                            f'… with a request body of length {len(body)} starting in {body_prefix!r}'
                             if debug == 1 and len(body) > prefix_len else
-                            f'… with a request body of length {len(body)} being {body}'
+                            f"… with a request body of length {len(body)} being {body!r}"
                         ),
                         (
                             INFO,

--- a/test/service/test_app_logging.py
+++ b/test/service/test_app_logging.py
@@ -59,33 +59,33 @@ class TestServiceAppLogging(DCP1CannedBundleTestCase, WebServiceTestCase):
         def filter_body(organ: str) -> JSON:
             return {'filters': json.dumps({'organ': {'is': [organ]}})}
 
-        for debug, authenticated, request_body_json in product(
+        for debug, authenticated, body_json in product(
             [0, 1, 2],
             [False, True],
             [None, filter_body('foo'), filter_body('foo' * int(prefix_len / 3 + 1))]
         ):
-            if request_body_json is None:
-                request_body = ''
+            if body_json is None:
+                body = ''
             else:
-                request_body = json.dumps(request_body_json)
+                body = json.dumps(body_json)
 
             with self.subTest(azul_debug=debug,
                               authenticated=authenticated,
-                              request_body=len(request_body)):
+                              body=len(body)):
                 url = self.base_url.set(path='/index/projects')
                 request_headers = {'authorization': 'Bearer foo_token'} if authenticated else {}
                 level = [INFO, DEBUG, DEBUG][debug]
                 with self.assertLogs(logger=log, level=level) as logs:
                     with patch.object(Config, 'debug', new=PropertyMock(return_value=debug)):
-                        if request_body:
+                        if body:
                             request_headers = {
-                                'content-length': str(len(request_body)),
+                                'content-length': str(len(body)),
                                 'content-type': 'application/json',
                                 **request_headers
                             }
                         response = requests.get(str(url),
                                                 headers=request_headers,
-                                                json=request_body_json)
+                                                json=body_json)
                 logs = [(r.levelno, r.getMessage()) for r in logs.records]
                 body_log_level, body_log_message = logs.pop()  # asserted separately
                 request_headers = {
@@ -117,7 +117,7 @@ class TestServiceAppLogging(DCP1CannedBundleTestCase, WebServiceTestCase):
                             INFO,
                             '… without a request body'
                         )
-                        if request_body == '' else
+                        if body == '' else
                         (
                             INFO,
                             "… with a request body of type (<class 'dict'>)"
@@ -125,9 +125,9 @@ class TestServiceAppLogging(DCP1CannedBundleTestCase, WebServiceTestCase):
                         if debug == 0 else
                         (
                             INFO,
-                            f'… with a request body starting in {request_body[:prefix_len]}'
-                            if debug == 1 and len(request_body) > prefix_len else
-                            f'… with a request body of length {len(request_body)} being {request_body}'
+                            f'… with a request body starting in {body[:prefix_len]}'
+                            if debug == 1 and len(body) > prefix_len else
+                            f'… with a request body of length {len(body)} being {body}'
                         ),
                         (
                             INFO,

--- a/test/service/test_app_logging.py
+++ b/test/service/test_app_logging.py
@@ -71,7 +71,7 @@ class TestServiceAppLogging(DCP1CannedBundleTestCase, WebServiceTestCase):
 
             with self.subTest(azul_debug=debug,
                               authenticated=authenticated,
-                              body=len(body)):
+                              body_len=len(body)):
                 url = self.base_url.set(path='/index/projects')
                 request_headers = {'authorization': 'Bearer foo_token'} if authenticated else {}
                 level = [INFO, DEBUG, DEBUG][debug]

--- a/test/test_http.py
+++ b/test/test_http.py
@@ -154,7 +154,7 @@ class TestHttp(AzulUnitTestCase):
                             [
                                 rf'^{prefix}Got 503 response after \d.\d\d\ds from GET to {url}$',
                                 rf'^{prefix}… with response headers HTTPHeaderDict\({http_header_pattern}\)$',
-                                f"^{prefix}… with a response body of length 0 being b''$",
+                                f"^{prefix}… without a response body$",
                             ]
                         )
                         if i < calls - 1:


### PR DESCRIPTION
Linked issues: DataBiosphere/azul-private#289


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to connected issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `requirements*.txt`, `common.mk`, `Makefile`, `Dockerfile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer


### Peer reviewer (after approval)

Note that when requesting changes, the PR must be assigned back to the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
