### PR TITLE
Log redacted HTTP request headers at AZUL_DEBUG=1 (#7489)

### DIFF
--- a/.github/ISSUE_TEMPLATE/upgrade.md
+++ b/.github/ISSUE_TEMPLATE/upgrade.md
@@ -2,7 +2,7 @@
 name: Upgrade software dependencies
 about: Issue template for the bi-weekly upgrade of Azul's software dependencies
 title: Upgrade software dependencies
-labels: -,operator,infra,debt
+labels: -,operator,infra
 type: Chore
 _start: 2023-11-27T09:00
 _period: 14 days

--- a/src/azul/http.py
+++ b/src/azul/http.py
@@ -75,8 +75,11 @@ class LoggingHttpClient(HttpClientDecorator):
     def urlopen(self, method, url, *args, body=None, **kwargs) -> urllib3.HTTPResponse:
         log = self._log
         log.info('Making %s request to %r', method, url)
-        if config.debug > 1:
-            log.debug('… with keyword args %r', kwargs)
+        headers = kwargs.get('headers')
+        if headers is None or headers == {}:
+            log.info('… without request headers')
+        else:
+            log.info('… with request headers %r', headers)
         log.info(http_body_log_message('request', body))
         start = time.monotonic()
         response = super().urlopen(method, url, *args, body=body, **kwargs)

--- a/src/azul/http.py
+++ b/src/azul/http.py
@@ -78,9 +78,9 @@ class LoggingHttpClient(HttpClientDecorator):
         if config.debug > 1:
             log.debug('… with keyword args %r', kwargs)
         log.info(http_body_log_message('request', body))
-        start = time.time()
+        start = time.monotonic()
         response = super().urlopen(method, url, *args, body=body, **kwargs)
-        duration = time.time() - start
+        duration = time.monotonic() - start
         assert isinstance(response, urllib3.HTTPResponse), type(response)
         log.info('Got %s response after %.3fs from %s to %s',
                  response.status, duration, method, url)
@@ -189,7 +189,7 @@ class _LimitedRetry(urllib3.Retry):
                    other=retries,
                    status_forcelist={500, 502, 503},
                    raise_on_status=True)
-        self.start = time.time()
+        self.start = time.monotonic()
         self.retries = retries
         self.timeout = timeout
         return self
@@ -202,7 +202,7 @@ class _LimitedRetry(urllib3.Retry):
         if super().is_exhausted():
             return True
         else:
-            elapsed = time.time() - self.start
+            elapsed = time.monotonic() - self.start
             return self.retries == 0 and elapsed > .01 or elapsed >= self.timeout
 
     def new(self, **kwargs) -> Self:

--- a/src/azul/http.py
+++ b/src/azul/http.py
@@ -2,6 +2,8 @@ import logging
 import sys
 import time
 from typing import (
+    Any,
+    ClassVar,
     Self,
 )
 
@@ -10,12 +12,14 @@ from furl import (
     furl,
 )
 import urllib3
+import urllib3.connection
 import urllib3.connectionpool
 import urllib3.exceptions
 import urllib3.request
 
 from azul import (
     R,
+    cache,
     cached_property,
     config,
     require,
@@ -72,14 +76,45 @@ class LoggingHttpClient(HttpClientDecorator):
         super().__init__(inner, headers)
         self._log = log
 
+        # As a request is being prepared by the various layers of urllib3,
+        # requests headers may being added, in addition to the ones supplied by
+        # the client. To ensure that all headers are logged, we'd therefore need
+        # to log them at the innermost layer. To get at that layer we need to
+        # dynamically subclass the connection pool class for each of the two
+        # schemes and make the pool manager use those subclasses when creating
+        # new pools. The dynamic subclasses inherit a static mixin that actually
+        # logs the headers. We need to use subclassing because we don't have any
+        # connection pool instances yet and the only place where we can stash
+        # the logger instance is in a class attribute. There is one subclass per
+        # scheme and logger instance, and since there is typically one logger
+        # instance per client module, the class duplication is manageable at two
+        # subclasses per client module. The alternative approach would have been
+        # to monkey patch the ``_new_pool`` factory method in the pool manager
+        # instance but I felt the subclassing approach is more transparent. The
+        # subclass name is prefixed with the logger name.
+        #
+        pool_manager = self.delegate(urllib3.PoolManager)
+        attribute_name = 'pool_classes_by_scheme'
+        # Use setattr to appease mypy, as the stubs don't declare the attribute.
+        attribute_value = getattr(pool_manager, attribute_name)
+        setattr(pool_manager, attribute_name, attribute_value | {
+            scheme: self._pool_cls(log, scheme)
+            for scheme in ['http', 'https']
+        })
+
+    @classmethod
+    @cache
+    def _pool_cls(cls, log: logging.Logger, scheme: str) -> type:
+        proto = scheme.upper()
+        return type(
+            f'{log.name}.Logging{proto}ConnectionPool',
+            (_LoggingConnectionPool, getattr(urllib3, f'{proto}ConnectionPool')),
+            {'_log': log}
+        )
+
     def urlopen(self, method, url, *args, body=None, **kwargs) -> urllib3.HTTPResponse:
         log = self._log
         log.info('Making %s request to %r', method, url)
-        headers = kwargs.get('headers')
-        if headers is None or headers == {}:
-            log.info('… without request headers')
-        else:
-            log.info('… with request headers %r', headers)
         log.info(http_body_log_message('request', body))
         start = time.monotonic()
         response = super().urlopen(method, url, *args, body=body, **kwargs)
@@ -96,6 +131,26 @@ class LoggingHttpClient(HttpClientDecorator):
 
     def log(self, message: str, *args):
         self._log.info(message, *args)
+
+
+class _LoggingConnectionPool(urllib3.connectionpool.HTTPConnectionPool):
+    _log: ClassVar[logging.Logger]
+
+    def _make_request(self, *args, **kwargs) -> Any:
+        log = self._log
+        headers = kwargs.get('headers')
+        if headers is None or len(headers) == 0:
+            log.info('… without request headers')
+        else:
+            # urllib3's HTTPHeaderDict.items() can yield multiple entries for
+            # the same key, or a key only different in case
+            headers = [
+                (k, 'REDACTED' if k.lower() == 'authorization' else v)
+                for k, v in headers.items()
+            ]
+            log.info('… with request headers %r', headers)
+        # The stubs for urllib3 v1.x don't declare any protected methods
+        return super()._make_request(*args, **kwargs)  # type: ignore[misc]
 
 
 class DisableCrossHostRedirectClient(HttpClientDecorator):

--- a/test/test_http.py
+++ b/test/test_http.py
@@ -149,9 +149,8 @@ class TestHttp(AzulUnitTestCase):
                                 if retries is None:
                                     client.request(method='GET', url=url)
                                 else:
-                                    retries = Retry(status=retries,
-                                                    raise_on_status=exception is not None)
-                                    client.request(method='GET', url=url, retries=retries)
+                                    retry = Retry(status=retries, raise_on_status=exception is not None)
+                                    client.request(method='GET', url=url, retries=retry)
 
                 self.assertEqual(requests, num_actual_requests)
 

--- a/test/test_http.py
+++ b/test/test_http.py
@@ -146,11 +146,12 @@ class TestHttp(AzulUnitTestCase):
                             assert restricted is client._timing_is_restricted
                         with self.assertRaises(exception) if exception else nullcontext():
                             with self.assertLogs(log) as logs:
+                                headers = {'Authorization': 'secret, should not be logged'}
                                 if retries is None:
-                                    client.request(method='GET', url=url)
+                                    client.request(method='GET', url=url, headers=headers)
                                 else:
                                     retry = Retry(status=retries, raise_on_status=exception is not None)
-                                    client.request(method='GET', url=url, retries=retry)
+                                    client.request(method='GET', url=url, retries=retry, headers=headers)
 
                 self.assertEqual(requests, num_actual_requests)
 
@@ -165,10 +166,15 @@ class TestHttp(AzulUnitTestCase):
                 for i in range(calls):
                     expected_logs.extend(
                         [
-                            f"^{prefix}Making GET request to '{url}'$",
-                            f'^{prefix}… without request headers$',
-                            f'^{prefix}… without a request body$'
-                        ]
+                            # The urlopen() call logs the method, URL and body
+                            fr"^{prefix}Making GET request to '{url}'$",
+                            fr'^{prefix}… without a request body$'
+                        ] + [
+                            # The headers are logged for the urlopen() call and
+                            # every retry so if we expect one call and three
+                            # requests, the headers will be logged three times.
+                            fr"^{prefix}… with request headers \[\('Authorization', 'REDACTED'\)\]$"
+                        ] * (requests // calls)
                     )
                     if responses:
                         expected_logs.extend(

--- a/test/test_http.py
+++ b/test/test_http.py
@@ -170,7 +170,7 @@ class TestHttp(AzulUnitTestCase):
                             f'^{prefix}… without a request body$'
                         ]
                     )
-                    if i < responses:
+                    if responses:
                         expected_logs.extend(
                             [
                                 rf'^{prefix}Got 503 response after \d.\d\d\ds from GET to {url}$',

--- a/test/test_http.py
+++ b/test/test_http.py
@@ -166,6 +166,7 @@ class TestHttp(AzulUnitTestCase):
                     expected_logs.extend(
                         [
                             f"^{prefix}Making GET request to '{url}'$",
+                            f'^{prefix}… without request headers$',
                             f'^{prefix}… without a request body$'
                         ]
                     )

--- a/test/test_http.py
+++ b/test/test_http.py
@@ -89,6 +89,25 @@ class TestHttp(AzulUnitTestCase):
 
     @mock.patch.object(type(config), 'debug', new=1)
     def test(self):
+        #: If True (False), use a limited retry client under restricted
+        #: (unrestricted) timing. If None, use a normal client.
+        restricted: bool | None
+        #: The number of retries to configure the client with or None to use
+        #: the default. Must be None if restricted is not.
+        retries: int | None
+        #: Number of seconds the server sleeps before responding to a request.
+        sleep: float
+        #: The type of exception expected to be raised, or None of no exception
+        #: is expected.
+        exception: Exception | None
+        #: The expected number of calls to LoggingHttpClient.urlopen(). Explicit
+        #: retries by StatusRetryHttpClient will cause more than one call.
+        calls: int
+        #: The expected number of requests to be made. Implicit retries done by
+        #: urllib3 can cause more than one request per call.
+        requests: int
+        #: The expected number of responses to be received.
+        responses: int
         for restricted, retries, sleep, exception, calls, requests, responses in [
             # @formatter:off
             (  None,    0,           0,                    None, 1, 1, 1 ),  # noqa
@@ -118,6 +137,8 @@ class TestHttp(AzulUnitTestCase):
                         self.end_headers()
 
                 with self.http_server(Handler) as url:
+                    # The standard client is a urllib3 PoolManager, wrapped by
+                    # a LoggingHttpClient and a StatusRetryHttpClient instance
                     client = http_client(log)
                     with self.mock_api_gateway() if restricted else nullcontext():
                         if restricted is not None:
@@ -157,6 +178,7 @@ class TestHttp(AzulUnitTestCase):
                                 f"^{prefix}… without a response body$",
                             ]
                         )
+                        # StatusRetryHttpClient sleeps between calls
                         if i < calls - 1:
                             expected_logs.append(f'^{prefix}Sleeping 1s to honor Retry-After header$')
                 for expected_log, actual_log in zip(expected_logs, logs.output, strict=True):


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #7489


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer


### Peer reviewer (after approval)

Note that when requesting changes, the PR must be assigned back to the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
