### PR TITLE
Re-enable content-type validation for all atlases except lungmap (#7244)

### DIFF
--- a/lambdas/indexer/app.py
+++ b/lambdas/indexer/app.py
@@ -6,7 +6,6 @@ from typing import (
 import chalice
 
 from azul import (
-    JSON,
     cached_property,
     config,
 )
@@ -39,6 +38,7 @@ from azul.openapi import (
     format_description as fd,
 )
 from azul.types import (
+    JSON,
     not_none,
 )
 

--- a/scripts/zenhub_to_github.py
+++ b/scripts/zenhub_to_github.py
@@ -35,7 +35,6 @@ from more_itertools import (
 )
 
 from azul import (
-    JSON,
     cached_property,
     format_description as fd,
 )
@@ -50,6 +49,7 @@ from azul.logging import (
 )
 from azul.types import (
     AnyJSON,
+    JSON,
     JSONs,
     PrimitiveJSON,
     json_bool,

--- a/src/azul/indexer/index_repository_service.py
+++ b/src/azul/indexer/index_repository_service.py
@@ -8,7 +8,6 @@ from typing import (
 
 from azul import (
     CatalogName,
-    JSON,
     cache,
 )
 from azul.indexer import (
@@ -18,6 +17,9 @@ from azul.indexer import (
 )
 from azul.plugins import (
     RepositoryPlugin,
+)
+from azul.types import (
+    JSON,
 )
 
 log = logging.getLogger(__name__)

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -19,7 +19,6 @@ from furl import (
 
 from azul import (
     CatalogName,
-    JSON,
     R,
     cached_property,
     config,
@@ -52,6 +51,9 @@ from azul.plugins import (
 from azul.service.storage_service import (
     StorageObjectNotFound,
     StorageService,
+)
+from azul.types import (
+    JSON,
 )
 
 if TYPE_CHECKING:

--- a/src/azul/plugins/metadata/hca/__init__.py
+++ b/src/azul/plugins/metadata/hca/__init__.py
@@ -10,7 +10,6 @@ from attrs import (
 )
 
 from azul import (
-    JSON,
     R,
     config,
     iif,
@@ -65,6 +64,7 @@ from azul.service.manifest_service import (
     ManifestFormat,
 )
 from azul.types import (
+    JSON,
     MutableJSON,
     json_dict,
     json_dict_of_dicts,

--- a/src/azul/plugins/metadata/hca/__init__.py
+++ b/src/azul/plugins/metadata/hca/__init__.py
@@ -10,6 +10,7 @@ from attrs import (
 )
 
 from azul import (
+    CatalogName,
     R,
     config,
     iif,
@@ -525,6 +526,7 @@ class HCAFile(File):
     @classmethod
     def from_metadata(cls,
                       *,
+                      catalog: CatalogName,
                       metadata: JSON,
                       descriptor: JSON,
                       drs_uri: str | None
@@ -539,10 +541,10 @@ class HCAFile(File):
         parameter_suffix = '; dcp-type=data'
         if content_type.endswith(parameter_suffix):
             content_type = content_type.removesuffix(parameter_suffix)
+        elif config.catalogs[catalog].atlas == 'lungmap':
+            pass
         else:
-            # FIXME: Re-enable assertion, potentially in a weakened form
-            #        https://github.com/DataBiosphere/azul/issues/7244
-            assert True or ';' not in content_type, R(
+            assert ';' not in content_type, R(
                 'Unexpected MIME parameter in content type', content_type)
         return cls(uuid=json_str(descriptor['file_id']),
                    name=json_str(json_mapping(metadata['file_core'])['file_name']),

--- a/src/azul/plugins/metadata/hca/__init__.py
+++ b/src/azul/plugins/metadata/hca/__init__.py
@@ -542,6 +542,8 @@ class HCAFile(File):
         if content_type.endswith(parameter_suffix):
             content_type = content_type.removesuffix(parameter_suffix)
         elif config.catalogs[catalog].atlas == 'lungmap':
+            # FIXME: Re-enable content-type validation for lungmap
+            #        https://github.com/DataBiosphere/azul/issues/7244
             pass
         else:
             assert ';' not in content_type, R(

--- a/src/azul/plugins/repository/canned/__init__.py
+++ b/src/azul/plugins/repository/canned/__init__.py
@@ -209,7 +209,8 @@ class Plugin(RepositoryPlugin[
         assert prefix == prefix.lower(), prefix
         staging_area = self.staging_area(source.spec.name)
         return [
-            HCAFile.from_metadata(metadata=staging_area.metadata[file_uuid].content,
+            HCAFile.from_metadata(catalog=self.catalog,
+                                  metadata=staging_area.metadata[file_uuid].content,
                                   descriptor=descriptor.content,
                                   drs_uri=None)
             for file_uuid, descriptor in staging_area.descriptors.items()

--- a/src/azul/plugins/repository/tdr_hca/__init__.py
+++ b/src/azul/plugins/repository/tdr_hca/__init__.py
@@ -279,7 +279,8 @@ class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
         bundle.metadata[str(entity)] = content
 
     def _file_from_row(self, row: BigQueryRow) -> HCAFile:
-        return HCAFile.from_metadata(metadata=json.loads(any_str(row['content'])),
+        return HCAFile.from_metadata(catalog=self.catalog,
+                                     metadata=json.loads(any_str(row['content'])),
                                      descriptor=json.loads(any_str(row['descriptor'])),
                                      drs_uri=optional(any_str, row['file_id']))
 

--- a/src/azul/schemas.py
+++ b/src/azul/schemas.py
@@ -4,7 +4,6 @@ from typing import (
 )
 
 from azul import (
-    JSON,
     format_description as fd,
     mutable_furl,
 )
@@ -15,6 +14,9 @@ from azul.openapi import (
     params,
     responses,
     schema,
+)
+from azul.types import (
+    JSON,
 )
 
 

--- a/terraform/cloudwatch_dashboard.template.json.py
+++ b/terraform/cloudwatch_dashboard.template.json.py
@@ -7,13 +7,15 @@ from more_itertools import (
 )
 
 from azul import (
-    JSON,
     R,
     config,
     iif,
 )
 from azul.deployment import (
     aws,
+)
+from azul.types import (
+    JSON,
 )
 
 es_instance_count = (

--- a/test/indexer/test_notifications.py
+++ b/test/indexer/test_notifications.py
@@ -13,14 +13,14 @@ import requests
 from app_test_case import (
     LocalAppTestCase,
 )
-from azul import (
-    JSON,
-)
 from azul.deployment import (
     aws,
 )
 from azul.hmac import (
     SignatureHelper,
+)
+from azul.types import (
+    JSON,
 )
 from azul_test_case import (
     DCP1TestCase,

--- a/test/service/test_app_logging.py
+++ b/test/service/test_app_logging.py
@@ -15,7 +15,6 @@ import requests
 
 from azul import (
     Config,
-    JSON,
 )
 from azul.chalice import (
     AzulChaliceApp,
@@ -23,6 +22,9 @@ from azul.chalice import (
 )
 from azul.logging import (
     configure_test_logging,
+)
+from azul.types import (
+    JSON,
 )
 from indexer import (
     DCP1CannedBundleTestCase,

--- a/test/service/test_response_anvil.py
+++ b/test/service/test_response_anvil.py
@@ -1,13 +1,13 @@
 import requests
 
-from azul import (
-    JSON,
-)
 from azul.logging import (
     configure_test_logging,
 )
 from azul.plugins.repository.tdr_anvil import (
     TDRAnvilBundleFQID,
+)
+from azul.types import (
+    JSON,
 )
 from indexer.test_anvil import (
     AnvilIndexerTestCase,

--- a/test/test_openapi.py
+++ b/test/test_openapi.py
@@ -7,7 +7,6 @@ from furl import (
 )
 
 from azul import (
-    JSON,
     RequirementError,
 )
 from azul.chalice import (
@@ -22,6 +21,9 @@ from azul.logging import (
 from azul.openapi import (
     params,
     schema,
+)
+from azul.types import (
+    JSON,
 )
 from azul_test_case import (
     AzulUnitTestCase,

--- a/test/test_tagging.py
+++ b/test/test_tagging.py
@@ -1,11 +1,11 @@
-from azul import (
-    JSON,
-)
 from azul.logging import (
     configure_test_logging,
 )
 from azul.terraform import (
     _transform_tf,
+)
+from azul.types import (
+    JSON,
 )
 from test.azul_test_case import (
     AzulUnitTestCase,


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #7244


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or [comment in PR explains why they're different](https://github.com/DataBiosphere/azul/pull/7490#issuecomment-3403529565)</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer


### Peer reviewer (after approval)

Note that when requesting changes, the PR must be assigned back to the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
