### PR TITLE
Fix: OpenSearch queries are huge (#7580)

### DIFF
--- a/src/azul/plugins/__init__.py
+++ b/src/azul/plugins/__init__.py
@@ -519,7 +519,7 @@ class MetadataPlugin[BUNDLE: Bundle](Plugin[BUNDLE]):
 
     @property
     def facets(self) -> Sequence[str]:
-        return [self.special_fields.source_id.name]
+        return []
 
     @property
     @abstractmethod

--- a/src/azul/service/__init__.py
+++ b/src/azul/service/__init__.py
@@ -343,6 +343,25 @@ class Filters:
     def update(self, filters: FiltersJSON) -> Self:
         return attr.evolve(self, explicit={**self.explicit, **filters})
 
+    def reify_implicit_only(self, plugin: MetadataPlugin) -> FiltersJSON:
+        """
+        Construct filters for *only* the implicit restriction on accessible
+        sources. This is conceptually equivalent to the set difference
+        `self.reify(limit_access=True) - self.reify(limit_access=False)`.
+
+        :param plugin: Metadata plugin for the current request's catalog
+        """
+        source_id_field = plugin.special_fields.source_id.name
+        filters = copy_json(self.explicit)
+        explicit_sources = self._extract_filter(filters, source_id_field, default=None)
+        if explicit_sources is not None:
+            self._forbid_explicit_inaccessible_sources(explicit_sources)
+        return {
+            source_id_field: {
+                'is': sorted(self.source_ids),
+            }
+        }
+
     def reify(self,
               plugin: MetadataPlugin,
               *,

--- a/src/azul/service/__init__.py
+++ b/src/azul/service/__init__.py
@@ -361,33 +361,20 @@ class Filters:
         filters = copy_json(self.explicit)
         special_fields = plugin.special_fields
 
-        def extract_filter(field: str, *, default: set | None) -> set | None:
-            filter = filters.pop(field, {})
-            # Other operators are not supported on string or boolean fields
-            assert filter.keys() <= {'is'}, filter
-            try:
-                values = filter['is']
-            except KeyError:
-                return default
-            else:
-                return set(values)
-
-        explicit_sources = extract_filter(special_fields.source_id.name,
-                                          default=None)
-        accessible = extract_filter(special_fields.accessible.name,
-                                    default={False, True})
+        explicit_sources = self._extract_filter(filters,
+                                                special_fields.source_id.name,
+                                                default=None)
+        accessible = self._extract_filter(filters,
+                                          special_fields.accessible.name,
+                                          default={False, True})
         source_relation = 'is'
 
         if limit_access:
             if explicit_sources is None:
                 sources = self.source_ids if True in accessible else []
             else:
-                forbidden_sources = explicit_sources - self.source_ids
-                if forbidden_sources:
-                    raise ForbiddenError('Cannot filter by inaccessible sources',
-                                         forbidden_sources)
-                else:
-                    sources = explicit_sources if True in accessible else []
+                self._forbid_explicit_inaccessible_sources(explicit_sources)
+                sources = explicit_sources if True in accessible else []
         else:
             if accessible == set():
                 sources = []
@@ -416,6 +403,23 @@ class Filters:
             assert set(filters[special_fields.source_id.name]['is']) <= self.source_ids
 
         return filters
+
+    def _extract_filter(self, filters, field: str, *, default: set | None) -> set | None:
+        filter = filters.pop(field, {})
+        # Other operators are not supported on string or boolean fields
+        assert filter.keys() <= {'is'}, filter
+        try:
+            values = filter['is']
+        except KeyError:
+            return default
+        else:
+            return set(values)
+
+    def _forbid_explicit_inaccessible_sources(self, explicit_sources: set[str]):
+        forbidden_sources = explicit_sources - self.source_ids
+        if forbidden_sources:
+            raise ForbiddenError('Cannot filter by inaccessible sources',
+                                 forbidden_sources)
 
 
 class BadArgumentException(Exception):

--- a/src/azul/service/elasticsearch_service.py
+++ b/src/azul/service/elasticsearch_service.py
@@ -179,7 +179,7 @@ class FilterStage(_ElasticsearchStage[Response, Response]):
     post_filter: bool
 
     def prepare_request(self, request: Search) -> Search:
-        query = self.prepare_query()
+        query = self.prepare_query(self.prepared_filters)
         if self.post_filter:
             request = request.post_filter(query)
         else:
@@ -223,12 +223,15 @@ class FilterStage(_ElasticsearchStage[Response, Response]):
             translated_filters[field] = {relation: list(values)}
         return translated_filters
 
-    def prepare_query(self, skip_field_paths: tuple[FieldPath] = ()) -> Query:
+    def prepare_query(self,
+                      prepared_filters: TranslatedFilters,
+                      skip_field_paths: tuple[FieldPath] = ()
+                      ) -> Query:
         """
         Converts the given filters into an Elasticsearch DSL Query object.
         """
         filter_list = []
-        for field_path, relation_and_values in self.prepared_filters.items():
+        for field_path, relation_and_values in prepared_filters.items():
             if field_path not in skip_field_paths:
                 relation, values = one(relation_and_values.items())
                 # Note that `is_not` is only used internally (for filtering by
@@ -320,7 +323,8 @@ class AggregationStage(_ElasticsearchStage[MutableJSON, MutableJSON]):
         """
         # Create a filter agg using a query that represents all filters
         # except for the current facet.
-        query = self.filter_stage.prepare_query(skip_field_paths=(facet_path,))
+        query = self.filter_stage.prepare_query(self.filter_stage.prepared_filters,
+                                                skip_field_paths=(facet_path,))
         agg = A('filter', query)
 
         field_type = self.service.field_type(self.catalog, facet_path)

--- a/src/azul/service/elasticsearch_service.py
+++ b/src/azul/service/elasticsearch_service.py
@@ -181,6 +181,9 @@ class FilterStage(_ElasticsearchStage[Response, Response]):
     def prepare_request(self, request: Search) -> Search:
         query = self.prepare_query(self.prepared_filters)
         if self.post_filter:
+            if self.service.always_limit_access or self._limit_access:
+                access_query = self.prepare_query(self.prepared_access_filter)
+                request = request.query(access_query)
             request = request.post_filter(query)
         else:
             request = request.query(query)
@@ -191,8 +194,15 @@ class FilterStage(_ElasticsearchStage[Response, Response]):
 
     @cached_property
     def prepared_filters(self) -> TranslatedFilters:
-        limit_access = self.service.always_limit_access or self._limit_access
+        # The implicit source filter is always applied via a query, and would
+        # therefore be redundant in the post_filter
+        limit_access = (self.service.always_limit_access or self._limit_access) and not self.post_filter
         filters_json = self.filters.reify(self.plugin, limit_access=limit_access)
+        return self._translate_filters(filters_json)
+
+    @cached_property
+    def prepared_access_filter(self) -> TranslatedFilters:
+        filters_json = self.filters.reify_implicit_only(self.plugin)
         return self._translate_filters(filters_json)
 
     @property

--- a/test/service/test_request_builder.py
+++ b/test/service/test_request_builder.py
@@ -107,6 +107,13 @@ class TestRequestBuilder(DCP1CannedBundleTestCase, WebServiceTestCase):
         Tests creation of a simple request
         """
         expected_output = {
+            'query': {
+                'bool': {
+                    'must': [
+                        self.sources_filter
+                    ]
+                }
+            },
             'post_filter': {
                 'bool': {
                     'must': [
@@ -121,7 +128,6 @@ class TestRequestBuilder(DCP1CannedBundleTestCase, WebServiceTestCase):
                                 }
                             }
                         },
-                        self.sources_filter
                     ]
                 }
             }
@@ -154,6 +160,13 @@ class TestRequestBuilder(DCP1CannedBundleTestCase, WebServiceTestCase):
         Tests creation of a complex request.
         """
         expected_output = {
+            'query': {
+                'bool': {
+                    'must': [
+                        self.sources_filter
+                    ]
+                }
+            },
             'post_filter': {
                 'bool': {
                     'must': [
@@ -168,7 +181,6 @@ class TestRequestBuilder(DCP1CannedBundleTestCase, WebServiceTestCase):
                                 }
                             }
                         },
-                        self.sources_filter
                     ]
                 }
             }
@@ -186,6 +198,13 @@ class TestRequestBuilder(DCP1CannedBundleTestCase, WebServiceTestCase):
         Tests creation of a request for facets that do not have a value
         """
         expected_output = {
+            'query': {
+                'bool': {
+                    'must': [
+                        self.sources_filter
+                    ]
+                }
+            },
             'post_filter': {
                 'bool': {
                     'must': [
@@ -221,7 +240,6 @@ class TestRequestBuilder(DCP1CannedBundleTestCase, WebServiceTestCase):
                                 }
                             }
                         },
-                        self.sources_filter
                     ]
                 }
             }
@@ -236,6 +254,13 @@ class TestRequestBuilder(DCP1CannedBundleTestCase, WebServiceTestCase):
         not have a value
         """
         expected_output = {
+            'query': {
+                'bool': {
+                    'must': [
+                        self.sources_filter
+                    ]
+                }
+            },
             'post_filter': {
                 'bool': {
                     'must': [
@@ -300,7 +325,6 @@ class TestRequestBuilder(DCP1CannedBundleTestCase, WebServiceTestCase):
                                 }
                             }
                         },
-                        self.sources_filter
                     ]
                 }
             }
@@ -346,9 +370,6 @@ class TestRequestBuilder(DCP1CannedBundleTestCase, WebServiceTestCase):
         expected_output = {
             'filter': {
                 'bool': {
-                    'must': [
-                        self.sources_filter
-                    ]
                 }
             },
             'aggs': {


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: DataBiosphere/azul-private#316


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [ ] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [ ] PR is awaiting requested review from a peer
- [ ] Status of PR is *Review requested*
- [ ] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [ ] Actually approved the PR
- [ ] PR is not a draft
- [ ] PR is awaiting requested review from system administrator
- [ ] Status of PR is *Review requested*
- [ ] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [ ] Actually approved the PR
- [ ] Labeled linked issues as `demo` or `no demo`
- [ ] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [ ] Decided if PR can be labeled `no sandbox`
- [ ] A comment to this PR details the completed security design review
- [ ] PR title is appropriate as title of merge commit
- [ ] `N reviews` label is accurate
- [ ] Status of PR is *Approved*
- [ ] PR is assigned to only the operator and the author


### Operator

- [ ] Checked `reindex:…` labels and `r` commit title tag
- [ ] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [ ] Squashed PR branch and rebased onto `develop`
- [ ] Sanity-checked history
- [ ] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [ ] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [ ] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [ ] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [ ] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [ ] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [ ] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [ ] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `dev`</sub>
- [ ] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvildev`</sub>
- [ ] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [ ] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [ ] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [ ] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [ ] All status checks passed and the PR is mergeable
- [ ] The title of the merge commit starts with the title of this PR
- [ ] Added PR # reference to merge commit title
- [ ] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [ ] Pushed merge commit to GitHub
- [ ] Status of PR is *Merged lower*
- [ ] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [ ] Pushed merge commit to GitLab `dev`
- [ ] Pushed merge commit to GitLab `anvildev`
- [ ] Build passes on GitLab `dev`
- [ ] Reviewed build logs for anomalies on GitLab `dev`
- [ ] Build passes on GitLab `anvildev`
- [ ] Reviewed build logs for anomalies on GitLab `anvildev`
- [ ] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Deleted PR branch from GitHub
- [ ] PR is assigned to only the operator
- [ ] Deleted PR branch from GitLab `dev`
- [ ] Deleted PR branch from GitLab `anvildev`
- [ ] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [ ] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [ ] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [ ] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [ ] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [ ] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [ ] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [ ] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [ ] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [ ] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [ ] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [ ] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [ ] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [ ] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [ ] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
