### PR TITLE
Support non-null DRS URIs in file descriptors (#3631)

### DIFF
--- a/src/azul/drs.py
+++ b/src/azul/drs.py
@@ -103,7 +103,7 @@ class DRSURI(metaclass=ABCMeta):
         #
         # https://ga4gh.github.io/data-repository-service-schemas/preview/develop/docs/#_drs_uris
         #
-        subcls = CompactDRSURI if drs_uri.find(':', len(prefix)) >= 0 else RegularDRSURI
+        subcls = CompactDRSURI if drs_uri.find(':', len(prefix)) >= 0 else HostBasedDRSURI
         return subcls.parse(drs_uri)
 
     @abstractmethod
@@ -116,7 +116,7 @@ class DRSURI(metaclass=ABCMeta):
 
 
 @attr.s(auto_attribs=True, kw_only=True, frozen=True, slots=True)
-class RegularDRSURI(DRSURI):
+class HostBasedDRSURI(DRSURI):
     uri: furl
 
     def __attrs_post_init__(self):

--- a/src/azul/drs.py
+++ b/src/azul/drs.py
@@ -14,10 +14,13 @@ from enum import (
 )
 import json
 import logging
+import re
 import time
 from typing import (
+    ClassVar,
     Self,
 )
+import urllib.parse
 
 import attr
 from furl import (
@@ -97,85 +100,199 @@ class DRSURI(metaclass=ABCMeta):
 
     @classmethod
     def parse(cls, drs_uri: str) -> 'DRSURI':
-        prefix = 'drs://'
-        assert drs_uri.startswith(prefix), R('Invalid DRS uri scheme', drs_uri)
-        # "The colon character is not allowed in a hostname-based DRS URI".
-        #
-        # https://ga4gh.github.io/data-repository-service-schemas/preview/develop/docs/#_drs_uris
-        #
-        subcls = CompactDRSURI if drs_uri.find(':', len(prefix)) >= 0 else HostBasedDRSURI
-        return subcls.parse(drs_uri)
+        """
+        A data repository service URI as defined by the GA4GH alliance.
+
+        https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.5.0/docs/
+
+        A straight-forward hostname-based DRS URI. Note the normalized server
+        name:
+
+        >>> DRSURI.parse('drs://SERVER/ID')
+        HostBasedDRSURI(server='server', object_id='ID')
+
+        A hostname-based URI with a percent-encoded question mark in the URL:
+
+        >>> DRSURI.parse('drs://SERVER/ID1%3fID2')
+        HostBasedDRSURI(server='server', object_id='ID1?ID2')
+
+        A hostname-based URI with a redundantly percent-encoded character in the
+        ID:
+
+        >>> DRSURI.parse('drs://SERVER/I%44')
+        HostBasedDRSURI(server='server', object_id='ID')
+
+        A real-world, compact identifier-based LungMAP DRS URI.
+
+        >>> DRSURI.parse('drs://dg.4503:44c5fa8e-c465-4187-8565-734b3ac0a32d')
+        ... # doctest: +NORMALIZE_WHITESPACE
+        CompactDRSURI(provider_code=None,
+                      namespace='dg.4503',
+                      accession='44c5fa8e-c465-4187-8565-734b3ac0a32d')
+
+        A compact identifier-based DRS URI without a provider code.
+
+        >>> DRSURI.parse('drs://NS:LP')
+        CompactDRSURI(provider_code=None, namespace='NS', accession='LP')
+
+        A compact identifier-based DRS URI whose prefix contains a provider
+        code. Note that this could also be interpreted as a hostname-based DRS
+        URI at server 'PC' and ID 'NS:LP'.
+
+        >>> DRSURI.parse('drs://PC/NS:LP')
+        CompactDRSURI(provider_code='PC', namespace='NS', accession='LP')
+
+        A more insidious version of the above. We still treat this as a compact
+        identifier-based DRS URI:
+
+        >>> DRSURI.parse('drs://pc.edu/NS:LP')
+        CompactDRSURI(provider_code='pc.edu', namespace='NS', accession='LP')
+
+        However, as soon as the colon is removed from the local part, we start
+        treating the URI as hostname-based:
+
+        >>> DRSURI.parse('drs://pc.edu/NSLP')
+        HostBasedDRSURI(server='pc.edu', object_id='NSLP')
+
+        A compact identifier-based DRS URI whose local part has a colon:
+
+        >>> DRSURI.parse('drs://NS:LP1:LP2')
+        CompactDRSURI(provider_code=None, namespace='NS', accession='LP1:LP2')
+
+        A more complicated compact identifier-based DRS URI with provider code
+        and a percent-encoded question mark. The question mark has to be
+        encoded, otherwise identifiers.org would discard it, or reject the
+        request:
+
+        >>> DRSURI.parse('drs://PC/NS1.NS2:LP1%3fLP2')
+        CompactDRSURI(provider_code='PC', namespace='NS1.NS2', accession='LP1?LP2')
+
+        Too many slashes in the prefix of a compact identifier-based DRS URI,
+        and a disallowed slash in the accession of a hostname-based URI.
+
+        >>> DRSURI.parse('foo://a/b')
+        Traceback (most recent call last):
+        ...
+        AssertionError: R('Invalid scheme', 'foo://a/b')
+
+        >>> DRSURI.parse('drs://a/b/c:d')
+        Traceback (most recent call last):
+        ...
+        AssertionError: R('Invalid path', 'drs://a/b/c:d')
+
+        >>> DRSURI.parse('drs://a/b?d')
+        Traceback (most recent call last):
+        ...
+        AssertionError: R('Query arguments are disallowed in a DRS URI')
+
+        >>> DRSURI.parse('drs://a/b#d')
+        Traceback (most recent call last):
+        ...
+        AssertionError: R('Fragment is disallowed in a DRS URI')
+
+        """
+        try:
+            return CompactDRSURI.parse(drs_uri)
+        except AssertionError as e:
+            if R.caused(e):
+                return HostBasedDRSURI.parse(drs_uri)
+            else:
+                raise
 
     @abstractmethod
     def to_url(self, client: 'DRSClient', access_id: str | None = None) -> furl:
         """
-        Translate the DRS URI into a DRS URL. All query params included in the
-        DRS URI (eg '{drs_uri}?version=123') will be carried over to the DRS URL.
+        Translate this DRS URI into a URL of the DRS REST API endpoint at which
+        the file identified by this DRS URI can be accessed.
         """
         raise NotImplementedError
 
 
 @attr.s(auto_attribs=True, kw_only=True, frozen=True, slots=True)
 class HostBasedDRSURI(DRSURI):
-    uri: furl
+    """
+    A hostname-based DRS URI. When DRS URIs were first standardized, this was
+    the only type defined in the standard.
+    """
 
-    def __attrs_post_init__(self):
-        assert self.uri.scheme == 'drs', self.uri
+    server: str
+    object_id: str
 
     @classmethod
     def parse(cls, drs_uri: str) -> Self:
-        return cls(uri=furl(drs_uri))
+        parsed_uri = furl(drs_uri)
+        assert parsed_uri.scheme == 'drs', R('Invalid scheme', drs_uri)
+        assert not parsed_uri.args, R('Query arguments are disallowed in a DRS URI')
+        assert not parsed_uri.fragment, R('Fragment is disallowed in a DRS URI')
+        path = parsed_uri.path.segments
+        assert len(path) == 1, R('Invalid path', drs_uri)
+        return cls(server=parsed_uri.netloc, object_id=path[0])
 
     def to_url(self, client: 'DRSClient', access_id: str | None = None) -> furl:
-        url = self.uri.copy().set(scheme='https')
-        url.set(path=drs_object_url_path(object_id=one(self.uri.path.segments),
-                                         access_id=access_id))
-        return url
+        path = drs_object_url_path(object_id=self.object_id, access_id=access_id)
+        return furl(scheme='https', netloc=self.server, path=path)
 
 
 @attr.s(auto_attribs=True, kw_only=True, frozen=True, slots=True)
 class CompactDRSURI(DRSURI):
     """
-    So-called DRS "URIs" [1] for Compact Identifiers [2] are NOT URIs according
-    to RFC 3986 [3] so we can't use off-the-shelf URI parsers.
+    A DRS URI that represents Compact Identifiers [1]. These were introduced in
+    a later revision of the standard. Note that DRS URIs of this type are not
+    URIs according to RFC 3986 [2] so we can't use off-the-shelf URI parsers.
+    The accession part of compact identifiers allows many more characters than
+    the port number of the netloc part defined in the RFC. Another complication
+    is that the slash separating the optional provider code introduces an
+    ambiguity when detecting the type of DRS URI to parse. See the doctests in
+    the parent class for details.
 
-    [1] https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.3.0/docs/
+    [1] https://www.nature.com/articles/sdata201829
 
-    [2] https://www.nature.com/articles/sdata201829
-
-    [3] https://datatracker.ietf.org/doc/html/rfc3986
+    [2] https://datatracker.ietf.org/doc/html/rfc3986
     """
+    provider_code: str | None = None
     namespace: str
     accession: str
 
-    def __attrs_post_init__(self):
-        assert '/' not in self.namespace and '?' not in self.accession, self
+    # We'll use the regex from HCA's file descriptor schema to detect this type.
+    #
+    # https://github.com/HumanCellAtlas/metadata-schema/blob/4800b29226bfa3d2bed3ad2e0b9240903ba40c32/json_schema/system/file_descriptor.json#L114C22-L114C62
+    #
+    regex: ClassVar[re.Pattern]
+    regex = re.compile(r'^drs://([A-Za-z0-9._]+/)?[A-Za-z0-9._]+:.+$')
 
     @classmethod
     def parse(cls, drs_uri: str) -> Self:
-        scheme, netloc = drs_uri.split('://', 1)
-        # Compact identifier-based URIs can be hard to parse when following
-        # RFC3986, with the 'namespace:accession' part matching either the
-        # heir-part or path production depending if the optional provider code
-        # and following slash is included.
-        #
-        # https://ga4gh.github.io/data-repository-service-schemas/preview/develop/docs/#compact-identifier-based-drs-uris
-        #
-        prefix, accession = netloc.split(':', 1)
-        assert '/' not in prefix, R(
-            'Compact identifiers with provider codes are not supported', drs_uri)
-        assert '?' not in accession, R(
-            'Compact identifiers must not contain query parameters', drs_uri)
-        return cls(namespace=prefix,
-                   accession=accession)
+        if cls.regex.match(drs_uri) is None:
+            assert False, R('Not a compact identifier-based URI')
+        prefix, accession = drs_uri[6:].split(':', 1)
+        provider_code: str | None
+        match prefix.split('/'):
+            case [provider_code, namespace]:
+                provider_code = cls._decode(provider_code)
+            case [namespace]:
+                provider_code = None
+            case _:
+                assert False, drs_uri
+        return cls(provider_code=provider_code,
+                   namespace=cls._decode(namespace),
+                   accession=cls._decode(accession))
+
+    @classmethod
+    def _decode(cls, s: str) -> str:
+        return urllib.parse.unquote(s, errors='strict')
 
     def to_url(self, client: 'DRSClient', access_id: str | None = None) -> furl:
+        if self.provider_code is not None:
+            raise NotImplementedError(
+                'Resolving compact identifier-based DRS URIs with '
+                'provider codes is currently not supported', self
+            )
         url = client.id_client.resolve(self.namespace, self.accession)
         # The URL pattern registered at identifiers.org ought to replicate the
         # DRS spec, but we have to re-create the path using the spec because the
         # registered pattern does not support embedding the access ID.
         assert str(url.path) == drs_object_url_path(object_id=self.accession), R(
-            'Unexpected DRS URL format', url)
+            'Format of resolved URL is incompatible with the DRS specification', url)
         url.set(path=drs_object_url_path(object_id=self.accession, access_id=access_id))
         return url
 

--- a/src/azul/plugins/metadata/hca/__init__.py
+++ b/src/azul/plugins/metadata/hca/__init__.py
@@ -503,24 +503,17 @@ class HCAFile(File):
     def _parse_drs_uri(cls, file_id: str | None, descriptor: JSON) -> str | None:
         if file_id is None:
             try:
-                external_drs_uri = descriptor['drs_uri']
+                external_drs_uri = optional(json_str, descriptor['drs_uri'])
             except KeyError:
                 assert False, R(
                     '`file_id` is null and `drs_uri` is not set in file descriptor',
                     descriptor)
             else:
-                # FIXME: Support non-null DRS URIs in file descriptors
-                #        https://github.com/DataBiosphere/azul/issues/3631
-                if external_drs_uri is not None:
-                    log.warning('Non-null `drs_uri` in file descriptor (%s)', external_drs_uri)
-                    external_drs_uri = None
                 return external_drs_uri
         else:
-            # This requirement prevent mismatches in the DRS domain, and ensures
-            # that changes to the column syntax don't go undetected.
             parsed = HostBasedDRSURI.parse(file_id)
-            assert parsed.uri.netloc == config.tdr_service_url.netloc, R(
-                'Unexpected DRS URI location', parsed.uri)
+            assert parsed.server == config.tdr_service_url.netloc, R(
+                'DRS URI must point to TDR as the server', file_id)
             return file_id
 
     @classmethod

--- a/src/azul/plugins/metadata/hca/__init__.py
+++ b/src/azul/plugins/metadata/hca/__init__.py
@@ -20,7 +20,7 @@ from azul.digests import (
     Digest,
 )
 from azul.drs import (
-    RegularDRSURI,
+    HostBasedDRSURI,
 )
 from azul.indexer.document import (
     Aggregate,
@@ -518,7 +518,7 @@ class HCAFile(File):
         else:
             # This requirement prevent mismatches in the DRS domain, and ensures
             # that changes to the column syntax don't go undetected.
-            parsed = RegularDRSURI.parse(file_id)
+            parsed = HostBasedDRSURI.parse(file_id)
             assert parsed.uri.netloc == config.tdr_service_url.netloc, R(
                 'Unexpected DRS URI location', parsed.uri)
             return file_id


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #3631


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator and the author


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] PR is assigned to only the operator
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
