### PR TITLE
Fix: External DRS URIs in lm10 snapshots break /repository/files (#7660)

### DIFF
--- a/src/azul/drs.py
+++ b/src/azul/drs.py
@@ -34,7 +34,6 @@ import urllib3.request
 from azul import (
     R,
     cache,
-    cached_property,
     mutable_furl,
 )
 from azul.http import (
@@ -199,14 +198,6 @@ class DRSURI(metaclass=ABCMeta):
             else:
                 raise
 
-    @abstractmethod
-    def to_url(self, client: 'DRSClient', access_id: str | None = None) -> furl:
-        """
-        Translate this DRS URI into a URL of the DRS REST API endpoint at which
-        the file identified by this DRS URI can be accessed.
-        """
-        raise NotImplementedError
-
 
 @attr.s(auto_attribs=True, kw_only=True, frozen=True, slots=True)
 class HostBasedDRSURI(DRSURI):
@@ -228,8 +219,8 @@ class HostBasedDRSURI(DRSURI):
         assert len(path) == 1, R('Invalid path', drs_uri)
         return cls(server=parsed_uri.netloc, object_id=path[0])
 
-    def to_url(self, client: 'DRSClient', access_id: str | None = None) -> furl:
-        path = drs_object_url_path(object_id=self.object_id, access_id=access_id)
+    def to_url(self) -> furl:
+        path = drs_object_url_path(object_id=self.object_id)
         return furl(scheme='https', netloc=self.server, path=path)
 
 
@@ -281,23 +272,23 @@ class CompactDRSURI(DRSURI):
     def _decode(cls, s: str) -> str:
         return urllib.parse.unquote(s, errors='strict')
 
-    def to_url(self, client: 'DRSClient', access_id: str | None = None) -> furl:
+    def to_url(self, id_client: 'IdentifiersDotOrgClient') -> furl:
         if self.provider_code is not None:
             raise NotImplementedError(
                 'Resolving compact identifier-based DRS URIs with '
                 'provider codes is currently not supported', self
             )
-        url = client.id_client.resolve(self.namespace, self.accession)
+        url = id_client.resolve(self.namespace, self.accession)
         # The URL pattern registered at identifiers.org ought to replicate the
-        # DRS spec, but we have to re-create the path using the spec because the
-        # registered pattern does not support embedding the access ID.
+        # DRS spec. If the response to a request to the returned URL includes an
+        # access ID, another request must be made to the returned URL followed
+        # by the string `/access/` and the ID.
         assert str(url.path) == drs_object_url_path(object_id=self.accession), R(
             'Format of resolved URL is incompatible with the DRS specification', url)
-        url.set(path=drs_object_url_path(object_id=self.accession, access_id=access_id))
         return url
 
 
-class IdentifiersDotOrgClient(HasCachedHttpClient):
+class _BaseClient(HasCachedHttpClient):
 
     def _create_http_client(self) -> urllib3.request.RequestMethods:
         return Propagate429HttpClient(
@@ -305,6 +296,26 @@ class IdentifiersDotOrgClient(HasCachedHttpClient):
                 super()._create_http_client()
             )
         )
+
+
+class DRSClient(metaclass=ABCMeta):
+
+    @abstractmethod
+    def drs_object(self, drs_url: furl) -> 'DRSObject':
+        raise NotImplementedError
+
+
+class UnauthenticatedDRSClient(DRSClient, _BaseClient):
+    """
+    A generic DRS client that does not send authentication to the server.
+    """
+
+    def drs_object(self, drs_url: furl) -> 'DRSObject':
+        return DRSObject(url=drs_url,
+                         http_client=self._http_client)
+
+
+class IdentifiersDotOrgClient(_BaseClient):
 
     def resolve(self, prefix: str, accession: str) -> mutable_furl:
         namespace_id = self._prefix_to_namespace(prefix)
@@ -343,26 +354,20 @@ class IdentifiersDotOrgClient(HasCachedHttpClient):
 
 
 @attr.s(auto_attribs=True, kw_only=True, frozen=True)
-class DRSClient:
+class DRSObject:
     _http_client: urllib3.request.RequestMethods
+    _url: furl
 
-    @cached_property
-    def id_client(self) -> IdentifiersDotOrgClient:
-        return IdentifiersDotOrgClient()
-
-    def get_object(self,
-                   drs_uri: str,
-                   access_method: AccessMethod = AccessMethod.https
-                   ) -> Access:
+    def get(self, access_method: AccessMethod = AccessMethod.https) -> Access:
         """
         Returns access to the content of the data object identified by the
         given URI. The scheme of the URL in the returned access object depends
         on the access method specified.
         """
-        return self._get_object(drs_uri, access_method)
+        return self._get(access_method)
 
-    def _get_object(self, drs_uri: str, access_method: AccessMethod) -> Access:
-        url = DRSURI.parse(drs_uri).to_url(self)
+    def _get(self, access_method: AccessMethod) -> Access:
+        url = self._url
         while True:
             response = self._request(url)
             if response.status == 200:
@@ -381,9 +386,9 @@ class DRSClient:
                     # https://github.com/ga4gh/data-repository-service-schemas/issues/361
                     assert access_method is AccessMethod.gs, R(
                         'Unexpected access method', access_method)
-                    return self._get_object_access(drs_uri, access_id, AccessMethod.https)
+                    return self._get_access(access_id, AccessMethod.https)
                 elif access_id is not None:
-                    return self._get_object_access(drs_uri, access_id, access_method)
+                    return self._get_access(access_id, access_method)
                 elif access_url is not None:
                     scheme = furl(access_url['url']).scheme
                     assert scheme == access_method.scheme, R(
@@ -400,12 +405,9 @@ class DRSClient:
             else:
                 raise DRSStatusException(url, response)
 
-    def _get_object_access(self,
-                           drs_uri: str,
-                           access_id: str,
-                           access_method: AccessMethod
-                           ) -> Access:
-        url = DRSURI.parse(drs_uri).to_url(self, access_id)
+    def _get_access(self, access_id: str, access_method: AccessMethod) -> Access:
+        url = self._url.copy()
+        url.path.add(['access', access_id])
         while True:
             response = self._request(url)
             if response.status == 200:

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -722,8 +722,8 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
             'Only TDR catalogs are supported', self.catalog)
         assert file.drs_uri is not None, R(
             'File cannot be downloaded', file)
-        drs = self._repository_plugin.drs_client(authentication=None)
-        access = drs.get_object(file.drs_uri, AccessMethod.gs)
+        object = self._repository_plugin.drs_object(file.drs_uri)
+        access = object.get(AccessMethod.gs)
         assert access.method is AccessMethod.https, access
         return furl(access.url)
 

--- a/src/azul/plugins/__init__.py
+++ b/src/azul/plugins/__init__.py
@@ -23,6 +23,9 @@ from typing import (
 )
 
 import attrs
+from furl import (
+    furl,
+)
 from more_itertools import (
     one,
 )
@@ -43,7 +46,12 @@ from azul.digests import (
     Digest,
 )
 from azul.drs import (
-    DRSClient,
+    CompactDRSURI,
+    DRSObject,
+    DRSURI,
+    HostBasedDRSURI,
+    IdentifiersDotOrgClient,
+    UnauthenticatedDRSClient,
 )
 from azul.indexer import (
     Bundle,
@@ -830,16 +838,36 @@ class RepositoryPlugin[BUNDLE: Bundle = Bundle[SourcedBundleFQID],
 
         raise NotImplementedError
 
-    @abstractmethod
-    def drs_client(self,
+    def drs_object(self,
+                   drs_uri: str,
                    authentication: Authentication | None = None
-                   ) -> DRSClient:
+                   ) -> DRSObject:
         """
         Returns a DRS client that uses the given authentication with requests to
         the DRS server. If a concrete subclass doesn't support authentication,
         it should assert that the argument is ``None``.
         """
-        raise NotImplementedError
+        assert authentication is None, type(authentication)
+        drs_url = self._resolve_drs_uri(drs_uri)
+        return self._unauthenticated_drs.drs_object(drs_url)
+
+    def _resolve_drs_uri(self, drs_uri: str) -> furl:
+        drs_uri = DRSURI.parse(drs_uri)
+        if isinstance(drs_uri, CompactDRSURI):
+            drs_url = drs_uri.to_url(self._identifiers_dot_org)
+        elif isinstance(drs_uri, HostBasedDRSURI):
+            drs_url = drs_uri.to_url()
+        else:
+            assert False
+        return drs_url
+
+    @cached_property
+    def _unauthenticated_drs(self) -> UnauthenticatedDRSClient:
+        return UnauthenticatedDRSClient()
+
+    @cached_property
+    def _identifiers_dot_org(self) -> IdentifiersDotOrgClient:
+        return IdentifiersDotOrgClient()
 
     @abstractmethod
     def file_download_class(self) -> type['RepositoryFileDownload']:

--- a/src/azul/plugins/repository/canned/__init__.py
+++ b/src/azul/plugins/repository/canned/__init__.py
@@ -27,9 +27,6 @@ from azul import (
 from azul.auth import (
     Authentication,
 )
-from azul.drs import (
-    DRSClient,
-)
 from azul.http import (
     HasCachedHttpClient,
 )
@@ -275,12 +272,6 @@ class Plugin(RepositoryPlugin[
 
     def file_download_class(self) -> type[RepositoryFileDownload]:
         return CannedFileDownload
-
-    def drs_client(self,
-                   authentication: Authentication | None = None
-                   ) -> DRSClient:
-        assert authentication is None, type(authentication)
-        return DRSClient(http_client=self._http_client)
 
     def validate_version(self, version: str) -> None:
         parse_dcp2_version(version)

--- a/src/azul/plugins/repository/dss/__init__.py
+++ b/src/azul/plugins/repository/dss/__init__.py
@@ -32,9 +32,6 @@ from azul.collections import (
 from azul.deployment import (
     aws,
 )
-from azul.drs import (
-    DRSClient,
-)
 from azul.http import (
     HasCachedHttpClient,
 )
@@ -197,12 +194,6 @@ class Plugin(RepositoryPlugin[
         url.path.add(['files', file_uuid])
         url.query.add(adict(version=file_version, replica=replica, token=token))
         return str(url)
-
-    def drs_client(self,
-                   authentication: Authentication | None = None
-                   ) -> DRSClient:
-        assert authentication is None, type(authentication)
-        return DRSClient(http_client=self._http_client)
 
     def file_download_class(self) -> type[RepositoryFileDownload]:
         return DSSFileDownload

--- a/src/azul/plugins/repository/tdr.py
+++ b/src/azul/plugins/repository/tdr.py
@@ -23,6 +23,7 @@ from furl import (
 
 from azul import (
     cache_per_thread,
+    config,
     require,
 )
 from azul.auth import (
@@ -35,7 +36,7 @@ from azul.bigquery import (
 )
 from azul.drs import (
     AccessMethod,
-    DRSClient,
+    DRSObject,
 )
 from azul.indexer import (
     Bundle,
@@ -177,13 +178,6 @@ class TDRPlugin[TDR_BUNDLE: TDRBundle,
                                   type(authentication))
         return tdr
 
-    @classmethod
-    @cache_per_thread
-    def _drs_client(cls,
-                    authentication: Authentication | None = None
-                    ) -> DRSClient:
-        return cls._user_authenticated_tdr(authentication).drs_client()
-
     def _lookup_source_id(self, spec: TDRSourceSpec) -> str:
         return self.tdr.lookup_source(spec)
 
@@ -209,10 +203,19 @@ class TDRPlugin[TDR_BUNDLE: TDRBundle,
     def _emulate_bundle(self, bundle_fqid: TDRBundleFQID) -> TDR_BUNDLE:
         raise NotImplementedError
 
-    def drs_client(self,
+    def drs_object(self,
+                   drs_uri: str,
                    authentication: Authentication | None = None
-                   ) -> DRSClient:
-        return self._drs_client(authentication)
+                   ) -> DRSObject:
+        drs_url = self._resolve_drs_uri(drs_uri)
+        tdr_url = config.tdr_service_url
+        # Authenticate only if the DRS server is TDR so that we don't leak user
+        # or service account tokens to untrusted servers.
+        if (drs_url.scheme, drs_url.host) == (tdr_url.scheme, tdr_url.host):
+            drs_client = self._user_authenticated_tdr(authentication)
+        else:
+            drs_client = self._unauthenticated_drs
+        return drs_client.drs_object(drs_url)
 
     def file_download_class(self) -> type[RepositoryFileDownload]:
         return TDRFileDownload
@@ -270,9 +273,8 @@ class TDRFileDownload(RepositoryFileDownload):
             assert self.location is None, self
             assert self.retry_after is None, self
         else:
-            drs_client = plugin.drs_client(authentication)
-            access = drs_client.get_object(self.file.drs_uri,
-                                           access_method=AccessMethod.gs)
+            drs_client = plugin.drs_object(self.file.drs_uri, authentication)
+            access = drs_client.get(access_method=AccessMethod.gs)
             require(access.method is AccessMethod.https, access.method)
             require(access.headers is None, access.headers)
             signed_url = access.url

--- a/src/azul/service/download_controller.py
+++ b/src/azul/service/download_controller.py
@@ -16,6 +16,7 @@ from chalice import (
     BadRequestError,
     NotFoundError,
     TooManyRequestsError,
+    UnauthorizedError,
 )
 
 from azul import (
@@ -32,6 +33,9 @@ from azul.chalice import (
 )
 from azul.collections import (
     adict,
+)
+from azul.drs import (
+    DRSStatusException,
 )
 from azul.http import (
     LimitedTimeoutException,
@@ -168,6 +172,12 @@ class DownloadController(ServiceAppController):
             raise ServiceUnavailableError(*e.args)
         except TooManyRequestsException as e:
             raise TooManyRequestsError(*e.args)
+        except DRSStatusException as e:
+            msg, status, data = e.args
+            if status == UnauthorizedError.STATUS_CODE:
+                raise UnauthorizedError(msg)
+            else:
+                raise
         if download.retry_after is not None:
             retry_after = min(download.retry_after, int(1.3 ** request_index))
             if wait is not None:

--- a/src/azul/terra.py
+++ b/src/azul/terra.py
@@ -77,6 +77,7 @@ from azul.deployment import (
 )
 from azul.drs import (
     DRSClient,
+    DRSObject,
 )
 from azul.http import (
     LimitedRetryHttpClient,
@@ -368,7 +369,7 @@ class SAMClient(TerraClient):
         return self.credentials_provider.insufficient_access(resource)
 
 
-class TDRClient(SAMClient):
+class TDRClient(SAMClient, DRSClient):
     """
     A client for the Broad Institute's Terra Data Repository aka "Jade".
     """
@@ -641,8 +642,8 @@ class TDRClient(SAMClient):
         else:
             return self
 
-    def drs_client(self) -> DRSClient:
-        return DRSClient(http_client=self._http_client)
+    def drs_object(self, drs_url: furl) -> DRSObject:
+        return DRSObject(url=drs_url, http_client=self._http_client)
 
     def get_duos(self,
                  source: TDRSourceRef

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -1209,13 +1209,13 @@ class IndexingIntegrationTest(IntegrationTestCase):
                   file: JSON
                   ) -> None:
         repository_plugin = self.azul_client.repository_plugin(catalog)
-        drs = repository_plugin.drs_client()
         file_uuid = lookup(file, 'document_id', 'uuid')
+        drs_uri = f'drs://{config.api_lambda_domain("service")}/{file_uuid}'
+        drs_object = repository_plugin.drs_object(drs_uri)
         for access_method in AccessMethod:
             with self.subTest('drs', catalog=catalog, access_method=AccessMethod.https):
                 log.info('Resolving file %r with DRS using %r', file_uuid, access_method)
-                drs_uri = f'drs://{config.api_lambda_domain("service")}/{file_uuid}'
-                access = drs.get_object(drs_uri, access_method=access_method)
+                access = drs_object.get(access_method)
                 self.assertIsNone(access.headers)
                 if access.method is AccessMethod.https:
                     response = self._get_url(GET, furl(access.url), stream=True)

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -1145,24 +1145,31 @@ class IndexingIntegrationTest(IntegrationTestCase):
                 self.assertIsNone(file_url, inner_file)
                 self.assertEqual('lungmap', config.catalogs[catalog].atlas, inner_file)
 
-    def _test_file_download(self, source: SourceSpec, file: JSON) -> mutable_furl:
+    def _test_file_download(self, source: SourceSpec, file: JSON) -> mutable_furl | None:
         file_url = furl(file['azul_url'])
         # FIXME: Use _check_endpoint() instead
         #        https://github.com/DataBiosphere/azul/issues/7373
         self.assertEqual(file_url.path.segments[0], 'repository')
         file_url.path.segments.insert(0, 'fetch')
         response = self._get_url_unchecked(GET, file_url)
-        self.assertEqual(200, response.status)
-        response = json.loads(response.data)
-        while response['Status'] != 302:
-            self.assertEqual(301, response['Status'])
+        if response.status == 401:
+            msg = json.loads(response.data)['Message']
+            prefix = 'Unexpected response from '
+            self.assertEqual(prefix, msg[:len(prefix)])
+            self.assertNotIn(str(config.tdr_service_url), msg)
+            return None
+        else:
+            self.assertEqual(200, response.status)
+            response = json.loads(response.data)
+            while response['Status'] != 302:
+                self.assertEqual(301, response['Status'])
+                self.assertNotIn('Retry-After', response)
+                response = self._get_url_json(GET, furl(response['Location']))
             self.assertNotIn('Retry-After', response)
-            response = self._get_url_json(GET, furl(response['Location']))
-        self.assertNotIn('Retry-After', response)
-        final_file_url = furl(response['Location'])
-        response = self._get_url(GET, final_file_url, stream=True)
-        self._validate_file_response(response, source, file)
-        return final_file_url
+            final_file_url = furl(response['Location'])
+            response = self._get_url(GET, final_file_url, stream=True)
+            self._validate_file_response(response, source, file)
+            return final_file_url
 
     def _file_ext(self, file: JSON) -> str:
         # We believe that the file extension is a more reliable indicator than
@@ -1795,6 +1802,7 @@ class IndexingIntegrationTest(IntegrationTestCase):
                             aws.mirror_bucket, '_it', 'file', f'{digest.value}.{digest.type}',
                         ])
                         actual_url = self._test_file_download(source.spec, file_response)
+                        self.assertIsNotNone(actual_url)
                         actual_url.set(args=None)
                         self.assertEqual(expected_url, actual_url)
             _delete()

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -43,7 +43,7 @@ from azul.deployment import (
 from azul.drs import (
     Access,
     AccessMethod,
-    DRSClient,
+    DRSObject,
 )
 from azul.http import (
     http_client,
@@ -168,10 +168,8 @@ class TestRepositoryFilesWithTDR(DCP2TestCase, RepositoryFilesTestCase):
                                              'X-Goog-SignedHeaders': 'host',
                                              'X-Goog-Signature': 'SOMESIGNATURE',
                                          })
-                    with mock.patch.object(DRSClient,
-                                           'get_object',
-                                           return_value=Access(method=AccessMethod.https,
-                                                               url=str(pre_signed_gs))):
+                    access = Access(method=AccessMethod.https, url=str(pre_signed_gs))
+                    with mock.patch.object(DRSObject, 'get', return_value=access):
                         response = client.request('GET', str(azul_url), redirect=False)
                         self.assertEqual(200 if fetch else 302, response.status)
                         if fetch:


### PR DESCRIPTION
Linked issues: #7660


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator and the author


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `sandbox`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilbox`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] PR is assigned to only the operator
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
