### PR TITLE
Hotfix prod: Index dcp55 in prod (#7552)

### DIFF
--- a/deployments/prod/environment.py
+++ b/deployments/prod/environment.py
@@ -1745,6 +1745,14 @@ dcp54_sources = mkdict(dcp53_sources, 521, mkdelta([
     mksrc('bigquery', 'datarepo-dcd21441', 'hca_prod_f77290ae0d7b4239b0fe3cf2c9e8858d__20250203_dcp2_20250930_dcp54'),
 ]))
 
+dcp55_sources = mkdict(dcp54_sources, 526, mkdelta([
+    mksrc('bigquery', 'datarepo-5cffc4da', 'hca_prod_2079bb2e676e4bbf8c68f9c6459edcbb__20240327_dcp2_20251104_dcp55'),
+    mksrc('bigquery', 'datarepo-03f25c54', 'hca_prod_4bcc16b57a4745bbb9c0be9d5336df2d__20240327_dcp2_20251104_dcp55'),
+    mksrc('bigquery', 'datarepo-b42d0841', 'hca_prod_9c20a245f2c043ae82c92232ec6b594f__20220212_dcp2_20251104_dcp55'),
+    mksrc('bigquery', 'datarepo-d840670b', 'hca_prod_b10cd3143e7144379a1677028d243e81__20251104_dcp2_20251104_dcp55'),
+    mksrc('bigquery', 'datarepo-bb0a7bc5', 'hca_prod_c7a342eb777e447995ce468f5bbcd893__20251104_dcp2_20251104_dcp55'),
+]))
+
 lungmap_sources = mkdict({}, 3, mkdelta([
     mksrc('bigquery', 'datarepo-32f75497', 'lungmap_prod_00f056f273ff43ac97ff69ca10e38c89__20220308_20220308'),
     mksrc('bigquery', 'datarepo-7066459d', 'lungmap_prod_1bdcecde16be420888f478cd2133d11d__20220308_20220308'),
@@ -1856,6 +1864,7 @@ def env() -> Mapping[str, str | None]:
                                        sources=mklist(sources))
             for atlas, catalog, sources in [
                 ('hca', 'dcp54', dcp54_sources),
+                ('hca', 'dcp55', dcp55_sources),
                 ('lungmap', 'lm9', lm9_sources)
             ] for suffix, internal in [
                 ('', False),


### PR DESCRIPTION
Linked issues: #7552

## Checklist

## Notes

- Perform a [catalog specific reindex](https://github.com/DataBiosphere/azul/blob/develop/OPERATOR.rst#reindexing-a-specific-catalog-or-sources-in-gitlab) of `dcp55` in `prod`

### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] Target branch is `prod`
- [ ] ~Name of PR branch matches~ `hotfixes/<GitHub handle of author>/<issue#>-<slug>-prod`
- [x] PR is linked to the issue it hotfixes
- [x] Status of linked issue is *In progress*
- [x] PR description links to linked issue
- [x] PR title is `Hotfix prod: ` followed by title of linked issue
- [x] PR title references the linked issue


### Author (hotfixes)

- [x] Added `h` tag to commit title <sub>or this PR does not include a temporary hotfix</sub>
- [x] Added `H` tag to commit title <sub>or this PR does not include a permanent hotfix</sub>
- [x] Added `hotfix` label to PR
- [ ] ~This PR is labeled `partial`~ <sub>or represents a permanent hotfix</sub>


### Author (before every review)

- [x] Rebased PR branch on `prod`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled PR as `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator


### Operator

- [x] Squashed PR branch and rebased onto `prod`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy runner image)

- [x] Ran `_select prod.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but excluded any `p` tags</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged stable*


### Operator (main build)

- [x] Pushed merge commit to GitLab `prod`
- [x] Build passes on GitLab `prod`
- [x] Reviewed build logs for anomalies on GitLab `prod`
- [x] Deleted PR branch from GitHub
- [x] Status of linked issue is *Stable*


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `prod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:prod`</sub>
- [x] Deindexed specific sources in `prod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:prod`</sub>
- [x] Indexed specific sources in `prod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:prod`</sub>
- [x] Started reindex in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Emptied fail queues in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/prod branch](https://gitlab.azul.data.humancellatlas.org/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fprod) on GitLab in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/prod branch](https://gitlab.azul.data.humancellatlas.org/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fprod) on GitLab in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [ ] ~Created backport PR and linked to it in a comment on this PR~ see end of CL


### Operator (mirroring)

@achave11-ucsc let's do this together, and once all other `prod` hotfixes (currently only PR #7579 for #7574) have landed.

- [x] Started mirroring in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Emptied mirror fail queue in `prod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>


### Operator

- [x] PR is assigned to only the system administrator


### System administrator

- [x] Backported changes to `develop`
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem