### PR TITLE
Refactor HCAFile construction (#7496)

### DIFF
--- a/src/azul/plugins/metadata/hca/__init__.py
+++ b/src/azul/plugins/metadata/hca/__init__.py
@@ -509,7 +509,7 @@ class HCAFile(File):
         api.Entity.validate_described_by(descriptor)
         return cls.from_metadata(descriptor,
                                  name=any_str(row['file_name']),
-                                 drs_uri=cls._parse_drs_uri(optional(any_str, row['file_id']), descriptor))
+                                 drs_uri=optional(any_str, row['file_id']))
 
     @classmethod
     def _parse_drs_uri(cls, file_id: str | None, descriptor: JSON) -> str | None:
@@ -540,7 +540,9 @@ class HCAFile(File):
                       descriptor: JSON,
                       *,
                       name: str,
-                      drs_uri: str | None) -> Self:
+                      drs_uri: str | None
+                      ) -> Self:
+        drs_uri = cls._parse_drs_uri(drs_uri, descriptor)
         content_type = json_str(descriptor['content_type'])
         # FIXME: Obsolete MIME parameter in file content types
         #        https://github.com/HumanCellAtlas/dcp2/issues/73

--- a/src/azul/plugins/metadata/hca/__init__.py
+++ b/src/azul/plugins/metadata/hca/__init__.py
@@ -69,6 +69,7 @@ from azul.service.manifest_service import (
 )
 from azul.types import (
     MutableJSON,
+    any_str,
     json_dict,
     json_dict_of_dicts,
     json_int,
@@ -501,21 +502,18 @@ class HCAFile(File):
                    s3_etag=optional(json_str, hit.get('s3_etag')))
 
     @classmethod
-    def file_from_row(cls, row: BigQueryRow) -> HCAFile:
-        descriptor = json.loads(row['descriptor'])
+    def file_from_row(cls, row: BigQueryRow) -> Self:
+        descriptor = json.loads(any_str(row['descriptor']))
         # FIXME: Move validation of descriptor to the metadata API
         #        https://github.com/DataBiosphere/azul/issues/6299
         api.Entity.validate_described_by(descriptor)
-        return HCAFile.from_metadata(descriptor,
-                                     uuid=descriptor['file_id'],
-                                     name=row['file_name'],
-                                     drs_uri=cls._parse_drs_uri(row['file_id'], descriptor))
+        return cls.from_metadata(descriptor,
+                                 uuid=json_str(descriptor['file_id']),
+                                 name=any_str(row['file_name']),
+                                 drs_uri=cls._parse_drs_uri(optional(any_str, row['file_id']), descriptor))
 
     @classmethod
-    def _parse_drs_uri(cls,
-                       file_id: str | None,
-                       descriptor: JSON
-                       ) -> str | None:
+    def _parse_drs_uri(cls, file_id: str | None, descriptor: JSON) -> str | None:
         if file_id is None:
             try:
                 external_drs_uri = descriptor['drs_uri']

--- a/src/azul/plugins/metadata/hca/__init__.py
+++ b/src/azul/plugins/metadata/hca/__init__.py
@@ -14,6 +14,7 @@ from azul import (
     R,
     config,
     iif,
+    json_mapping,
 )
 from azul.digests import (
     Digest,
@@ -522,9 +523,9 @@ class HCAFile(File):
 
     @classmethod
     def from_metadata(cls,
-                      descriptor: JSON,
                       *,
-                      name: str,
+                      metadata: JSON,
+                      descriptor: JSON,
                       drs_uri: str | None
                       ) -> Self:
         # FIXME: Move validation of descriptor to the metadata API
@@ -543,7 +544,7 @@ class HCAFile(File):
             assert True or ';' not in content_type, R(
                 'Unexpected MIME parameter in content type', content_type)
         return cls(uuid=json_str(descriptor['file_id']),
-                   name=name,
+                   name=json_str(json_mapping(metadata['file_core'])['file_name']),
                    version=json_str(descriptor['file_version']),
                    size=json_int(descriptor['size']),
                    content_type=content_type,

--- a/src/azul/plugins/metadata/hca/__init__.py
+++ b/src/azul/plugins/metadata/hca/__init__.py
@@ -504,9 +504,6 @@ class HCAFile(File):
     @classmethod
     def file_from_row(cls, row: BigQueryRow) -> Self:
         descriptor = json.loads(any_str(row['descriptor']))
-        # FIXME: Move validation of descriptor to the metadata API
-        #        https://github.com/DataBiosphere/azul/issues/6299
-        api.Entity.validate_described_by(descriptor)
         return cls.from_metadata(descriptor,
                                  name=any_str(row['file_name']),
                                  drs_uri=optional(any_str, row['file_id']))
@@ -542,6 +539,9 @@ class HCAFile(File):
                       name: str,
                       drs_uri: str | None
                       ) -> Self:
+        # FIXME: Move validation of descriptor to the metadata API
+        #        https://github.com/DataBiosphere/azul/issues/6299
+        api.Entity.validate_described_by(descriptor)
         drs_uri = cls._parse_drs_uri(drs_uri, descriptor)
         content_type = json_str(descriptor['content_type'])
         # FIXME: Obsolete MIME parameter in file content types

--- a/src/azul/plugins/metadata/hca/__init__.py
+++ b/src/azul/plugins/metadata/hca/__init__.py
@@ -1,3 +1,5 @@
+import json
+import logging
 from typing import (
     Iterable,
     Self,
@@ -14,8 +16,14 @@ from azul import (
     config,
     iif,
 )
+from azul.bigquery import (
+    BigQueryRow,
+)
 from azul.digests import (
     Digest,
+)
+from azul.drs import (
+    RegularDRSURI,
 )
 from azul.indexer.document import (
     Aggregate,
@@ -71,6 +79,8 @@ from azul.types import (
 from humancellatlas.data.metadata import (
     api,
 )
+
+log = logging.getLogger(__name__)
 
 
 class Plugin(MetadataPlugin[HCABundle]):
@@ -489,6 +499,44 @@ class HCAFile(File):
                    crc32c=json_str(hit['crc32c']),
                    sha1=optional(json_str, hit.get('sha1')),
                    s3_etag=optional(json_str, hit.get('s3_etag')))
+
+    @classmethod
+    def file_from_row(cls, row: BigQueryRow) -> HCAFile:
+        descriptor = json.loads(row['descriptor'])
+        # FIXME: Move validation of descriptor to the metadata API
+        #        https://github.com/DataBiosphere/azul/issues/6299
+        api.Entity.validate_described_by(descriptor)
+        return HCAFile.from_metadata(descriptor,
+                                     uuid=descriptor['file_id'],
+                                     name=row['file_name'],
+                                     drs_uri=cls._parse_drs_uri(row['file_id'], descriptor))
+
+    @classmethod
+    def _parse_drs_uri(cls,
+                       file_id: str | None,
+                       descriptor: JSON
+                       ) -> str | None:
+        if file_id is None:
+            try:
+                external_drs_uri = descriptor['drs_uri']
+            except KeyError:
+                assert False, R(
+                    '`file_id` is null and `drs_uri` is not set in file descriptor',
+                    descriptor)
+            else:
+                # FIXME: Support non-null DRS URIs in file descriptors
+                #        https://github.com/DataBiosphere/azul/issues/3631
+                if external_drs_uri is not None:
+                    log.warning('Non-null `drs_uri` in file descriptor (%s)', external_drs_uri)
+                    external_drs_uri = None
+                return external_drs_uri
+        else:
+            # This requirement prevent mismatches in the DRS domain, and ensures
+            # that changes to the column syntax don't go undetected.
+            parsed = RegularDRSURI.parse(file_id)
+            assert parsed.uri.netloc == config.tdr_service_url.netloc, R(
+                'Unexpected DRS URI location', parsed.uri)
+            return file_id
 
     @classmethod
     def from_metadata(cls,

--- a/src/azul/plugins/metadata/hca/__init__.py
+++ b/src/azul/plugins/metadata/hca/__init__.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from typing import (
     Iterable,
@@ -15,9 +14,6 @@ from azul import (
     R,
     config,
     iif,
-)
-from azul.bigquery import (
-    BigQueryRow,
 )
 from azul.digests import (
     Digest,
@@ -69,7 +65,6 @@ from azul.service.manifest_service import (
 )
 from azul.types import (
     MutableJSON,
-    any_str,
     json_dict,
     json_dict_of_dicts,
     json_int,
@@ -500,13 +495,6 @@ class HCAFile(File):
                    crc32c=json_str(hit['crc32c']),
                    sha1=optional(json_str, hit.get('sha1')),
                    s3_etag=optional(json_str, hit.get('s3_etag')))
-
-    @classmethod
-    def file_from_row(cls, row: BigQueryRow) -> Self:
-        descriptor = json.loads(any_str(row['descriptor']))
-        return cls.from_metadata(descriptor,
-                                 name=any_str(row['file_name']),
-                                 drs_uri=optional(any_str, row['file_id']))
 
     @classmethod
     def _parse_drs_uri(cls, file_id: str | None, descriptor: JSON) -> str | None:

--- a/src/azul/plugins/metadata/hca/__init__.py
+++ b/src/azul/plugins/metadata/hca/__init__.py
@@ -508,7 +508,6 @@ class HCAFile(File):
         #        https://github.com/DataBiosphere/azul/issues/6299
         api.Entity.validate_described_by(descriptor)
         return cls.from_metadata(descriptor,
-                                 uuid=json_str(descriptor['file_id']),
                                  name=any_str(row['file_name']),
                                  drs_uri=cls._parse_drs_uri(optional(any_str, row['file_id']), descriptor))
 
@@ -540,7 +539,6 @@ class HCAFile(File):
     def from_metadata(cls,
                       descriptor: JSON,
                       *,
-                      uuid: str,
                       name: str,
                       drs_uri: str | None) -> Self:
         content_type = json_str(descriptor['content_type'])
@@ -554,7 +552,7 @@ class HCAFile(File):
             #        https://github.com/DataBiosphere/azul/issues/7244
             assert True or ';' not in content_type, R(
                 'Unexpected MIME parameter in content type', content_type)
-        return cls(uuid=uuid,
+        return cls(uuid=json_str(descriptor['file_id']),
                    name=name,
                    version=json_str(descriptor['file_version']),
                    size=json_int(descriptor['size']),

--- a/src/azul/plugins/repository/canned/__init__.py
+++ b/src/azul/plugins/repository/canned/__init__.py
@@ -210,7 +210,7 @@ class Plugin(RepositoryPlugin[
         staging_area = self.staging_area(source.spec.name)
         return [
             HCAFile.from_metadata(descriptor.content,
-                                  uuid=file_uuid,
+                                  uuid=descriptor.content['file_id'],
                                   name=descriptor.content['file_name'],
                                   drs_uri=None)
             for file_uuid, descriptor in staging_area.descriptors.items()

--- a/src/azul/plugins/repository/canned/__init__.py
+++ b/src/azul/plugins/repository/canned/__init__.py
@@ -210,7 +210,6 @@ class Plugin(RepositoryPlugin[
         staging_area = self.staging_area(source.spec.name)
         return [
             HCAFile.from_metadata(descriptor.content,
-                                  uuid=descriptor.content['file_id'],
                                   name=descriptor.content['file_name'],
                                   drs_uri=None)
             for file_uuid, descriptor in staging_area.descriptors.items()

--- a/src/azul/plugins/repository/canned/__init__.py
+++ b/src/azul/plugins/repository/canned/__init__.py
@@ -209,8 +209,8 @@ class Plugin(RepositoryPlugin[
         assert prefix == prefix.lower(), prefix
         staging_area = self.staging_area(source.spec.name)
         return [
-            HCAFile.from_metadata(descriptor.content,
-                                  name=descriptor.content['file_name'],
+            HCAFile.from_metadata(metadata=staging_area.metadata[file_uuid].content,
+                                  descriptor=descriptor.content,
                                   drs_uri=None)
             for file_uuid, descriptor in staging_area.descriptors.items()
             if descriptor.content['sha256'].lower().startswith(prefix)

--- a/src/azul/plugins/repository/tdr_hca/__init__.py
+++ b/src/azul/plugins/repository/tdr_hca/__init__.py
@@ -70,6 +70,8 @@ from azul.types import (
     JSONs,
     MutableJSON,
     MutableJSONs,
+    any_str,
+    optional,
 )
 from humancellatlas.data.metadata import (
     api,
@@ -211,7 +213,7 @@ class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
             for entity_type, entity_cls in api.entity_types.items()
             if entity_type.endswith('_file')
         ))
-        return list(map(HCAFile.file_from_row, rows))
+        return list(map(self._file_from_row, rows))
 
     def _query_unique_sorted(self,
                              query: str,
@@ -266,7 +268,7 @@ class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
         if is_stitched:
             bundle.stitched.add(entity.entity_id)
         if entity.entity_type.endswith('_file'):
-            file = HCAFile.file_from_row(row)
+            file = self._file_from_row(row)
             file_json = file.to_json()
             file_json['content-type'] = file_json.pop('content_type')
             file_json['indexed'] = False
@@ -275,6 +277,12 @@ class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
         bundle.metadata[str(entity)] = (json.loads(content)
                                         if isinstance(content, str)
                                         else content)
+
+    def _file_from_row(self, row: BigQueryRow) -> HCAFile:
+        descriptor = json.loads(any_str(row['descriptor']))
+        return HCAFile.from_metadata(descriptor,
+                                     name=any_str(row['file_name']),
+                                     drs_uri=optional(any_str, row['file_id']))
 
     def _stitch_bundles(self,
                         root_bundle: TDRHCABundle

--- a/src/azul/plugins/repository/tdr_hca/__init__.py
+++ b/src/azul/plugins/repository/tdr_hca/__init__.py
@@ -164,14 +164,6 @@ class TDRHCABundle(HCABundle[TDRBundleFQID], TDRBundle):
         'project_id'
     )
 
-    def _add_manifest_entry(self,
-                            entity: EntityReference,
-                            file: HCAFile) -> None:
-        file_json = file.to_json()
-        file_json['content-type'] = file_json.pop('content_type')
-        file_json['indexed'] = False
-        self.manifest[str(entity)] = file_json
-
 
 class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
 
@@ -290,11 +282,20 @@ class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
         if is_stitched:
             bundle.stitched.add(entity.entity_id)
         if entity.entity_type.endswith('_file'):
-            bundle._add_manifest_entry(entity, HCAFile.file_from_row(row))
+            self._add_manifest_entry(bundle, entity, HCAFile.file_from_row(row))
         content = row['content']
         bundle.metadata[str(entity)] = (json.loads(content)
                                         if isinstance(content, str)
                                         else content)
+
+    def _add_manifest_entry(self,
+                            bundle: TDRHCABundle,
+                            entity: EntityReference,
+                            file: HCAFile) -> None:
+        file_json = file.to_json()
+        file_json['content-type'] = file_json.pop('content_type')
+        file_json['indexed'] = False
+        bundle.manifest[str(entity)] = file_json
 
     def _stitch_bundles(self,
                         root_bundle: TDRHCABundle

--- a/src/azul/plugins/repository/tdr_hca/__init__.py
+++ b/src/azul/plugins/repository/tdr_hca/__init__.py
@@ -274,9 +274,9 @@ class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
             file_json['indexed'] = False
             bundle.manifest[str(entity)] = file_json
         content = row['content']
-        bundle.metadata[str(entity)] = (json.loads(content)
-                                        if isinstance(content, str)
-                                        else content)
+        if isinstance(content, str):
+            content = json.loads(content)
+        bundle.metadata[str(entity)] = content
 
     def _file_from_row(self, row: BigQueryRow) -> HCAFile:
         descriptor = json.loads(any_str(row['descriptor']))

--- a/src/azul/plugins/repository/tdr_hca/__init__.py
+++ b/src/azul/plugins/repository/tdr_hca/__init__.py
@@ -148,21 +148,6 @@ class TDRHCABundle(HCABundle[TDRBundleFQID], TDRBundle):
     def canning_qualifier(cls) -> str:
         return super().canning_qualifier() + '.hca'
 
-    def add_entity(self,
-                   *,
-                   entity: EntityReference,
-                   row: BigQueryRow,
-                   is_stitched: bool
-                   ) -> None:
-        if is_stitched:
-            self.stitched.add(entity.entity_id)
-        if entity.entity_type.endswith('_file'):
-            self._add_manifest_entry(entity, HCAFile.file_from_row(row))
-        content = row['content']
-        self.metadata[str(entity)] = (json.loads(content)
-                                      if isinstance(content, str)
-                                      else content)
-
     metadata_columns: ClassVar[frozenset[str]] = singleton(
         'content'
     )
@@ -288,14 +273,28 @@ class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
                     for row in rows:
                         entity = EntityReference(entity_id=row[pk_column], entity_type=entity_type)
                         is_stitched = entity not in root_entities
-                        bundle.add_entity(entity=entity,
-                                          row=row,
-                                          is_stitched=is_stitched)
+                        self._add_entity(bundle, entity=entity, row=row, is_stitched=is_stitched)
                 else:
                     log.error('TDR worker failed to retrieve entities of type %r',
                               entity_type, exc_info=e)
                     raise e
         return bundle
+
+    def _add_entity(self,
+                    bundle: TDRHCABundle,
+                    *,
+                    entity: EntityReference,
+                    row: BigQueryRow,
+                    is_stitched: bool
+                    ) -> None:
+        if is_stitched:
+            bundle.stitched.add(entity.entity_id)
+        if entity.entity_type.endswith('_file'):
+            bundle._add_manifest_entry(entity, HCAFile.file_from_row(row))
+        content = row['content']
+        bundle.metadata[str(entity)] = (json.loads(content)
+                                        if isinstance(content, str)
+                                        else content)
 
     def _stitch_bundles(self,
                         root_bundle: TDRHCABundle

--- a/src/azul/plugins/repository/tdr_hca/__init__.py
+++ b/src/azul/plugins/repository/tdr_hca/__init__.py
@@ -39,9 +39,6 @@ from azul.bigquery import (
 from azul.collections import (
     singleton,
 )
-from azul.drs import (
-    RegularDRSURI,
-)
 from azul.indexer import (
     BundleFQID,
 )
@@ -160,7 +157,7 @@ class TDRHCABundle(HCABundle[TDRBundleFQID], TDRBundle):
         if is_stitched:
             self.stitched.add(entity.entity_id)
         if entity.entity_type.endswith('_file'):
-            self._add_manifest_entry(entity, self.file_from_row(row))
+            self._add_manifest_entry(entity, HCAFile.file_from_row(row))
         content = row['content']
         self.metadata[str(entity)] = (json.loads(content)
                                       if isinstance(content, str)
@@ -182,17 +179,6 @@ class TDRHCABundle(HCABundle[TDRBundleFQID], TDRBundle):
         'project_id'
     )
 
-    @classmethod
-    def file_from_row(cls, row: BigQueryRow) -> HCAFile:
-        descriptor = json.loads(row['descriptor'])
-        # FIXME: Move validation of descriptor to the metadata API
-        #        https://github.com/DataBiosphere/azul/issues/6299
-        api.Entity.validate_described_by(descriptor)
-        return HCAFile.from_metadata(descriptor,
-                                     uuid=descriptor['file_id'],
-                                     name=row['file_name'],
-                                     drs_uri=cls._parse_drs_uri(row['file_id'], descriptor))
-
     def _add_manifest_entry(self,
                             entity: EntityReference,
                             file: HCAFile) -> None:
@@ -200,33 +186,6 @@ class TDRHCABundle(HCABundle[TDRBundleFQID], TDRBundle):
         file_json['content-type'] = file_json.pop('content_type')
         file_json['indexed'] = False
         self.manifest[str(entity)] = file_json
-
-    @classmethod
-    def _parse_drs_uri(cls,
-                       file_id: str | None,
-                       descriptor: JSON
-                       ) -> str | None:
-        if file_id is None:
-            try:
-                external_drs_uri = descriptor['drs_uri']
-            except KeyError:
-                assert False, R(
-                    '`file_id` is null and `drs_uri` is not set in file descriptor',
-                    descriptor)
-            else:
-                # FIXME: Support non-null DRS URIs in file descriptors
-                #        https://github.com/DataBiosphere/azul/issues/3631
-                if external_drs_uri is not None:
-                    log.warning('Non-null `drs_uri` in file descriptor (%s)', external_drs_uri)
-                    external_drs_uri = None
-                return external_drs_uri
-        else:
-            # This requirement prevent mismatches in the DRS domain, and ensures
-            # that changes to the column syntax don't go undetected.
-            parsed = RegularDRSURI.parse(file_id)
-            assert parsed.uri.netloc == config.tdr_service_url.netloc, R(
-                'Unexpected DRS URI location', parsed.uri)
-            return file_id
 
 
 class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
@@ -291,7 +250,7 @@ class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
             for entity_type, entity_cls in api.entity_types.items()
             if entity_type.endswith('_file')
         ))
-        return list(map(TDRHCABundle.file_from_row, rows))
+        return list(map(HCAFile.file_from_row, rows))
 
     def _query_unique_sorted(self,
                              query: str,

--- a/src/azul/plugins/repository/tdr_hca/__init__.py
+++ b/src/azul/plugins/repository/tdr_hca/__init__.py
@@ -202,9 +202,10 @@ class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
         self._assert_source(source)
         self._assert_partition(source, prefix)
         assert prefix == prefix.lower(), prefix
+        columns = self.metadata_columns + self.data_columns
         rows = self._run_sql(' UNION ALL '.join(
             f'''
-            SELECT {', '.join(self.data_columns)}
+            SELECT {', '.join(columns)}
             FROM {backtick(self._full_table_name(source.spec, entity_type))}
             WHERE STARTS_WITH(LOWER(JSON_EXTRACT_SCALAR(descriptor, "$.sha256")),
                               {prefix!r})
@@ -278,9 +279,8 @@ class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
         bundle.metadata[str(entity)] = content
 
     def _file_from_row(self, row: BigQueryRow) -> HCAFile:
-        descriptor = json.loads(any_str(row['descriptor']))
-        return HCAFile.from_metadata(descriptor,
-                                     name=any_str(row['file_name']),
+        return HCAFile.from_metadata(metadata=json.loads(any_str(row['content'])),
+                                     descriptor=json.loads(any_str(row['descriptor'])),
                                      drs_uri=optional(any_str, row['file_id']))
 
     def _stitch_bundles(self,
@@ -357,11 +357,7 @@ class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
 
     metadata_columns = ('content',)
 
-    data_columns = (
-        'descriptor',
-        'JSON_EXTRACT_SCALAR(content, "$.file_core.file_name") AS file_name',
-        'file_id'
-    )
+    data_columns = ('descriptor', 'file_id')
 
     links_columns = ('project_id',)
 

--- a/src/azul/plugins/repository/tdr_hca/__init__.py
+++ b/src/azul/plugins/repository/tdr_hca/__init__.py
@@ -148,12 +148,6 @@ class TDRHCABundle(HCABundle[TDRBundleFQID], TDRBundle):
     def canning_qualifier(cls) -> str:
         return super().canning_qualifier() + '.hca'
 
-    data_columns: ClassVar[frozenset[str]] = frozenset({
-        'descriptor',
-        'JSON_EXTRACT_SCALAR(content, "$.file_core.file_name") AS file_name',
-        'file_id'
-    })
-
     # `links_id` is omitted for consistency since the other sets do not include
     # the primary key
     links_columns: ClassVar[frozenset[str]] = singleton(
@@ -215,7 +209,7 @@ class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
         assert prefix == prefix.lower(), prefix
         rows = self._run_sql(' UNION ALL '.join(
             f'''
-            SELECT {', '.join(TDRHCABundle.data_columns)}
+            SELECT {', '.join(self.data_columns)}
             FROM {backtick(self._full_table_name(source.spec, entity_type))}
             WHERE STARTS_WITH(LOWER(JSON_EXTRACT_SCALAR(descriptor, "$.sha256")),
                               {prefix!r})
@@ -364,6 +358,12 @@ class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
         'content'
     )
 
+    data_columns: ClassVar[frozenset[str]] = frozenset({
+        'descriptor',
+        'JSON_EXTRACT_SCALAR(content, "$.file_core.file_name") AS file_name',
+        'file_id'
+    })
+
     def _retrieve_entities(self,
                            source: TDRSourceSpec,
                            entity_type: EntityType,
@@ -385,7 +385,7 @@ class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
             pk_column,
             *self.metadata_columns,
             *iif(entity_type == 'links', TDRHCABundle.links_columns),
-            *iif(entity_type.endswith('_file'), TDRHCABundle.data_columns)
+            *iif(entity_type.endswith('_file'), self.data_columns)
         }
         table_name = backtick(self._full_table_name(source, entity_type))
         entity_id_type = one(set(map(type, entity_ids)))

--- a/src/azul/plugins/repository/tdr_hca/__init__.py
+++ b/src/azul/plugins/repository/tdr_hca/__init__.py
@@ -148,12 +148,6 @@ class TDRHCABundle(HCABundle[TDRBundleFQID], TDRBundle):
     def canning_qualifier(cls) -> str:
         return super().canning_qualifier() + '.hca'
 
-    # `links_id` is omitted for consistency since the other sets do not include
-    # the primary key
-    links_columns: ClassVar[frozenset[str]] = singleton(
-        'project_id'
-    )
-
 
 class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
 
@@ -364,6 +358,13 @@ class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
         'file_id'
     })
 
+    # `links_id` is omitted for consistency since the other sets do not include
+    # the primary key
+    #
+    links_columns: ClassVar[frozenset[str]] = singleton(
+        'project_id'
+    )
+
     def _retrieve_entities(self,
                            source: TDRSourceSpec,
                            entity_type: EntityType,
@@ -384,7 +385,7 @@ class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
         columns = {
             pk_column,
             *self.metadata_columns,
-            *iif(entity_type == 'links', TDRHCABundle.links_columns),
+            *iif(entity_type == 'links', self.links_columns),
             *iif(entity_type.endswith('_file'), self.data_columns)
         }
         table_name = backtick(self._full_table_name(source, entity_type))

--- a/src/azul/plugins/repository/tdr_hca/__init__.py
+++ b/src/azul/plugins/repository/tdr_hca/__init__.py
@@ -282,20 +282,15 @@ class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
         if is_stitched:
             bundle.stitched.add(entity.entity_id)
         if entity.entity_type.endswith('_file'):
-            self._add_manifest_entry(bundle, entity, HCAFile.file_from_row(row))
+            file = HCAFile.file_from_row(row)
+            file_json = file.to_json()
+            file_json['content-type'] = file_json.pop('content_type')
+            file_json['indexed'] = False
+            bundle.manifest[str(entity)] = file_json
         content = row['content']
         bundle.metadata[str(entity)] = (json.loads(content)
                                         if isinstance(content, str)
                                         else content)
-
-    def _add_manifest_entry(self,
-                            bundle: TDRHCABundle,
-                            entity: EntityReference,
-                            file: HCAFile) -> None:
-        file_json = file.to_json()
-        file_json['content-type'] = file_json.pop('content_type')
-        file_json['indexed'] = False
-        bundle.manifest[str(entity)] = file_json
 
     def _stitch_bundles(self,
                         root_bundle: TDRHCABundle

--- a/src/azul/plugins/repository/tdr_hca/__init__.py
+++ b/src/azul/plugins/repository/tdr_hca/__init__.py
@@ -148,10 +148,6 @@ class TDRHCABundle(HCABundle[TDRBundleFQID], TDRBundle):
     def canning_qualifier(cls) -> str:
         return super().canning_qualifier() + '.hca'
 
-    metadata_columns: ClassVar[frozenset[str]] = singleton(
-        'content'
-    )
-
     data_columns: ClassVar[frozenset[str]] = frozenset({
         'descriptor',
         'JSON_EXTRACT_SCALAR(content, "$.file_core.file_name") AS file_name',
@@ -364,6 +360,10 @@ class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
             links_json['content'] = json.loads(links_json['content'])
         return links
 
+    metadata_columns: ClassVar[frozenset[str]] = singleton(
+        'content'
+    )
+
     def _retrieve_entities(self,
                            source: TDRSourceSpec,
                            entity_type: EntityType,
@@ -383,7 +383,7 @@ class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
         version_column = 'version'
         columns = {
             pk_column,
-            *TDRHCABundle.metadata_columns,
+            *self.metadata_columns,
             *iif(entity_type == 'links', TDRHCABundle.links_columns),
             *iif(entity_type.endswith('_file'), TDRHCABundle.data_columns)
         }

--- a/src/azul/plugins/repository/tdr_hca/__init__.py
+++ b/src/azul/plugins/repository/tdr_hca/__init__.py
@@ -13,7 +13,6 @@ from operator import (
     itemgetter,
 )
 from typing import (
-    ClassVar,
     Iterable,
     Self,
     cast,
@@ -37,7 +36,7 @@ from azul.bigquery import (
     backtick,
 )
 from azul.collections import (
-    singleton,
+    OrderedSet,
 )
 from azul.indexer import (
     BundleFQID,
@@ -356,22 +355,15 @@ class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
             links_json['content'] = json.loads(links_json['content'])
         return links
 
-    metadata_columns: ClassVar[frozenset[str]] = singleton(
-        'content'
-    )
+    metadata_columns = ('content',)
 
-    data_columns: ClassVar[frozenset[str]] = frozenset({
+    data_columns = (
         'descriptor',
         'JSON_EXTRACT_SCALAR(content, "$.file_core.file_name") AS file_name',
         'file_id'
-    })
-
-    # `links_id` is omitted for consistency since the other sets do not include
-    # the primary key
-    #
-    links_columns: ClassVar[frozenset[str]] = singleton(
-        'project_id'
     )
+
+    links_columns = ('project_id',)
 
     def _retrieve_entities(self,
                            source: TDRSourceSpec,
@@ -390,12 +382,12 @@ class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
         """
         pk_column = entity_type + '_id'
         version_column = 'version'
-        columns = {
+        columns = OrderedSet([
             pk_column,
             *self.metadata_columns,
             *iif(entity_type == 'links', self.links_columns),
             *iif(entity_type.endswith('_file'), self.data_columns)
-        }
+        ])
         table_name = backtick(self._full_table_name(source, entity_type))
         entity_id_type = one(set(map(type, entity_ids)))
 

--- a/src/azul/types.py
+++ b/src/azul/types.py
@@ -162,26 +162,46 @@ def json_sorted(vs: Iterable[PrimitiveJSON]) -> MutableJSONArray:
 
 
 def json_str(v: AnyMutableJSON | AnyJSON) -> str:
+    return any_str(v)
+
+
+def any_str(v: Any) -> str:
     assert isinstance(v, str), type(v)
     return v
 
 
 def json_int(v: AnyMutableJSON | AnyJSON) -> int:
+    return any_int(v)
+
+
+def any_int(v: Any) -> int:
     assert isinstance(v, int), type(v)
     return v
 
 
 def json_float(v: AnyMutableJSON | AnyJSON) -> float:
+    return any_float(v)
+
+
+def any_float(v: Any) -> float:
     assert isinstance(v, float), type(v)
     return v
 
 
 def json_bool(v: AnyMutableJSON | AnyJSON) -> bool:
+    return any_bool(v)
+
+
+def any_bool(v: Any) -> bool:
     assert isinstance(v, bool), type(v)
     return v
 
 
 def json_none(v: AnyMutableJSON | AnyJSON) -> None:
+    return any_none(v)
+
+
+def any_none(v: Any) -> None:
     assert v is None, type(v)
     return v
 

--- a/src/azul/types.py
+++ b/src/azul/types.py
@@ -157,7 +157,7 @@ def json_items_are_dicts(vs: MutableJSON) -> TypeGuard[dict[str, MutableJSON]]:
     return True
 
 
-def json_sorted[S: PrimitiveJSON](vs: Iterable[S]) -> MutableJSONArray:
+def json_sorted(vs: Iterable[PrimitiveJSON]) -> MutableJSONArray:
     return sorted(vs, key=none_safe_key(none_last=True))
 
 


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #7496


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [X] PR description links to linked issues
- [X] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer


### Peer reviewer (after approval)

Note that when requesting changes, the PR must be assigned back to the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
