### PR TITLE
Add mirror URI column to compact manifest (#7151)

### DIFF
--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -164,6 +164,16 @@ class BaseMirrorFileService:
             bucket = aws.mirror_bucket
         return StorageService(bucket)
 
+    def get_mirror_uri(self, file: File) -> str:
+        """
+        Speculative S3 URI of the given file. No check is performed to see if
+        the file is currently mirrored, so there is no guarantee that requests
+        to the URI will succeed.
+        """
+        return str(furl(scheme='s3',
+                        netloc=self._storage.bucket_name,
+                        path=self.mirror_object_key(file)))
+
     def get_mirror_url(self, file: File) -> str:
         return self._storage.get_presigned_url(key=self.mirror_object_key(file),
                                                file_name=file.name,

--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -164,7 +164,7 @@ class BaseMirrorFileService:
             bucket = aws.mirror_bucket
         return StorageService(bucket)
 
-    def get_mirror_uri(self, file: File) -> str:
+    def mirror_uri(self, file: File) -> str:
         """
         Speculative S3 URI of the given file. No check is performed to see if
         the file is currently mirrored, so there is no guarantee that requests

--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -174,7 +174,7 @@ class BaseMirrorFileService:
                         netloc=self._storage.bucket_name,
                         path=self.mirror_object_key(file)))
 
-    def get_mirror_url(self, file: File) -> str:
+    def mirror_url(self, file: File) -> str:
         return self._storage.get_presigned_url(key=self.mirror_object_key(file),
                                                file_name=file.name,
                                                content_type=file.content_type)

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -132,19 +132,22 @@ class BaseMirrorService:
         return Queues()
 
     @classmethod
-    def do_not_mirror(cls, catalog: CatalogName, file_size: int = 0) -> bool:
+    def may_mirror(cls, catalog: CatalogName, file_size: int = 0) -> bool:
+        """
+        Test whether it makes sense to request the mirroring of files from the
+        given catalog if they are of the given size or larger. If this method
+        returns True, such files may or may not be mirrored. If this method
+        returns False, the service will definitely refuse to mirror such files,
+        although it may accept smaller files.
+        """
         max_size = config.catalogs[catalog].mirror_limit
-        return max_size is not None and file_size > max_size
+        return max_size is None or file_size <= max_size
 
     def mirror_sources(self,
                        catalog: CatalogName,
                        sources: Iterable[tuple[SourceRef, SourceConfig]]
                        ):
-        if self.do_not_mirror(catalog):
-            log.info('Not mirroring any files in catalog %r because the file '
-                     'size limit is negative', catalog)
-        else:
-
+        if self.may_mirror(catalog):
             def messages():
                 for source, source_config in sources:
                     if source_config.mirror:
@@ -157,6 +160,9 @@ class BaseMirrorService:
                                  str(source.spec), catalog)
 
             self._queue_messages(messages())
+        else:
+            log.info('Not mirroring any files in catalog %r because the file '
+                     'size limit is negative', catalog)
 
     def mirror_file(self, catalog: CatalogName, source: SourceRef, file: File):
         self._queue_messages([MirrorFileAction(catalog=catalog,
@@ -244,14 +250,14 @@ class MirrorService(BaseMirrorService):
         files = plugin.list_files(a.source, a.prefix)
         for file in files:
             assert file.size is not None, R('File size unknown', file)
-            if self.do_not_mirror(a.catalog, file.size):
-                log.info('Not mirroring file to save cost: %r', file)
-            else:
+            if self.may_mirror(a.catalog, file.size):
                 log.debug('Queueing file %r', file)
                 yield MirrorFileAction(catalog=a.catalog,
                                        source=a.source,
                                        prefix=a.prefix,
                                        file=file)
+            else:
+                log.info('Not mirroring file to save cost: %r', file)
         log.info('Queued %d files in partition %r of source %r in catalog %r',
                  len(files), a.prefix, str(a.source), a.catalog)
 

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -146,8 +146,8 @@ class BaseMirrorService:
         else:
 
             def messages():
-                for source, cfg in sources:
-                    if cfg.mirror:
+                for source, source_config in sources:
+                    if source_config.mirror:
                         log.info('Mirroring files in source %r from catalog %r',
                                  str(source.spec), catalog)
                         yield MirrorSourceAction(catalog=catalog, source=source)

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -140,8 +140,11 @@ class BaseMirrorService:
         returns False, the service will definitely refuse to mirror such files,
         although it may accept smaller files.
         """
-        max_size = config.catalogs[catalog].mirror_limit
-        return max_size is None or file_size <= max_size
+        if config.enable_mirroring:
+            max_size = config.catalogs[catalog].mirror_limit
+            return max_size is None or file_size <= max_size
+        else:
+            return False
 
     def mirror_sources(self,
                        catalog: CatalogName,

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -131,12 +131,16 @@ class BaseMirrorService:
     def _queues(self) -> Queues:
         return Queues()
 
+    @classmethod
+    def do_not_mirror(cls, catalog: CatalogName, file_size: int = 0) -> bool:
+        max_size = config.catalogs[catalog].mirror_limit
+        return max_size is not None and file_size > max_size
+
     def mirror_sources(self,
                        catalog: CatalogName,
                        sources: Iterable[tuple[SourceRef, SourceConfig]]
                        ):
-        mirror_limit = config.catalogs[catalog].mirror_limit
-        if mirror_limit is not None and mirror_limit < 0:
+        if self.do_not_mirror(catalog):
             log.info('Not mirroring any files in catalog %r because the file '
                      'size limit is negative', catalog)
         else:
@@ -238,10 +242,9 @@ class MirrorService(BaseMirrorService):
     def _(self, a: MirrorPartitionAction) -> Iterable[MirrorAction]:
         plugin = self._repository_plugin(a.catalog)
         files = plugin.list_files(a.source, a.prefix)
-        max_size = config.catalogs[a.catalog].mirror_limit
         for file in files:
             assert file.size is not None, R('File size unknown', file)
-            if max_size is not None and file.size > max_size:
+            if self.do_not_mirror(a.catalog, file.size):
                 log.info('Not mirroring file to save cost: %r', file)
             else:
                 log.debug('Queueing file %r', file)

--- a/src/azul/plugins/metadata/anvil/__init__.py
+++ b/src/azul/plugins/metadata/anvil/__init__.py
@@ -359,6 +359,7 @@ class Plugin(MetadataPlugin[AnvilBundle]):
         # Above, we already configured these two fields to be omitted from the
         # manifest since they are not informative to the user.
         result[('contents', 'files')]['file_url'] = 'files.azul_url'
+        result[('contents', 'files')]['file_mirror_uri'] = 'files.azul_mirror_uri'
         return result
 
     primary_keys_by_table = {

--- a/src/azul/plugins/metadata/anvil/__init__.py
+++ b/src/azul/plugins/metadata/anvil/__init__.py
@@ -359,7 +359,10 @@ class Plugin(MetadataPlugin[AnvilBundle]):
         # Above, we already configured these two fields to be omitted from the
         # manifest since they are not informative to the user.
         result[('contents', 'files')]['file_url'] = 'files.azul_url'
-        result[('contents', 'files')]['file_mirror_uri'] = 'files.azul_mirror_uri'
+        # FIXME: AnVIL uses uncommon encoding for MD5 digests
+        #        https://github.com/DataBiosphere/azul/issues/7154
+        if False:
+            result[('contents', 'files')]['file_mirror_uri'] = 'files.azul_mirror_uri'
         return result
 
     primary_keys_by_table = {

--- a/src/azul/plugins/metadata/hca/__init__.py
+++ b/src/azul/plugins/metadata/hca/__init__.py
@@ -381,7 +381,8 @@ class Plugin(MetadataPlugin[HCABundle]):
                 'sha256': 'file_sha256',
                 'content-type': 'file_content_type',
                 'drs_uri': 'file_drs_uri',
-                'file_url': 'file_azul_url'
+                'file_url': 'file_azul_url',
+                'file_mirror_uri': 'file_mirror_uri',
             },
             ('contents', 'cell_suspensions'): {
                 'document_id': 'cell_suspension.provenance.document_id',

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -1671,7 +1671,8 @@ class CompactManifestGenerator(PagedManifestGenerator):
                     entities = self._get_entities(field_path, doc)
                     if field_path == ('contents', 'files'):
                         file = copy_json(one(entities))
-                        file['file_url'] = self._azul_file_url(file)
+                        if 'file_url' in column_mapping:
+                            file['file_url'] = self._azul_file_url(file)
                         entities = [file]
                     self._extract_fields(field_path=field_path,
                                          entities=entities,
@@ -1684,7 +1685,8 @@ class CompactManifestGenerator(PagedManifestGenerator):
                             for related_file in file['related_files']:
                                 related_row = {}
                                 file.update(related_file)
-                                file['file_url'] = self._azul_file_url(file)
+                                if 'file_url' in column_mapping:
+                                    file['file_url'] = self._azul_file_url(file)
                                 self._extract_fields(field_path=field_path,
                                                      entities=[file],
                                                      column_mapping=column_mapping,

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -1157,10 +1157,10 @@ class ManifestGenerator(metaclass=ABCMeta):
 
     def _azul_mirror_uri(self, file: JSON) -> str | None:
         file = self.metadata_plugin.file_class.from_index(file)
-        if BaseMirrorService.do_not_mirror(self.catalog, file.size):
-            return None
-        else:
+        if BaseMirrorService.may_mirror(self.catalog, file.size):
             return self.mirror_file_service.mirror_uri(file)
+        else:
+            return None
 
     @cached_property
     def manifest_content_hash(self) -> int:

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -1160,7 +1160,7 @@ class ManifestGenerator(metaclass=ABCMeta):
         if BaseMirrorService.do_not_mirror(self.catalog, file.size):
             return None
         else:
-            return self.mirror_file_service.get_mirror_uri(file)
+            return self.mirror_file_service.mirror_uri(file)
 
     @cached_property
     def manifest_content_hash(self) -> int:

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -107,6 +107,12 @@ from azul.indexer.field import (
     FieldTypes,
     null_str,
 )
+from azul.indexer.mirror_file_service import (
+    BaseMirrorFileService,
+)
+from azul.indexer.mirror_service import (
+    BaseMirrorService,
+)
 from azul.json import (
     copy_json,
 )
@@ -814,6 +820,10 @@ class ManifestGenerator(metaclass=ABCMeta):
     def metadata_plugin(self) -> MetadataPlugin:
         return self.service.metadata_plugin(self.catalog)
 
+    @cached_property
+    def mirror_file_service(self) -> BaseMirrorFileService:
+        return BaseMirrorFileService(catalog=self.catalog)
+
     @classmethod
     @abstractmethod
     def file_name_extension(cls) -> str:
@@ -1083,7 +1093,7 @@ class ManifestGenerator(metaclass=ABCMeta):
             try:
                 field_type = field_types[field_name]
             except KeyError:
-                if field_name == 'file_url':
+                if field_name in ('file_url', 'file_mirror_uri'):
                     field_type = null_str
                 else:
                     raise
@@ -1144,6 +1154,13 @@ class ManifestGenerator(metaclass=ABCMeta):
                                           version=file['version'],
                                           fetch=False,
                                           **args))
+
+    def _azul_mirror_uri(self, file: JSON) -> str | None:
+        file = self.metadata_plugin.file_class.from_index(file)
+        if BaseMirrorService.do_not_mirror(self.catalog, file.size):
+            return None
+        else:
+            return self.mirror_file_service.get_mirror_uri(file)
 
     @cached_property
     def manifest_content_hash(self) -> int:
@@ -1673,6 +1690,8 @@ class CompactManifestGenerator(PagedManifestGenerator):
                         file = copy_json(one(entities))
                         if 'file_url' in column_mapping:
                             file['file_url'] = self._azul_file_url(file)
+                        if 'file_mirror_uri' in column_mapping:
+                            file['file_mirror_uri'] = self._azul_mirror_uri(file)
                         entities = [file]
                     self._extract_fields(field_path=field_path,
                                          entities=entities,
@@ -1687,6 +1706,8 @@ class CompactManifestGenerator(PagedManifestGenerator):
                                 file.update(related_file)
                                 if 'file_url' in column_mapping:
                                     file['file_url'] = self._azul_file_url(file)
+                                if 'file_mirror_uri' in column_mapping:
+                                    file['file_mirror_uri'] = self._azul_mirror_uri(file)
                                 self._extract_fields(field_path=field_path,
                                                      entities=[file],
                                                      column_mapping=column_mapping,

--- a/src/azul/service/repository_controller.py
+++ b/src/azul/service/repository_controller.py
@@ -275,7 +275,7 @@ class RepositoryController(ServiceAppController):
             assert request_index == 0, request_index
             download = MirrorFileDownload(
                 file=file,
-                location=mirror_service.get_mirror_url(file),
+                location=mirror_service.mirror_url(file),
                 replica=replica,
                 token=token
             )

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -227,13 +227,13 @@ class TestMirrorController(DCP2TestCase,
 
         catalog = config.catalogs[self.catalog]
 
-        def patch_max_file_size(size):
+        def patch_mirror_limit(size):
             return patch.dict(config.catalogs, {
                 self.catalog: attrs.evolve(catalog, mirror_limit=size)
             })
 
         with self.subTest(mirror_limit=-1):
-            with patch_max_file_size(-1):
+            with patch_mirror_limit(-1):
                 messages = self._mirror_sources()
                 self.assertEqual([], messages)
 
@@ -243,5 +243,5 @@ class TestMirrorController(DCP2TestCase,
                                    size=self._file.size + 1)
             source_message = self._test_mirror_sources()
             partition_message = self._test_mirror_source(source_message)
-            with patch_max_file_size(self._file.size):
+            with patch_mirror_limit(self._file.size):
                 self._test_mirror_partition(partition_message, [too_big, self._file])

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -468,7 +468,7 @@ class IndexingIntegrationTest(IntegrationTestCase):
                     # If test_mirroring is run for the catalog, ensure that the
                     # source is not flagged as no_mirror so that we can test
                     # downloading a mirrored file
-                    mirror=config.enable_mirroring and catalog.mirror_limit >= 0
+                    mirror=self.azul_client.mirror_service.may_mirror(catalog.name)
                 )
                 ma_source = self._select_source(catalog.name, public=False)
                 if ma_source is not None:
@@ -1744,7 +1744,7 @@ class IndexingIntegrationTest(IntegrationTestCase):
             catalogs = [
                 c.name
                 for c in config.catalogs.values()
-                if c.is_integration_test_catalog and c.mirror_limit >= 0
+                if c.is_integration_test_catalog and mirror_service.may_mirror(c.name)
             ]
             sources_by_catalog = {
                 catalog: [self._select_source(catalog, public=True, mirror=True)]

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -135,6 +135,7 @@ from indexer import (
 )
 from service import (
     DocumentCloningTestCase,
+    MirrorTestCase,
     StorageServiceTestCase,
     WebServiceTestCase,
 )
@@ -340,7 +341,10 @@ class DCP1ManifestTestCase(ManifestTestCase, DCP1CannedBundleTestCase):
     pass
 
 
-class TestManifests(DCP1ManifestTestCase):
+class TestManifests(DCP1ManifestTestCase, MirrorTestCase):
+
+    def _mirror_uri(self, sha256: str):
+        return f's3://{self.mirror_bucket}/file/{sha256}.sha256'
 
     def run(self,
             result: Optional[unittest.result.TestResult] = None
@@ -499,6 +503,10 @@ class TestManifests(DCP1ManifestTestCase):
                             '2018-09-14T12:33:47.012715Z'),
              self._file_url('f2b6c6f0-8d25-4aae-b255-1974cc110cfe',
                             '2018-09-14T12:33:43.720332Z')),
+
+            ('file_mirror_uri',
+             self._mirror_uri('2f6866c4ede92123f90dd15fb180fac56e33309b8fd3f4f52f263ed2f8af2f16'),
+             self._mirror_uri('3125f2f86092798b85be93fbc66f4e733e9aec0929b558589c06929627115582')),
 
             ('cell_suspension.provenance.document_id',
              '',


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #7151


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator and the author


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] PR is assigned to only the operator
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
