### PR TITLE
Fix: NoSuchUpload exception when finalizing mirrored file (#7673)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/anvilprod-hotfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/anvilprod-hotfix.md
@@ -59,11 +59,6 @@ Linked issue: #0000
 - [ ] Pushed PR branch to GitHub
 
 
-### Operator (deploy runner image)
-
-- [ ] Ran `_select anvilprod.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
-
-
 ### Operator (sandbox build)
 
 - [ ] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>

--- a/.github/PULL_REQUEST_TEMPLATE/backport.md
+++ b/.github/PULL_REQUEST_TEMPLATE/backport.md
@@ -46,12 +46,6 @@ This is the PR template for backport PRs against `develop`.
 - [ ] Pushed PR branch to GitHub
 
 
-### Operator (deploy runner image)
-
-- [ ] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
-- [ ] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
-
-
 ### Operator (sandbox build)
 
 - [ ] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>

--- a/.github/PULL_REQUEST_TEMPLATE/prod-hotfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/prod-hotfix.md
@@ -59,11 +59,6 @@ Linked issue: #0000
 - [ ] Pushed PR branch to GitHub
 
 
-### Operator (deploy runner image)
-
-- [ ] Ran `_select prod.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
-
-
 ### Operator (merge the branch)
 
 - [ ] All status checks passed and the PR is mergeable

--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -798,21 +798,23 @@ def emit(t: T, target_branch: str):
                     'content': 'PR is assigned to only the operator and the author',
                 },
             ]),
-            {
-                'type': 'h2',
-                'content': 'Operator (deploy runner image)'
-            },
-            *[
+            *iif(t not in (T.hotfix, T.backport), [
                 {
-                    'type': 'cli',
-                    'content': 'Ran ' + bq(
-                        f'_select {d}.gitlab && '
-                        f'make -C terraform/gitlab/runner'
-                    ),
-                    'alt': 'or this PR is not labeled `deploy:runner`'
-                }
-                for d in t.target_deployments(target_branch)
-            ],
+                    'type': 'h2',
+                    'content': 'Operator (deploy runner image)'
+                },
+                *[
+                    {
+                        'type': 'cli',
+                        'content': 'Ran ' + bq(
+                            f'_select {d}.gitlab && '
+                            f'make -C terraform/gitlab/runner'
+                        ),
+                        'alt': 'or this PR is not labeled `deploy:runner`'
+                    }
+                    for d in t.target_deployments(target_branch)
+                ]
+            ]),
             *iif(t.has_sandbox_for(target_branch), [
                 {
                     'type': 'h2',

--- a/src/azul/attrs.py
+++ b/src/azul/attrs.py
@@ -28,6 +28,9 @@ from uuid import (
     UUID,
 )
 
+from attr import (
+    AttrsInstance,
+)
 import attrs
 from more_itertools import (
     flatten,
@@ -915,3 +918,49 @@ def polymorphic[T](field: T | None = None,
     <azul.attrs.Inner object at ...>
     """
     return _set_field_metadata(field, 'discriminator', discriminator)
+
+
+def devolve[T: AttrsInstance](cls: type[T],
+                              inst: AttrsInstance,
+                              **changes: Any
+                              ) -> T:
+    """
+    Like attrs.evolve but for an arbitrary class. The most common use case is
+    to evolve an instance of a class to an instance of a subclass of that class,
+    in which case the keyword arguments must supply values for all the fields
+    that the subclass adds. When evolving to an instance of a superclass, any
+    instance fields not defined in the superclass will be discarded.
+
+    >>> @attrs.frozen()
+    ... class Foo:
+    ...     x: int
+    ...     _y: str
+
+    >>> @attrs.frozen()
+    ... class Bar(Foo):
+    ...     z: str
+    ...     c: float = attrs.field(default=3.14159, init=False)
+
+    >>> devolve(Bar, Foo(x=42, y='foo'), z='bar')
+    Bar(x=42, _y='foo', z='bar', c=3.14159)
+
+    >>> devolve(Foo, Bar(x=42, y='foo', z='bar'), x=24)
+    Foo(x=24, _y='foo')
+
+    >>> devolve(Bar, Foo(x=42, y='foo'))
+    Traceback (most recent call last):
+    ....
+    AttributeError: 'Foo' object has no attribute 'z'
+
+    >>> devolve(Bar, Foo(x=42, y='foo'), z='bar', c=2.71828)
+    Traceback (most recent call last):
+    ...
+    TypeError: Bar.__init__() got an unexpected keyword argument 'c'
+    """
+    fields = attrs.fields(cls)
+    for field in fields:
+        if field.init:
+            init_name = field.alias
+            if init_name not in changes:
+                changes[init_name] = getattr(inst, field.name)
+    return cls(**changes)

--- a/src/azul/indexer/action_controller.py
+++ b/src/azul/indexer/action_controller.py
@@ -41,16 +41,9 @@ class ActionController[A: Action](AppController, metaclass=ABCMeta):
                        event: Iterable[SQSRecord],
                        message_handler: Callable[[A], None]):
         for record in event:
-            message: SQSMessage
-            if self.actions_are_fifo:
-                message = SQSFifoMessage.from_record(record)
-                suffix, args = ', group ID %s', [message.group_id]
-            else:
-                message = SQSMessage.from_record(record)
-                suffix, args = '', []
-            log.info('Worker handling message %r, ' +
-                     'attempt #%i (approx), message ID %s' + suffix,
-                     message.body, message.attempts, message.id, *args)
+            message_cls = SQSFifoMessage if self.actions_are_fifo else SQSMessage
+            message = message_cls.from_record(record)
+            log.info('Worker handling message %r', message)
             start = time.time()
             try:
                 action = self.action_cls.from_json(message.body)

--- a/src/azul/indexer/index_queue_service.py
+++ b/src/azul/indexer/index_queue_service.py
@@ -118,7 +118,6 @@ class IndexQueueService:
                            ) -> None:
         queue = self.notifications_queue(retry=retry)
         self.queues.send_message(queue, message)
-        log.info('Queued notification message %r', message)
 
     def queue_tallies(self,
                       messages: Iterable[SQSMessage],
@@ -126,7 +125,8 @@ class IndexQueueService:
                       retry: bool = False
                       ) -> int:
         queue = self.tallies_queue(retry=retry)
-        return self.queues.send_messages(queue, messages)
+        # Logging tallies would be excessively verbose
+        return self.queues.send_messages(queue, messages, log_level=0)
 
     def index_bundle_message(self,
                              catalog: CatalogName,

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -467,6 +467,8 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
     _file_object_content_type = 'application/octet-stream'
 
     def mirror(self, action: MirrorAction):
+        assert action.catalog == self.catalog, R(
+            'Action references unexpected catalog', action, self.catalog)
         self._queue_actions(self._mirror(action))
 
     @singledispatchmethod
@@ -489,16 +491,16 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
             / config.mirroring_concurrency  # number of concurrent invocations
             / 2  # safety margin
         ))
-        partitioned_source = plugin.partition_source_for_mirroring(self.catalog,
+        partitioned_source = plugin.partition_source_for_mirroring(a.catalog,
                                                                    a.source,
                                                                    partition_size)
         prefix = partitioned_source.prefix
         assert prefix is not None, partitioned_source
         log.info('Queueing %d partitions of source %r in catalog %r',
-                 prefix.num_partitions, str(partitioned_source.spec), self.catalog)
+                 prefix.num_partitions, str(partitioned_source.spec), a.catalog)
 
         for partition in prefix.partition_prefixes():
-            yield MirrorPartitionAction(catalog=self.catalog,
+            yield MirrorPartitionAction(catalog=a.catalog,
                                         source=partitioned_source,
                                         prefix=partition)
 
@@ -514,14 +516,14 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
             assert file.size <= self.max_file_size, R(
                 'File too big', file, self.max_file_size)
             if self.may_mirror(file.size):
-                yield MirrorFileAction(catalog=self.catalog,
+                yield MirrorFileAction(catalog=a.catalog,
                                        source=a.source,
                                        prefix=a.prefix,
                                        file=file)
             else:
                 log.info('Not mirroring file to save cost: %r', file)
         log.info('Queued %d files in partition %r of source %r in catalog %r',
-                 len(files), a.prefix, str(a.source), self.catalog)
+                 len(files), a.prefix, str(a.source), a.catalog)
 
     @_mirror.register
     def _(self, a: MirrorFileAction) -> Iterator[MirrorAction]:
@@ -540,7 +542,7 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
                 log.info('Mirroring file via multi-part upload: %r', a.file)
                 upload = self._create_upload(a.file)
                 next_part = self._mirror_first_part(a.file, upload)
-                yield MirrorPartAction(catalog=self.catalog,
+                yield MirrorPartAction(catalog=a.catalog,
                                        source=a.source,
                                        prefix=a.prefix,
                                        file=a.file,
@@ -601,13 +603,13 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
         next_part = self._mirror_part(a.file, upload, a.part)
         if next_part is None:
             log.info('Uploaded all %d parts for file %r', len(upload.etags), a.file)
-            yield FinalizeFileAction(catalog=self.catalog,
+            yield FinalizeFileAction(catalog=a.catalog,
                                      source=a.source,
                                      prefix=a.prefix,
                                      file=a.file,
                                      upload=upload)
         else:
-            yield MirrorPartAction(catalog=self.catalog,
+            yield MirrorPartAction(catalog=a.catalog,
                                    source=a.source,
                                    prefix=a.prefix,
                                    file=a.file,

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -20,6 +20,7 @@ from typing import (
 )
 from uuid import (
     UUID,
+    uuid4,
     uuid5,
 )
 
@@ -191,6 +192,18 @@ class SchemaUrlFunc(Protocol):
 class MirrorAction(Action, metaclass=ABCMeta):
     catalog: CatalogName
 
+    #: When performing a mirror action results in more secondary actions, this
+    #: field should be copied from the action being performed to those secondary
+    #: actions. When constructing primary actions, this field should be omitted
+    #: so that the default is used. The indirection via a class method for the
+    #: default factory allows for easy patching during unit tests.
+    #:
+    operation_id: str = attrs.field(factory=lambda: MirrorAction._operation_id())
+
+    @classmethod
+    def _operation_id(cls):
+        return str(uuid4())
+
     @property
     @abstractmethod
     def group_id(self) -> tuple[str, ...]:
@@ -214,7 +227,7 @@ class MirrorAction(Action, metaclass=ABCMeta):
         # Since different catalogs may be configured to handle the same file in
         # different ways, we can't conflate two messages that only differ in
         # the catalog they are targetting.
-        return str(type(self)), self.catalog
+        return str(type(self)), self.catalog, self.operation_id
 
     def to_sqs(self) -> SQSFifoMessage:
         return SQSFifoMessage(body=json_mapping(self.to_json()),

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -34,6 +34,7 @@ from azul import (
 )
 from azul.attrs import (
     SerializableAttrs,
+    devolve,
     serializable,
 )
 from azul.auth import (
@@ -491,18 +492,16 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
             / config.mirroring_concurrency  # number of concurrent invocations
             / 2  # safety margin
         ))
-        partitioned_source = plugin.partition_source_for_mirroring(a.catalog,
-                                                                   a.source,
-                                                                   partition_size)
-        prefix = partitioned_source.prefix
-        assert prefix is not None, partitioned_source
+        source = plugin.partition_source_for_mirroring(a.catalog,
+                                                       a.source,
+                                                       partition_size)
+        prefix = source.prefix
+        assert prefix is not None, source
         log.info('Queueing %d partitions of source %r in catalog %r',
-                 prefix.num_partitions, str(partitioned_source.spec), a.catalog)
+                 prefix.num_partitions, str(source.spec), a.catalog)
 
         for partition in prefix.partition_prefixes():
-            yield MirrorPartitionAction(catalog=a.catalog,
-                                        source=partitioned_source,
-                                        prefix=partition)
+            yield devolve(MirrorPartitionAction, a, source=source, prefix=partition)
 
     def _list_public_source_ids(self) -> set[str]:
         return self._source_service.list_source_ids(self.catalog, authentication=None)
@@ -516,10 +515,7 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
             assert file.size <= self.max_file_size, R(
                 'File too big', file, self.max_file_size)
             if self.may_mirror(file.size):
-                yield MirrorFileAction(catalog=a.catalog,
-                                       source=a.source,
-                                       prefix=a.prefix,
-                                       file=file)
+                yield devolve(MirrorFileAction, a, file=file)
             else:
                 log.info('Not mirroring file to save cost: %r', file)
         log.info('Queued %d files in partition %r of source %r in catalog %r',
@@ -542,12 +538,7 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
                 log.info('Mirroring file via multi-part upload: %r', a.file)
                 upload = self._create_upload(a.file)
                 next_part = self._mirror_first_part(a.file, upload)
-                yield MirrorPartAction(catalog=a.catalog,
-                                       source=a.source,
-                                       prefix=a.prefix,
-                                       file=a.file,
-                                       upload=upload,
-                                       part=next_part)
+                yield devolve(MirrorPartAction, a, upload=upload, part=next_part)
 
     def _mirror_file(self, file: File):
         """
@@ -603,18 +594,9 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
         next_part = self._mirror_part(a.file, upload, a.part)
         if next_part is None:
             log.info('Uploaded all %d parts for file %r', len(upload.etags), a.file)
-            yield FinalizeFileAction(catalog=a.catalog,
-                                     source=a.source,
-                                     prefix=a.prefix,
-                                     file=a.file,
-                                     upload=upload)
+            yield devolve(FinalizeFileAction, a, upload=upload)
         else:
-            yield MirrorPartAction(catalog=a.catalog,
-                                   source=a.source,
-                                   prefix=a.prefix,
-                                   file=a.file,
-                                   upload=upload,
-                                   part=next_part)
+            yield devolve(MirrorPartAction, a, upload=upload, part=next_part)
 
     @_mirror.register
     def _(self, a: FinalizeFileAction) -> Iterator[MirrorAction]:

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -304,7 +304,7 @@ class BaseMirrorService:
 
     def mirror_sources(self, sources: Iterable[tuple[SourceRef, SourceConfig]]):
         if self.may_mirror():
-            def messages():
+            def actions():
                 for source, source_config in sources:
                     if source_config.mirror:
                         log.info('Mirroring files in source %r from catalog %r',
@@ -315,27 +315,27 @@ class BaseMirrorService:
                                  'mirroring is explicitly disabled',
                                  str(source.spec), self.catalog)
 
-            self._queue_messages(messages())
+            self._queue_actions(actions())
         else:
             log.info('Not mirroring any files in catalog %r because the file '
                      'size limit is negative', self.catalog)
 
     def mirror_file(self, source: SourceRef, file: File):
-        self._queue_messages([MirrorFileAction(catalog=self.catalog,
-                                               source=source,
-                                               prefix='',
-                                               file=file)])
+        self._queue_actions([MirrorFileAction(catalog=self.catalog,
+                                              source=source,
+                                              prefix='',
+                                              file=file)])
 
     def _mirror_queue(self):
         name = config.mirror_queue.name
         return aws.sqs_queue(name)
 
-    def _queue_messages(self, messages: Iterable[MirrorAction]) -> int:
+    def _queue_actions(self, actions: Iterable[MirrorAction]) -> int:
         rate_limit = float(aws.sqs_fifo_rate_limit)
         if config.is_in_lambda:
             rate_limit /= config.mirroring_concurrency
         return self._queues.send_messages(self._mirror_queue(),
-                                          map(MirrorAction.to_sqs, messages),
+                                          map(MirrorAction.to_sqs, actions),
                                           rate_limit=rate_limit)
 
     #: Since we track the ETags of all parts of a multipart file in SQS
@@ -467,7 +467,7 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
     _file_object_content_type = 'application/octet-stream'
 
     def mirror(self, action: MirrorAction):
-        self._queue_messages(self._mirror(action))
+        self._queue_actions(self._mirror(action))
 
     @singledispatchmethod
     def _mirror(self, a: MirrorAction):

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -498,7 +498,6 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
                  prefix.num_partitions, str(partitioned_source.spec), self.catalog)
 
         for partition in prefix.partition_prefixes():
-            log.debug('Queueing partition %r', partition)
             yield MirrorPartitionAction(catalog=self.catalog,
                                         source=partitioned_source,
                                         prefix=partition)
@@ -515,7 +514,6 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
             assert file.size <= self.max_file_size, R(
                 'File too big', file, self.max_file_size)
             if self.may_mirror(file.size):
-                log.debug('Queueing file %r', file)
                 yield MirrorFileAction(catalog=self.catalog,
                                        source=a.source,
                                        prefix=a.prefix,
@@ -542,7 +540,6 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
                 log.info('Mirroring file via multi-part upload: %r', a.file)
                 upload = self._create_upload(a.file)
                 next_part = self._mirror_first_part(a.file, upload)
-                log.info('Queueing part #%d of file %r', next_part.index, a.file)
                 yield MirrorPartAction(catalog=self.catalog,
                                        source=a.source,
                                        prefix=a.prefix,
@@ -610,7 +607,6 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
                                      file=a.file,
                                      upload=upload)
         else:
-            log.info('Queueing part #%d of file %r', next_part.index, a.file)
             yield MirrorPartAction(catalog=self.catalog,
                                    source=a.source,
                                    prefix=a.prefix,

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -453,10 +453,6 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
     def _source_service(self) -> SourceService:
         return SourceService()
 
-    @cached_property
-    def _repository_plugin(self) -> RepositoryPlugin:
-        return RepositoryPlugin.load(self.catalog).create(self.catalog)
-
     # We don't store the mirrored files' actual content type(s) in S3's
     # `Content-Type` metadata because a single file object may store the
     # contents of multiple file metadata entities, which may declare different

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -16,6 +16,11 @@ from typing import (
     Iterator,
     Protocol,
     Self,
+    final,
+)
+from uuid import (
+    UUID,
+    uuid5,
 )
 
 import attr
@@ -188,12 +193,40 @@ class MirrorAction(Action, metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def group_id(self) -> str:
+    def group_id(self) -> tuple[str, ...]:
+        """
+        The SQS FIFO message group ID of a message about this action. Messages
+        in different groups can be handled in parallel. Messages in the same
+        group are handled serially. Use this property to prevent concurrent
+        actions against a particular resource, by making the ID of that resource
+        the group ID of those actions.
+        """
         raise NotImplementedError
+
+    @property
+    def dedup_id(self) -> tuple[str, ...]:
+        """
+        The SQS message deduplication ID to use for a message about this action.
+        If two messages with the same deduplication ID are sent within 5 min or
+        less of each other, the second message will be discarded silently. Use
+        this property to avoid redundant work.
+        """
+        # Since different catalogs may be configured to handle the same file in
+        # different ways, we can't conflate two messages that only differ in
+        # the catalog they are targetting.
+        return str(type(self)), self.catalog
 
     def to_sqs(self) -> SQSFifoMessage:
         return SQSFifoMessage(body=json_mapping(self.to_json()),
-                              group_id=self.group_id)
+                              group_id=self._make_id(self.group_id),
+                              dedup_id=self._make_id(self.dedup_id))
+
+    dedup_uuid_namespace = UUID('cb3a5301-5ad4-44f4-9020-cd34e7c61d3e')
+
+    def _make_id(self, id: tuple[str, ...]) -> str:
+        joiner = ':'
+        assert not any(joiner in s for s in id)
+        return str(uuid5(self.dedup_uuid_namespace, joiner.join(id)))
 
 
 @attrs.frozen(kw_only=True)
@@ -201,8 +234,12 @@ class MirrorSourceAction(MirrorAction):
     source: SourceRef
 
     @property
-    def group_id(self):
-        return self.source.id
+    def group_id(self) -> tuple[str, ...]:
+        return self.source.id,
+
+    @property
+    def dedup_id(self) -> tuple[str, ...]:
+        return *super().dedup_id, self.source.id
 
 
 @attrs.frozen(kw_only=True)
@@ -210,8 +247,12 @@ class MirrorPartitionAction(MirrorSourceAction):
     prefix: str
 
     @property
-    def group_id(self):
-        return super().group_id + ':' + self.prefix
+    def group_id(self) -> tuple[str, ...]:
+        return *super().group_id, self.prefix
+
+    @property
+    def dedup_id(self) -> tuple[str, ...]:
+        return *super().dedup_id, self.prefix
 
 
 @attrs.frozen(kw_only=True)
@@ -219,8 +260,16 @@ class MirrorFileAction(MirrorPartitionAction):
     file: File
 
     @property
-    def group_id(self):
-        return self.file.digest.value
+    @final
+    def group_id(self) -> tuple[str, ...]:
+        # This method is final because we need to serialize all actions that
+        # target a specific file in the mirror bucket.
+        digest = self.file.digest
+        return digest.type, digest.value
+
+    @property
+    def dedup_id(self) -> tuple[str, ...]:
+        return *super().dedup_id, self.file.uuid,
 
 
 @attrs.frozen(kw_only=True)
@@ -245,6 +294,10 @@ class MultiPartUploadAction(MirrorFileAction):
 @attrs.frozen(kw_only=True)
 class MirrorPartAction(MultiPartUploadAction):
     part: FilePart
+
+    @property
+    def dedup_id(self) -> tuple[str, ...]:
+        return *super().dedup_id, str(self.part.index)
 
 
 class FinalizeFileAction(MultiPartUploadAction):

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -13,6 +13,7 @@ import time
 from typing import (
     ClassVar,
     Iterable,
+    Iterator,
     Protocol,
     Self,
 )
@@ -321,16 +322,19 @@ class BaseMirrorService:
                      'size limit is negative', self.catalog)
 
     def mirror_file(self, source: SourceRef, file: File):
-        self._queue_actions([MirrorFileAction(catalog=self.catalog,
-                                              source=source,
-                                              prefix='',
-                                              file=file)])
+        def actions():
+            yield MirrorFileAction(catalog=self.catalog,
+                                   source=source,
+                                   prefix='',
+                                   file=file)
+
+        self._queue_actions(actions())
 
     def _mirror_queue(self):
         name = config.mirror_queue.name
         return aws.sqs_queue(name)
 
-    def _queue_actions(self, actions: Iterable[MirrorAction]) -> int:
+    def _queue_actions(self, actions: Iterator[MirrorAction]) -> int:
         rate_limit = float(aws.sqs_fifo_rate_limit)
         if config.is_in_lambda:
             rate_limit /= config.mirroring_concurrency
@@ -474,7 +478,7 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
         raise NotImplementedError
 
     @_mirror.register
-    def _(self, a: MirrorSourceAction) -> Iterable[MirrorAction]:
+    def _(self, a: MirrorSourceAction) -> Iterator[MirrorAction]:
         assert a.source.id in self._list_public_source_ids(), R(
             'Cannot mirror non-public source', a.source)
         plugin = self._repository_plugin
@@ -506,7 +510,7 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
         return self._source_service.list_source_ids(self.catalog, authentication=None)
 
     @_mirror.register
-    def _(self, a: MirrorPartitionAction) -> Iterable[MirrorAction]:
+    def _(self, a: MirrorPartitionAction) -> Iterator[MirrorAction]:
         plugin = self._repository_plugin
         files = plugin.list_files(a.source, a.prefix)
         for file in files:
@@ -524,7 +528,7 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
                  len(files), a.prefix, str(a.source), self.catalog)
 
     @_mirror.register
-    def _(self, a: MirrorFileAction) -> Iterable[MirrorAction]:
+    def _(self, a: MirrorFileAction) -> Iterator[MirrorAction]:
         assert a.file.size is not None, R('File size unknown', a.file)
         if self.info_exists(a.file):
             log.info('File is already mirrored, skipping upload: %r', a.file)
@@ -595,7 +599,7 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
         return next_part
 
     @_mirror.register
-    def _(self, a: MirrorPartAction) -> Iterable[MirrorAction]:
+    def _(self, a: MirrorPartAction) -> Iterator[MirrorAction]:
         # Some upload field values are mutable so we should make a copy
         upload = a.upload.copy()
         next_part = self._mirror_part(a.file, upload, a.part)
@@ -615,7 +619,7 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
                                    part=next_part)
 
     @_mirror.register
-    def _(self, a: FinalizeFileAction) -> Iterable[MirrorAction]:
+    def _(self, a: FinalizeFileAction) -> Iterator[MirrorAction]:
         assert len(a.upload.etags) > 0
         self._verify_digest(a.file, a.upload.hasher)
         object_key = self._file_object_key(a.file)
@@ -631,7 +635,7 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
         self._get_info(a.file)
         self._put_info(a.file)
         log.info('Successfully mirrored file via multi-part upload: %r', a.file)
-        return ()
+        return iter(())
 
     def _info(self, file: File) -> JSON:
         return {

--- a/src/azul/queues.py
+++ b/src/azul/queues.py
@@ -48,6 +48,7 @@ from azul import (
 )
 from azul.attrs import (
     DiscriminatingPolymorphicSerializableAttrs,
+    SerializableAttrs,
 )
 from azul.deployment import (
     aws,
@@ -84,8 +85,8 @@ if TYPE_CHECKING:
     )
 
 
-@attrs.frozen(kw_only=True)
-class SQSMessage:
+@attrs.frozen(kw_only=True, repr=False)
+class SQSMessage(SerializableAttrs):
     body: JSON
 
     #: Approximate number of times this message has been received, or None if
@@ -110,6 +111,11 @@ class SQSMessage:
         return cls(id=json_str(record.to_dict()['messageId']),
                    body=json.loads(record.body),
                    attempts=int(json_str(attributes['ApproximateReceiveCount'])))
+
+    def __repr__(self) -> str:
+        # We profusely log instances of this class, so we would like their
+        # logged form to benefit from CloudWatch's automatic parsing of JSON
+        return json.dumps(self.to_json())
 
 
 @attrs.frozen(kw_only=True)
@@ -195,13 +201,16 @@ class Queues:
     def send_messages(self,
                       queue: 'Queue',
                       messages: Iterable[SQSMessage],
-                      rate_limit: float | None = None
+                      rate_limit: float | None = None,
+                      log_level: int = logging.DEBUG
                       ) -> int:
         num_messages = 0
         for batch in chunked(messages, self.batch_size):
             entries = [message.to_batch_entry(i) for i, message in enumerate(batch)]
             start = time.time()
             queue.send_messages(Entries=entries)
+            for message in batch:
+                self._log_queued_message(message, log_level)
             if rate_limit is not None:
                 period = 1 / rate_limit
                 time_spent = time.time() - start
@@ -212,8 +221,15 @@ class Queues:
             num_messages += len(batch)
         return num_messages
 
-    def send_message(self, queue: 'Queue', message: SQSMessage):
+    def send_message(self,
+                     queue: 'Queue',
+                     message: SQSMessage,
+                     log_level: int = logging.DEBUG):
         queue.send_message(**message.to_entry())
+        self._log_queued_message(message, log_level)
+
+    def _log_queued_message(self, message: SQSMessage, log_level: int):
+        log.log(log_level, 'Queued message %r', message)
 
     def _cleanup_messages(self, queue: 'Queue', messages: Iterable['Message']):
         message_batches = list(more_itertools.chunked(messages, self.batch_size))

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -31,6 +31,7 @@ from azul.indexer.mirror_controller import (
     MirrorController,
 )
 from azul.indexer.mirror_service import (
+    MirrorAction,
     MirrorService,
 )
 from azul.json import (
@@ -77,12 +78,17 @@ class TestMirrorController(DCP2TestCase,
     def app_name(cls) -> str:
         return 'indexer'
 
+    operation_id = 'foo_op'
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.addClassPatch(patch.object(SourceService,
                                        'list_source_ids',
                                        return_value={cls.source.id}))
+        cls.addClassPatch(patch.object(MirrorAction,
+                                       '_operation_id',
+                                       return_value=cls.operation_id))
 
     _file_contents = b'lorem ipsum dolor sit\n'
 
@@ -137,6 +143,7 @@ class TestMirrorController(DCP2TestCase,
         source_message = one(self._mirror_sources())
         expected_message = dict(action='MirrorSourceAction',
                                 catalog=self.catalog,
+                                operation_id=self.operation_id,
                                 source=self.source.to_json())
         self.assertEqual(expected_message, source_message)
         return source_message
@@ -151,6 +158,7 @@ class TestMirrorController(DCP2TestCase,
             partitions.append(message.pop('prefix'))
             self.assertEqual(dict(action='MirrorPartitionAction',
                                   catalog=self.catalog,
+                                  operation_id=self.operation_id,
                                   source=self.source.to_json()),
                              message)
         self.assertEqual(list(self.source.prefix.partition_prefixes()), partitions)
@@ -164,6 +172,7 @@ class TestMirrorController(DCP2TestCase,
         file_message = one(self._read_queue(self.service._mirror_queue()))
         expected_message = dict(action='MirrorFileAction',
                                 catalog=self.catalog,
+                                operation_id=self.operation_id,
                                 source=self.source.to_json(),
                                 prefix='00',
                                 file=self._file.to_json())

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -78,15 +78,11 @@ class TestMirrorController(DCP2TestCase,
         return 'indexer'
 
     @classmethod
-    def _patch_list_source_ids(cls):
+    def setUpClass(cls):
+        super().setUpClass()
         cls.addClassPatch(patch.object(SourceService,
                                        'list_source_ids',
                                        return_value={cls.source.id}))
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls._patch_list_source_ids()
 
     _file_contents = b'lorem ipsum dolor sit\n'
 


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #7673

## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator and the author


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `sandbox`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilbox`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] PR is assigned to only the operator
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
