### PR TITLE
Fix: Content type in mirror info objects inconsistent with index (#7193, #7675)

### DIFF
--- a/docs/mirror.rst
+++ b/docs/mirror.rst
@@ -57,6 +57,10 @@ one of ``sha1``, ``md5`` or ``sha256``, denoting the type of algorithm used to
 derive that hash. Henceforth we'll be referring to the pair of ``digest_type``
 and ``digest_value`` as *digest*.
 
+Any content type associated directly with a file object should be ignored. The
+authoritative source of information about a file's content type(s) is its
+associated info object (see below).
+
 
 Alias objects
 +++++++++++++

--- a/docs/mirror.rst
+++ b/docs/mirror.rst
@@ -89,8 +89,9 @@ hexadecimal form of a hash of the corresponding file object's content and
 algorithm used to derive that hash. The content of an ``info`` object is JSON of
 the form ``{"$schema":"…", "content-type":…}``.
 
-The ``content-type`` property contains the content type of the file, as defined
-for the HTTP response header of the same name [6]_.
+The ``content-type`` property contains a list of all content types known to be
+associated with the file, as defined for the HTTP response header of the same
+name [6]_.
 
 .. [6] https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Type
 

--- a/schemas/mirror/info/v2.json
+++ b/schemas/mirror/info/v2.json
@@ -1,0 +1,25 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "info",
+    "description": "Information describing a file mirrored by Azul",
+    "type": "object",
+    "properties": {
+        "content-type": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "description": "Content types associated with the mirrored file, as defined for the HTTP response header of the same name"
+        },
+        "$schema": {
+            "type": "string",
+            "format": "uri",
+            "pattern": "^https?://.*/info/v\\d+\\.json$",
+            "description": "URL of a JSON schema the JSON containing this property is valid against"
+        }
+    },
+    "required": [
+        "content-type",
+        "$schema"
+    ]
+}

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -84,7 +84,6 @@ from azul.service.source_service import (
 )
 from azul.service.storage_service import (
     StorageObjectExists,
-    StorageObjectNotFound,
     StorageService,
 )
 from azul.types import (
@@ -469,21 +468,6 @@ class BaseMirrorService:
     def _file_exists(self, file: File) -> bool:
         return self._storage.object_exists(self._file_object_key(file))
 
-    def _get_info(self, file: File) -> JSON | None:
-        object_key = self._info_object_key(file)
-        try:
-            content = self._storage.get_object(object_key)
-        except StorageObjectNotFound:
-            return None
-        else:
-            json_content = json.loads(content)
-            content_type = json_content['content-type']
-            if content_type != file.content_type:
-                # FIXME: Content type in mirror info objects inconsistent with index
-                #        https://github.com/DataBiosphere/azul/issues/7193
-                log.warning('Conflicting content type %r for file %r', content_type, file)
-            return json_content
-
     info_prefix, file_prefix = 'info', 'file'
 
     def _info_object_key(self, file: File) -> str:
@@ -694,7 +678,6 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
             log.info('Discarding redundant upload %r of %r', a.upload.upload_id, a.file)
             self._storage.abort_multipart_upload(object_key=object_key,
                                                  upload_id=a.upload.upload_id)
-        self._get_info(a.file)
         self._put_info(a.file)
         log.info('Successfully mirrored file via multi-part upload: %r', a.file)
         return iter(())
@@ -710,7 +693,8 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
         info = self._info(file)
         self._storage.put_object(object_key=object_key,
                                  data=json.dumps(info).encode(),
-                                 content_type='application/json')
+                                 content_type='application/json',
+                                 overwrite=False)
 
     def _repository_url(self, file: File) -> furl:
         assert config.is_tdr_enabled(self.catalog), R(

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -46,6 +46,9 @@ from azul.attrs import (
 from azul.auth import (
     Authentication,
 )
+from azul.collections import (
+    alist,
+)
 from azul.deployment import (
     aws,
 )
@@ -592,6 +595,7 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
         assert a.file.size is not None, R('File size unknown', a.file)
         if self.info_exists(a.file):
             log.info('File is already mirrored, skipping upload: %r', a.file)
+            self._update_info(a.file)
         elif self._file_exists(a.file):
             assert False, R('File object is already present', a.file)
         else:
@@ -684,9 +688,24 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
 
     def _info(self, file: File) -> JSON:
         return {
-            'content-type': file.content_type,
-            '$schema': str(self._schema_url_func(schema_name='info', version=1))
+            'content-type': alist(file.content_type),
+            '$schema': str(self._schema_url_func(schema_name='info', version=2))
         }
+
+    def _update_info(self, file: File):
+        content_type = file.content_type
+        if content_type is not None:
+
+            def update(data: bytes) -> bytes:
+                json_content = json.loads(data)
+                content_types = json_content['content-type']
+                content_types = set(content_types)
+                content_types.add(content_type)
+                json_content['content-type'] = sorted(content_types)
+                return json.dumps(json_content).encode()
+
+            key = self._info_object_key(file)
+            self._storage.update_object(key, update)
 
     def _put_info(self, file: File):
         object_key = self._info_object_key(file)

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -699,7 +699,10 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
             def update(data: bytes) -> bytes:
                 json_content = json.loads(data)
                 content_types = json_content['content-type']
-                content_types = set(content_types)
+                if isinstance(content_types, list):
+                    content_types = set(content_types)
+                else:
+                    content_types = set()
                 content_types.add(content_type)
                 json_content['content-type'] = sorted(content_types)
                 return json.dumps(json_content).encode()

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -466,7 +466,7 @@ class BaseMirrorService:
     def info_exists(self, file: File) -> bool:
         return self._get_info(file) is not None
 
-    def file_exists(self, file: File) -> bool:
+    def _file_exists(self, file: File) -> bool:
         return self._storage.object_exists(self._file_object_key(file))
 
     def _get_info(self, file: File) -> JSON | None:
@@ -608,7 +608,7 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
         assert a.file.size is not None, R('File size unknown', a.file)
         if self.info_exists(a.file):
             log.info('File is already mirrored, skipping upload: %r', a.file)
-        elif self.file_exists(a.file):
+        elif self._file_exists(a.file):
             assert False, R('File object is already present', a.file)
         else:
             part_size = FilePart.default_size

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -467,12 +467,7 @@ class BaseMirrorService:
         return self._get_info(file) is not None
 
     def file_exists(self, file: File) -> bool:
-        try:
-            self._storage.head_object(self._file_object_key(file))
-        except StorageObjectNotFound:
-            return False
-        else:
-            return True
+        return self._storage.object_exists(self._file_object_key(file))
 
     def _get_info(self, file: File) -> JSON | None:
         object_key = self._info_object_key(file)

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -464,7 +464,7 @@ class BaseMirrorService:
                                                content_type=file.content_type)
 
     def info_exists(self, file: File) -> bool:
-        return self._get_info(file) is not None
+        return self._storage.object_exists(self._info_object_key(file))
 
     def _file_exists(self, file: File) -> bool:
         return self._storage.object_exists(self._file_object_key(file))

--- a/src/azul/plugins/metadata/hca/__init__.py
+++ b/src/azul/plugins/metadata/hca/__init__.py
@@ -538,13 +538,18 @@ class HCAFile(File):
         parameter_suffix = '; dcp-type=data'
         if content_type.endswith(parameter_suffix):
             content_type = content_type.removesuffix(parameter_suffix)
-        elif config.catalogs[catalog].atlas == 'lungmap':
+
+        atlas = config.catalogs[catalog].atlas
+        if atlas == 'hca':
+            assert ';' not in content_type, R(
+                'Unexpected MIME parameter in content type', content_type)
+        elif atlas == 'lungmap':
             # FIXME: Re-enable content-type validation for lungmap
             #        https://github.com/DataBiosphere/azul/issues/7244
             pass
         else:
-            assert ';' not in content_type, R(
-                'Unexpected MIME parameter in content type', content_type)
+            assert False, atlas
+
         return cls(uuid=json_str(descriptor['file_id']),
                    name=json_str(json_mapping(metadata['file_core'])['file_name']),
                    version=json_str(descriptor['file_version']),

--- a/src/azul/plugins/metadata/hca/__init__.py
+++ b/src/azul/plugins/metadata/hca/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import (
     Iterable,
     Self,
@@ -543,6 +544,9 @@ class HCAFile(File):
         if atlas == 'hca':
             assert ';' not in content_type, R(
                 'Unexpected MIME parameter in content type', content_type)
+            content_type = cls._content_type_corrections.get(content_type, content_type)
+            assert cls._content_type_re.match(content_type), R(
+                'Invalid content type', content_type)
         elif atlas == 'lungmap':
             # FIXME: Re-enable content-type validation for lungmap
             #        https://github.com/DataBiosphere/azul/issues/7244
@@ -571,3 +575,22 @@ class HCAFile(File):
         entry['content-type'] = entry.pop('content_type')
         entry['indexed'] = False
         return entry
+
+    _content_type_corrections = {
+        # Only correct for files created with Excel 2007 or later. Hopefully we
+        # don't have any files older than that.
+        'xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    }
+
+    # We use the stricter character set and 127-char limit from
+    # https://datatracker.ietf.org/doc/html/rfc6838#section-4.2, for the media
+    # type and subtype, but since this RFC does not describe MIME parameters or
+    # what character to use for the joiner, we draw those specifications from
+    # https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.1.5
+    _restricted_name_re = r'[a-zA-Z0-9]([a-zA-Z0-9!#$&^_.+-]{,125}[a-zA-Z0-9!#$&^_-])?'
+    _token_re = r'[a-zA-Z0-9!#$%&\'*+.^_`|~-]+'
+    _qstr_re = r'"[\t !#-[\]-~\x80-\xff]*"'
+    _content_type_re = re.compile(
+        fr'^{_restricted_name_re}/{_restricted_name_re}'
+        fr'([\t ]*;[\t ]*{_token_re}=(({_token_re})|({_qstr_re})))?$'
+    )

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -86,6 +86,14 @@ class StorageService:
     def _s3(self) -> 'S3Client':
         return aws.s3
 
+    def object_exists(self, object_key: str) -> bool:
+        try:
+            self.head_object(object_key)
+        except StorageObjectNotFound:
+            return False
+        else:
+            return True
+
     def head_object(self, object_key: str) -> 'HeadObjectOutputTypeDef':
         try:
             return self._s3.head_object(Bucket=self.bucket_name,

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -16,8 +16,10 @@ from email.utils import (
 from logging import (
     getLogger,
 )
+import random
 import time
 from typing import (
+    Callable,
     Collection,
     IO,
     TYPE_CHECKING,
@@ -123,6 +125,7 @@ class StorageService:
                    data: bytes,
                    content_type: str | None = None,
                    tagging: Tagging | None = None,
+                   etag: str | None = None,
                    overwrite: bool = True):
         try:
             request: PutObjectRequestTypeDef
@@ -131,11 +134,54 @@ class StorageService:
                 request['ContentType'] = content_type
             if tagging is not None:
                 request['Tagging'] = urlencode(tagging)
+            if etag is not None:
+                request['IfMatch'] = etag
             if overwrite is False:
                 request['IfNoneMatch'] = '*'
             self._s3.put_object(**request)
         except botocore.exceptions.ClientError as e:
             self._handle_overwrite(e, object_key)
+
+    def update_object(self,
+                      object_key: str,
+                      updater: Callable[[bytes], bytes],
+                      max_attempts: int = 10
+                      ):
+        """
+        Updates the contents of an object, based on its existing contents, while
+        ensuring that concurrent updates are not overwritten. Expects a callback
+        that returns the desired contents of the object given its current
+        contents. If the callback ever returns its argument unchanged, no
+        further writes will be attempted. If the object does not exist at any
+        point during the update, StorageObjectNotFound is raised.
+        """
+        for i in range(max_attempts):
+            response = self._get_object(object_key)
+            etag = response['ETag']
+            data = response['Body'].read()
+            new_data = updater(data)
+            if new_data == data:
+                log.info('Object contents of %r is already up to date during attempt #%r/%r.',
+                         object_key, i + 1, max_attempts)
+                break
+            else:
+                try:
+                    self.put_object(object_key=object_key, data=new_data, etag=etag)
+                except botocore.exceptions.ClientError as e:
+                    error = e.response['Error']
+                    code, condition = error['Code'], error.get('Condition')
+                    if code == 'PreconditionFailed' and condition == 'If-Match':
+                        log.info('Conflict during attempt #%r/%r of updating %r from %r to %r',
+                                 i + 1, max_attempts, object_key)
+                        if i >= max_attempts - 1:
+                            raise
+                        else:
+                            time.sleep(random.uniform(0.5, 5.0))
+                    else:
+                        raise
+                else:
+                    log.info('Update of %r succeeded after %r attempts', object_key, i + 1)
+                    break
 
     def delete_objects(self,
                        object_keys: Collection[str],

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -57,6 +57,7 @@ if TYPE_CHECKING:
         CompletedPartTypeDef,
         CreateMultipartUploadRequestTypeDef,
         DeleteObjectsRequestTypeDef,
+        GetObjectOutputTypeDef,
         HeadObjectOutputTypeDef,
         PutObjectRequestTypeDef,
         PutObjectTaggingRequestTypeDef,
@@ -105,13 +106,16 @@ class StorageService:
                 raise e
 
     def get_object(self, object_key: str) -> bytes:
+        return self._get_object(object_key)['Body'].read()
+
+    def _get_object(self, object_key: str) -> 'GetObjectOutputTypeDef':
         try:
             response = self._s3.get_object(Bucket=self.bucket_name,
                                            Key=object_key)
         except self._s3.exceptions.NoSuchKey:
             raise StorageObjectNotFound(object_key)
         else:
-            return response['Body'].read()
+            return response
 
     def put_object(self,
                    *,

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -115,6 +115,9 @@ class TestMirrorController(DCP2TestCase,
                     with self.subTest('mirror_file (fresh upload)'):
                         self._test_mirror_file(file, file_message)
 
+                    with self.subTest('mirror_file (update existing info)'):
+                        self._test_content_type_update(file, file_message)
+
                     self._s3.delete_object(Bucket=self.mirror_bucket,
                                            Key=self.service._info_object_key(file))
 
@@ -203,6 +206,35 @@ class TestMirrorController(DCP2TestCase,
                 self.mirror_controller.mirror(event)
         self.assertTrue(R.caused(e.exception))
         self.assertEqual(e.exception.args[0].args[0], 'File object is already present')
+
+    def _test_content_type_update(self, file, file_message):
+        for content_type in [
+            'application/octet-stream',
+            'application/octet-stream',
+            'text/csv; charset="utf-8"',
+            'application/octet-stream',
+            'text/plain',
+        ]:
+            changed_message = {
+                **file_message,
+                'file': attrs.evolve(file, content_type=content_type).to_json()
+            }
+            old_content_types = self._get_content_types_from_info_object(file)
+            event = self._mirror_event(changed_message)
+            self.mirror_controller.mirror(event)
+            new_content_types = self._get_content_types_from_info_object(file)
+            if content_type in old_content_types:
+                self.assertEqual(old_content_types, new_content_types)
+            else:
+                self.assertIn(content_type, new_content_types)
+
+    def _get_content_types_from_info_object(self, file) -> list[str]:
+        service = self.service
+        info = json.loads(service._storage.get_object(service._info_object_key(file)))
+        content_types = info['content-type']
+        self.assertIsInstance(content_types, list)
+        self.assertEqual(sorted(set(content_types)), content_types)
+        return content_types
 
     def test_info_schema(self):
         client = http_client(log)

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -112,16 +112,16 @@ class TestMirrorController(DCP2TestCase,
                 with self.subTest('mirror_partition'):
                     file_message = self._test_mirror_partition(partition_message, [file])
 
-                    with self.subTest('mirror_file', corrupted=False, exists=False):
+                    with self.subTest('mirror_file (fresh upload)'):
                         self._test_mirror_file(file, file_message)
 
                     self._s3.delete_object(Bucket=self.mirror_bucket,
                                            Key=self.service._info_object_key(file))
 
-                    with self.subTest('mirror_file', corrupted=True):
+                    with self.subTest('mirror_file (corrupted contents)'):
                         self._test_corrupted_download(file_message)
 
-                    with self.subTest('mirror_file', corrupted=False, exists=True):
+                    with self.subTest('mirror_file (exception on overwrite)'):
                         self._test_reuploaded_file(file_message)
 
     @property


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #7193, #7675

This requires re-mirroring all deployments.


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator and the author


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `sandbox`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilbox`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] PR is assigned to only the operator
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub> https://github.com/DataBiosphere/azul/pull/7656#issuecomment-3812384525
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
