### PR TITLE
Fix: No test coverage of HCA count_{bundles,files} or list_files  (#7500, #7507)

### DIFF
--- a/src/azul/plugins/repository/tdr_hca/__init__.py
+++ b/src/azul/plugins/repository/tdr_hca/__init__.py
@@ -158,7 +158,7 @@ class Plugin(TDRPlugin[TDRHCABundle, TDRBundleFQID]):
         query = f'''
         SELECT COUNT(*) AS count
         FROM {backtick(self._full_table_name(source.spec, 'links'))}
-        WHERE STARTS_WITH(LOWER(datarepo_row_id), {prefix!r})
+        WHERE STARTS_WITH(LOWER(links_id), {prefix!r})
         '''
         rows = self._run_sql(query)
         return one(rows)['count']

--- a/test/indexer/__init__.py
+++ b/test/indexer/__init__.py
@@ -9,9 +9,6 @@ from pathlib import (
 from typing import (
     ClassVar,
     Literal,
-    Optional,
-    Type,
-    Union,
     cast,
 )
 
@@ -83,7 +80,7 @@ class ForcedRefreshIndexService(IndexService):
 
     def _create_writer(self,
                        doc_type: DocumentType,
-                       catalog: Optional[CatalogName]
+                       catalog: CatalogName | None
                        ) -> IndexWriter:
         writer = super()._create_writer(doc_type, catalog)
         # With a single client thread, refresh=True is faster than
@@ -108,7 +105,7 @@ class CannedFileTestCase(AzulUnitTestCase):
     def _load_canned_file(cls,
                           bundle: BundleFQID,
                           extension: str
-                          ) -> Union[MutableJSONs, MutableJSON]:
+                          ) -> MutableJSON | MutableJSONs:
         def load(version):
             return cls._load_canned_file_version(uuid=bundle.uuid,
                                                  version=version,
@@ -123,9 +120,9 @@ class CannedFileTestCase(AzulUnitTestCase):
     def _load_canned_file_version(cls,
                                   *,
                                   uuid: str,
-                                  version: Optional[str],
+                                  version: str | None,
                                   extension: str
-                                  ) -> Union[MutableJSONs, MutableJSON]:
+                                  ) -> MutableJSON | MutableJSONs:
         suffix = '' if version is None else '.' + version
         file_name = f'{uuid}{suffix}.{extension}.json'
         with open(cls._data_path('indexer', file_name), 'r') as infile:
@@ -141,7 +138,7 @@ class CannedBundleTestCase[BUNDLE: Bundle](CannedFileTestCase):
 
     @classmethod
     @abstractmethod
-    def _bundle_cls(cls) -> Type[BUNDLE]:
+    def _bundle_cls(cls) -> type[BUNDLE]:
         raise NotImplementedError
 
     @classmethod
@@ -157,7 +154,7 @@ class CannedBundleTestCase[BUNDLE: Bundle](CannedFileTestCase):
 class DCP1CannedBundleTestCase(DCP1TestCase, CannedBundleTestCase[DSSBundle]):
 
     @classmethod
-    def _bundle_cls(cls) -> Type[DSSBundle]:
+    def _bundle_cls(cls) -> type[DSSBundle]:
         return DSSBundle
 
     @classmethod
@@ -170,7 +167,7 @@ class DCP1CannedBundleTestCase(DCP1TestCase, CannedBundleTestCase[DSSBundle]):
 class DCP2CannedBundleTestCase(DCP2TestCase, CannedBundleTestCase[TDRHCABundle]):
 
     @classmethod
-    def _bundle_cls(cls) -> Type[TDRHCABundle]:
+    def _bundle_cls(cls) -> type[TDRHCABundle]:
         return TDRHCABundle
 
     @classmethod
@@ -185,7 +182,7 @@ class AnvilCannedBundleTestCase(AnvilTestCase, CannedBundleTestCase[TDRAnvilBund
     version = '2022-06-01T00:00:00.000000Z'
 
     @classmethod
-    def _bundle_cls(cls) -> Type[TDRAnvilBundle]:
+    def _bundle_cls(cls) -> type[TDRAnvilBundle]:
         return TDRAnvilBundle
 
     @classmethod

--- a/test/indexer/data/d8c20944-739f-4e7d-9161-b720953432ce.tables.tdr.json
+++ b/test/indexer/data/d8c20944-739f-4e7d-9161-b720953432ce.tables.tdr.json
@@ -2233,6 +2233,70 @@
                     }
                 }
             ]
+        },
+        "reference_file": {
+            "schema": {
+                "columns": [
+                    {
+                        "name": "reference_file_id",
+                        "field_type": "STRING",
+                        "mode": "NULLABLE"
+                    },
+                    {
+                        "name": "version",
+                        "field_type": "TIMESTAMP",
+                        "mode": "NULLABLE"
+                    },
+                    {
+                        "name": "content",
+                        "field_type": "STRING",
+                        "mode": "NULLABLE"
+                    },
+                    {
+                        "name": "file_id",
+                        "field_type": "STRING",
+                        "mode": "NULLABLE"
+                    },
+                    {
+                        "name": "descriptor",
+                        "field_type": "STRING",
+                        "mode": "NULLABLE"
+                    }
+                ]
+            },
+            "rows": []
+        },
+        "image_file": {
+            "schema": {
+                "columns": [
+                    {
+                        "name": "image_file_id",
+                        "field_type": "STRING",
+                        "mode": "NULLABLE"
+                    },
+                    {
+                        "name": "version",
+                        "field_type": "TIMESTAMP",
+                        "mode": "NULLABLE"
+                    },
+                    {
+                        "name": "content",
+                        "field_type": "STRING",
+                        "mode": "NULLABLE"
+                    },
+                    {
+                        "name": "file_id",
+                        "field_type": "STRING",
+                        "mode": "NULLABLE"
+                    },
+                    {
+                        "name": "descriptor",
+                        "field_type": "STRING",
+                        "mode": "NULLABLE"
+                    }
+                ]
+            },
+            "rows": []
         }
     }
 }

--- a/test/indexer/test_anvil.py
+++ b/test/indexer/test_anvil.py
@@ -166,7 +166,7 @@ class TestAnvilIndexer(AnvilIndexerTestCase,
     def test_list_and_fetch_bundles(self):
         self._mock_normal_duos()
         source_ref = self.source
-        self._make_mock_tdr_tables(source_ref)
+        self._make_mock_tables(source_ref)
         canned_bundle_fqids = [
             self.primary_bundle(),
             self.supplementary_bundle(),
@@ -206,7 +206,7 @@ class TestAnvilIndexer(AnvilIndexerTestCase,
 
     def test_absent_duos_id(self):
         source_ref = self.source
-        self._make_mock_tdr_tables(source_ref)
+        self._make_mock_tables(source_ref)
         cases = {
             'Absent duosFirecloudGroup': [
                 {'name': self.source.spec.name}

--- a/test/indexer/test_tdr.py
+++ b/test/indexer/test_tdr.py
@@ -199,11 +199,8 @@ class TDRPluginTestCase(TDRTestCase,
         can = self._load_canned_file_version(uuid=source.id,
                                              version=None,
                                              extension='tables.tdr')
-        for table_name, table_contents in can['tables'].items():
-            self._make_mock_table(source.spec,
-                                  table_name,
-                                  table_contents['rows'],
-                                  table_contents.get('schema'))
+        for name, table in can['tables'].items():
+            self._make_mock_table(source.spec, name, table['rows'], table.get('schema'))
 
     def _make_mock_table(self,
                          source: TDRSourceSpec,

--- a/test/indexer/test_tdr.py
+++ b/test/indexer/test_tdr.py
@@ -195,23 +195,23 @@ class TDRPluginTestCase(TDRTestCase,
                                            ])
         cls._patch_tdr_client()
 
-    def _make_mock_tdr_tables(self, source: TDRSourceRef) -> JSON:
+    def _make_mock_tables(self, source: TDRSourceRef) -> JSON:
         tables = self._load_canned_file_version(uuid=source.id,
                                                 version=None,
                                                 extension='tables.tdr')['tables']
         for table_name, table_contents in tables.items():
-            self._make_mock_entity_table(source.spec,
-                                         table_name,
-                                         table_contents['rows'],
-                                         table_contents.get('schema'))
+            self._make_mock_table(source.spec,
+                                  table_name,
+                                  table_contents['rows'],
+                                  table_contents.get('schema'))
         return tables
 
-    def _make_mock_entity_table(self,
-                                source: TDRSourceSpec,
-                                table_name: str,
-                                rows: JSONs,
-                                canned_schema: JSON | None = None
-                                ) -> None:
+    def _make_mock_table(self,
+                         source: TDRSourceSpec,
+                         table_name: str,
+                         rows: JSONs,
+                         canned_schema: JSON | None = None
+                         ) -> None:
         if canned_schema is None:
             assert len(rows) > 0, 'Empty tables require an explicit schema'
             schema = self._bq_schema_from_row(rows[0])
@@ -277,14 +277,14 @@ class TestTDRHCAPlugin(DCP2CannedBundleTestCase,
         source = self.source
         current_version = '2001-01-01T00:00:00.100001Z'
         links_ids = ['42-abc', '42-def', '42-ghi', '86-xyz']
-        self._make_mock_entity_table(source=source.spec,
-                                     table_name='links',
-                                     rows=[
-                                         dict(links_id=links_id,
-                                              version=current_version,
-                                              content={})
-                                         for links_id in links_ids
-                                     ])
+        self._make_mock_table(source=source.spec,
+                              table_name='links',
+                              rows=[
+                                  dict(links_id=links_id,
+                                       version=current_version,
+                                       content={})
+                                  for links_id in links_ids
+                              ])
         expected_bundle_ids = [
             TDRBundleFQID(source=source, uuid='42-abc', version=current_version),
             TDRBundleFQID(source=source, uuid='42-def', version=current_version),
@@ -305,7 +305,7 @@ class TestTDRHCAPlugin(DCP2CannedBundleTestCase,
 
     def test_list_and_count_files(self):
         source = self.source
-        self._make_mock_tdr_tables(source)
+        self._make_mock_tables(source)
         tables = self._load_canned_file_version(uuid=source.id,
                                                 version=None,
                                                 extension='tables.tdr')['tables']
@@ -399,7 +399,7 @@ class TestTDRHCAPlugin(DCP2CannedBundleTestCase,
                            *,
                            load_tables: bool):
         if load_tables:
-            self._make_mock_tdr_tables(test_bundle.fqid.source)
+            self._make_mock_tables(test_bundle.fqid.source)
         emulated_bundle = self.plugin.fetch_bundle(test_bundle.fqid)
 
         self.assertEqual(test_bundle.fqid, emulated_bundle.fqid)

--- a/test/indexer/test_tdr.py
+++ b/test/indexer/test_tdr.py
@@ -271,13 +271,14 @@ class TestTDRHCAPlugin(DCP2CannedBundleTestCase,
                                               content={})
                                          for links_id in links_ids
                                      ])
-        bundle_ids = self.plugin.list_bundles(source, prefix='42')
-        bundle_ids.sort(key=attrgetter('uuid'))
-        self.assertEqual(bundle_ids, [
+        expected_bundle_ids = [
             TDRBundleFQID(source=source, uuid='42-abc', version=current_version),
             TDRBundleFQID(source=source, uuid='42-def', version=current_version),
             TDRBundleFQID(source=source, uuid='42-ghi', version=current_version)
-        ])
+        ]
+        actual_bundle_ids = self.plugin.list_bundles(source, prefix='42')
+        actual_bundle_ids.sort(key=attrgetter('uuid'))
+        self.assertEqual(expected_bundle_ids, actual_bundle_ids)
 
     def test_fetch_bundle(self):
         fqid = self.bundle_fqid(uuid='1b6d8348-d6e9-406a-aa6a-7ee886e52bf9',

--- a/test/indexer/test_tdr.py
+++ b/test/indexer/test_tdr.py
@@ -61,6 +61,9 @@ from azul.bigquery import (
 from azul.docker import (
     resolve_docker_image_for_launch,
 )
+from azul.indexer import (
+    Prefix,
+)
 from azul.logging import (
     configure_test_logging,
     get_test_logger,
@@ -270,7 +273,7 @@ class TestTDRHCAPlugin(DCP2CannedBundleTestCase,
     def _plugin_cls(cls) -> Type[tdr_hca.Plugin]:
         return tdr_hca.Plugin
 
-    def test_list_bundles(self):
+    def test_list_and_count_bundles(self):
         source = self.source
         current_version = '2001-01-01T00:00:00.100001Z'
         links_ids = ['42-abc', '42-def', '42-ghi', '86-xyz']
@@ -287,9 +290,53 @@ class TestTDRHCAPlugin(DCP2CannedBundleTestCase,
             TDRBundleFQID(source=source, uuid='42-def', version=current_version),
             TDRBundleFQID(source=source, uuid='42-ghi', version=current_version)
         ]
-        actual_bundle_ids = self.plugin.list_bundles(source, prefix='42')
-        actual_bundle_ids.sort(key=attrgetter('uuid'))
-        self.assertEqual(expected_bundle_ids, actual_bundle_ids)
+        with self.subTest('list_bundles'):
+            actual_bundle_ids = self.plugin.list_bundles(source, prefix='42')
+            actual_bundle_ids.sort(key=attrgetter('uuid'))
+            self.assertEqual(expected_bundle_ids, actual_bundle_ids)
+        with self.subTest('count_bundles_unpartitioned'):
+            unpartitioned_src = attr.evolve(source, prefix=None)
+            actual_bundle_count = self.plugin.count_bundles(unpartitioned_src)
+            self.assertEqual(len(links_ids), actual_bundle_count)
+        with self.subTest('count_bundles_partitioned'):
+            partitioned_src = attr.evolve(source, prefix=Prefix.parse('42/0'))
+            actual_bundle_count = self.plugin.count_bundles(partitioned_src)
+            self.assertEqual(len(expected_bundle_ids), actual_bundle_count)
+
+    def test_list_and_count_files(self):
+        source = self.source
+        self._make_mock_tdr_tables(source)
+        tables = self._load_canned_file_version(uuid=source.id,
+                                                version=None,
+                                                extension='tables.tdr')['tables']
+        all_files = [
+            row['descriptor']
+            for table_name, table_contents in tables.items()
+            if table_name.endswith('_file')
+            for row in table_contents['rows']
+        ]
+        prefix = '3'
+        partition_file_uuids = [
+            file['file_id']
+            for file in all_files
+            if file['sha256'].startswith(prefix)
+        ]
+        self.assertGreater(len(partition_file_uuids), 0, 'Empty prefix')
+        with mock.patch.object(tdr_hca.Plugin, '_assert_partition'):
+            with self.subTest('list_files'):
+                actual_file_uuids = [
+                    file.uuid
+                    for file in self.plugin.list_files(source, prefix=prefix)
+                ]
+                self.assertEqual(partition_file_uuids, actual_file_uuids)
+        with self.subTest('count_files_unpartitioned'):
+            unpartitioned_src = attr.evolve(source, prefix=None)
+            actual_file_count = self.plugin.count_files(unpartitioned_src)
+            self.assertEqual(len(all_files), actual_file_count)
+        with self.subTest('count_files_partitioned'):
+            partitioned_src = attr.evolve(source, prefix=Prefix.parse(f'{prefix}/0'))
+            actual_file_count = self.plugin.count_files(partitioned_src)
+            self.assertEqual(len(partition_file_uuids), actual_file_count)
 
     def test_fetch_bundle(self):
         fqid = self.bundle_fqid(uuid='1b6d8348-d6e9-406a-aa6a-7ee886e52bf9',

--- a/test/indexer/test_tdr.py
+++ b/test/indexer/test_tdr.py
@@ -199,14 +199,25 @@ class TDRPluginTestCase(TDRTestCase,
         for table_name, table_contents in tables.items():
             self._make_mock_entity_table(source.spec,
                                          table_name,
-                                         table_contents['rows'])
+                                         table_contents['rows'],
+                                         table_contents.get('schema'))
         return tables
 
     def _make_mock_entity_table(self,
                                 source: TDRSourceSpec,
                                 table_name: str,
-                                rows: JSONs) -> None:
-        schema = self._bq_schema_from_row(rows[0])
+                                rows: JSONs,
+                                canned_schema: JSON | None = None
+                                ) -> None:
+        if canned_schema is None:
+            assert len(rows) > 0, 'Empty tables require an explicit schema'
+            schema = self._bq_schema_from_row(rows[0])
+        else:
+            schema = [
+                bigquery.SchemaField(**column_schema)
+                for column_schema in canned_schema['columns']
+            ]
+
         columns = {column.name for column in schema}
         json_type = reify(JSON)
 

--- a/test/indexer/test_tdr.py
+++ b/test/indexer/test_tdr.py
@@ -196,17 +196,17 @@ class TDRPluginTestCase(TDRTestCase,
         tables = self._load_canned_file_version(uuid=source.id,
                                                 version=None,
                                                 extension='tables.tdr')['tables']
-        for table_name, table_rows in tables.items():
+        for table_name, table_contents in tables.items():
             self._make_mock_entity_table(source.spec,
                                          table_name,
-                                         table_rows['rows'])
+                                         table_contents['rows'])
         return tables
 
     def _make_mock_entity_table(self,
                                 source: TDRSourceSpec,
                                 table_name: str,
                                 rows: JSONs) -> None:
-        schema = self._bq_schema(rows[0])
+        schema = self._bq_schema_from_row(rows[0])
         columns = {column.name for column in schema}
         json_type = reify(JSON)
 
@@ -232,7 +232,7 @@ class TDRPluginTestCase(TDRTestCase,
         self.addCleanup(bq.delete_table, table)
         bq.insert_rows(table=table, selected_fields=schema, rows=map(dump_row, rows))
 
-    def _bq_schema(self, row: BigQueryRow) -> list[bigquery.SchemaField]:
+    def _bq_schema_from_row(self, row: BigQueryRow) -> list[bigquery.SchemaField]:
 
         def field_type(key: str, value: AnyJSON) -> str:
             if key == 'version':

--- a/test/indexer/test_tdr.py
+++ b/test/indexer/test_tdr.py
@@ -196,10 +196,10 @@ class TDRPluginTestCase(TDRTestCase,
         cls._patch_tdr_client()
 
     def _make_mock_tables(self, source: TDRSourceRef) -> None:
-        tables = self._load_canned_file_version(uuid=source.id,
-                                                version=None,
-                                                extension='tables.tdr')['tables']
-        for table_name, table_contents in tables.items():
+        can = self._load_canned_file_version(uuid=source.id,
+                                             version=None,
+                                             extension='tables.tdr')
+        for table_name, table_contents in can['tables'].items():
             self._make_mock_table(source.spec,
                                   table_name,
                                   table_contents['rows'],

--- a/test/indexer/test_tdr.py
+++ b/test/indexer/test_tdr.py
@@ -195,7 +195,7 @@ class TDRPluginTestCase(TDRTestCase,
                                            ])
         cls._patch_tdr_client()
 
-    def _make_mock_tables(self, source: TDRSourceRef) -> JSON:
+    def _make_mock_tables(self, source: TDRSourceRef) -> None:
         tables = self._load_canned_file_version(uuid=source.id,
                                                 version=None,
                                                 extension='tables.tdr')['tables']
@@ -204,7 +204,6 @@ class TDRPluginTestCase(TDRTestCase,
                                   table_name,
                                   table_contents['rows'],
                                   table_contents.get('schema'))
-        return tables
 
     def _make_mock_table(self,
                          source: TDRSourceSpec,


### PR DESCRIPTION


<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #7500, #7507


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer


### Peer reviewer (after approval)

Note that when requesting changes, the PR must be assigned back to the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
