### PR TITLE
Fix: Effective value of azul_current_{catalog,source} is not obvious (#7503)

### DIFF
--- a/scripts/find_in_snapshots.py
+++ b/scripts/find_in_snapshots.py
@@ -37,7 +37,8 @@ def main(args):
     invalid_sources: list[JSON] = list()
 
     azul = AzulClient(num_workers=1)
-    sources_by_catalog = azul.matching_sources(args.catalogs, set(args.sources))
+    sources = {'*'} if args.sources is None else set(args.sources)
+    sources_by_catalog = azul.matching_sources(args.catalogs, sources)
     previous_sources: set[TDRSourceSpec] = set()
     for catalog, sources in sources_by_catalog.items():
         plugin = azul.repository_plugin(catalog)

--- a/scripts/mirror.py
+++ b/scripts/mirror.py
@@ -38,27 +38,26 @@ def mirror_catalog(azul: AzulClient,
         source.spec: source
         for source in plugin.list_sources(authentication=None)
     }
-    source_specs = azul.matching_sources([catalog], source_globs)[catalog]
     # When the user doesn't specify a source or provides "*" as a source glob,
     # we implicitly filter out managed-access sources. This lets us assert that
     # all sources matching the provided globs are public, without forcing the
     # user to manually specify every public source.
     if '*' in source_globs:
-        source_specs = {
-            spec: cfg
-            for spec, cfg in source_specs.items()
-            if spec in public_sources_by_spec
-        }
-
-    try:
+        source_specs = azul.repository_plugin(catalog).sources
         source_refs = {
-            public_sources_by_spec[spec]: cfg
-            for spec, cfg in source_specs.items()
+            source: source_specs[spec]
+            for spec, source in public_sources_by_spec.items()
         }
-    except KeyError as e:
-        assert False, R(
-            'Cannot mirror managed-access source', e.args[0])
-
+    else:
+        source_specs = azul.matching_sources([catalog], source_globs)[catalog]
+        try:
+            source_refs = {
+                public_sources_by_spec[spec]: cfg
+                for spec, cfg in source_specs.items()
+            }
+        except KeyError as e:
+            assert False, R(
+                'Cannot mirror managed-access source', e.args[0])
     azul.mirror_service.remote_mirror(catalog, source_refs.items())
 
     if wait:

--- a/scripts/mirror.py
+++ b/scripts/mirror.py
@@ -13,6 +13,7 @@ from azul import (
 )
 from azul.args import (
     AzulArgumentHelpFormatter,
+    get_sources,
 )
 from azul.azulclient import (
     AzulClient,
@@ -75,7 +76,6 @@ def main(args):
                         default=config.default_catalog,
                         help='The name of the catalog to mirror.')
     parser.add_argument('--sources',
-                        default=config.current_sources,
                         nargs='+',
                         help='Limit mirroring to a subset of the configured sources. '
                              'Supports shell-style wildcards to match multiple sources per argument. '
@@ -99,7 +99,7 @@ def main(args):
     if args.purge:
         azul.queues.purge_mirror()
     if args.mirror:
-        mirror_catalog(azul, args.catalog, set(args.sources), args.wait)
+        mirror_catalog(azul, args.catalog, get_sources(args.sources), args.wait)
 
 
 if __name__ == '__main__':

--- a/scripts/mirror.py
+++ b/scripts/mirror.py
@@ -80,7 +80,9 @@ def main(args):
                         nargs='+',
                         help='Limit mirroring to a subset of the configured sources. '
                              'Supports shell-style wildcards to match multiple sources per argument. '
-                             'All sources must be public.')
+                             'All sources must be public. If no values are passed, this argument will be set from the '
+                             'environment variable ``azul_current_sources``. If that variable is unset, all sources in '
+                             'the selected catalog will be used.')
     parser.add_argument('--mirror',
                         action='store_true',
                         help='Mirror files in the specified catalog and sources')

--- a/scripts/reindex.py
+++ b/scripts/reindex.py
@@ -11,6 +11,8 @@ from azul import (
 )
 from azul.args import (
     AzulArgumentHelpFormatter,
+    get_catalogs,
+    get_sources,
 )
 from azul.azulclient import (
     AzulClient,
@@ -57,21 +59,11 @@ parser.add_argument('--local',
 parser.add_argument('--catalogs',
                     nargs='+',
                     metavar='NAME',
-                    default=[
-                        catalog.name
-                        for catalog in config.catalogs.values()
-                        if not catalog.is_integration_test_catalog
-                    ]
-                    if config.current_catalog is None else
-                    [
-                        config.catalogs[config.current_catalog].name
-                    ],
                     choices=config.catalogs,
                     help='Limit reindexing to a subset of the configured catalogs. If no values are passed, this '
                          'argument will be set from the environment variable ``azul_current_catalog``. If that '
                          'variable is unset, all non-IT catalogs will be used.')
 parser.add_argument('--sources',
-                    default=config.current_sources,
                     nargs='+',
                     help='Limit reindexing to a subset of the configured sources. '
                          'Supports shell-style wildcards to match multiple sources per argument. '
@@ -132,7 +124,9 @@ def main(argv: list[str]):
 
     azul = AzulClient(num_workers=args.num_workers)
 
-    source_globs = set(args.sources)
+    catalogs = get_catalogs(args.catalogs)
+    source_globs = get_sources(args.sources)
+
     every_source = '*' in source_globs
     deindex = args.deindex or (args.delete and not every_source)
     delete = args.delete and every_source
@@ -150,7 +144,7 @@ def main(argv: list[str]):
         parser.error('--deindex is incompatible with --create and --delete.')
         assert False
 
-    sources_by_catalog = azul.matching_sources(args.catalogs, source_globs)
+    sources_by_catalog = azul.matching_sources(catalogs, source_globs)
     azul.require_no_failures_before()
 
     if deindex:
@@ -158,7 +152,7 @@ def main(argv: list[str]):
             if sources:
                 azul.deindex(catalog, sources)
 
-    azul.reset_indexer(args.catalogs,
+    azul.reset_indexer(catalogs,
                        purge_queues=args.purge,
                        delete_indices=delete,
                        create_indices=args.create or args.index and delete)
@@ -186,7 +180,7 @@ def main(argv: list[str]):
         if args.wait:
             if num_notifications == 0:
                 log.warning('No notifications for prefix %r and catalogs %r were sent',
-                            args.prefix, args.catalogs)
+                            args.prefix, catalogs)
             else:
                 azul.wait_for_indexer()
                 azul.require_no_failures_after()

--- a/scripts/reindex.py
+++ b/scripts/reindex.py
@@ -67,13 +67,17 @@ parser.add_argument('--catalogs',
                         config.catalogs[config.current_catalog].name
                     ],
                     choices=config.catalogs,
-                    help='Limit reindexing to a subset of the configured catalogs.')
+                    help='Limit reindexing to a subset of the configured catalogs. If no values are passed, this '
+                         'argument will be set from the environment variable ``azul_current_catalog``. If that '
+                         'variable is unset, all non-IT catalogs will be used.')
 parser.add_argument('--sources',
                     default=config.current_sources,
                     nargs='+',
                     help='Limit reindexing to a subset of the configured sources. '
                          'Supports shell-style wildcards to match multiple sources per argument. '
-                         'Must be * for local reindexing i.e., if --local is given.')
+                         'Must be * for local reindexing i.e., if --local is given. If no values are passed, this '
+                         'argument will be set from the environment variable ``azul_current_sources``. If that '
+                         'variable is unset, all sources in the selected catalogs will be used.')
 parser.add_argument('--delete',
                     default=False,
                     action='store_true',

--- a/scripts/reindex.py
+++ b/scripts/reindex.py
@@ -67,7 +67,7 @@ parser.add_argument('--catalogs',
                         config.catalogs[config.current_catalog].name
                     ],
                     choices=config.catalogs,
-                    help='The names of the catalogs to reindex.')
+                    help='Limit reindexing to a subset of the configured catalogs.')
 parser.add_argument('--sources',
                     default=config.current_sources,
                     nargs='+',

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -1669,11 +1669,15 @@ class Config:
         return self.qualified_resource_name('sources_cache_by_auth')
 
     @property
-    def current_sources(self) -> list[str]:
-        sources = self.environ.get('azul_current_sources', '*')
-        sources = shlex.split(sources)
-        assert bool(sources), R('Sources cannot be empty', sources)
-        return sources
+    def current_sources(self) -> list[str] | None:
+        try:
+            sources = self.environ['azul_current_sources']
+        except KeyError:
+            return None
+        else:
+            sources = shlex.split(sources)
+            assert bool(sources), R('Sources cannot be empty', sources)
+            return sources
 
     terms_aggregation_size = 99999
 

--- a/src/azul/args.py
+++ b/src/azul/args.py
@@ -2,6 +2,11 @@ import argparse
 import logging
 import shutil
 
+from azul import (
+    CatalogName,
+    config,
+)
+
 log = logging.getLogger(__name__)
 
 
@@ -11,3 +16,39 @@ class AzulArgumentHelpFormatter(argparse.ArgumentDefaultsHelpFormatter):
         super().__init__(prog,
                          max_help_position=50,
                          width=min(shutil.get_terminal_size((80, 25)).columns, 120))
+
+
+def get_catalogs(catalogs_arg: list[str] | None) -> list[CatalogName]:
+    if catalogs_arg is None:
+        current_catalog = config.current_catalog
+        if current_catalog is None:
+            catalog_origin = 'deployment configuration (no specific catalogs provided)'
+            catalogs = [
+                catalog.name
+                for catalog in config.catalogs.values()
+                if not catalog.is_integration_test_catalog
+            ]
+        else:
+            catalog_origin = 'environment variable'
+            catalogs = [config.catalogs[current_catalog].name]
+    else:
+        catalog_origin = 'command line argument'
+        catalogs = catalogs_arg
+    log.info('Using catalog(s) specified via %s: %r', catalog_origin, catalogs)
+    return catalogs
+
+
+def get_sources(sources_arg: list[str] | None) -> set[str]:
+    if sources_arg is None:
+        current_sources = config.current_sources
+        if current_sources is None:
+            source_origin = 'deployment configuration (no specific sources provided)'
+            source_globs = {'*'}
+        else:
+            source_origin = 'environment variable'
+            source_globs = set(current_sources)
+    else:
+        source_origin = 'command line argument'
+        source_globs = set(sources_arg)
+    log.info('Using source glob(s) specified via %s: %r', source_origin, source_globs)
+    return source_globs

--- a/src/azul/azulclient.py
+++ b/src/azul/azulclient.py
@@ -213,11 +213,13 @@ class AzulClient(SignatureHelper, HasCachedHttpClient):
                          globs: AbstractSet[str] = frozenset('*')
                          ) -> dict[CatalogName, dict[SourceSpec, SourceConfig]]:
         result = {}
-        matched_globs = set()
+        matched_globs: set[str] = set()
         for catalog in catalogs:
             raw_specs = config.sources(catalog)
             specs = dict(self.repository_plugin(catalog).sources)
-            if '*' not in globs:
+            if '*' in globs:
+                matched_globs.update(globs)
+            else:
                 matching_raw_specs: set[str] = set()
                 for glob in globs:
                     _matching_raw_specs = fnmatch.filter(raw_specs, glob)


### PR DESCRIPTION
Linked issues: #7503


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to ~~only~~ the peer


### Peer reviewer (after approval)

Note that when requesting changes, the PR must be assigned back to the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to ~only~ the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
