### PR TITLE
Hotfix anvilprod: StorageObjectExists when finalizing files with same digest but different ID (#7662)

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -89,6 +89,7 @@ modules =
     azul.indexer.transform,
     azul.indexer.mirror_service,
     azul.functions,
+    azul.service.storage_service
 
 packages =
     azul.openapi

--- a/src/azul/deployment.py
+++ b/src/azul/deployment.py
@@ -211,6 +211,12 @@ class AWS:
     def s3_resource(self) -> 'S3ServiceResource':
         return self.resource('s3', azul_logging=True)
 
+    #: https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
+    #:
+    s3_min_part_size = 5 * 1024 ** 2
+    s3_max_part_size = 5 * 1024 ** 3
+    s3_max_num_parts = 10000
+
     @property
     def securityhub(self) -> 'SecurityHubClient':
         return self.client('securityhub')
@@ -752,6 +758,12 @@ class AWS:
     #: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html
     #:
     sqs_fifo_rate_limit = 300
+
+    #: In 2025, the message size limit was increased from 256 KiB to 1 MiB.
+    #:
+    #: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html
+    #:
+    sqs_max_message_size = 1 * 1024 ** 2
 
 
 aws = AWS()

--- a/src/azul/health.py
+++ b/src/azul/health.py
@@ -134,7 +134,7 @@ class HealthController(AppController):
                                 self.app.catalog, config.default_catalog)
         else:
             try:
-                cache = json.loads(self.storage_service.get(self._cache_key))
+                cache = json.loads(self.storage_service.get_object(self._cache_key))
             except StorageObjectNotFound:
                 raise NotFoundError('Cached health object does not exist')
             else:

--- a/src/azul/health.py
+++ b/src/azul/health.py
@@ -134,7 +134,7 @@ class HealthController(AppController):
                                 self.app.catalog, config.default_catalog)
         else:
             try:
-                cache = json.loads(self.storage_service.get(f'health/{self.app_name}'))
+                cache = json.loads(self.storage_service.get(self._cache_key))
             except StorageObjectNotFound:
                 raise NotFoundError('Cached health object does not exist')
             else:
@@ -148,8 +148,12 @@ class HealthController(AppController):
     def update_cache(self) -> None:
         assert self.app.catalog == config.default_catalog
         health_object = dict(time=time.time(), health=self._health.as_json_fast())
-        self.storage_service.put(object_key=f'health/{self.app_name}',
+        self.storage_service.put(object_key=self._cache_key,
                                  data=json.dumps(health_object).encode())
+
+    @property
+    def _cache_key(self) -> str:
+        return 'health/' + self.app_name
 
     @property
     def _health(self):

--- a/src/azul/health.py
+++ b/src/azul/health.py
@@ -148,8 +148,8 @@ class HealthController(AppController):
     def update_cache(self) -> None:
         assert self.app.catalog == config.default_catalog
         health_object = dict(time=time.time(), health=self._health.as_json_fast())
-        self.storage_service.put(object_key=self._cache_key,
-                                 data=json.dumps(health_object).encode())
+        self.storage_service.put_object(object_key=self._cache_key,
+                                        data=json.dumps(health_object).encode())
 
     @property
     def _cache_key(self) -> str:

--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -69,12 +69,14 @@ class FilePart(SerializableAttrs):
     """
     A part of a mirrored file
     """
+
     #: The part number, starting at 0 for the first part, unlike S3 API part
     #: numbers, which start at 1.
     #:
     index: int
 
     #: Offset of the first byte of this part, relative to the start of the file
+    #:
     offset: int
 
     #: The size of this part
@@ -155,6 +157,7 @@ class BaseMirrorFileService:
     Service for reading mirrored files, plus some test support. The most
     prominent reader of mirrored files is the service app.
     """
+
     catalog: CatalogName
 
     @cached_property

--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -296,7 +296,7 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
     _file_object_content_type = 'application/octet-stream'
 
     @cached_property
-    def repository_plugin(self) -> RepositoryPlugin:
+    def _repository_plugin(self) -> RepositoryPlugin:
         return RepositoryPlugin.load(self.catalog).create(self.catalog)
 
     def mirror_file(self, file: File):
@@ -379,7 +379,7 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
             'Only TDR catalogs are supported', self.catalog)
         assert file.drs_uri is not None, R(
             'File cannot be downloaded', file)
-        drs = self.repository_plugin.drs_client(authentication=None)
+        drs = self._repository_plugin.drs_client(authentication=None)
         access = drs.get_object(file.drs_uri, AccessMethod.gs)
         assert access.method is AccessMethod.https, access
         return furl(access.url)

--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -57,9 +57,7 @@ from azul.types import (
 )
 
 if TYPE_CHECKING:
-    from mypy_boto3_s3.service_resource import (
-        MultipartUpload,
-    )
+    pass
 
 log = logging.getLogger(__name__)
 
@@ -321,9 +319,9 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
         """
         object_key = self._file_object_key(file)
         content_type = self._file_object_content_type
-        upload = self._storage.create_multipart_upload(object_key=object_key,
-                                                       content_type=content_type)
-        return upload.id
+        upload_id = self._storage.create_multipart_upload(object_key=object_key,
+                                                          content_type=content_type)
+        return upload_id
 
     def mirror_file_part(self,
                          file: File,
@@ -336,12 +334,13 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
         :meth:`begin_mirroring_file` and return the uploaded part's ETag.
         The provided hasher is mutated to incorporated the part's content.
         """
-        upload = self._get_upload(file, upload_id)
+        object_key = self._file_object_key(file)
         content = self._download(file, part)
         hasher.update(content)
-        return self._storage.upload_multipart_part(buffer=content,
+        return self._storage.upload_multipart_part(object_key=object_key,
+                                                   upload_id=upload_id,
                                                    part_number=part.index + 1,
-                                                   upload=upload)
+                                                   buffer=content)
 
     def finish_mirroring_file(self,
                               *,
@@ -353,8 +352,9 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
         """
         Complete a multipart upload begun with :meth:`begin_mirroring_file`.
         """
-        upload = self._get_upload(file, upload_id)
-        self._storage.complete_multipart_upload(upload=upload,
+        object_key = self._file_object_key(file)
+        self._storage.complete_multipart_upload(object_key=object_key,
+                                                upload_id=upload_id,
                                                 etags=etags,
                                                 overwrite=False)
         self._verify_digest(file, hasher)
@@ -406,15 +406,6 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
             return response.data
         else:
             raise RuntimeError('Unexpected response from repository', response.status)
-
-    def _get_upload(self,
-                    file: File,
-                    upload_id: str
-                    ) -> 'MultipartUpload':
-        storage = self._storage
-        key = self._file_object_key(file)
-        return storage.load_multipart_upload(object_key=key,
-                                             upload_id=upload_id)
 
     def _verify_digest(self, file: File, hasher: Hasher):
         expected_digest = file.digest

--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -361,7 +361,7 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
         self._get_info(file)
         self._put_info(file)
 
-    def info_object(self, file: File) -> JSON:
+    def _info(self, file: File) -> JSON:
         return {
             'content-type': file.content_type,
             '$schema': str(self._schema_url_func(schema_name='info', version=1))
@@ -369,7 +369,7 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
 
     def _put_info(self, file: File):
         key = self._info_object_key(file)
-        content = self.info_object(file)
+        content = self._info(file)
         self._storage.put(object_key=key,
                           data=json.dumps(content).encode(),
                           content_type='application/json')

--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -259,7 +259,7 @@ class BaseMirrorFileService:
             'Not an IT catalog', self.catalog)
         prefix = self._mirror_prefix
         assert len(prefix) > 1 and prefix.endswith('/'), prefix
-        keys = self._storage.list(prefix)
+        keys = self._storage.list_objects(prefix)
         assert len(keys) <= 300, R('Too many objects', len(keys))
         self._storage.delete_objects(keys, batch_size=100)
 

--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -268,11 +268,7 @@ class BaseMirrorFileService:
 
 class SchemaUrlFunc(Protocol):
 
-    def __call__(self,
-                 *,
-                 schema_name: str,
-                 version: int
-                 ) -> mutable_furl: ...
+    def __call__(self, *, schema_name: str, version: int) -> mutable_furl: ...
 
 
 @attrs.frozen(kw_only=True, slots=False)

--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -49,6 +49,7 @@ from azul.plugins import (
     RepositoryPlugin,
 )
 from azul.service.storage_service import (
+    StorageObjectExists,
     StorageObjectNotFound,
     StorageService,
 )
@@ -302,14 +303,14 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
         Upload the file in a single request. For larger files, use
         :meth:`begin_mirroring_file` instead.
         """
+        hasher = get_resumable_hasher(file.digest.type)
         file_content = self._download(file)
+        hasher.update(file_content)
+        self._verify_digest(file, hasher)
         self._storage.put_object(object_key=self._file_object_key(file),
                                  data=file_content,
                                  content_type=self._file_object_content_type,
                                  overwrite=False)
-        hasher = get_resumable_hasher(file.digest.type)
-        hasher.update(file_content)
-        self._verify_digest(file, hasher)
         self._put_info(file)
 
     def begin_mirroring_file(self, file: File) -> str:
@@ -352,12 +353,17 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
         """
         Complete a multipart upload begun with :meth:`begin_mirroring_file`.
         """
-        object_key = self._file_object_key(file)
-        self._storage.complete_multipart_upload(object_key=object_key,
-                                                upload_id=upload_id,
-                                                etags=etags,
-                                                overwrite=False)
         self._verify_digest(file, hasher)
+        object_key = self._file_object_key(file)
+        try:
+            self._storage.complete_multipart_upload(object_key=object_key,
+                                                    upload_id=upload_id,
+                                                    etags=etags,
+                                                    overwrite=False)
+        except StorageObjectExists:
+            log.info('Discarding redundant upload %r of %r', upload_id, file)
+            self._storage.abort_multipart_upload(object_key=object_key,
+                                                 upload_id=upload_id)
         self._get_info(file)
         self._put_info(file)
 

--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -203,6 +203,17 @@ class BaseMirrorFileService:
                                                file_name=file.name,
                                                content_type=file.content_type)
 
+    def info_exists(self, file: File) -> bool:
+        return self._get_info(file) is not None
+
+    def file_exists(self, file: File) -> bool:
+        try:
+            self._storage.head(self._file_object_key(file))
+        except StorageObjectNotFound:
+            return False
+        else:
+            return True
+
     def _get_info(self, file: File) -> JSON | None:
         key = self._info_object_key(file)
         try:
@@ -220,22 +231,23 @@ class BaseMirrorFileService:
 
     info_prefix, file_prefix = 'info', 'file'
 
-    def _file_object_key(self, file: File) -> str:
-        return self._object_key(self.file_prefix, file)
-
     def _info_object_key(self, file: File) -> str:
         return self._object_key(self.info_prefix, file, extension='.json')
 
-    def info_exists(self, file: File) -> bool:
-        return self._get_info(file) is not None
+    def _file_object_key(self, file: File) -> str:
+        return self._object_key(self.file_prefix, file)
 
-    def file_exists(self, file: File) -> bool:
-        try:
-            self._storage.head(self._file_object_key(file))
-        except StorageObjectNotFound:
-            return False
-        else:
-            return True
+    def _object_key(self, prefix: str, file: File, *, extension: str = '') -> str:
+        digest = file.digest
+        digest_value = digest.value.lower()
+        assert all(c in string.hexdigits for c in digest_value), R(
+            'Expected a hexadecimal digest', digest)
+        mirror_prefix = self._mirror_prefix
+        return f'{mirror_prefix}{prefix}/{digest_value}.{digest.type}{extension}'
+
+    @cached_property
+    def _mirror_prefix(self) -> str:
+        return '_it/' if self.catalog in config.integration_test_catalogs else ''
 
     def delete_it_files(self):
         """
@@ -252,18 +264,6 @@ class BaseMirrorFileService:
         keys = self._storage.list(prefix)
         assert len(keys) <= 300, R('Too many objects', len(keys))
         self._storage.delete(keys, batch_size=100)
-
-    @cached_property
-    def _mirror_prefix(self) -> str:
-        return '_it/' if self.catalog in config.integration_test_catalogs else ''
-
-    def _object_key(self, prefix: str, file: File, *, extension: str = '') -> str:
-        digest = file.digest
-        digest_value = digest.value.lower()
-        assert all(c in string.hexdigits for c in digest_value), R(
-            'Expected a hexadecimal digest', digest)
-        mirror_prefix = self._mirror_prefix
-        return f'{mirror_prefix}{prefix}/{digest_value}.{digest.type}{extension}'
 
 
 class SchemaUrlFunc(Protocol):

--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -204,7 +204,7 @@ class BaseMirrorFileService:
                                                content_type=file.content_type)
 
     def _get_info(self, file: File) -> JSON | None:
-        key = self.info_object_key(file)
+        key = self._info_object_key(file)
         try:
             content = self._storage.get(key)
         except StorageObjectNotFound:
@@ -223,7 +223,7 @@ class BaseMirrorFileService:
     def mirror_object_key(self, file: File) -> str:
         return self._object_key(self.file_prefix, file)
 
-    def info_object_key(self, file: File) -> str:
+    def _info_object_key(self, file: File) -> str:
         return self._object_key(self.info_prefix, file, extension='.json')
 
     def info_exists(self, file: File) -> bool:
@@ -372,7 +372,7 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
         }
 
     def _put_info(self, file: File):
-        key = self.info_object_key(file)
+        key = self._info_object_key(file)
         content = self.info_object(file)
         self._storage.put(object_key=key,
                           data=json.dumps(content).encode(),

--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -259,9 +259,9 @@ class BaseMirrorFileService:
             'Not an IT catalog', self.catalog)
         prefix = self._mirror_prefix
         assert len(prefix) > 1 and prefix.endswith('/'), prefix
-        keys = self._storage.list_objects(prefix)
-        assert len(keys) <= 300, R('Too many objects', len(keys))
-        self._storage.delete_objects(keys, batch_size=100)
+        object_keys = self._storage.list_objects(prefix)
+        assert len(object_keys) <= 300, R('Too many objects', len(object_keys))
+        self._storage.delete_objects(object_keys, batch_size=100)
 
 
 class SchemaUrlFunc(Protocol):

--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -84,9 +84,9 @@ class FilePart(SerializableAttrs):
     #: Various S3 quotas related to parts and part sizes
     #: https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
     #:
-    min_size: ClassVar[int] = 5 * 1024 ** 2
-    max_size: ClassVar[int] = 5 * 1024 ** 3
-    max_num_parts: ClassVar[int] = 10000
+    min_size: ClassVar[int] = aws.s3_min_part_size
+    max_size: ClassVar[int] = aws.s3_max_part_size
+    max_num_parts: ClassVar[int] = aws.s3_max_num_parts
 
     #: We observe a download rate of ~14 MB/s. Download time should ideally be
     #: 1/4 of the Lambda timeout. Since we track the ETag of each part in SQS

--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -197,7 +197,7 @@ class BaseMirrorFileService:
                         path=self._file_object_key(file)))
 
     def mirror_url(self, file: File) -> str:
-        return self._storage.get_presigned_url(key=self._file_object_key(file),
+        return self._storage.get_presigned_url(object_key=self._file_object_key(file),
                                                file_name=file.name,
                                                content_type=file.content_type)
 

--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -374,7 +374,7 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
                           data=json.dumps(content).encode(),
                           content_type='application/json')
 
-    def _get_repository_url(self, file: File) -> furl:
+    def _repository_url(self, file: File) -> furl:
         assert config.is_tdr_enabled(self.catalog), R(
             'Only TDR catalogs are supported', self.catalog)
         assert file.drs_uri is not None, R(
@@ -385,7 +385,7 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
         return furl(access.url)
 
     def _download(self, file: File, part: FilePart | None = None) -> bytes:
-        download_url = self._get_repository_url(file)
+        download_url = self._repository_url(file)
         start = time.time()
         if part is None:
             headers = {}

--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -385,7 +385,7 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
         return furl(access.url)
 
     def _download(self, file: File, part: FilePart | None = None) -> bytes:
-        download_url = self._repository_url(file)
+        url = self._repository_url(file)
         start = time.time()
         if part is None:
             headers = {}
@@ -397,9 +397,7 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
             expected_status = 206
         # Ideally we would stream the response, but boto only supports uploading
         # from streams that are seekable.
-        response = self._http_client.request('GET',
-                                             str(download_url),
-                                             headers=headers)
+        response = self._http_client.request('GET', str(url), headers=headers)
         if response.status == expected_status:
             actual_size = len(response.data)
             log.info('Downloaded %d bytes in %.3fs from file %r',

--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -215,7 +215,7 @@ class BaseMirrorFileService:
     def _get_info(self, file: File) -> JSON | None:
         key = self._info_object_key(file)
         try:
-            content = self._storage.get(key)
+            content = self._storage.get_object(key)
         except StorageObjectNotFound:
             return None
         else:

--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -303,10 +303,10 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
         :meth:`begin_mirroring_file` instead.
         """
         file_content = self._download(file)
-        self._storage.put(object_key=self._file_object_key(file),
-                          data=file_content,
-                          content_type=self._file_object_content_type,
-                          overwrite=False)
+        self._storage.put_object(object_key=self._file_object_key(file),
+                                 data=file_content,
+                                 content_type=self._file_object_content_type,
+                                 overwrite=False)
         hasher = get_resumable_hasher(file.digest.type)
         hasher.update(file_content)
         self._verify_digest(file, hasher)
@@ -370,9 +370,9 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
     def _put_info(self, file: File):
         object_key = self._info_object_key(file)
         info = self._info(file)
-        self._storage.put(object_key=object_key,
-                          data=json.dumps(info).encode(),
-                          content_type='application/json')
+        self._storage.put_object(object_key=object_key,
+                                 data=json.dumps(info).encode(),
+                                 content_type='application/json')
 
     def _repository_url(self, file: File) -> furl:
         assert config.is_tdr_enabled(self.catalog), R(

--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -196,10 +196,10 @@ class BaseMirrorFileService:
         """
         return str(furl(scheme='s3',
                         netloc=self._storage.bucket_name,
-                        path=self.mirror_object_key(file)))
+                        path=self._file_object_key(file)))
 
     def mirror_url(self, file: File) -> str:
-        return self._storage.get_presigned_url(key=self.mirror_object_key(file),
+        return self._storage.get_presigned_url(key=self._file_object_key(file),
                                                file_name=file.name,
                                                content_type=file.content_type)
 
@@ -220,7 +220,7 @@ class BaseMirrorFileService:
 
     info_prefix, file_prefix = 'info', 'file'
 
-    def mirror_object_key(self, file: File) -> str:
+    def _file_object_key(self, file: File) -> str:
         return self._object_key(self.file_prefix, file)
 
     def _info_object_key(self, file: File) -> str:
@@ -231,7 +231,7 @@ class BaseMirrorFileService:
 
     def file_exists(self, file: File) -> bool:
         try:
-            self._storage.head(self.mirror_object_key(file))
+            self._storage.head(self._file_object_key(file))
         except StorageObjectNotFound:
             return False
         else:
@@ -309,7 +309,7 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
         :meth:`begin_mirroring_file` instead.
         """
         file_content = self._download(file)
-        self._storage.put(object_key=self.mirror_object_key(file),
+        self._storage.put(object_key=self._file_object_key(file),
                           data=file_content,
                           content_type=self.file_object_content_type,
                           overwrite=False)
@@ -324,7 +324,7 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
         ID.
         """
         storage = self._storage
-        key = self.mirror_object_key(file)
+        key = self._file_object_key(file)
         upload = storage.create_multipart_upload(object_key=key,
                                                  content_type=self.file_object_content_type)
         return upload.id
@@ -418,7 +418,7 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
                     upload_id: str
                     ) -> 'MultipartUpload':
         storage = self._storage
-        key = self.mirror_object_key(file)
+        key = self._file_object_key(file)
         return storage.load_multipart_upload(object_key=key,
                                              upload_id=upload_id)
 

--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -284,7 +284,7 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
     by the indexer app.
     """
 
-    schema_url_func: SchemaUrlFunc
+    _schema_url_func: SchemaUrlFunc
 
     # We don't store the mirrored files' actual content type(s) in S3's
     # `Content-Type` metadata because a single file object may store the
@@ -368,7 +368,7 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
     def info_object(self, file: File) -> JSON:
         return {
             'content-type': file.content_type,
-            '$schema': str(self.schema_url_func(schema_name='info', version=1))
+            '$schema': str(self._schema_url_func(schema_name='info', version=1))
         }
 
     def _put_info(self, file: File):

--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -319,10 +319,10 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
         Initiate a multipart upload of the file's content and return the upload
         ID.
         """
-        storage = self._storage
-        key = self._file_object_key(file)
-        upload = storage.create_multipart_upload(object_key=key,
-                                                 content_type=self._file_object_content_type)
+        object_key = self._file_object_key(file)
+        content_type = self._file_object_content_type
+        upload = self._storage.create_multipart_upload(object_key=object_key,
+                                                       content_type=content_type)
         return upload.id
 
     def mirror_file_part(self,
@@ -337,11 +337,11 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
         The provided hasher is mutated to incorporated the part's content.
         """
         upload = self._get_upload(file, upload_id)
-        file_content = self._download(file, part)
-        hasher.update(file_content)
-        return self._storage.upload_multipart_part(file_content,
-                                                   part.index + 1,
-                                                   upload)
+        content = self._download(file, part)
+        hasher.update(content)
+        return self._storage.upload_multipart_part(buffer=content,
+                                                   part_number=part.index + 1,
+                                                   upload=upload)
 
     def finish_mirroring_file(self,
                               *,
@@ -354,8 +354,8 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
         Complete a multipart upload begun with :meth:`begin_mirroring_file`.
         """
         upload = self._get_upload(file, upload_id)
-        self._storage.complete_multipart_upload(upload,
-                                                etags,
+        self._storage.complete_multipart_upload(upload=upload,
+                                                etags=etags,
                                                 overwrite=False)
         self._verify_digest(file, hasher)
         self._get_info(file)
@@ -368,10 +368,10 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
         }
 
     def _put_info(self, file: File):
-        key = self._info_object_key(file)
-        content = self._info(file)
-        self._storage.put(object_key=key,
-                          data=json.dumps(content).encode(),
+        object_key = self._info_object_key(file)
+        info = self._info(file)
+        self._storage.put(object_key=object_key,
+                          data=json.dumps(info).encode(),
                           content_type='application/json')
 
     def _repository_url(self, file: File) -> furl:

--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -293,7 +293,7 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
     # value in the `Content-Type` metadata. We haven't found an efficient way to
     # update the content type of an existing object without copying its data.
     #
-    file_object_content_type = 'application/octet-stream'
+    _file_object_content_type = 'application/octet-stream'
 
     @cached_property
     def repository_plugin(self) -> RepositoryPlugin:
@@ -307,7 +307,7 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
         file_content = self._download(file)
         self._storage.put(object_key=self._file_object_key(file),
                           data=file_content,
-                          content_type=self.file_object_content_type,
+                          content_type=self._file_object_content_type,
                           overwrite=False)
         hasher = get_resumable_hasher(file.digest.type)
         hasher.update(file_content)
@@ -322,7 +322,7 @@ class MirrorFileService(BaseMirrorFileService, HasCachedHttpClient):
         storage = self._storage
         key = self._file_object_key(file)
         upload = storage.create_multipart_upload(object_key=key,
-                                                 content_type=self.file_object_content_type)
+                                                 content_type=self._file_object_content_type)
         return upload.id
 
     def mirror_file_part(self,

--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -206,7 +206,7 @@ class BaseMirrorFileService:
 
     def file_exists(self, file: File) -> bool:
         try:
-            self._storage.head(self._file_object_key(file))
+            self._storage.head_object(self._file_object_key(file))
         except StorageObjectNotFound:
             return False
         else:

--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -90,16 +90,19 @@ class FilePart(SerializableAttrs):
     max_size: ClassVar[int] = aws.s3_max_part_size
     max_num_parts: ClassVar[int] = aws.s3_max_num_parts
 
-    #: We observe a download rate of ~14 MB/s. Download time should ideally be
-    #: 1/4 of the Lambda timeout. Since we track the ETag of each part in SQS
-    #: messages, message size becomes another constraint: we observe ETags to be
-    #: 32 byte hexadecimal strings which, if represented in a JSON array, take
-    #: up 35 bytes per item, 36 if the comma is followed by a space. With a
-    #: maximum SQS message size of 256 KiB, we can store approximately 7280
-    #: ETags in an SQS messages, so the largest file we can mirror using a part
-    #: size of 256 MiB is 1.5 TiB.
+    #: In experiments, we observed a download rate of ~25 MB/s for an AWS Lambda
+    #: function downloading from GCS. To leave room for network impairments or
+    #: other partial outages, the normal download time for a single part should
+    #: be one third of the Lambda function timeout. Also, we heuristically
+    #: decided for the part size to not exceed 1 GiB in size in stable
+    # deployments, or 256 MiB in elsewhere.
     #:
-    default_size: ClassVar[int] = 256 * 1024 ** 2
+    default_size: ClassVar[int] = min(
+        1024 ** 3 if config.deployment.is_stable else 256 * 1024 ** 2,
+        int(config.mirror_lambda_timeout * 25 * 1024 ** 2 / 3)
+    )
+
+    assert min_size <= default_size <= max_size
 
     @classmethod
     def first(cls, file: File, part_size: int) -> Self:
@@ -166,6 +169,24 @@ class BaseMirrorFileService:
         if bucket is None or self.catalog in config.integration_test_catalogs:
             bucket = aws.mirror_bucket
         return StorageService(bucket)
+
+    #: Since we track the ETags of all parts of a multipart file in SQS
+    #: messages, the maximum file size is primarily constrained by the SQS
+    #: message size. We observe ETags to be 32-byte hexadecimal strings which,
+    #: if represented in a JSON array, take up 35 bytes per item, 36 if the
+    #: comma is followed by a space. This limits the number of ETags we can
+    #: store in a message, while leaving room for 64 KiB of other information,
+    #: and thereby also limits the maximum size of files we can mirror.
+    #:
+    max_file_size = (
+        FilePart.default_size
+        * (aws.sqs_max_message_size - 64 * 1024) / 36
+    )
+
+    # We should be able to copy files 1.5 TiB in size or larger. Currently, the
+    # largest file in the open-access datasets for AnVIL is 1.3 TiB.
+    #
+    assert 1.5 * 1024 ** 4 <= max_file_size
 
     def mirror_uri(self, file: File) -> str:
         """

--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -213,9 +213,9 @@ class BaseMirrorFileService:
             return True
 
     def _get_info(self, file: File) -> JSON | None:
-        key = self._info_object_key(file)
+        object_key = self._info_object_key(file)
         try:
-            content = self._storage.get_object(key)
+            content = self._storage.get_object(object_key)
         except StorageObjectNotFound:
             return None
         else:

--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -221,10 +221,10 @@ class BaseMirrorFileService:
     info_prefix, file_prefix = 'info', 'file'
 
     def mirror_object_key(self, file: File) -> str:
-        return self._file_key(self.file_prefix, file)
+        return self._object_key(self.file_prefix, file)
 
     def info_object_key(self, file: File) -> str:
-        return self._file_key(self.info_prefix, file, extension='.json')
+        return self._object_key(self.info_prefix, file, extension='.json')
 
     def info_exists(self, file: File) -> bool:
         return self._get_info(file) is not None
@@ -257,12 +257,7 @@ class BaseMirrorFileService:
     def _mirror_prefix(self) -> str:
         return '_it/' if self.catalog in config.integration_test_catalogs else ''
 
-    def _file_key(self,
-                  prefix: str,
-                  file: File,
-                  *,
-                  extension: str = ''
-                  ) -> str:
+    def _object_key(self, prefix: str, file: File, *, extension: str = '') -> str:
         digest = file.digest
         digest_value = digest.value.lower()
         assert all(c in string.hexdigits for c in digest_value), R(

--- a/src/azul/indexer/mirror_file_service.py
+++ b/src/azul/indexer/mirror_file_service.py
@@ -261,7 +261,7 @@ class BaseMirrorFileService:
         assert len(prefix) > 1 and prefix.endswith('/'), prefix
         keys = self._storage.list(prefix)
         assert len(keys) <= 300, R('Too many objects', len(keys))
-        self._storage.delete(keys, batch_size=100)
+        self._storage.delete_objects(keys, batch_size=100)
 
 
 class SchemaUrlFunc(Protocol):

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -328,7 +328,7 @@ class MirrorService(BaseMirrorService):
         etags = [*a.etags, etag]
         next_part = a.part.next(a.file)
         if next_part is None:
-            log.info('File fully uploaded in %d parts: %r', len(etags), a.file)
+            log.info('Uploaded all %d parts for file %r', len(etags), a.file)
             yield FinalizeFileAction(catalog=a.catalog,
                                      source=a.source,
                                      prefix=a.prefix,

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -271,6 +271,8 @@ class MirrorService(BaseMirrorService):
         files = plugin.list_files(a.source, a.prefix)
         for file in files:
             assert file.size is not None, R('File size unknown', file)
+            assert file.size <= MirrorFileService.max_file_size, R(
+                'File too big', file, MirrorFileService.max_file_size)
             if self.may_mirror(a.catalog, file.size):
                 log.debug('Queueing file %r', file)
                 yield MirrorFileAction(catalog=a.catalog,

--- a/src/azul/queues.py
+++ b/src/azul/queues.py
@@ -207,7 +207,7 @@ class Queues:
                 time_spent = time.time() - start
                 time_to_sleep = period - time_spent
                 if time_to_sleep > 0:
-                    log.debug('Sleeping %.3fs to prevent exceeding rate limit', time_to_sleep)
+                    log.debug('Sleeping %.3fs to avoid SQS rate limit', time_to_sleep)
                     time.sleep(time_to_sleep)
             num_messages += len(batch)
         return num_messages

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -729,7 +729,7 @@ class ManifestService(ElasticsearchService):
                         file_name=file_name)
 
     def get_manifest_url(self, manifest: Manifest) -> str:
-        return self.storage_service.get_presigned_url(key=manifest.object_key,
+        return self.storage_service.get_presigned_url(object_key=manifest.object_key,
                                                       file_name=manifest.file_name)
 
     file_name_tag = 'azul_file_name'

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -144,7 +144,6 @@ from azul.service.elasticsearch_service import (
     ToDictStage,
 )
 from azul.service.storage_service import (
-    AWS_S3_DEFAULT_MINIMUM_PART_SIZE,
     StorageObjectNotFound,
     StorageService,
 )
@@ -1310,7 +1309,7 @@ class PagedManifestGenerator(ClientSidePagingManifestGenerator):
 
     part_size = 50 * 1024 * 1024
 
-    assert part_size >= AWS_S3_DEFAULT_MINIMUM_PART_SIZE
+    assert aws.s3_min_part_size <= part_size <= aws.s3_max_part_size
 
     def write(self,
               manifest_key: ManifestKey,

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -1238,7 +1238,7 @@ class ManifestGenerator(metaclass=ABCMeta):
         raise NotImplementedError
 
     @property
-    def storage(self):
+    def storage(self) -> StorageService:
         return self.service.storage_service
 
 

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -1326,11 +1326,10 @@ class PagedManifestGenerator(ClientSidePagingManifestGenerator):
             type(self).manifest_config.fset(self, config)
         object_key = self.s3_object_key(manifest_key)
         if partition.multipart_upload_id is None:
-            upload = self.storage.create_multipart_upload(object_key)
-            partition = partition.with_upload(upload.id)
+            upload_id = self.storage.create_multipart_upload(object_key=object_key)
+            partition = partition.with_upload(upload_id)
         else:
-            upload = self.storage.load_multipart_upload(object_key=object_key,
-                                                        upload_id=partition.multipart_upload_id)
+            upload_id = partition.multipart_upload_id
         if partition.page_index is None:
             partition = partition.first_page()
         with BytesIO() as buffer:
@@ -1343,10 +1342,15 @@ class PagedManifestGenerator(ClientSidePagingManifestGenerator):
                         break
                 if buffer.tell() > 0:
                     buffer.seek(0)
-                    part_etag = self.storage.upload_multipart_part(buffer, partition.index + 1, upload)
+                    part_etag = self.storage.upload_multipart_part(object_key=object_key,
+                                                                   upload_id=upload_id,
+                                                                   part_number=partition.index + 1,
+                                                                   buffer=buffer)
                     partition = partition.next(part_etag=part_etag)
                 if partition.is_last_page:
-                    self.storage.complete_multipart_upload(upload, partition.part_etags)
+                    self.storage.complete_multipart_upload(object_key=object_key,
+                                                           upload_id=upload_id,
+                                                           etags=partition.part_etags)
                     file_name = self.file_name(manifest_key, base_name=partition.file_name)
                     tagging = self.tagging(file_name)
                     if tagging is not None:

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -21,7 +21,6 @@ from typing import (
     Collection,
     IO,
     TYPE_CHECKING,
-    Union,
 )
 from urllib.parse import (
     urlencode,
@@ -120,7 +119,8 @@ class StorageService:
                 request['ContentType'] = content_type
             if tagging is not None:
                 request['Tagging'] = urlencode(tagging)
-            self._add_overwrite(request, overwrite)
+            if overwrite is False:
+                request['IfNoneMatch'] = '*'
             self._s3.put_object(**request)
         except botocore.exceptions.ClientError as e:
             self._handle_overwrite(e, object_key)
@@ -196,7 +196,8 @@ class StorageService:
                            Key=object_key,
                            UploadId=upload_id,
                            MultipartUpload={'Parts': parts})
-            self._add_overwrite(request, overwrite)
+            if overwrite is False:
+                request['IfNoneMatch'] = '*'
             self._s3.complete_multipart_upload(**request)
         except botocore.exceptions.ClientError as e:
             self._handle_overwrite(e, object_key)
@@ -217,15 +218,6 @@ class StorageService:
         # https://stackoverflow.com/a/56351011/7830612
         if tagging:
             self.put_object_tagging(object_key, tagging)
-
-    def _add_overwrite(self,
-                       request: Union[
-                           'PutObjectRequestTypeDef',
-                           'CompleteMultipartUploadRequestTypeDef'
-                       ],
-                       overwrite: bool):
-        if overwrite is False:
-            request['IfNoneMatch'] = '*'
 
     def get_presigned_url(self,
                           key: str,

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -21,6 +21,7 @@ from typing import (
     Collection,
     IO,
     TYPE_CHECKING,
+    Union,
 )
 from urllib.parse import (
     urlencode,
@@ -53,8 +54,13 @@ if TYPE_CHECKING:
         S3Client,
     )
     from mypy_boto3_s3.type_defs import (
+        CompleteMultipartUploadRequestTypeDef,
         CompletedPartTypeDef,
+        CreateMultipartUploadRequestTypeDef,
+        DeleteObjectsRequestTypeDef,
         HeadObjectOutputTypeDef,
+        PutObjectRequestTypeDef,
+        PutObjectTaggingRequestTypeDef,
     )
 
 log = getLogger(__name__)
@@ -108,13 +114,12 @@ class StorageService:
             tagging: Tagging | None = None,
             overwrite: bool = True):
         try:
-            kwargs = self._object_creation_kwargs(content_type=content_type,
-                                                  tagging=tagging,
-                                                  overwrite=overwrite)
-            self._s3.put_object(Bucket=self.bucket_name,
-                                Key=object_key,
-                                Body=data,
-                                **kwargs)
+            request: PutObjectRequestTypeDef
+            request = dict(Bucket=self.bucket_name, Key=object_key, Body=data)
+            self._add_content_type(request, content_type)
+            self._add_tagging(request, tagging)
+            self._add_overwrite(request, overwrite)
+            self._s3.put_object(**request)
         except botocore.exceptions.ClientError as e:
             self._handle_overwrite(e, object_key)
 
@@ -123,12 +128,15 @@ class StorageService:
         num_keys = len(keys)
         for batch in chunked(keys, batch_size):
             log.debug('Deleting batch of objects: %r', batch)
-            delete = {'Objects': [{'Key': key} for key in batch]}
-            self._s3.delete_objects(Bucket=self.bucket_name, Delete=delete)
+            request: DeleteObjectsRequestTypeDef
+            request = dict(Bucket=self.bucket_name,
+                           Delete=dict(Objects=[dict(Key=key) for key in batch]))
+            self._s3.delete_objects(**request)
         log.info('Deleted %d objects overall', num_keys)
 
     def list(self, prefix: str) -> OrderedSet[str]:
-        keys, num_keys = OrderedSet(), 0
+        keys: OrderedSet[str] = OrderedSet()
+        num_keys = 0
         paginator = self._s3.get_paginator('list_objects_v2')
         for page in paginator.paginate(Bucket=self.bucket_name, Prefix=prefix):
             contents = page.get('Contents', ())
@@ -143,11 +151,11 @@ class StorageService:
                                 content_type: str | None = None,
                                 tagging: Tagging | None = None
                                 ) -> str:
-        kwargs = self._object_creation_kwargs(content_type=content_type,
-                                              tagging=tagging)
-        response = self._s3.create_multipart_upload(Bucket=self.bucket_name,
-                                                    Key=object_key,
-                                                    **kwargs)
+        request: CreateMultipartUploadRequestTypeDef
+        request = dict(Bucket=self.bucket_name, Key=object_key)
+        self._add_content_type(request, content_type)
+        self._add_tagging(request, tagging)
+        response = self._s3.create_multipart_upload(**request)
         return response['UploadId']
 
     def upload_multipart_part(self,
@@ -179,11 +187,13 @@ class StorageService:
             for index, etag in enumerate(etags)
         ]
         try:
-            self._s3.complete_multipart_upload(Bucket=self.bucket_name,
-                                               Key=object_key,
-                                               UploadId=upload_id,
-                                               MultipartUpload={'Parts': parts},
-                                               **self._object_creation_kwargs(overwrite=overwrite))
+            request: CompleteMultipartUploadRequestTypeDef
+            request = dict(Bucket=self.bucket_name,
+                           Key=object_key,
+                           UploadId=upload_id,
+                           MultipartUpload={'Parts': parts})
+            self._add_overwrite(request, overwrite)
+            self._s3.complete_multipart_upload(**request)
         except botocore.exceptions.ClientError as e:
             self._handle_overwrite(e, object_key)
 
@@ -192,29 +202,44 @@ class StorageService:
                object_key: str,
                content_type: str | None = None,
                tagging: Tagging | None = None):
+        extra_args: dict[str, str] = {}
+        self._add_content_type(extra_args, content_type)
         self._s3.upload_file(Filename=file_path,
                              Bucket=self.bucket_name,
                              Key=object_key,
-                             ExtraArgs=self._object_creation_kwargs(content_type=content_type))
+                             ExtraArgs=extra_args)
         # upload_file doesn't support tags so we need to make a separate request
         # https://stackoverflow.com/a/56351011/7830612
         if tagging:
             self.put_object_tagging(object_key, tagging)
 
-    def _object_creation_kwargs(self,
-                                *,
-                                content_type: str | None = None,
-                                tagging: Tagging | None = None,
-                                overwrite: bool = True
-                                ) -> dict[str, str]:
-        kwargs = {}
+    def _add_content_type(self,
+                          request: Union[
+                              'PutObjectRequestTypeDef',
+                              'CreateMultipartUploadRequestTypeDef',
+                              dict[str, str]
+                          ],
+                          content_type: str | None):
         if content_type is not None:
-            kwargs['ContentType'] = content_type
+            request['ContentType'] = content_type
+
+    def _add_tagging(self,
+                     request: Union[
+                         'PutObjectRequestTypeDef',
+                         'CreateMultipartUploadRequestTypeDef'
+                     ],
+                     tagging: Mapping[str, str] | None):
         if tagging is not None:
-            kwargs['Tagging'] = urlencode(tagging)
+            request['Tagging'] = urlencode(tagging)
+
+    def _add_overwrite(self,
+                       request: Union[
+                           'PutObjectRequestTypeDef',
+                           'CompleteMultipartUploadRequestTypeDef'
+                       ],
+                       overwrite: bool):
         if overwrite is False:
-            kwargs['IfNoneMatch'] = '*'
-        return kwargs
+            request['IfNoneMatch'] = '*'
 
     def get_presigned_url(self,
                           key: str,
@@ -258,13 +283,14 @@ class StorageService:
 
     def put_object_tagging(self, object_key: str, tagging: Tagging):
         log.info('Tagging object %r with %r', object_key, tagging)
-        tagging = {'TagSet': [{'Key': k, 'Value': v} for k, v in tagging.items()]}
+        request: PutObjectTaggingRequestTypeDef
+        request = dict(Bucket=self.bucket_name,
+                       Key=object_key,
+                       Tagging=dict(TagSet=[dict(Key=k, Value=v) for k, v in tagging.items()]))
         deadline = time.time() + 60
         while True:
             try:
-                self._s3.put_object_tagging(Bucket=self.bucket_name,
-                                            Key=object_key,
-                                            Tagging=tagging)
+                self._s3.put_object_tagging(**request)
             except self._s3.exceptions.NoSuchKey:
                 if time.time() > deadline:
                     log.error('Unable to tag %s on object.', tagging)

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -221,7 +221,7 @@ class StorageService:
                              ExtraArgs=extra_args)
 
     def get_presigned_url(self,
-                          key: str,
+                          object_key: str,
                           *,
                           file_name: str | None = None,
                           content_type: str | None = None
@@ -229,8 +229,8 @@ class StorageService:
         """
         Return a pre-signed URL to the given key.
 
-        :param key: The key of the S3 object whose content a request to the
-                    signed URL will return
+        :param object_key: The key of the S3 object whose content a request to
+                           the signed URL will return
 
         :param file_name: the file name to be returned as part of a
                           Content-Disposition header in the response to a
@@ -247,7 +247,7 @@ class StorageService:
             ClientMethod=self._s3.get_object.__name__,
             Params={
                 'Bucket': self.bucket_name,
-                'Key': key,
+                'Key': object_key,
                 **(
                     {}
                     if file_name is None else

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -256,7 +256,7 @@ class StorageService:
                 )
             })
 
-    def put_object_tagging(self, object_key: str, tagging: Tagging = None):
+    def put_object_tagging(self, object_key: str, tagging: Tagging):
         deadline = time.time() + 60
         tagging = {'TagSet': [{'Key': k, 'Value': v} for k, v in tagging.items()]}
         log.info('Tagging object %r with %r', object_key, tagging)

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -126,12 +126,12 @@ class StorageService:
             self._handle_overwrite(e, object_key)
 
     def delete_objects(self,
-                       keys: Collection[str],
+                       object_keys: Collection[str],
                        batch_size: int = 1000
                        ) -> None:
         assert batch_size <= 1000, R('Batch size must <= 1000', batch_size)
-        num_keys = len(keys)
-        for batch in chunked(keys, batch_size):
+        num_keys = len(object_keys)
+        for batch in chunked(object_keys, batch_size):
             log.debug('Deleting batch of objects: %r', batch)
             request: DeleteObjectsRequestTypeDef
             request = dict(Bucket=self.bucket_name,

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -243,22 +243,16 @@ class StorageService:
                              used.
         """
         assert file_name is None or '"' not in file_name, file_name
-        return self._s3.generate_presigned_url(
-            ClientMethod=self._s3.get_object.__name__,
-            Params={
-                'Bucket': self.bucket_name,
-                'Key': object_key,
-                **(
-                    {}
-                    if file_name is None else
-                    {'ResponseContentDisposition': f'attachment;filename="{file_name}"'}
-                ),
-                **(
-                    {}
-                    if content_type is None else
-                    {'ResponseContentType': content_type}
-                )
-            })
+        params = {
+            'Bucket': self.bucket_name,
+            'Key': object_key,
+        }
+        if file_name is not None:
+            params['ResponseContentDisposition'] = f'attachment;filename="{file_name}"'
+        if content_type is not None:
+            params['ResponseContentType'] = content_type
+        return self._s3.generate_presigned_url(Params=params,
+                                               ClientMethod=self._s3.get_object.__name__)
 
     def put_object_tagging(self, object_key: str, tagging: Tagging):
         log.info('Tagging object %r with %r', object_key, tagging)

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -103,20 +103,19 @@ class StorageService:
             return response['Body'].read()
 
     def put(self,
+            *,
             object_key: str,
             data: bytes,
             content_type: str | None = None,
             tagging: Tagging | None = None,
-            *,
-            overwrite: bool = True,
-            **kwargs):
+            overwrite: bool = True):
         try:
+            kwargs = self._object_creation_kwargs(content_type=content_type,
+                                                  tagging=tagging,
+                                                  overwrite=overwrite)
             self._s3.put_object(Bucket=self.bucket_name,
                                 Key=object_key,
                                 Body=data,
-                                **self._object_creation_kwargs(content_type=content_type,
-                                                               tagging=tagging,
-                                                               overwrite=overwrite),
                                 **kwargs)
         except botocore.exceptions.ClientError as e:
             self._handle_overwrite(e, object_key)

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -139,7 +139,7 @@ class StorageService:
             self._s3.delete_objects(**request)
         log.info('Deleted %d objects overall', num_keys)
 
-    def list(self, prefix: str) -> OrderedSet[str]:
+    def list_objects(self, prefix: str) -> OrderedSet[str]:
         keys: OrderedSet[str] = OrderedSet()
         num_keys = 0
         paginator = self._s3.get_paginator('list_objects_v2')

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -210,14 +210,12 @@ class StorageService:
         extra_args: dict[str, str] = {}
         if content_type is not None:
             extra_args['ContentType'] = content_type
+        if tagging is not None:
+            extra_args['Tagging'] = urlencode(tagging)
         self._s3.upload_file(Filename=file_path,
                              Bucket=self.bucket_name,
                              Key=object_key,
                              ExtraArgs=extra_args)
-        # upload_file doesn't support tags so we need to make a separate request
-        # https://stackoverflow.com/a/56351011/7830612
-        if tagging:
-            self.put_object_tagging(object_key, tagging)
 
     def get_presigned_url(self,
                           key: str,

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -52,13 +52,10 @@ if TYPE_CHECKING:
     from mypy_boto3_s3.client import (
         S3Client,
     )
-    from mypy_boto3_s3.service_resource import (
-        MultipartUpload,
-    )
     from mypy_boto3_s3.type_defs import (
-        DeleteTypeDef,
+        CompletedPartTypeDef,
         HeadObjectOutputTypeDef,
-)
+    )
 
 log = getLogger(__name__)
 
@@ -141,39 +138,40 @@ class StorageService:
         return keys
 
     def create_multipart_upload(self,
+                                *,
                                 object_key: str,
                                 content_type: str | None = None,
                                 tagging: Tagging | None = None
-                                ) -> 'MultipartUpload':
+                                ) -> str:
         kwargs = self._object_creation_kwargs(content_type=content_type,
                                               tagging=tagging)
-        return self._create_multipart_upload(object_key=object_key, **kwargs)
-
-    def _create_multipart_upload(self, *, object_key, **kwargs) -> 'MultipartUpload':
-        api_response = self._s3.create_multipart_upload(Bucket=self.bucket_name,
-                                                        Key=object_key,
-                                                        **kwargs)
-        upload_id = api_response['UploadId']
-        return self.load_multipart_upload(object_key, upload_id)
-
-    def load_multipart_upload(self, object_key, upload_id) -> 'MultipartUpload':
-        s3 = aws.s3_resource
-        return s3.MultipartUpload(self.bucket_name, object_key, upload_id)
+        response = self._s3.create_multipart_upload(Bucket=self.bucket_name,
+                                                    Key=object_key,
+                                                    **kwargs)
+        return response['UploadId']
 
     def upload_multipart_part(self,
-                              buffer: str | bytes | IO | StreamingBody,
+                              *,
+                              object_key: str,
+                              upload_id: str,
                               part_number: int,
-                              upload: 'MultipartUpload'
+                              buffer: str | bytes | IO | StreamingBody
                               ) -> str:
-        return upload.Part(part_number).upload(Body=buffer)['ETag']
+        response = self._s3.upload_part(Bucket=self.bucket_name,
+                                        Key=object_key,
+                                        UploadId=upload_id,
+                                        PartNumber=part_number,
+                                        Body=buffer)
+        return response['ETag']
 
     def complete_multipart_upload(self,
-                                  upload: 'MultipartUpload',
-                                  etags: Sequence[str],
                                   *,
+                                  object_key: str,
+                                  upload_id: str,
+                                  etags: Sequence[str],
                                   overwrite: bool = True,
                                   ) -> None:
-        parts = [
+        parts: list[CompletedPartTypeDef] = [
             {
                 'PartNumber': index + 1,
                 'ETag': etag
@@ -181,10 +179,13 @@ class StorageService:
             for index, etag in enumerate(etags)
         ]
         try:
-            upload.complete(MultipartUpload={'Parts': parts},
-                            **self._object_creation_kwargs(overwrite=overwrite))
+            self._s3.complete_multipart_upload(Bucket=self.bucket_name,
+                                               Key=object_key,
+                                               UploadId=upload_id,
+                                               MultipartUpload={'Parts': parts},
+                                               **self._object_creation_kwargs(overwrite=overwrite))
         except botocore.exceptions.ClientError as e:
-            self._handle_overwrite(e, upload.object_key)
+            self._handle_overwrite(e, object_key)
 
     def upload(self,
                file_path: str,

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -205,6 +205,14 @@ class StorageService:
         except botocore.exceptions.ClientError as e:
             self._handle_overwrite(e, object_key)
 
+    def abort_multipart_upload(self,
+                               *,
+                               object_key: str,
+                               upload_id: str):
+        self._s3.abort_multipart_upload(Bucket=self.bucket_name,
+                                        Key=object_key,
+                                        UploadId=upload_id)
+
     def upload(self,
                file_path: str,
                object_key: str,

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -116,7 +116,8 @@ class StorageService:
         try:
             request: PutObjectRequestTypeDef
             request = dict(Bucket=self.bucket_name, Key=object_key, Body=data)
-            self._add_content_type(request, content_type)
+            if content_type is not None:
+                request['ContentType'] = content_type
             self._add_tagging(request, tagging)
             self._add_overwrite(request, overwrite)
             self._s3.put_object(**request)
@@ -153,7 +154,8 @@ class StorageService:
                                 ) -> str:
         request: CreateMultipartUploadRequestTypeDef
         request = dict(Bucket=self.bucket_name, Key=object_key)
-        self._add_content_type(request, content_type)
+        if content_type is not None:
+            request['ContentType'] = content_type
         self._add_tagging(request, tagging)
         response = self._s3.create_multipart_upload(**request)
         return response['UploadId']
@@ -203,7 +205,8 @@ class StorageService:
                content_type: str | None = None,
                tagging: Tagging | None = None):
         extra_args: dict[str, str] = {}
-        self._add_content_type(extra_args, content_type)
+        if content_type is not None:
+            extra_args['ContentType'] = content_type
         self._s3.upload_file(Filename=file_path,
                              Bucket=self.bucket_name,
                              Key=object_key,
@@ -212,16 +215,6 @@ class StorageService:
         # https://stackoverflow.com/a/56351011/7830612
         if tagging:
             self.put_object_tagging(object_key, tagging)
-
-    def _add_content_type(self,
-                          request: Union[
-                              'PutObjectRequestTypeDef',
-                              'CreateMultipartUploadRequestTypeDef',
-                              dict[str, str]
-                          ],
-                          content_type: str | None):
-        if content_type is not None:
-            request['ContentType'] = content_type
 
     def _add_tagging(self,
                      request: Union[

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -209,7 +209,7 @@ class StorageService:
                                 content_type: str | None = None,
                                 tagging: Tagging | None = None,
                                 overwrite: bool = True
-                                ) -> Mapping[str, str]:
+                                ) -> dict[str, str]:
         kwargs = {}
         if content_type is not None:
             kwargs['ContentType'] = content_type

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -86,7 +86,7 @@ class StorageService:
     def _s3(self) -> 'S3Client':
         return aws.s3
 
-    def head(self, object_key: str) -> 'HeadObjectOutputTypeDef':
+    def head_object(self, object_key: str) -> 'HeadObjectOutputTypeDef':
         try:
             return self._s3.head_object(Bucket=self.bucket_name,
                                         Key=object_key)
@@ -293,7 +293,7 @@ class StorageService:
                            lifecycle rule. This parameter is solely used to
                            verify the return value.
         """
-        response = self.head(object_key)
+        response = self.head_object(object_key)
         return self._time_until_object_expires(response, expiration)
 
     def _time_until_object_expires(self,

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -227,7 +227,7 @@ class StorageService:
                           content_type: str | None = None
                           ) -> str:
         """
-        Return a pre-signed URL to the given key.
+        Return a pre-signed URL of the object at the given key.
 
         :param object_key: The key of the S3 object whose content a request to
                            the signed URL will return

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -125,7 +125,10 @@ class StorageService:
         except botocore.exceptions.ClientError as e:
             self._handle_overwrite(e, object_key)
 
-    def delete(self, keys: Collection[str], batch_size: int = 1000) -> None:
+    def delete_objects(self,
+                       keys: Collection[str],
+                       batch_size: int = 1000
+                       ) -> None:
         assert batch_size <= 1000, R('Batch size must <= 1000', batch_size)
         num_keys = len(keys)
         for batch in chunked(keys, batch_size):

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -105,13 +105,13 @@ class StorageService:
         else:
             return response['Body'].read()
 
-    def put(self,
-            *,
-            object_key: str,
-            data: bytes,
-            content_type: str | None = None,
-            tagging: Tagging | None = None,
-            overwrite: bool = True):
+    def put_object(self,
+                   *,
+                   object_key: str,
+                   data: bytes,
+                   content_type: str | None = None,
+                   tagging: Tagging | None = None,
+                   overwrite: bool = True):
         try:
             request: PutObjectRequestTypeDef
             request = dict(Bucket=self.bucket_name, Key=object_key, Body=data)

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -257,9 +257,9 @@ class StorageService:
             })
 
     def put_object_tagging(self, object_key: str, tagging: Tagging):
+        log.info('Tagging object %r with %r', object_key, tagging)
         deadline = time.time() + 60
         tagging = {'TagSet': [{'Key': k, 'Value': v} for k, v in tagging.items()]}
-        log.info('Tagging object %r with %r', object_key, tagging)
         while True:
             try:
                 self._s3.put_object_tagging(Bucket=self.bucket_name,

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -118,7 +118,8 @@ class StorageService:
             request = dict(Bucket=self.bucket_name, Key=object_key, Body=data)
             if content_type is not None:
                 request['ContentType'] = content_type
-            self._add_tagging(request, tagging)
+            if tagging is not None:
+                request['Tagging'] = urlencode(tagging)
             self._add_overwrite(request, overwrite)
             self._s3.put_object(**request)
         except botocore.exceptions.ClientError as e:
@@ -156,7 +157,8 @@ class StorageService:
         request = dict(Bucket=self.bucket_name, Key=object_key)
         if content_type is not None:
             request['ContentType'] = content_type
-        self._add_tagging(request, tagging)
+        if tagging is not None:
+            request['Tagging'] = urlencode(tagging)
         response = self._s3.create_multipart_upload(**request)
         return response['UploadId']
 
@@ -215,15 +217,6 @@ class StorageService:
         # https://stackoverflow.com/a/56351011/7830612
         if tagging:
             self.put_object_tagging(object_key, tagging)
-
-    def _add_tagging(self,
-                     request: Union[
-                         'PutObjectRequestTypeDef',
-                         'CreateMultipartUploadRequestTypeDef'
-                     ],
-                     tagging: Mapping[str, str] | None):
-        if tagging is not None:
-            request['Tagging'] = urlencode(tagging)
 
     def _add_overwrite(self,
                        request: Union[

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -64,12 +64,6 @@ log = getLogger(__name__)
 # 5 MB; see https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
 AWS_S3_DEFAULT_MINIMUM_PART_SIZE = 5242880
 
-MULTIPART_UPLOAD_MAX_WORKERS = 4
-
-# The amount of pending tasks that can be queued for execution. A value of 0
-# allows no tasks to be queued, only running tasks allowed in the thread pool.
-MULTIPART_UPLOAD_MAX_PENDING_PARTS = 4
-
 Tagging = Mapping[str, str]
 
 

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -56,8 +56,9 @@ if TYPE_CHECKING:
         MultipartUpload,
     )
     from mypy_boto3_s3.type_defs import (
+        DeleteTypeDef,
         HeadObjectOutputTypeDef,
-    )
+)
 
 log = getLogger(__name__)
 
@@ -125,13 +126,8 @@ class StorageService:
         num_keys = len(keys)
         for batch in chunked(keys, batch_size):
             log.debug('Deleting batch of objects: %r', batch)
-            self._s3.delete_objects(Bucket=self.bucket_name,
-                                    Delete={
-                                        'Objects': [
-                                            {'Key': key}
-                                            for key in batch
-                                        ]
-                                    })
+            delete = {'Objects': [{'Key': key} for key in batch]}
+            self._s3.delete_objects(Bucket=self.bucket_name, Delete=delete)
         log.info('Deleted %d objects overall', num_keys)
 
     def list(self, prefix: str) -> OrderedSet[str]:

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -96,7 +96,7 @@ class StorageService:
             else:
                 raise e
 
-    def get(self, object_key: str) -> bytes:
+    def get_object(self, object_key: str) -> bytes:
         try:
             response = self._s3.get_object(Bucket=self.bucket_name,
                                            Key=object_key)

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -61,9 +61,6 @@ if TYPE_CHECKING:
 
 log = getLogger(__name__)
 
-# 5 MB; see https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
-AWS_S3_DEFAULT_MINIMUM_PART_SIZE = 5242880
-
 Tagging = Mapping[str, str]
 
 

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -302,7 +302,9 @@ class StorageService:
         # Example header value
         # expiry-date="Fri, 21 Dec 2012 00:00:00 GMT", rule-id="Rule for testfile.txt"
         expiration_header = parse_dict_header(head_response['Expiration'])
-        expiry = parsedate_to_datetime(expiration_header['expiry-date'])
+        expiry_date = expiration_header['expiry-date']
+        assert expiry_date is not None
+        expiry = parsedate_to_datetime(expiry_date)
         time_left = (expiry - now).total_seconds()
         # Verify the 'Expiration' value is what is expected given the
         # 'LastModified' value, the number of days before expiration, and that

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -258,8 +258,8 @@ class StorageService:
 
     def put_object_tagging(self, object_key: str, tagging: Tagging):
         log.info('Tagging object %r with %r', object_key, tagging)
-        deadline = time.time() + 60
         tagging = {'TagSet': [{'Key': k, 'Value': v} for k, v in tagging.items()]}
+        deadline = time.time() + 60
         while True:
             try:
                 self._s3.put_object_tagging(Bucket=self.bucket_name,

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -212,7 +212,7 @@ class TestMirrorController(DCP2TestCase,
         client = http_client(log)
         file = MagicMock(content_type='text/plain')
         service = self.file_service
-        info = service.info_object(file)
+        info = service._info(file)
         response = client.request('GET', info['$schema'])
         self.assertEqual(200, response.status, response.data)
         schema = json.loads(response.data)

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -118,7 +118,7 @@ class TestMirrorController(DCP2TestCase,
 
                     service = self.file_service
                     self._s3.delete_object(Bucket=self.mirror_bucket,
-                                           Key=service.info_object_key(file))
+                                           Key=service._info_object_key(file))
 
                     with self.subTest('mirror_file', corrupted=True):
                         self._test_corrupted_download(file_message)

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -188,7 +188,7 @@ class TestMirrorController(DCP2TestCase,
             self.mirror_controller.mirror(event)
         service = self.file_service
         response = self._s3.get_object(Bucket=self.mirror_bucket,
-                                       Key=service.mirror_object_key(file))
+                                       Key=service._file_object_key(file))
         mirrored_file_contents = response['Body'].read()
         self.assertEqual(mirrored_file_contents, self._file_contents)
 

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -438,7 +438,7 @@ class TestRepositoryFilesWithMirroring(DCP2TestCase,
         self.assertEqual('https', signed_url.scheme)
         self.assertEqual(f'{self.mirror_bucket}.s3.{config.region}.amazonaws.com',
                          signed_url.netloc)
-        self.assertEqual('/' + mirror_service.mirror_object_key(file),
+        self.assertEqual('/' + mirror_service._file_object_key(file),
                          str(signed_url.path))
         self.assertEqual(f'attachment;filename="{file.name}"',
                          signed_url.args.get('response-content-disposition'))

--- a/test/service/test_storage_service.py
+++ b/test/service/test_storage_service.py
@@ -62,7 +62,7 @@ class StorageServiceTest(StorageServiceTestCase):
         with self.assertRaises(StorageObjectNotFound):
             self.storage_service.get(sample_key)
 
-        self.storage_service.put(sample_key, sample_content)
+        self.storage_service.put(object_key=sample_key, data=sample_content)
 
         self.assertEqual(sample_content, self.storage_service.get(sample_key))
 
@@ -76,7 +76,7 @@ class StorageServiceTest(StorageServiceTestCase):
         sample_key = 'foo-presigned-url'
         sample_content = json.dumps({'a': 1})
 
-        self.storage_service.put(sample_key, sample_content.encode())
+        self.storage_service.put(object_key=sample_key, data=sample_content.encode())
 
         for file_name in None, 'foo.json':
             with self.subTest(file_name=file_name):

--- a/test/service/test_storage_service.py
+++ b/test/service/test_storage_service.py
@@ -51,8 +51,7 @@ class StorageServiceTest(StorageServiceTestCase):
                     if tags is None:
                         tags = {}
                     upload_tags = self.storage_service.get_object_tagging(object_key)
-                    self.assertEqual(tags,
-                                     upload_tags)
+                    self.assertEqual(tags, upload_tags)
 
     def test_simple_get_put(self):
         sample_key = 'foo-simple'

--- a/test/service/test_storage_service.py
+++ b/test/service/test_storage_service.py
@@ -61,7 +61,7 @@ class StorageServiceTest(StorageServiceTestCase):
         with self.assertRaises(StorageObjectNotFound):
             self.storage_service.get_object(sample_key)
 
-        self.storage_service.put(object_key=sample_key, data=sample_content)
+        self.storage_service.put_object(object_key=sample_key, data=sample_content)
 
         self.assertEqual(sample_content, self.storage_service.get_object(sample_key))
 
@@ -75,7 +75,7 @@ class StorageServiceTest(StorageServiceTestCase):
         sample_key = 'foo-presigned-url'
         sample_content = json.dumps({'a': 1})
 
-        self.storage_service.put(object_key=sample_key, data=sample_content.encode())
+        self.storage_service.put_object(object_key=sample_key, data=sample_content.encode())
 
         for file_name in None, 'foo.json':
             with self.subTest(file_name=file_name):

--- a/test/service/test_storage_service.py
+++ b/test/service/test_storage_service.py
@@ -105,7 +105,7 @@ class StorageServiceTest(StorageServiceTestCase):
                         'Expiration': 'expiry-date="Wed, 01 Jan 2020 00:00:00 UTC", rule-id="Test Rule"',
                         'LastModified': now - timedelta(days=float(expiration), seconds=object_age)
                     }
-                    with patch.object(self.storage_service, 'head', return_value=headers):
+                    with patch.object(self.storage_service, 'head_object', return_value=headers):
                         with self.assertLogs(logger=storage_service.log, level='DEBUG') as logs:
                             actual = self.storage_service.time_until_object_expires('foo', expiration)
                             self.assertEqual(0, actual)

--- a/test/service/test_storage_service.py
+++ b/test/service/test_storage_service.py
@@ -3,7 +3,6 @@ from datetime import (
     timedelta,
     timezone,
 )
-import json
 import tempfile
 from unittest.mock import (
     patch,
@@ -72,16 +71,13 @@ class StorageServiceTest(StorageServiceTestCase):
             self.storage_service.get_object(sample_key)
 
     def test_presigned_url(self):
-        sample_key = 'foo-presigned-url'
-        sample_content = json.dumps({'a': 1})
-
-        self.storage_service.put_object(object_key=sample_key, data=sample_content.encode())
-
+        object_key, object_content = 'foo-presigned-url', b'{"a": 1}'
+        service = self.storage_service
+        service.put_object(object_key=object_key, data=object_content)
         for file_name in None, 'foo.json':
             with self.subTest(file_name=file_name):
-                presigned_url = self.storage_service.get_presigned_url(sample_key,
-                                                                       file_name=file_name)
-                response = requests.get(presigned_url)
+                url = service.get_presigned_url(object_key, file_name=file_name)
+                response = requests.get(url)
                 if file_name is None:
                     self.assertNotIn('Content-Disposition', response.headers)
                 else:
@@ -90,8 +86,9 @@ class StorageServiceTest(StorageServiceTestCase):
                         # mechanism of specifying response headers via request
                         # parameters (https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGET.html,
                         # section Request Parameters).
-                        self.assertEqual(response.headers['Content-Disposition'], f'attachment;filename="{file_name}"')
-                self.assertEqual(sample_content, response.text)
+                        self.assertEqual(response.headers['Content-Disposition'],
+                                         f'attachment;filename="{file_name}"')
+                self.assertEqual(object_content, response.content)
 
     def test_time_until_object_expires(self):
         test_data = [(1, False), (0, False), (-1, True)]

--- a/test/service/test_storage_service.py
+++ b/test/service/test_storage_service.py
@@ -59,17 +59,17 @@ class StorageServiceTest(StorageServiceTestCase):
 
         # NOTE: Ensure that the key does not exist before writing.
         with self.assertRaises(StorageObjectNotFound):
-            self.storage_service.get(sample_key)
+            self.storage_service.get_object(sample_key)
 
         self.storage_service.put(object_key=sample_key, data=sample_content)
 
-        self.assertEqual(sample_content, self.storage_service.get(sample_key))
+        self.assertEqual(sample_content, self.storage_service.get_object(sample_key))
 
     def test_simple_get_unknown_item(self):
         sample_key = 'foo-simple'
 
         with self.assertRaises(StorageObjectNotFound):
-            self.storage_service.get(sample_key)
+            self.storage_service.get_object(sample_key)
 
     def test_presigned_url(self):
         sample_key = 'foo-presigned-url'


### PR DESCRIPTION
<!--
This is the PR template for hotfix PRs against `anvilprod`.
-->

Linked issue: #7662


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] Target branch is `anvilprod`
- [ ] ~Name of PR branch matches `hotfixes/<GitHub handle of author>/<issue#>-<slug>-anvilprod`~ forgot to name branch correctly
- [x] PR is linked to the issue it hotfixes
- [x] Status of linked issue is *In progress*
- [x] PR description links to linked issue
- [x] PR title is `Hotfix anvilprod: ` followed by title of linked issue
- [x] PR title references the linked issue


### Author (hotfixes)

- [x] Added `h` tag to commit title <sub>or this PR does not include a temporary hotfix</sub>
- [x] Added `H` tag to commit title <sub>or this PR does not include a permanent hotfix</sub>
- [x] Added `hotfix` label to PR
- [x] This PR is labeled `partial` <sub>or represents a permanent hotfix</sub>


### Author (before every review)

- [x] Rebased PR branch on `anvilprod`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator and the author


### Operator

- [x] Squashed PR branch and rebased onto `anvilprod`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy runner image)

- [x] Ran `_select anvilprod.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `hammerbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `hammerbox`</sub>
- [x] Started reindex in `hammerbox` <sub>or this PR is not labeled `reindex:anvilprod`</sub>
- [x] Checked for failures in `hammerbox` <sub>or this PR is not labeled `reindex:anvilprod`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but excluded any `p` tags</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged stable*


### Operator (main build)

- [x] Pushed merge commit to GitLab `anvilprod`
- [x] Build passes on GitLab `anvilprod`
- [x] Reviewed build logs for anomalies on GitLab `anvilprod`
- [x] Deleted PR branch from GitHub
- [x] PR is assigned to only the operator
- [x] Deleted PR branch from GitLab `anvilprod`
- [x] Status of linked issue is *Stable*


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `anvilprod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvilprod`</sub>
- [x] Deindexed specific sources in `anvilprod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvilprod`</sub>
- [x] Indexed specific sources in `anvilprod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvilprod`</sub>
- [x] Started reindex in `anvilprod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvilprod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Emptied fail queues in `anvilprod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvilprod branch](https://gitlab.explore.anvilproject.org/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvilprod) on GitLab in `anvilprod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvilprod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Created backport PR and linked to it in a comment on this PR


### Operator (mirroring)

- [x] Started mirroring in `anvilprod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvilprod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Emptied mirror fail queue in `anvilprod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>


### Operator

- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
