### PR TITLE
Fix: Incorrect mirror bucket value when testing on GitHub (#7711)

### DIFF
--- a/test/indexer/__init__.py
+++ b/test/indexer/__init__.py
@@ -74,6 +74,9 @@ from azul_test_case import (
 from es_test_case import (
     ElasticsearchTestCase,
 )
+from mirror_test_case import (
+    MirroringEnabledTestCase,
+)
 
 
 class ForcedRefreshIndexService(IndexService):
@@ -210,6 +213,7 @@ class AnvilCannedBundleTestCase(AnvilTestCase,
 class IndexerTestCase(CatalogTestCase,
                       ElasticsearchTestCase,
                       CannedBundleTestCase,
+                      MirroringEnabledTestCase,
                       metaclass=ABCMeta):
     index_service: ClassVar[IndexService | None] = None
 

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -54,7 +54,7 @@ from azul.types import (
 from azul_test_case import (
     DCP2TestCase,
 )
-from service import (
+from mirror_test_case import (
     MirrorTestCase,
 )
 from sqs_test_case import (

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -55,7 +55,7 @@ from azul_test_case import (
     DCP2TestCase,
 )
 from mirror_test_case import (
-    MirrorTestCase,
+    MirrorFilesTestCase,
 )
 from sqs_test_case import (
     WorkQueueTestCase,
@@ -72,7 +72,7 @@ def setUpModule():
 class TestMirrorController(DCP2TestCase,
                            LocalAppTestCase,
                            WorkQueueTestCase,
-                           MirrorTestCase):
+                           MirrorFilesTestCase):
 
     @classmethod
     def app_name(cls) -> str:

--- a/test/mirror_test_case.py
+++ b/test/mirror_test_case.py
@@ -6,12 +6,15 @@ from unittest.mock import (
 from azul import (
     config,
 )
+from azul_test_case import (
+    AzulUnitTestCase,
+)
 from s3_test_case import (
     S3TestCase,
 )
 
 
-class MirrorTestCase(S3TestCase):
+class MirroringEnabledTestCase(AzulUnitTestCase):
     mirror_bucket = 'test-mirror-bucket'
 
     @classmethod
@@ -23,6 +26,9 @@ class MirrorTestCase(S3TestCase):
         cls.addClassPatch(patch.object(type(config),
                                        'mirror_bucket',
                                        new=PropertyMock(return_value=cls.mirror_bucket)))
+
+
+class MirrorFilesTestCase(MirroringEnabledTestCase, S3TestCase):
 
     def setUp(self):
         super().setUp()

--- a/test/mirror_test_case.py
+++ b/test/mirror_test_case.py
@@ -14,12 +14,16 @@ from s3_test_case import (
 class MirrorTestCase(S3TestCase):
     mirror_bucket = 'test-mirror-bucket'
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.addClassPatch(patch.object(type(config),
+                                       'enable_mirroring',
+                                       new=PropertyMock(return_value=True)))
+        cls.addClassPatch(patch.object(type(config),
+                                       'mirror_bucket',
+                                       new=PropertyMock(return_value=cls.mirror_bucket)))
+
     def setUp(self):
         super().setUp()
-        self.addPatch(patch.object(type(config),
-                                   'enable_mirroring',
-                                   new=PropertyMock(return_value=True)))
-        self.addPatch(patch.object(type(config),
-                                   'mirror_bucket',
-                                   new=PropertyMock(return_value=self.mirror_bucket)))
         self._create_test_bucket(self.mirror_bucket)

--- a/test/mirror_test_case.py
+++ b/test/mirror_test_case.py
@@ -1,0 +1,25 @@
+from unittest.mock import (
+    PropertyMock,
+    patch,
+)
+
+from azul import (
+    config,
+)
+from s3_test_case import (
+    S3TestCase,
+)
+
+
+class MirrorTestCase(S3TestCase):
+    mirror_bucket = 'test-mirror-bucket'
+
+    def setUp(self):
+        super().setUp()
+        self.addPatch(patch.object(type(config),
+                                   'enable_mirroring',
+                                   new=PropertyMock(return_value=True)))
+        self.addPatch(patch.object(type(config),
+                                   'mirror_bucket',
+                                   new=PropertyMock(return_value=self.mirror_bucket)))
+        self._create_test_bucket(self.mirror_bucket)

--- a/test/s3_test_case.py
+++ b/test/s3_test_case.py
@@ -1,0 +1,41 @@
+from typing import (
+    cast,
+    get_args,
+)
+
+from moto import (
+    mock_aws,
+)
+from mypy_boto3_s3.client import (
+    S3Client,
+)
+from mypy_boto3_s3.literals import (
+    BucketLocationConstraintType,
+)
+
+from azul import (
+    config,
+)
+from azul.deployment import (
+    aws,
+)
+from azul_test_case import (
+    AzulUnitTestCase,
+)
+
+
+class S3TestCase(AzulUnitTestCase):
+
+    @property
+    def _s3(self) -> S3Client:
+        return aws.s3
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.addPatch(mock_aws())
+
+    def _create_test_bucket(self, bucket_name: str):
+        assert config.region in get_args(BucketLocationConstraintType)
+        location = cast(BucketLocationConstraintType, config.region)
+        self._s3.create_bucket(Bucket=bucket_name,
+                               CreateBucketConfiguration={'LocationConstraint': location})

--- a/test/service/__init__.py
+++ b/test/service/__init__.py
@@ -13,12 +13,9 @@ from typing import (
     ClassVar,
     Optional,
     Union,
-    cast,
-    get_args,
 )
 from unittest.mock import (
     MagicMock,
-    PropertyMock,
     patch,
 )
 import uuid
@@ -30,25 +27,12 @@ from more_itertools import (
     flatten,
     one,
 )
-from moto import (
-    mock_aws,
-)
-from mypy_boto3_s3.client import (
-    S3Client,
-)
-from mypy_boto3_s3.literals import (
-    BucketLocationConstraintType,
-)
 
 from app_test_case import (
     LocalAppTestCase,
 )
 from azul import (
     cached_property,
-    config,
-)
-from azul.deployment import (
-    aws,
 )
 from azul.indexer import (
     Bundle,
@@ -78,11 +62,11 @@ from azul.types import (
     JSON,
     JSONs,
 )
-from azul_test_case import (
-    AzulUnitTestCase,
-)
 from indexer import (
     IndexerTestCase,
+)
+from s3_test_case import (
+    S3TestCase,
 )
 
 log = get_test_logger(__name__)
@@ -220,23 +204,6 @@ class DocumentCloningTestCase(WebServiceTestCase, metaclass=ABCMeta):
                                     doc_type=DocumentType.aggregate))
 
 
-class S3TestCase(AzulUnitTestCase):
-
-    @property
-    def _s3(self) -> S3Client:
-        return aws.s3
-
-    def setUp(self) -> None:
-        super().setUp()
-        self.addPatch(mock_aws())
-
-    def _create_test_bucket(self, bucket_name: str):
-        assert config.region in get_args(BucketLocationConstraintType)
-        location = cast(BucketLocationConstraintType, config.region)
-        self._s3.create_bucket(Bucket=bucket_name,
-                               CreateBucketConfiguration={'LocationConstraint': location})
-
-
 class StorageServiceTestCase(S3TestCase):
     """
     A mixin for test cases that utilize StorageService.
@@ -249,20 +216,6 @@ class StorageServiceTestCase(S3TestCase):
     def setUp(self) -> None:
         super().setUp()
         self._create_test_bucket(self.storage_service.bucket_name)
-
-
-class MirrorTestCase(S3TestCase):
-    mirror_bucket = 'test-mirror-bucket'
-
-    def setUp(self):
-        super().setUp()
-        self.addPatch(patch.object(type(config),
-                                   'enable_mirroring',
-                                   new=PropertyMock(return_value=True)))
-        self.addPatch(patch.object(type(config),
-                                   'mirror_bucket',
-                                   new=PropertyMock(return_value=self.mirror_bucket)))
-        self._create_test_bucket(self.mirror_bucket)
 
 
 @deprecated('Instead of decorating your test case, or its test methods in it, '

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -134,9 +134,11 @@ from indexer import (
     CannedFileTestCase,
     DCP1CannedBundleTestCase,
 )
+from mirror_test_case import (
+    MirrorTestCase,
+)
 from service import (
     DocumentCloningTestCase,
-    MirrorTestCase,
     StorageServiceTestCase,
     WebServiceTestCase,
 )

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -135,7 +135,7 @@ from indexer import (
     DCP1CannedBundleTestCase,
 )
 from mirror_test_case import (
-    MirrorTestCase,
+    MirrorFilesTestCase,
 )
 from service import (
     DocumentCloningTestCase,
@@ -252,7 +252,7 @@ class CannedManifestTestCase(CannedFileTestCase):
 class ManifestTestCase(WebServiceTestCase,
                        StorageServiceTestCase,
                        CannedManifestTestCase,
-                       MirrorTestCase,
+                       MirrorFilesTestCase,
                        metaclass=ABCMeta):
 
     def setUp(self):

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -78,8 +78,10 @@ from azul_test_case import (
     DCP1TestCase,
     DCP2TestCase,
 )
-from service import (
+from mirror_test_case import (
     MirrorTestCase,
+)
+from s3_test_case import (
     S3TestCase,
 )
 

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -79,7 +79,7 @@ from azul_test_case import (
     DCP2TestCase,
 )
 from mirror_test_case import (
-    MirrorTestCase,
+    MirrorFilesTestCase,
 )
 from s3_test_case import (
     S3TestCase,
@@ -405,7 +405,7 @@ class TestRepositoryFilesWithDSS(DCP1TestCase,
 
 class TestRepositoryFilesWithMirroring(DCP2TestCase,
                                        RepositoryFilesTestCase,
-                                       MirrorTestCase):
+                                       MirrorFilesTestCase):
 
     def test_repository_files(self):
         file_content = b'Contents of foo'

--- a/test/service/test_response.py
+++ b/test/service/test_response.py
@@ -42,9 +42,6 @@ from azul import (
 from azul.collections import (
     none_safe_key,
 )
-from azul.deployment import (
-    aws,
-)
 from azul.indexer import (
     BundleFQID,
     Prefix,
@@ -254,7 +251,7 @@ class TestIndexResponse(IndexResponseTestCase):
                         'azul_url': f'{self.base_url}/repository/files/'
                                     f'7b07f99e-4a8a-4ad0-bd4f-db0d7a00c7bb'
                                     f'?catalog=test&version=2018-11-02T11%3A33%3A44.698028Z',
-                        'azul_mirror_uri': f's3://{aws.mirror_bucket}/file/'
+                        'azul_mirror_uri': f's3://{self.mirror_bucket}/file/'
                                            f'77337cb51b2e584b5ae1b99db6c163b988cbc5b894dda2f5d22424978c3bfc7a.sha256',
                         'drs_uri': f'drs://{self._drs_domain_name}/'
                                    f'7b07f99e-4a8a-4ad0-bd4f-db0d7a00c7bb?version=2018-11-02T11%3A33%3A44.698028Z',
@@ -985,7 +982,7 @@ class TestIndexResponse(IndexResponseTestCase):
             'azul_url': f'{self.base_url}/repository/files/'
                         f'a8b8479d-cfa9-4f74-909f-49552439e698'
                         f'?catalog=test&version=2019-10-09T17%3A22%3A51.560099Z',
-            'azul_mirror_uri': f's3://{aws.mirror_bucket}/file/'
+            'azul_mirror_uri': f's3://{self.mirror_bucket}/file/'
                                f'709fede4736213f0f71ae4d76719fd51fa402a9112582a4c52983973cb7d7e47.sha256',
             'drs_uri': f'drs://{self._drs_domain_name}/'
                        f'a8b8479d-cfa9-4f74-909f-49552439e698?version=2019-10-09T17%3A22%3A51.560099Z',
@@ -2970,7 +2967,7 @@ class TestProjectMatrices(IndexResponseTestCase):
                                                     path='/repository/files/bd98f428-881e-501a-ac16-24f27a68ce2f',
                                                     args=dict(catalog='test', version='2021-02-11T23:11:45.000000Z')
                                                 )),
-                                                'azul_mirror_uri': f's3://{aws.mirror_bucket}/file/'
+                                                'azul_mirror_uri': f's3://{self.mirror_bucket}/file/'
                                                                    f'6a6483c2e78da77017e912a4d350f141'
                                                                    f'bda1ec7b269f20ca718b55145ee5c83c.sha256'
                                             }
@@ -3005,7 +3002,7 @@ class TestProjectMatrices(IndexResponseTestCase):
                                                     path='/repository/files/538faa28-3235-5e4b-a998-5672e2d964e8',
                                                     args=dict(catalog='test', version='2020-12-03T10:39:17.144517Z')
                                                 )),
-                                                'azul_mirror_uri': f's3://{aws.mirror_bucket}/file/'
+                                                'azul_mirror_uri': f's3://{self.mirror_bucket}/file/'
                                                                    f'edb8e0139fece9702d89ae5fe7f761c4'
                                                                    f'1c291ef6a71129c6420857e025228a24.sha256',
                                             },
@@ -3030,7 +3027,7 @@ class TestProjectMatrices(IndexResponseTestCase):
                                                     path='/repository/files/6c142250-567c-5b63-bd4f-0d78499863f8',
                                                     args=dict(catalog='test', version='2020-12-03T10:39:17.144517Z')
                                                 )),
-                                                'azul_mirror_uri': f's3://{aws.mirror_bucket}/file/'
+                                                'azul_mirror_uri': f's3://{self.mirror_bucket}/file/'
                                                                    f'cb1467f4d23a2429b4928943b51652b3'
                                                                    f'2edb949099250d28cf400d13074f5440.sha256',
                                             },
@@ -3055,7 +3052,7 @@ class TestProjectMatrices(IndexResponseTestCase):
                                                     path='/repository/files/8d2ba1c1-bc9f-5c2a-a74d-fe5e09bdfb18',
                                                     args=dict(catalog='test', version='2020-12-03T10:39:17.144517Z')
                                                 )),
-                                                'azul_mirror_uri': f's3://{aws.mirror_bucket}/file/'
+                                                'azul_mirror_uri': f's3://{self.mirror_bucket}/file/'
                                                                    f'724b2c0ddf33c662b362179bc6ca90cd'
                                                                    f'866b99b340d061463c35d27cfd5a23c5.sha256',
                                             }
@@ -3099,7 +3096,7 @@ class TestProjectMatrices(IndexResponseTestCase):
                                                     path='/repository/files/87f31102-ebbc-5875-abdf-4fa5cea48e8d',
                                                     args=dict(catalog='test', version='2021-02-10T16:56:40.419579Z')
                                                 )),
-                                                'azul_mirror_uri': f's3://{aws.mirror_bucket}/file/'
+                                                'azul_mirror_uri': f's3://{self.mirror_bucket}/file/'
                                                                    f'331bd925c08539194eb06e197a1238e1'
                                                                    f'306c3b7876b6fe13548d03824cc4b68b.sha256',
                                             },
@@ -3124,7 +3121,7 @@ class TestProjectMatrices(IndexResponseTestCase):
                                                     path='/repository/files/733318e0-19c2-51e8-9ad6-d94ad562dd46',
                                                     args=dict(catalog='test', version='2021-02-10T16:56:40.419579Z')
                                                 )),
-                                                'azul_mirror_uri': f's3://{aws.mirror_bucket}/file/'
+                                                'azul_mirror_uri': f's3://{self.mirror_bucket}/file/'
                                                                    f'cb7beb6f4e8c684e41d25aa4dc1294dc'
                                                                    f'b1e070e87f9ed852463bf651d511a36b.sha256',
                                             },
@@ -3149,7 +3146,7 @@ class TestProjectMatrices(IndexResponseTestCase):
                                                     path='/repository/files/c59e2de5-01fe-56eb-be56-679ed14161bf',
                                                     args=dict(catalog='test', version='2021-02-10T16:56:40.419579Z')
                                                 )),
-                                                'azul_mirror_uri': f's3://{aws.mirror_bucket}/file/'
+                                                'azul_mirror_uri': f's3://{self.mirror_bucket}/file/'
                                                                    f'6372732e9fe9b8d58c8be8df88ea439d'
                                                                    f'5c68ee9bb02e3d472c94633fadf782a1.sha256',
                                             },
@@ -3174,7 +3171,7 @@ class TestProjectMatrices(IndexResponseTestCase):
                                                     path='/repository/files/68bda896-3b3e-5f2a-9212-f4030a0f37e2',
                                                     args=dict(catalog='test', version='2021-02-10T16:56:40.419579Z')
                                                 )),
-                                                'azul_mirror_uri': f's3://{aws.mirror_bucket}/file/'
+                                                'azul_mirror_uri': f's3://{self.mirror_bucket}/file/'
                                                                    f'f1458913c223553d09966ff94f0ed3d8'
                                                                    f'7e7cdfce21904f32943d70f691d8f7a0.sha256',
                                             },
@@ -3199,7 +3196,7 @@ class TestProjectMatrices(IndexResponseTestCase):
                                                     path='/repository/files/0c5ab869-da2d-5c11-b4ae-f978a052899f',
                                                     args=dict(catalog='test', version='2021-02-10T16:56:40.419579Z')
                                                 )),
-                                                'azul_mirror_uri': f's3://{aws.mirror_bucket}/file/'
+                                                'azul_mirror_uri': f's3://{self.mirror_bucket}/file/'
                                                                    f'053074e25a96a463c081e38bcd02662b'
                                                                    f'a1536dd0cb71411bd111b8a2086a03e1.sha256',
                                             },
@@ -3224,7 +3221,7 @@ class TestProjectMatrices(IndexResponseTestCase):
                                                     path='/repository/files/cade4593-bfba-56ed-80ab-080d0de7d5a4',
                                                     args=dict(catalog='test', version='2021-02-10T16:56:40.419579Z')
                                                 )),
-                                                'azul_mirror_uri': f's3://{aws.mirror_bucket}/file/'
+                                                'azul_mirror_uri': f's3://{self.mirror_bucket}/file/'
                                                                    f'1c57cba1ade259fc9ec56b914b507507'
                                                                    f'd75ccbf6ddeebf03ba00c922c30e0c6e.sha256',
                                             },
@@ -3249,7 +3246,7 @@ class TestProjectMatrices(IndexResponseTestCase):
                                                     path='/repository/files/5b465aad-0981-5152-b468-e615e20f5884',
                                                     args=dict(catalog='test', version='2021-02-10T16:56:40.419579Z')
                                                 )),
-                                                'azul_mirror_uri': f's3://{aws.mirror_bucket}/file/'
+                                                'azul_mirror_uri': f's3://{self.mirror_bucket}/file/'
                                                                    f'af3ea779ca01a2ba65f9415720a44648'
                                                                    f'ef28a6ed73c9ec30e54ed4ba9895f590.sha256',
                                             },
@@ -3274,7 +3271,7 @@ class TestProjectMatrices(IndexResponseTestCase):
                                                     path='/repository/files/b905c8be-2e2d-592c-8481-3eb7a87c6484',
                                                     args=dict(catalog='test', version='2021-02-10T16:56:40.419579Z')
                                                 )),
-                                                'azul_mirror_uri': f's3://{aws.mirror_bucket}/file/'
+                                                'azul_mirror_uri': f's3://{self.mirror_bucket}/file/'
                                                                    f'4f515b8fbbec8bfbc72c8c0d656897ee'
                                                                    f'37bfa30bab6eb50fdc641924227be674.sha256',
                                             }
@@ -3804,7 +3801,7 @@ class TestResponseWithDCP2Cans(DCP2CannedBundleTestCase, WebServiceTestCase):
                 version='2022-07-26T00:16:47.748000Z'
             )
         ))
-        mirror_uri = (f's3://{aws.mirror_bucket}/file/'
+        mirror_uri = (f's3://{self.mirror_bucket}/file/'
                       f'649c45bd2f01b028c974c7e2a9604b9cf564d8afcf528eb299eaf3d7fe92bae3.sha256')
         expected_file = {
             'contentDescription': ['Count matrix', 'Feature table'],

--- a/test/service/test_response_anvil.py
+++ b/test/service/test_response_anvil.py
@@ -1,8 +1,5 @@
 import requests
 
-from azul.deployment import (
-    aws,
-)
 from azul.logging import (
     configure_test_logging,
 )
@@ -1275,7 +1272,8 @@ class TestAnvilResponse(AnvilIndexerTestCase, WebServiceTestCase):
                                     path='/repository/files/15b76f9c-6b46-433f-851d-34e89f1b9ba6',
                                     args=dict(catalog='test', version=self.version)
                                 )),
-                                'azul_mirror_uri': f's3://{aws.mirror_bucket}/file/beec606ee0aa299fdf913f4259316622.md5'
+                                'azul_mirror_uri': f's3://{self.mirror_bucket}/file/'
+                                                   f'beec606ee0aa299fdf913f4259316622.md5'
                             }
                         ]
                     },
@@ -1354,7 +1352,8 @@ class TestAnvilResponse(AnvilIndexerTestCase, WebServiceTestCase):
                                     path='/repository/files/3b17377b-16b1-431c-9967-e5d01fc5923f',
                                     args=dict(catalog='test', version=self.version)
                                 )),
-                                'azul_mirror_uri': f's3://{aws.mirror_bucket}/file/7cd9fd7b54a8bf380e44e93706f1fa2d.md5'
+                                'azul_mirror_uri': f's3://{self.mirror_bucket}/file/'
+                                                   f'7cd9fd7b54a8bf380e44e93706f1fa2d.md5'
                             }
                         ]
                     }


### PR DESCRIPTION
to avoid circular imports between test/indexer/__init__.py and test/service/__init__.py

<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #7711


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [ ] Actually approved the PR
- [ ] Labeled linked issues as `demo` or `no demo`
- [ ] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [ ] Decided if PR can be labeled `no sandbox`
- [ ] A comment to this PR details the completed security design review
- [ ] PR title is appropriate as title of merge commit
- [ ] `N reviews` label is accurate
- [ ] Status of PR is *Approved*
- [ ] PR is assigned to only the operator and the author


### Operator

- [ ] Checked `reindex:…` labels and `r` commit title tag
- [ ] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [ ] Squashed PR branch and rebased onto `develop`
- [ ] Sanity-checked history
- [ ] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [ ] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [ ] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [ ] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [ ] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [ ] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [ ] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [ ] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `sandbox`</sub>
- [ ] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilbox`</sub>
- [ ] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [ ] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [ ] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [ ] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [ ] All status checks passed and the PR is mergeable
- [ ] The title of the merge commit starts with the title of this PR
- [ ] Added PR # reference to merge commit title
- [ ] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [ ] Pushed merge commit to GitHub
- [ ] Status of PR is *Merged lower*
- [ ] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [ ] Pushed merge commit to GitLab `dev`
- [ ] Pushed merge commit to GitLab `anvildev`
- [ ] Build passes on GitLab `dev`
- [ ] Reviewed build logs for anomalies on GitLab `dev`
- [ ] Build passes on GitLab `anvildev`
- [ ] Reviewed build logs for anomalies on GitLab `anvildev`
- [ ] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Deleted PR branch from GitHub
- [ ] PR is assigned to only the operator
- [ ] Deleted PR branch from GitLab `dev`
- [ ] Deleted PR branch from GitLab `anvildev`
- [ ] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [ ] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [ ] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [ ] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [ ] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [ ] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [ ] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [ ] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [ ] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [ ] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [ ] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [ ] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [ ] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [ ] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [ ] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
