### PR TITLE
Fix: Excessive bundle partitioning in AnVIL (#7528)

### DIFF
--- a/src/azul/indexer/__init__.py
+++ b/src/azul/indexer/__init__.py
@@ -580,7 +580,16 @@ class Bundle[BUNDLE_FQID: BundleFQID](SerializableAttrs, metaclass=ABCMeta):
 class BundlePartition(UUIDPartition):
     """
     A binary partitioning of the UUIDs of outer entities in a bundle.
+
+    >>> BundlePartition.root
+    BundlePartition(prefix_length=0, prefix=0, group=4)
     """
+
+    #: We use the fifth group because the first group may not produce a random
+    #: distribution of the entities in some types of bundles. For example, all
+    #: entity UUIDs in an AnVIL replica bundle share a specifc batch prefix.
+    #:
+    group: int = 4
 
     #: 512 caused timeouts writing contributions, even in the retry Lambda
     #:

--- a/src/azul/indexer/__init__.py
+++ b/src/azul/indexer/__init__.py
@@ -588,10 +588,3 @@ class BundlePartition(UUIDPartition):
 
     def divisions(self, num_entities: int) -> int:
         return math.ceil(num_entities / self.max_partition_size)
-
-    def __attrs_post_init__(self):
-        super().__attrs_post_init__()
-        # Most bits in a v4 or v5 UUID are pseudo-random, including the leading
-        # 32 bits but those are followed by a couple of deterministic ones.
-        # For simplicity, we'll limit ourselves to 2 ** 32 leaf partitions.
-        assert self.prefix_length <= 32, R('Too many partitions', self.prefix_length)

--- a/src/azul/indexer/__init__.py
+++ b/src/azul/indexer/__init__.py
@@ -583,6 +583,7 @@ class BundlePartition(UUIDPartition):
     """
 
     #: 512 caused timeouts writing contributions, even in the retry Lambda
+    #:
     max_partition_size: ClassVar[int] = 256
 
     def divisions(self, num_entities: int) -> int:

--- a/src/azul/uuids.py
+++ b/src/azul/uuids.py
@@ -3,6 +3,7 @@ from hashlib import (
 )
 import math
 from typing import (
+    Any,
     ClassVar,
     Self,
     dataclass_transform,
@@ -11,7 +12,9 @@ from uuid import (
     UUID,
 )
 
-import attr
+from attrs import (
+    frozen,
+)
 
 from azul import (
     R,
@@ -137,12 +140,28 @@ def change_version(uuid: str, old_version: int, new_version: int) -> str:
     return uuid
 
 
-@dataclass_transform(frozen_default=True, kw_only_default=True)
+@dataclass_transform(frozen_default=True,
+                     kw_only_default=True,
+                     order_default=True)
 class UUIDPartitionMeta(type):
 
-    def __init__(cls, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        attr.s(frozen=True, kw_only=True, auto_attribs=True)(cls)
+    def __init__(cls, name: str, bases: tuple[type, ...], members: dict[str, Any]):
+        super().__init__(name, bases, members)
+
+        # We can't use slots=True for two reasons:
+        #
+        # 1) slots=True causes attrs to duplicate the class (the instance of
+        #    this metaclass), which then causes this method to be invoked twice,
+        #    the second time feeding an already decorated class back to attrs.
+        #    This could be addressed by overriding __new__ instead of __init__.
+        #
+        # 2) We would like to be able to use @cached_property on methods of
+        #    instances, and @cached_property does not work with slotted classes.
+        #
+        # The assert below ensures that attrs does not duplicate the class, and
+        # instead only augments it.
+        #
+        assert cls is frozen(kw_only=True, slots=False, order=True)(cls)
         cls.root = cls(prefix_length=0, prefix=0)
 
 

--- a/src/azul/uuids.py
+++ b/src/azul/uuids.py
@@ -150,10 +150,21 @@ class UUIDPartition(metaclass=UUIDPartitionMeta):
     space use a prefix of the hexadecimal representation of UUIDs. This class
     uses the binary representation and is therefore more granular.
     """
+    #: The number of high-order bits of the binary representation of a UUID that
+    #: have to be equal to the prefix for a UUID to be part of this partion.
+    #:
     prefix_length: int
+
+    #: The prefix. Only the `prefix_length` low-order bits are compared. The
+    #: remaining high-order bits have to be 0.
+    #:
     prefix: int
 
-    root: ClassVar[Self]  # see metaclass above
+    #: The partition that includes all UUIDs. Since this attribute holds an
+    #: instance of this class, we can't initialize it here, but have to do so in
+    #: the metaclass constructor.
+    #:
+    root: ClassVar[Self]
 
     # This stub is only needed to aid PyCharm's type inference. Without this,
     # a constructor invocation that doesn't refer to the class explicitly, but

--- a/src/azul/uuids.py
+++ b/src/azul/uuids.py
@@ -217,6 +217,14 @@ class UUIDPartition(metaclass=UUIDPartitionMeta):
         sub-partitions. The length of the return value will always be the
         smallest a power of two that is greater than ``num_divisions`.
 
+        >>> UUIDPartition.root.divide(0)
+        Traceback (most recent call last):
+        ...
+        AssertionError: R('Number of divisions must be 1 or more')
+
+        >>> UUIDPartition.root.divide(1) == [UUIDPartition.root]
+        True
+
         >>> sorted(UUIDPartition.root.divide(3))
         ... # doctest: +NORMALIZE_WHITESPACE
         [UUIDPartition(prefix_length=2, prefix=0),
@@ -224,6 +232,7 @@ class UUIDPartition(metaclass=UUIDPartitionMeta):
         UUIDPartition(prefix_length=2, prefix=2),
         UUIDPartition(prefix_length=2, prefix=3)]
         """
+        assert num_divisions > 0, R('Number of divisions must be 1 or more')
         prefix_length = math.ceil(math.log2(num_divisions))
         num_divisions = 2 ** prefix_length
         cls = type(self)

--- a/src/azul/uuids.py
+++ b/src/azul/uuids.py
@@ -203,7 +203,7 @@ class UUIDPartition(metaclass=UUIDPartitionMeta):
 
     def contains(self, member: UUID) -> bool:
         """
-        >>> p = UUIDPartition(prefix_length=7, prefix=0b0111_1111)
+        >>> p = UUIDPartition(prefix_length=7, prefix=0b1111_111)
         >>> p.contains(UUID('fdd4524e-14c4-41d7-9071-6cadab09d75c'))
         False
         >>> p.contains(UUID('fed4524e-14c4-41d7-9071-6cadab09d75c'))

--- a/src/azul/uuids.py
+++ b/src/azul/uuids.py
@@ -13,8 +13,7 @@ from uuid import (
 import attr
 
 from azul import (
-    reject,
-    require,
+    R,
 )
 from azul.types import (
     JSON,
@@ -94,12 +93,12 @@ def validate_uuid_prefix(uuid_prefix: str) -> None:
     >>> validate_uuid_prefix('8f538f5-')
     Traceback (most recent call last):
     ...
-    azul.RequirementError: UUID prefix ends with an invalid character: 8f538f5-
+    AssertionError: R('UUID prefix ends with an invalid character', '8f538f5-')
 
     >>> validate_uuid_prefix('8f538f-')
     Traceback (most recent call last):
     ...
-    azul.RequirementError: UUID prefix ends with an invalid character: 8f538f-
+    AssertionError: R('UUID prefix ends with an invalid character', '8f538f-')
 
     >>> validate_uuid_prefix('8f538f53a')
     Traceback (most recent call last):
@@ -107,8 +106,8 @@ def validate_uuid_prefix(uuid_prefix: str) -> None:
     azul.uuids.InvalidUUIDPrefixError: '8f538f53a' is not a valid UUID prefix.
     """
     valid_uuid_str = '26a8fccd-bbd2-4342-9c19-6ed7c9bb9278'
-    reject(uuid_prefix.endswith('-'),
-           f'UUID prefix ends with an invalid character: {uuid_prefix}')
+    assert not uuid_prefix.endswith('-'), R(
+        'UUID prefix ends with an invalid character', uuid_prefix)
     try:
         validate_uuid(uuid_prefix + valid_uuid_str[len(uuid_prefix):])
     except InvalidUUIDError:
@@ -166,8 +165,26 @@ class UUIDPartition(metaclass=UUIDPartitionMeta):
     def __init__(self, *, prefix_length: int, prefix: int) -> None: ...
 
     def __attrs_post_init__(self):
-        reject(self.prefix_length == 0 and self.prefix != 0)
-        require(0 <= self.prefix < 2 ** self.prefix_length)
+        """
+        >>> UUIDPartition(prefix_length=0, prefix=1)
+        ... # doctest: +NORMALIZE_WHITESPACE
+        Traceback (most recent call last):
+        ...
+        AssertionError: R('If prefix length is 0, the prefix must be, too',
+        UUIDPartition(prefix_length=0, prefix=1))
+
+        >>> UUIDPartition(prefix_length=1, prefix=3)
+        ... # doctest: +NORMALIZE_WHITESPACE
+        Traceback (most recent call last):
+        ...
+        AssertionError: R('Prefix has extra high-order bits set',
+        UUIDPartition(prefix_length=1, prefix=3))
+
+        """
+        assert self.prefix_length != 0 or self.prefix == 0, R(
+            'If prefix length is 0, the prefix must be, too', self)
+        assert 0 <= self.prefix < 2 ** self.prefix_length, R(
+            'Prefix has extra high-order bits set', self)
 
     @classmethod
     def from_json(cls, json: JSON) -> Self:
@@ -202,9 +219,9 @@ class UUIDPartition(metaclass=UUIDPartitionMeta):
 
         >>> sorted(UUIDPartition.root.divide(3))
         ... # doctest: +NORMALIZE_WHITESPACE
-        [UUIDPartition(prefix_length=2, prefix=0),\
-        UUIDPartition(prefix_length=2, prefix=1),\
-        UUIDPartition(prefix_length=2, prefix=2),\
+        [UUIDPartition(prefix_length=2, prefix=0),
+        UUIDPartition(prefix_length=2, prefix=1),
+        UUIDPartition(prefix_length=2, prefix=2),
         UUIDPartition(prefix_length=2, prefix=3)]
         """
         prefix_length = math.ceil(math.log2(num_divisions))

--- a/src/azul/uuids.py
+++ b/src/azul/uuids.py
@@ -5,6 +5,7 @@ import math
 from typing import (
     ClassVar,
     Self,
+    dataclass_transform,
 )
 from uuid import (
     UUID,
@@ -136,6 +137,7 @@ def change_version(uuid: str, old_version: int, new_version: int) -> str:
     return uuid
 
 
+@dataclass_transform(frozen_default=True, kw_only_default=True)
 class UUIDPartitionMeta(type):
 
     def __init__(cls, *args, **kwargs):
@@ -165,15 +167,6 @@ class UUIDPartition(metaclass=UUIDPartitionMeta):
     #: the metaclass constructor.
     #:
     root: ClassVar[Self]
-
-    # This stub is only needed to aid PyCharm's type inference. Without this,
-    # a constructor invocation that doesn't refer to the class explicitly, but
-    # through a variable will cause a warning. I suspect a bug in PyCharm:
-    #
-    # https://youtrack.jetbrains.com/issue/PY-44728
-    #
-    # noinspection PyDataclass
-    def __init__(self, *, prefix_length: int, prefix: int) -> None: ...
 
     def __attrs_post_init__(self):
         """

--- a/src/azul/uuids.py
+++ b/src/azul/uuids.py
@@ -1,6 +1,9 @@
 from hashlib import (
     sha1,
 )
+from itertools import (
+    accumulate,
+)
 import math
 from typing import (
     Any,
@@ -18,6 +21,7 @@ from attrs import (
 
 from azul import (
     R,
+    cached_property,
 )
 from azul.types import (
     JSON,
@@ -181,11 +185,32 @@ class UUIDPartition(metaclass=UUIDPartitionMeta):
     #:
     prefix: int
 
+    #: The canonical string representation of UUIDs has five groups of
+    #: hexadecimal digits separated by dash. The first group is eight digits
+    #: long, the last group twelve and the three groups in between are four
+    #: digits long. The first and the last group are best suited for a random
+    #: distribution of v4 v5 UUIDs across partitions. By default, UUID
+    #: partitions use the first group.
+    #:
+    group: int = 0
+
     #: The partition that includes all UUIDs. Since this attribute holds an
     #: instance of this class, we can't initialize it here, but have to do so in
     #: the metaclass constructor.
     #:
     root: ClassVar[Self]
+
+    #: The width of each group in bits.
+    #:
+    group_lengths: ClassVar[tuple[int, ...]]
+    group_lengths = tuple(4 * n for n in [8, 4, 4, 4, 12])
+
+    #: For each group, the number of bits to right-shift the binary, 128-bit-
+    #: wide representation of a UUID in order to have the bits of that group
+    #: become the low-order bits.
+    #:
+    group_shifts: ClassVar[tuple[int, ...]]
+    group_shifts = tuple(accumulate(group_lengths[:-1], initial=0))
 
     def __attrs_post_init__(self):
         """
@@ -194,30 +219,60 @@ class UUIDPartition(metaclass=UUIDPartitionMeta):
         Traceback (most recent call last):
         ...
         AssertionError: R('If prefix length is 0, the prefix must be, too',
-        UUIDPartition(prefix_length=0, prefix=1))
+        UUIDPartition(prefix_length=0, prefix=1, group=0))
 
         >>> UUIDPartition(prefix_length=1, prefix=3)
         ... # doctest: +NORMALIZE_WHITESPACE
         Traceback (most recent call last):
         ...
         AssertionError: R('Prefix has extra high-order bits set',
-        UUIDPartition(prefix_length=1, prefix=3))
+        UUIDPartition(prefix_length=1, prefix=3, group=0))
 
+        >>> UUIDPartition(prefix_length=1, prefix=0, group=5)
+        ... # doctest: +NORMALIZE_WHITESPACE
+        Traceback (most recent call last):
+        ...
+        AssertionError: R('Invalid group',
+        UUIDPartition(prefix_length=1, prefix=0, group=5))
+
+        >>> UUIDPartition(prefix_length=1, prefix=0, group=-1)
+        ... # doctest: +NORMALIZE_WHITESPACE
+        Traceback (most recent call last):
+        ...
+        AssertionError: R('Invalid group',
+        UUIDPartition(prefix_length=1, prefix=0, group=-1))
+
+        >>> UUIDPartition(prefix_length=49, prefix=0, group=4)
+        Traceback (most recent call last):
+        ...
+        AssertionError: R('Length of prefix exceeds that of group', 49, 48)
+
+        >>> UUIDPartition(prefix_length=17, prefix=0, group=1)
+        Traceback (most recent call last):
+        ...
+        AssertionError: R('Length of prefix exceeds that of group', 17, 16)
         """
         assert self.prefix_length != 0 or self.prefix == 0, R(
             'If prefix length is 0, the prefix must be, too', self)
+        assert 0 <= self.group < len(self.group_shifts), R(
+            'Invalid group', self)
+        group_length = self.group_lengths[self.group]
+        assert self.prefix_length <= group_length, R(
+            'Length of prefix exceeds that of group', self.prefix_length, group_length)
         assert 0 <= self.prefix < 2 ** self.prefix_length, R(
             'Prefix has extra high-order bits set', self)
 
     @classmethod
     def from_json(cls, json: JSON) -> Self:
         return cls(prefix_length=json_int(json['prefix_length']),
-                   prefix=json_int(json['prefix']))
+                   prefix=json_int(json['prefix']),
+                   group=json_int(json['group']))
 
     def to_json(self) -> MutableJSON:
         return {
             'prefix_length': self.prefix_length,
-            'prefix': self.prefix
+            'prefix': self.prefix,
+            'group': self.group
         }
 
     def contains(self, member: UUID) -> bool:
@@ -229,10 +284,30 @@ class UUIDPartition(metaclass=UUIDPartitionMeta):
         True
         >>> p.contains(UUID('ffd4524e-14c4-41d7-9071-6cadab09d75c'))
         True
+
+        >>> p = UUIDPartition(prefix_length=5, prefix=0b0110_0, group=4)
+        >>> p.contains(UUID('fdd4524e-14c4-41d7-9071-66adab09d75c'))
+        True
+        >>> p.contains(UUID('fdd4524e-14c4-41d7-9071-67adab09d75c'))
+        True
+        >>> p.contains(UUID('fdd4524e-14c4-41d7-9071-68adab09d75c'))
+        False
+
+        >>> p = UUIDPartition(prefix_length=48, prefix=0x68adab09d75c, group=4)
+        >>> p.contains(UUID('fdd4524e-14c4-41d7-9071-68adab09d75c'))
+        True
+        >>> p.contains(UUID('fdd4524e-14c4-41d7-9071-68adab09d75d'))
+        False
         """
-        # UUIDs are 128 bit integers
-        shift = 128 - self.prefix_length
-        return member.int >> shift == self.prefix
+        mask, shift = self._mask_and_shift
+        return (member.int & mask) >> shift == self.prefix
+
+    @cached_property
+    def _mask_and_shift(self) -> tuple[int, int]:
+        group_shift = self.group_shifts[self.group]
+        shift = 128 - self.prefix_length - group_shift
+        mask = (1 << (128 - group_shift)) - 1
+        return mask, shift
 
     def divide(self, num_divisions: int) -> list[Self]:
         """
@@ -250,10 +325,15 @@ class UUIDPartition(metaclass=UUIDPartitionMeta):
 
         >>> sorted(UUIDPartition.root.divide(3))
         ... # doctest: +NORMALIZE_WHITESPACE
-        [UUIDPartition(prefix_length=2, prefix=0),
-        UUIDPartition(prefix_length=2, prefix=1),
-        UUIDPartition(prefix_length=2, prefix=2),
-        UUIDPartition(prefix_length=2, prefix=3)]
+        [UUIDPartition(prefix_length=2, prefix=0, group=0),
+        UUIDPartition(prefix_length=2, prefix=1, group=0),
+        UUIDPartition(prefix_length=2, prefix=2, group=0),
+        UUIDPartition(prefix_length=2, prefix=3, group=0)]
+
+        >>> UUIDPartition(prefix_length=2, prefix=0, group=4).divide(2)
+        ... # doctest: +NORMALIZE_WHITESPACE
+        [UUIDPartition(prefix_length=3, prefix=0, group=4),
+        UUIDPartition(prefix_length=3, prefix=1, group=4)]
         """
         assert num_divisions > 0, R('Number of divisions must be 1 or more')
         prefix_length = math.ceil(math.log2(num_divisions))
@@ -261,7 +341,8 @@ class UUIDPartition(metaclass=UUIDPartitionMeta):
         cls = type(self)
         return [
             cls(prefix_length=self.prefix_length + prefix_length,
-                prefix=(self.prefix << prefix_length) + prefix)
+                prefix=(self.prefix << prefix_length) + prefix,
+                group=self.group)
             for prefix in range(num_divisions)
         ]
 
@@ -273,19 +354,19 @@ class UUIDPartition(metaclass=UUIDPartitionMeta):
         returned by this function.
 
         >>> str(UUIDPartition.root)
-        '-'
+        '-@0'
 
                                                       0b1111_1110 == 0xfe
                                                       0b1111_1111 == 0xff
-        >>> str(UUIDPartition(prefix_length=7, prefix=0b1111_111))
-        'fe-ff'
+        >>> str(UUIDPartition(prefix_length=7, prefix=0b1111_111, group=4))
+        'fe-ff@4'
 
         Leading zeroes in the high and low end of the range:
 
                                                       0b0000_1110 == 0x0e
                                                       0b0000_1111 == 0x0f
-        >>> str(UUIDPartition(prefix_length=7, prefix=0b0000_111))
-        '0e-0f'
+        >>> str(UUIDPartition(prefix_length=7, prefix=0b0000_111, group=4))
+        '0e-0f@4'
 
         A partition twice as big (a binary prefix that's one bit shorter):
 
@@ -293,8 +374,8 @@ class UUIDPartition(metaclass=UUIDPartitionMeta):
                                                       0b0000_1101 = 0x0d
                                                       0b0000_1110 = 0x0e
                                                       0b0000_1111 = 0x0f
-        >>> str(UUIDPartition(prefix_length=6, prefix=0b0000_11))
-        '0c-0f'
+        >>> str(UUIDPartition(prefix_length=6, prefix=0b0000_11, group=4))
+        '0c-0f@4'
         """
         shift = 4 - self.prefix_length % 4  # shift to align at nibble boundary
         all_ones = (1 << shift) - 1
@@ -306,7 +387,7 @@ class UUIDPartition(metaclass=UUIDPartitionMeta):
         def hex(i):
             return format(i, f'0{hex_len}x')[:hex_len]
 
-        return '-'.join(map(hex, (lo, hi)))
+        return f'{hex(lo)}-{hex(hi)}@{self.group}'
 
 
 def uuid5_for_bytes(namespace: UUID, name: bytes) -> UUID:


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #7528


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer


### Peer reviewer (after approval)

Note that when requesting changes, the PR must be assigned back to the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
