### PR TITLE
Fix: Race between layer and Lambda update (#5927)

### DIFF
--- a/src/azul/terraform.py
+++ b/src/azul/terraform.py
@@ -894,7 +894,7 @@ class Chalice:
             permissions_by_function = defaultdict(set)
             permissions = resources['aws_lambda_permission']
             for permission_name, permission in json_item_dicts(permissions):
-                alias = alias_ref(permission['function_name'])
+                alias = alias_ref(json_str(permission['function_name']))
                 permissions_by_function[alias].add(permission_name)
             permissions_by_function = dict(permissions_by_function)
             for resource_name, notification in resource_items(resource_type):
@@ -902,7 +902,9 @@ class Chalice:
                 notification['depends_on'] = [
                     f'aws_lambda_permission.{permission_name}'
                     for function in json_element_dicts(notification['lambda_function'])
-                    for permission_name in permissions_by_function[function['lambda_function_arn']]
+                    for permission_name in permissions_by_function[json_str(
+                        function['lambda_function_arn']
+                    )]
                 ]
         else:
             assert resource_type not in resources

--- a/src/azul/terraform.py
+++ b/src/azul/terraform.py
@@ -51,7 +51,6 @@ from azul.types import (
     json_element_dicts,
     json_item_dicts,
     json_item_mappings,
-    json_list_of_dicts,
     json_mapping,
     json_str,
     not_none,
@@ -788,40 +787,66 @@ class Chalice:
         # Replace any references to unqualified function ARNs in the OpenAPI
         # spec emitted by Chalice with references to the alias.
         #
-        def functions_to_aliases[T: AnyMutableJSON](v: T) -> T:
+        def alias_ref(v: str) -> str:
+            return v.replace('${aws_lambda_function', '${aws_lambda_alias')
+
+        def alias_invoke_arns[T: AnyMutableJSON](v: T) -> T:
             if isinstance(v, dict):
-                return type(v)((k, functions_to_aliases(v)) for k, v in v.items())
+                return type(v)((k, alias_invoke_arns(v)) for k, v in v.items())
             elif isinstance(v, list):
-                return type(v)(map(functions_to_aliases, v))
+                return type(v)(map(alias_invoke_arns, v))
             elif isinstance(v, str) and v.endswith('.invoke_arn}'):
-                r = function_to_alias(v)
+                r = alias_ref(v)
                 assert isinstance(r, type(v))
                 return r
             else:
                 return v
 
-        def function_to_alias(v: str) -> str:
-            return v.replace('${aws_lambda_function', '${aws_lambda_alias')
-
         openapi_spec = json_dict(json.loads(json_str(locals[app_name])))
-        openapi_spec = functions_to_aliases(openapi_spec)
+        openapi_spec = alias_invoke_arns(openapi_spec)
 
         # Replace any references to unqualified function ARNs in the resources
         # emitted by Chalice with references to the alias.
         #
-        for _, r in json_item_dicts(resources.get('aws_lambda_permission', {})):
-            alias = function_to_alias(json_str(r['function_name']))
+        # There are two ways for a aws_lambda_permission resource to reference a
+        # Lambda function alias: as a suffix, by appending the alias name to the
+        # function ARN in the `function_name` property, or by setting the
+        # `qualifier` property of the aws_lambda_permission resource to the
+        # alias name. Unfortunately, the suffix reference is silently converted
+        # to the `qualifier` property and Terraform treats this conversion as
+        # drift, resulting in perpetually non-empty plans. To avoid the drift,
+        # we use the second method directly.
+        #
+        for resource_name, resource in resource_items('aws_lambda_permission'):
+            alias = alias_ref(json_str(resource['function_name']))
             assert alias.endswith('.arn}'), alias
-            r['qualifier'] = alias.replace('.arn', '.name')
-        for _, r in json_item_dicts(resources.get('aws_cloudwatch_event_target', {})):
-            r['arn'] = function_to_alias(json_str(r['arn']))
-        for _, r in json_item_dicts(resources.get('aws_lambda_event_source_mapping', {})):
-            r['function_name'] = function_to_alias(json_str(r['function_name']))
-        for _, r in json_item_dicts(resources.get('aws_s3_bucket_notification', {})):
-            for lf in json_list_of_dicts(r['lambda_function']):
-                lf['lambda_function_arn'] = function_to_alias(
-                    json_str(lf['lambda_function_arn'])
-                )
+            assert 'qualifier' not in resource
+            resource['qualifier'] = alias.replace('.arn', '.name')
+
+        # Patch any remaining resources with properties holding function ARNs
+        # with the ARN of the corresponding alias.
+        #
+        def alias_property(property_name: str, resource: MutableJSON):
+            alias = alias_ref(json_str(resource[property_name]))
+            resource[property_name] = alias
+
+        for resource_name, resource in resource_items('aws_cloudwatch_event_target'):
+            alias_property('arn', resource)
+
+        resource_type = 'aws_lambda_event_source_mapping'
+        if app_name == 'indexer':
+            for resource_name, resource in resource_items(resource_type):
+                alias_property('function_name', resource)
+        else:
+            assert resource_type not in resources
+
+        resource_type = 'aws_s3_bucket_notification'
+        if config.enable_log_forwarding and app_name == 'indexer':
+            for resource_name, resource in resource_items(resource_type):
+                for notified_function in json_element_dicts(resource['lambda_function']):
+                    alias_property('lambda_function_arn', notified_function)
+        else:
+            assert resource_type not in resources
 
         # Pre-create a CloudWatch log group for every Lambda function so that
         # we can set the log retention explicitly.
@@ -869,8 +894,8 @@ class Chalice:
             permissions_by_function = defaultdict(set)
             permissions = resources['aws_lambda_permission']
             for permission_name, permission in json_item_dicts(permissions):
-                function_ref = permission['function_name']
-                permissions_by_function[function_ref].add(permission_name)
+                alias = alias_ref(permission['function_name'])
+                permissions_by_function[alias].add(permission_name)
             permissions_by_function = dict(permissions_by_function)
             for resource_name, notification in resource_items(resource_type):
                 assert 'depends_on' not in notification, notification

--- a/src/azul/terraform.py
+++ b/src/azul/terraform.py
@@ -891,20 +891,17 @@ class Chalice:
             }
             # To prevent a race condition by Terraform, we make the bucket
             # notifications depend on the related aws_lambda_permission.
-            permissions_by_function = defaultdict(set)
-            permissions = resources['aws_lambda_permission']
-            for permission_name, permission in json_item_dicts(permissions):
+            permissions = defaultdict(set)
+            for permission_name, permission in resource_items('aws_lambda_permission'):
                 alias = alias_ref(json_str(permission['function_name']))
-                permissions_by_function[alias].add(permission_name)
-            permissions_by_function = dict(permissions_by_function)
+                permissions[alias].add(permission_name)
+            permissions = dict(permissions)
             for resource_name, notification in resource_items(resource_type):
                 assert 'depends_on' not in notification, notification
                 notification['depends_on'] = [
                     f'aws_lambda_permission.{permission_name}'
                     for function in json_element_dicts(notification['lambda_function'])
-                    for permission_name in permissions_by_function[json_str(
-                        function['lambda_function_arn']
-                    )]
+                    for permission_name in permissions[json_str(function['lambda_function_arn'])]
                 ]
         else:
             assert resource_type not in resources

--- a/src/azul/terraform.py
+++ b/src/azul/terraform.py
@@ -957,7 +957,8 @@ class Chalice:
         if app_name == 'indexer':
             event_source_mappings = resources['aws_lambda_event_source_mapping']
             for _, resource in json_item_dicts(event_source_mappings):
-                _, _, resource_name = json_str(resource['event_source_arn']).rpartition(':')
+                arn = json_str(resource['event_source_arn'])
+                _, _, resource_name = arn.rpartition(':')
                 suffix = '.fifo' if resource_name.endswith('.fifo') else ''
                 sqs_name, _ = config.unqualified_resource_name(resource_name, suffix)
                 resource['event_source_arn'] = f'${{aws_sqs_queue.{sqs_name}.arn}}'

--- a/src/azul/terraform.py
+++ b/src/azul/terraform.py
@@ -801,6 +801,9 @@ class Chalice:
         openapi_spec = function_to_alias(openapi_spec)
         resources = function_to_alias(resources)
 
+        # Pre-create a CloudWatch log group for every Lambda function so that
+        # we can set the log retention explicitly.
+        #
         assert 'aws_cloudwatch_log_group' not in resources
         functions = json_item_dicts(resources['aws_lambda_function'])
         resources['aws_cloudwatch_log_group'] = {

--- a/src/azul/terraform.py
+++ b/src/azul/terraform.py
@@ -834,12 +834,11 @@ class Chalice:
         # (https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html),
         # so replacing the periods with underscores results in valid resource
         # names while retaining the correlation with bucket names.
-        try:
-            bucket_notifications = resources['aws_s3_bucket_notification']
-        except KeyError:
-            pass
-        else:
-            resources['aws_s3_bucket_notification'] = {
+        #
+        resource_type = 'aws_s3_bucket_notification'
+        if config.enable_log_forwarding and app_name == 'indexer':
+            bucket_notifications = resources[resource_type]
+            resources[resource_type] = {
                 key.replace('.', '_'): value
                 for key, value in json_item_dicts(bucket_notifications)
             }
@@ -850,13 +849,16 @@ class Chalice:
             for permission_name, permission in json_item_dicts(permissions):
                 function_ref = permission['function_name']
                 permissions_by_function[function_ref].add(permission_name)
-            for _, notification in json_item_dicts(resources['aws_s3_bucket_notification']):
+            permissions_by_function = dict(permissions_by_function)
+            for _, notification in json_item_dicts(resources[resource_type]):
                 assert 'depends_on' not in notification, notification
                 notification['depends_on'] = [
                     f'aws_lambda_permission.{permission_name}'
                     for function in json_element_dicts(notification['lambda_function'])
                     for permission_name in permissions_by_function[function['lambda_function_arn']]
                 ]
+        else:
+            assert resource_type not in resources
 
         # The fix for https://github.com/aws/chalice/issues/1237 introduced the
         # create_before_destroy hack and it may have helped but has far-ranging

--- a/src/azul/terraform.py
+++ b/src/azul/terraform.py
@@ -743,6 +743,9 @@ class Chalice:
         data = json_dict(tf_config['data'])
         locals = json_dict(tf_config['locals'])
 
+        def resource_items(resource_type: str) -> Iterable[tuple[str, MutableJSON]]:
+            return json_item_dicts(resources[resource_type])
+
         # null_data_source has been deprecated and locals should be used instead.
         # However, the data sources defined underneath it aren't actually used
         # anywhere so we can just delete the entry.
@@ -757,8 +760,7 @@ class Chalice:
                 '${aws_vpc_endpoint.%s.id}' % app_name
             ]
 
-        functions = json_item_dicts(resources['aws_lambda_function'])
-        for resource_name, resource in functions:
+        for resource_name, resource in resource_items('aws_lambda_function'):
             assert 'layers' not in resource
             resource['layers'] = ['${aws_lambda_layer_version.dependencies.arn}']
             # Publishing a new Lambda function version each time lets us perform
@@ -805,13 +807,12 @@ class Chalice:
         # we can set the log retention explicitly.
         #
         assert 'aws_cloudwatch_log_group' not in resources
-        functions = json_item_dicts(resources['aws_lambda_function'])
         resources['aws_cloudwatch_log_group'] = {
             f'{resource_name}_lambda': {
                 'name': f'/aws/lambda/{resource['function_name']}',
                 'retention_in_days': config.audit_log_retention_days
             }
-            for resource_name, resource in functions
+            for resource_name, resource in resource_items('aws_lambda_function')
         }
 
         for resource_type, property_name in [
@@ -822,7 +823,7 @@ class Chalice:
             # need them to be prefixed with `azul-` to allow for limiting the
             # scope of certain IAM permissions for Gitlab and, more importantly,
             # the deployment stage so these resources are segregated by deployment.
-            for _, resource in json_item_dicts(resources[resource_type]):
+            for resource_name, resource in resource_items(resource_type):
                 unqualified = json_str(resource[property_name])
                 function_name, _, suffix = unqualified.partition('-')
                 assert suffix == 'event', suffix
@@ -851,7 +852,7 @@ class Chalice:
                 function_ref = permission['function_name']
                 permissions_by_function[function_ref].add(permission_name)
             permissions_by_function = dict(permissions_by_function)
-            for _, notification in json_item_dicts(resources[resource_type]):
+            for resource_name, notification in resource_items(resource_type):
                 assert 'depends_on' not in notification, notification
                 notification['depends_on'] = [
                     f'aws_lambda_permission.{permission_name}'
@@ -956,7 +957,7 @@ class Chalice:
         #
         if app_name == 'indexer':
             event_source_mappings = resources['aws_lambda_event_source_mapping']
-            for _, resource in json_item_dicts(event_source_mappings):
+            for resource_name, resource in json_item_dicts(event_source_mappings):
                 arn = json_str(resource['event_source_arn'])
                 _, _, resource_name = arn.rpartition(':')
                 suffix = '.fifo' if resource_name.endswith('.fifo') else ''
@@ -967,7 +968,7 @@ class Chalice:
         # deleted until after the permissions for the new aliases have been
         # created.
         #
-        for name, resource in json_item_dicts(resources['aws_lambda_permission']):
+        for name, resource in resource_items('aws_lambda_permission'):
             assert 'lifecycle' not in resource, resource
             resource['lifecycle'] = {'create_before_destroy': True}
 

--- a/src/azul/terraform.py
+++ b/src/azul/terraform.py
@@ -823,7 +823,8 @@ class Chalice:
             # scope of certain IAM permissions for Gitlab and, more importantly,
             # the deployment stage so these resources are segregated by deployment.
             for _, resource in json_item_dicts(resources[resource_type]):
-                function_name, _, suffix = json_str(resource[property_name]).partition('-')
+                unqualified = json_str(resource[property_name])
+                function_name, _, suffix = unqualified.partition('-')
                 assert suffix == 'event', suffix
                 assert function_name, function_name
                 resource[property_name] = config.qualified_resource_name(function_name)

--- a/src/azul/terraform.py
+++ b/src/azul/terraform.py
@@ -51,6 +51,7 @@ from azul.types import (
     json_element_dicts,
     json_item_dicts,
     json_item_mappings,
+    json_list_of_dicts,
     json_mapping,
     json_str,
     not_none,
@@ -784,24 +785,43 @@ class Chalice:
             resource['source_code_hash'] = '${filebase64sha256("%s")}' % package_zip
             resource['filename'] = package_zip
 
-        # Replace any references to unqualified function ARNs emitted by Chalice
-        # with references to the alias.
+        # Replace any references to unqualified function ARNs in the OpenAPI
+        # spec emitted by Chalice with references to the alias.
         #
-        def function_to_alias[T: AnyMutableJSON](v: T) -> T:
+        def functions_to_aliases[T: AnyMutableJSON](v: T) -> T:
             if isinstance(v, dict):
-                return type(v)((k, function_to_alias(v)) for k, v in v.items())
+                return type(v)((k, functions_to_aliases(v)) for k, v in v.items())
             elif isinstance(v, list):
-                return type(v)(map(function_to_alias, v))
-            elif isinstance(v, str) and v.endswith(('.arn}', '.invoke_arn}')):
-                r = v.replace('${aws_lambda_function', '${aws_lambda_alias')
+                return type(v)(map(functions_to_aliases, v))
+            elif isinstance(v, str) and v.endswith('.invoke_arn}'):
+                r = function_to_alias(v)
                 assert isinstance(r, type(v))
                 return r
             else:
                 return v
 
+        def function_to_alias(v: str) -> str:
+            return v.replace('${aws_lambda_function', '${aws_lambda_alias')
+
         openapi_spec = json_dict(json.loads(json_str(locals[app_name])))
-        openapi_spec = function_to_alias(openapi_spec)
-        resources = function_to_alias(resources)
+        openapi_spec = functions_to_aliases(openapi_spec)
+
+        # Replace any references to unqualified function ARNs in the resources
+        # emitted by Chalice with references to the alias.
+        #
+        for _, r in json_item_dicts(resources.get('aws_lambda_permission', {})):
+            alias = function_to_alias(json_str(r['function_name']))
+            assert alias.endswith('.arn}'), alias
+            r['qualifier'] = alias.replace('.arn', '.name')
+        for _, r in json_item_dicts(resources.get('aws_cloudwatch_event_target', {})):
+            r['arn'] = function_to_alias(json_str(r['arn']))
+        for _, r in json_item_dicts(resources.get('aws_lambda_event_source_mapping', {})):
+            r['function_name'] = function_to_alias(json_str(r['function_name']))
+        for _, r in json_item_dicts(resources.get('aws_s3_bucket_notification', {})):
+            for lf in json_list_of_dicts(r['lambda_function']):
+                lf['lambda_function_arn'] = function_to_alias(
+                    json_str(lf['lambda_function_arn'])
+                )
 
         # Pre-create a CloudWatch log group for every Lambda function so that
         # we can set the log retention explicitly.

--- a/src/azul/terraform.py
+++ b/src/azul/terraform.py
@@ -969,7 +969,7 @@ class Chalice:
         # created.
         #
         for resource_name, resource in resource_items('aws_lambda_permission'):
-            assert 'lifecycle' not in resource, resource
+            assert 'lifecycle' not in resource, (resource_name, resource)
             resource['lifecycle'] = {'create_before_destroy': True}
 
         return {

--- a/src/azul/terraform.py
+++ b/src/azul/terraform.py
@@ -968,7 +968,7 @@ class Chalice:
         # deleted until after the permissions for the new aliases have been
         # created.
         #
-        for name, resource in resource_items('aws_lambda_permission'):
+        for resource_name, resource in resource_items('aws_lambda_permission'):
             assert 'lifecycle' not in resource, resource
             resource['lifecycle'] = {'create_before_destroy': True}
 

--- a/src/azul/terraform.py
+++ b/src/azul/terraform.py
@@ -814,7 +814,7 @@ class Chalice:
             for resource_name, resource in functions
         }
 
-        for resource_type, argument in [
+        for resource_type, property_name in [
             ('aws_cloudwatch_event_rule', 'name'),
             ('aws_cloudwatch_event_target', 'target_id')
         ]:
@@ -823,10 +823,10 @@ class Chalice:
             # scope of certain IAM permissions for Gitlab and, more importantly,
             # the deployment stage so these resources are segregated by deployment.
             for _, resource in json_item_dicts(resources[resource_type]):
-                function_name, _, suffix = json_str(resource[argument]).partition('-')
+                function_name, _, suffix = json_str(resource[property_name]).partition('-')
                 assert suffix == 'event', suffix
                 assert function_name, function_name
-                resource[argument] = config.qualified_resource_name(function_name)
+                resource[property_name] = config.qualified_resource_name(function_name)
 
         # Chalice-generated S3 bucket notifications include the bucket name in
         # the resource name, resulting in an invalid resource name when the


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #5927


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [ ] ~PR is awaiting requested review from a peer~
- [ ] ~Status of PR is *Review requested*~
- [ ] ~PR is assigned to only the peer~


### Peer reviewer (after approval)

Note that when requesting changes, the PR must be assigned back to the author.

- [ ] ~Actually approved the PR~
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
