### PR TITLE
Fix: IT does not cover downloads of mirrored files (#7531)

### DIFF
--- a/scripts/mirror.py
+++ b/scripts/mirror.py
@@ -59,7 +59,7 @@ def mirror_catalog(azul: AzulClient,
         except KeyError as e:
             assert False, R(
                 'Cannot mirror managed-access source', e.args[0])
-    azul.mirror_service.remote_mirror(catalog, source_refs.items())
+    azul.mirror_service.mirror_sources(catalog, source_refs.items())
 
     if wait:
         azul.wait_for_mirroring()

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -154,6 +154,12 @@ class BaseMirrorService:
 
             self._queue_messages(messages())
 
+    def mirror_file(self, catalog: CatalogName, source: SourceRef, file: File):
+        self._queue_messages([MirrorFileAction(catalog=catalog,
+                                               source=source,
+                                               prefix='',
+                                               file=file)])
+
     def _mirror_queue(self):
         name = config.mirror_queue.name
         return aws.sqs_queue(name)

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -131,10 +131,10 @@ class BaseMirrorService:
     def _queues(self) -> Queues:
         return Queues()
 
-    def remote_mirror(self,
-                      catalog: CatalogName,
-                      sources: Iterable[tuple[SourceRef, SourceConfig]]
-                      ):
+    def mirror_sources(self,
+                       catalog: CatalogName,
+                       sources: Iterable[tuple[SourceRef, SourceConfig]]
+                       ):
         mirror_limit = config.catalogs[catalog].mirror_limit
         if mirror_limit is not None and mirror_limit < 0:
             log.info('Not mirroring any files in catalog %r because the file '

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -141,9 +141,8 @@ class TestMirrorController(DCP2TestCase,
     def _mirror_event(self, body: JSON) -> list[SQSRecord]:
         return [self._mock_sqs_record(body, fifo=True)]
 
-    def _remote_mirror(self, mirror_source_cfg: bool = True) -> MutableJSONs:
-        cfg = SourceConfig(mirror=mirror_source_cfg)
-        self.service.remote_mirror(self.catalog, [(self.source, cfg)])
+    def _remote_mirror(self, source_config=SourceConfig(mirror=True)) -> MutableJSONs:
+        self.service.remote_mirror(self.catalog, [(self.source, source_config)])
         return self._read_queue(self.service._mirror_queue())
 
     def _test_remote_mirror(self):
@@ -223,7 +222,7 @@ class TestMirrorController(DCP2TestCase,
         self._create_mock_queues(config.mirror_queue_names)
 
         with self.subTest(no_mirror=True):
-            messages = self._remote_mirror(mirror_source_cfg=False)
+            messages = self._remote_mirror(SourceConfig(mirror=False))
             self.assertEqual([], messages)
 
         catalog = config.catalogs[self.catalog]

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -104,8 +104,8 @@ class TestMirrorController(DCP2TestCase,
     def test_mirroring(self):
         self._create_mock_queues(config.mirror_queue_names)
         file = self._file
-        with self.subTest('remote_mirror'):
-            source_message = self._test_remote_mirror()
+        with self.subTest('mirror_sources'):
+            source_message = self._test_mirror_sources()
 
             with self.subTest('mirror_source'):
                 partition_message = self._test_mirror_source(source_message)
@@ -141,12 +141,12 @@ class TestMirrorController(DCP2TestCase,
     def _mirror_event(self, body: JSON) -> list[SQSRecord]:
         return [self._mock_sqs_record(body, fifo=True)]
 
-    def _remote_mirror(self, source_config=SourceConfig(mirror=True)) -> MutableJSONs:
-        self.service.remote_mirror(self.catalog, [(self.source, source_config)])
+    def _mirror_sources(self, source_config=SourceConfig(mirror=True)) -> MutableJSONs:
+        self.service.mirror_sources(self.catalog, [(self.source, source_config)])
         return self._read_queue(self.service._mirror_queue())
 
-    def _test_remote_mirror(self):
-        source_message = one(self._remote_mirror())
+    def _test_mirror_sources(self):
+        source_message = one(self._mirror_sources())
         expected_message = dict(action='MirrorSourceAction',
                                 catalog=self.catalog,
                                 source=self.source.to_json())
@@ -222,7 +222,7 @@ class TestMirrorController(DCP2TestCase,
         self._create_mock_queues(config.mirror_queue_names)
 
         with self.subTest(no_mirror=True):
-            messages = self._remote_mirror(SourceConfig(mirror=False))
+            messages = self._mirror_sources(SourceConfig(mirror=False))
             self.assertEqual([], messages)
 
         catalog = config.catalogs[self.catalog]
@@ -234,14 +234,14 @@ class TestMirrorController(DCP2TestCase,
 
         with self.subTest(mirror_limit=-1):
             with patch_max_file_size(-1):
-                messages = self._remote_mirror()
+                messages = self._mirror_sources()
                 self.assertEqual([], messages)
 
         with self.subTest(mirror_limit=self._file.size):
             too_big = attrs.evolve(self._file,
                                    uuid='2873c8ef-8f76-4ccf-add7-26afe8c62873',
                                    size=self._file.size + 1)
-            source_message = self._test_remote_mirror()
+            source_message = self._test_mirror_sources()
             partition_message = self._test_mirror_source(source_message)
             with patch_max_file_size(self._file.size):
                 self._test_mirror_partition(partition_message, [too_big, self._file])

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -1734,11 +1734,11 @@ class IndexingIntegrationTest(IntegrationTestCase):
             self._assert_queues_empty([config.mirror_queue.name,
                                        config.mirror_queue.to_fail.name])
             _delete()
-            for _ in range(2):
-                for catalog, sources in sources_by_catalog.items():
+            for catalog, sources in sources_by_catalog.items():
+                for _ in range(2):
                     mirror_service.remote_mirror(catalog, sources)
-                self.azul_client.wait_for_mirroring()
-                self._assert_queues_empty([config.mirror_queue.to_fail.name])
+                    self.azul_client.wait_for_mirroring()
+                    self._assert_queues_empty([config.mirror_queue.to_fail.name])
             _delete()
 
 

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -149,6 +149,7 @@ from azul.oauth2 import (
     OAuth2Client,
 )
 from azul.plugins import (
+    File,
     MetadataPlugin,
     RepositoryPlugin,
 )
@@ -461,7 +462,14 @@ class IndexingIntegrationTest(IntegrationTestCase):
         catalogs: list[Catalog] = []
         for catalog in config.integration_test_catalogs.values():
             if index:
-                public_source, _ = self._select_source(catalog.name, public=True)
+                public_source, _ = self._select_source(
+                    catalog.name,
+                    public=True,
+                    # If test_mirroring is run for the catalog, ensure that the
+                    # source is not flagged as no_mirror so that we can test
+                    # downloading a mirrored file
+                    mirror=config.enable_mirroring and catalog.mirror_limit >= 0
+                )
                 ma_source = self._select_source(catalog.name, public=False)
                 if ma_source is not None:
                     ma_source = ma_source[0]
@@ -502,6 +510,9 @@ class IndexingIntegrationTest(IntegrationTestCase):
                                       public_source=catalog.public_source,
                                       ma_source=catalog.ma_source)
 
+        if config.enable_mirroring:
+            self._test_mirroring(delete=delete)
+
         if index and delete:
             # FIXME: Test delete notifications
             #        https://github.com/DataBiosphere/azul/issues/3548
@@ -513,9 +524,6 @@ class IndexingIntegrationTest(IntegrationTestCase):
             log.warning('Will skip deletions due to overriding IT flag')
 
         self._test_other_endpoints()
-
-        if config.enable_mirroring:
-            self._test_mirroring(delete=delete)
 
     def _reset_indexer(self):
         # While it's OK to erase the integration test catalog, the queues are
@@ -736,6 +744,24 @@ class IndexingIntegrationTest(IntegrationTestCase):
             elif response.status == status:
                 urls.append(furl(response.headers['Location']))
         return urls
+
+    def _get_one_mirrorable_file(self,
+                                 catalog: CatalogName
+                                 ) -> tuple[File, SourceRef, JSON]:
+        plugin = self.repository_plugin(catalog)
+        with self._public_service_account_credentials:
+            # This depends on the indexing test choosing a public source that
+            # is not flagged as no_mirror
+            outer_file, inner_file = self._get_one_inner_file(catalog)
+        file_digest = lookup(inner_file, 'sha256', 'file_md5sum')
+        source = one(outer_file['sources'])
+        # In principle, we could use the entire digest here, but Prefix only
+        # allows up to 8 chars because it can be used with UUIDs
+        prefix = Prefix(common=file_digest[:8], partition=0)
+        source = self._source_from_response(catalog, source)
+        files = plugin.list_files(source.with_prefix(prefix), prefix=prefix.common)
+        file = one(file for file in files if file.digest.value == file_digest)
+        return file, source, inner_file
 
     def _get_one_inner_file(self, catalog: CatalogName) -> tuple[JSON, JSON]:
         outer_file = self._get_one_outer_file(catalog)
@@ -1734,11 +1760,27 @@ class IndexingIntegrationTest(IntegrationTestCase):
             self._assert_queues_empty([config.mirror_queue.name,
                                        config.mirror_queue.to_fail.name])
             _delete()
-            for catalog, sources in sources_by_catalog.items():
-                for _ in range(2):
-                    mirror_service.remote_mirror(catalog, sources)
-                    self.azul_client.wait_for_mirroring()
-                    self._assert_queues_empty([config.mirror_queue.to_fail.name])
+
+            indexed_files: dict[File, tuple[SourceRef, JSON]] = {}
+            with self.subTest('remote_mirror'):
+                for catalog, sources in sources_by_catalog.items():
+                    repository_file, source, file_response = self._get_one_mirrorable_file(catalog)
+                    indexed_files[repository_file] = source, file_response
+                    for _ in range(2):
+                        mirror_service.remote_mirror(catalog, sources)
+                        mirror_service.mirror_file(catalog, source, repository_file)
+                        self.azul_client.wait_for_mirroring()
+                        self._assert_queues_empty([config.mirror_queue.to_fail.name])
+
+                with self.subTest('mirror_repository_files'):
+                    for repository_file, (source, file_response) in indexed_files.items():
+                        digest = repository_file.digest
+                        expected_url = furl(scheme='https', host='s3.amazonaws.com', path=[
+                            aws.mirror_bucket, '_it', 'file', f'{digest.value}.{digest.type}',
+                        ])
+                        actual_url = self._test_file_download(source.spec, file_response)
+                        actual_url.set(args=None)
+                        self.assertEqual(expected_url, actual_url)
             _delete()
 
 

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -759,6 +759,8 @@ class IndexingIntegrationTest(IntegrationTestCase):
         # allows up to 8 chars because it can be used with UUIDs
         prefix = Prefix(common=file_digest[:8], partition=0)
         source = self._source_from_response(catalog, source)
+        # FIXME: Avoid use of plugin, instantiate file from hit instead
+        #        https://github.com/DataBiosphere/azul/issues/7615
         files = plugin.list_files(source.with_prefix(prefix), prefix=prefix.common)
         file = one(file for file in files if file.digest.value == file_digest)
         return file, source, inner_file

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -1738,7 +1738,7 @@ class IndexingIntegrationTest(IntegrationTestCase):
 
     def _test_mirroring(self, *, delete: bool):
         mirror_service = self.azul_client.mirror_service
-        with self.subTest('mirror_files'):
+        with self.subTest('mirroring'):
             catalogs = [
                 c.name
                 for c in config.catalogs.values()
@@ -1762,17 +1762,17 @@ class IndexingIntegrationTest(IntegrationTestCase):
             _delete()
 
             indexed_files: dict[File, tuple[SourceRef, JSON]] = {}
-            with self.subTest('remote_mirror'):
+            with self.subTest('mirror_sources_and_files'):
                 for catalog, sources in sources_by_catalog.items():
                     repository_file, source, file_response = self._get_one_mirrorable_file(catalog)
                     indexed_files[repository_file] = source, file_response
                     for _ in range(2):
-                        mirror_service.remote_mirror(catalog, sources)
+                        mirror_service.mirror_sources(catalog, sources)
                         mirror_service.mirror_file(catalog, source, repository_file)
                         self.azul_client.wait_for_mirroring()
                         self._assert_queues_empty([config.mirror_queue.to_fail.name])
 
-                with self.subTest('mirror_repository_files'):
+                with self.subTest('download_mirrored_files'):
                     for repository_file, (source, file_response) in indexed_files.items():
                         digest = repository_file.digest
                         expected_url = furl(scheme='https', host='s3.amazonaws.com', path=[

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -1711,6 +1711,7 @@ class IndexingIntegrationTest(IntegrationTestCase):
                 self.assertIn(expected_auth_header, command_line)
 
     def _test_mirroring(self, *, delete: bool):
+        mirror_service = self.azul_client.mirror_service
         with self.subTest('mirror_files'):
             catalogs = [
                 c.name
@@ -1735,7 +1736,7 @@ class IndexingIntegrationTest(IntegrationTestCase):
             _delete()
             for _ in range(2):
                 for catalog, sources in sources_by_catalog.items():
-                    self.azul_client.mirror_service.remote_mirror(catalog, sources)
+                    mirror_service.remote_mirror(catalog, sources)
                 self.azul_client.wait_for_mirroring()
                 self._assert_queues_empty([config.mirror_queue.to_fail.name])
             _delete()

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -761,13 +761,8 @@ class IndexingIntegrationTest(IntegrationTestCase):
         return one(hits)
 
     def _source_spec(self, catalog: CatalogName, entity: JSON) -> SourceSpec:
-        if config.is_hca_enabled(catalog):
-            field = 'sourceSpec'
-        elif config.is_anvil_enabled(catalog):
-            field = 'source_spec'
-        else:
-            assert False, catalog
-        return TDRSourceSpec.parse(one(entity['sources'])[field])
+        source = self._source_from_response(catalog, one(entity['sources']))
+        return source.spec
 
     def _file_size_facet(self, catalog: CatalogName) -> str:
         if config.is_hca_enabled(catalog):
@@ -1271,6 +1266,13 @@ class IndexingIntegrationTest(IntegrationTestCase):
         notifications.extend(duplicate_bundles)
         return notifications, bundle_fqids
 
+    def _source_from_response(self, catalog: CatalogName, source_json: JSON) -> SourceRef:
+        special_fields = self.metadata_plugin(catalog).special_fields
+        source = dict(id=source_json[special_fields.source_id],
+                      spec=source_json[special_fields.source_spec],
+                      prefix=source_json[special_fields.source_prefix])
+        return self.repository_plugin(catalog).source_ref_cls.from_json(source)
+
     def _get_indexed_bundles(self,
                              catalog: CatalogName,
                              filters: JSON | None = None
@@ -1280,10 +1282,7 @@ class IndexingIntegrationTest(IntegrationTestCase):
         special_fields = self.metadata_plugin(catalog).special_fields
         for hit in hits:
             source, bundle = one(hit['sources']), one(hit['bundles'])
-            source = dict(id=source[special_fields.source_id],
-                          spec=source[special_fields.source_spec],
-                          prefix=source[special_fields.source_prefix])
-            source = self.repository_plugin(catalog).source_ref_cls.from_json(source)
+            source = self._source_from_response(catalog, source)
             bundle_fqid = SourcedBundleFQID(uuid=bundle[special_fields.bundle_uuid],
                                             version=bundle[special_fields.bundle_version],
                                             source=source)

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -459,23 +459,24 @@ class IndexingIntegrationTest(IntegrationTestCase):
             log.warning('Will skip indexing due to overriding IT flag.')
 
         catalogs: list[Catalog] = []
-        for catalog in config.integration_test_catalogs:
+        for catalog in config.integration_test_catalogs.values():
             if index:
-                public_source, _ = self._select_source(catalog, public=True)
-                ma_source = self._select_source(catalog, public=False)
+                public_source, _ = self._select_source(catalog.name, public=True)
+                ma_source = self._select_source(catalog.name, public=False)
                 if ma_source is not None:
                     ma_source = ma_source[0]
                 sources = alist(public_source, ma_source)
-                notifications, fqids = self._prepare_notifications(catalog, sources)
+                notifications, fqids = self._prepare_notifications(catalog.name, sources)
             else:
                 with self._service_account_credentials:
-                    fqids = self._get_indexed_bundles(catalog)
+                    fqids = self._get_indexed_bundles(catalog.name)
                 indexed_sources = {fqid.source for fqid in fqids}
-                ma_source_ids = {s.id for s in self.managed_access_sources_by_catalog[catalog]}
+                ma_sources = self.managed_access_sources_by_catalog[catalog.name]
+                ma_source_ids = {s.id for s in ma_sources}
                 public_source = one(s for s in indexed_sources if s.id not in ma_source_ids)
                 ma_source = only(s for s in indexed_sources if s.id in ma_source_ids)
                 notifications = []
-            catalogs.append(Catalog(name=catalog,
+            catalogs.append(Catalog(name=catalog.name,
                                     bundles=fqids,
                                     notifications=notifications,
                                     public_source=public_source,

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -85,6 +85,7 @@ from azul import (
     config,
     drs,
     false,
+    mutable_furl,
 )
 from azul.auth import (
     OAuth2,
@@ -1106,26 +1107,31 @@ class IndexingIntegrationTest(IntegrationTestCase):
             outer_file, inner_file = self._get_one_inner_file(catalog)
             file_url = inner_file['azul_url']
             if file_url:
-                file_url = furl(file_url)
-                # FIXME: Use _check_endpoint() instead
-                #        https://github.com/DataBiosphere/azul/issues/7373
-                self.assertEqual(file_url.path.segments[0], 'repository')
-                file_url.path.segments.insert(0, 'fetch')
-                response = self._get_url_unchecked(GET, file_url)
-                self.assertEqual(200, response.status)
-                response = json.loads(response.data)
-                while response['Status'] != 302:
-                    self.assertEqual(301, response['Status'])
-                    self.assertNotIn('Retry-After', response)
-                    response = self._get_url_json(GET, furl(response['Location']))
-                self.assertNotIn('Retry-After', response)
-                response = self._get_url(GET, furl(response['Location']), stream=True)
                 source = self._source_spec(catalog, outer_file)
-                self._validate_file_response(response, source, inner_file)
+                self._test_file_download(source, inner_file)
             else:
                 # Phantom files lack DRS URIs and cannot be downloaded
                 self.assertIsNone(file_url, inner_file)
                 self.assertEqual('lungmap', config.catalogs[catalog].atlas, inner_file)
+
+    def _test_file_download(self, source: SourceSpec, file: JSON) -> mutable_furl:
+        file_url = furl(file['azul_url'])
+        # FIXME: Use _check_endpoint() instead
+        #        https://github.com/DataBiosphere/azul/issues/7373
+        self.assertEqual(file_url.path.segments[0], 'repository')
+        file_url.path.segments.insert(0, 'fetch')
+        response = self._get_url_unchecked(GET, file_url)
+        self.assertEqual(200, response.status)
+        response = json.loads(response.data)
+        while response['Status'] != 302:
+            self.assertEqual(301, response['Status'])
+            self.assertNotIn('Retry-After', response)
+            response = self._get_url_json(GET, furl(response['Location']))
+        self.assertNotIn('Retry-After', response)
+        final_file_url = furl(response['Location'])
+        response = self._get_url(GET, final_file_url, stream=True)
+        self._validate_file_response(response, source, file)
+        return final_file_url
 
     def _file_ext(self, file: JSON) -> str:
         # We believe that the file extension is a more reliable indicator than


### PR DESCRIPTION
Linked issues: #7531


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer


### Peer reviewer (after approval)

Note that when requesting changes, the PR must be assigned back to the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
