### PR TITLE
Fix: Eliminate uses of requests library (#7633)

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -78,6 +78,7 @@ modules =
     scripts.pull_request,
     scripts.claude_mv,
     service.test_user_controller,
+    urllib3_mock,
 
 
 packages =

--- a/scripts/request_flooder.py
+++ b/scripts/request_flooder.py
@@ -11,10 +11,11 @@ import logging
 import sys
 import time
 
-import requests
-
 from azul.args import (
     AzulArgumentHelpFormatter,
+)
+from azul.http import (
+    http_client,
 )
 from azul.lib import (
     R,
@@ -57,10 +58,6 @@ def parse_args(argv):
                         type=int,
                         default='300',
                         help='Total duration of the test in seconds.')
-    parser.add_argument('--log-headers',
-                        default=False,
-                        action='store_true',
-                        help='Include response headers in log output')
     args = parser.parse_args(argv)
     args.method = args.method.upper()
     assert args.method in ['HEAD', 'GET', 'PUT'], R(
@@ -75,16 +72,12 @@ def parse_args(argv):
     return args
 
 
-def request_url(method: str, url: str, log_headers: bool) -> int:
-    log.info('Making %s request to %r', method, url)
-    start_time = time.time()
-    response = requests.request(method=method, url=url)
-    duration = time.time() - start_time
-    if log_headers:
-        log.info('… with response headers %r', response.headers)
-    log.info('Got %i response after %.3fs from %s to %s',
-             response.status_code, duration, method, url)
-    return response.status_code
+http = http_client(log=log)
+
+
+def request_url(method: str, url: str) -> int:
+    response = http.request(method=method, url=url)
+    return response.status
 
 
 def main(argv):
@@ -98,7 +91,7 @@ def main(argv):
         end_time = start_time + args.duration
         while time.time() < end_time:
             time.sleep(sleep_delay)
-            futures.append(tpe.submit(request_url, args.method, args.url, args.log_headers))
+            futures.append(tpe.submit(request_url, args.method, args.url))
         for f in as_completed(futures):
             assert f.result() in [200, 429]
 

--- a/src/azul/health.py
+++ b/src/azul/health.py
@@ -26,7 +26,6 @@ from chalice.app import (
 from furl import (
     furl,
 )
-import requests
 
 from azul import (
     CatalogName,
@@ -39,6 +38,11 @@ from azul.chalice import (
 )
 from azul.deployment import (
     aws,
+)
+from azul.http import (
+    HTTPStatusError,
+    HasCachedHttpClient,
+    raise_on_status,
 )
 from azul.lib import (
     R,
@@ -176,7 +180,7 @@ class HealthController(Controller):
 
 
 @attr.s(frozen=True, kw_only=True, auto_attribs=True)
-class Health:
+class Health(HasCachedHttpClient):
     """
     Encapsulates information about the health status of an Azul deployment. All
     aspects of health are exposed as lazily loaded properties. Instantiating the
@@ -262,14 +266,10 @@ class Health:
     def _api_endpoint(self, entity_type: str) -> JSON:
         relative_url = furl(path=('index', entity_type), args={'size': '1'})
         url = str(config.service_endpoint.join(relative_url))
-        log.info('Making HEAD request to %s', url)
-        start = time.time()
-        response = requests.api.head(url)
-        log.info('Got %s response after %.3fs from HEAD request to %s',
-                 response.status_code, time.time() - start, url)
+        response = self._http_client.request('HEAD', url)
         try:
-            response.raise_for_status()
-        except requests.exceptions.HTTPError as e:
+            raise_on_status(response)
+        except HTTPStatusError as e:
             return {'up': False, 'error': repr(e)}
         else:
             return {'up': True}
@@ -300,9 +300,8 @@ class Health:
         try:
             url = config.lambda_endpoint(lambda_name).set(path='/health/basic',
                                                           args={'catalog': self.catalog})
-            log.info('Requesting %r', url)
-            response = requests.api.get(str(url))
-            response.raise_for_status()
+            response = self._http_client.request('GET', str(url))
+            raise_on_status(response)
             up = response.json()['up']
         except Exception as e:
             return {

--- a/src/azul/http.py
+++ b/src/azul/http.py
@@ -197,6 +197,43 @@ def http_client(log: logging.Logger | None = None) -> HttpClient:
     return StatusRetryHttpClient(client)
 
 
+class HTTPStatusError(Exception):
+
+    def __init__(self, url: str | None, status: int, reason: str | None = None):
+        # The URL is intentionally passed last, as it tends to be long and we
+        # don't want it to displace the other two arguments in the log line.
+        super().__init__('Unexpected response status', status, reason, url)
+
+
+def raise_on_status(response: urllib3.BaseHTTPResponse) -> None:
+    if not 200 <= response.status < 400:
+        raise HTTPStatusError(response.url, response.status, response.reason)
+
+
+class DefaultRetryHttpClient(HttpClientDecorator):
+
+    def __init__(self,
+                 inner: HttpClient,
+                 retries: urllib3.util.Retry,
+                 headers: dict | None = None):
+        super().__init__(inner, headers)
+        self.retries = retries
+
+    def urlopen(self,
+                method: str,
+                url: str,
+                *args,
+                **kwargs
+                ) -> urllib3.BaseHTTPResponse:
+        assert 'retries' not in kwargs, R("Argument 'retries' is disallowed")
+        response = super().urlopen(method,
+                                   url,
+                                   *args,
+                                   retries=self.retries,
+                                   **kwargs)
+        return response
+
+
 class LimitedTimeoutException(Exception):
 
     def __init__(self, url: furl, timeout: float):

--- a/src/azul/plugins/repository/dss/__init__.py
+++ b/src/azul/plugins/repository/dss/__init__.py
@@ -18,7 +18,6 @@ from furl import (
 from more_itertools import (
     one,
 )
-import requests
 
 from azul import (
     config,
@@ -31,6 +30,7 @@ from azul.deployment import (
 )
 from azul.http import (
     HasCachedHttpClient,
+    raise_on_status,
 )
 from azul.indexer import (
     SourcedBundleFQID,
@@ -208,7 +208,7 @@ class Plugin(RepositoryPlugin[
         parse_dcp2_version(version)
 
 
-class DSSFileDownload(RepositoryFileDownload):
+class DSSFileDownload(RepositoryFileDownload, HasCachedHttpClient):
     _location: str | None = None
     _retry_after: int | None = None
 
@@ -222,8 +222,8 @@ class DSSFileDownload(RepositoryFileDownload):
                                                 file_version=self.file.version,
                                                 replica=self.replica,
                                                 token=self.token)
-        dss_response = requests.get(dss_url, allow_redirects=False)
-        if dss_response.status_code == 301:
+        dss_response = self._http_client.request('GET', dss_url, redirect=False)
+        if dss_response.status == 301:
             retry_after = int(dss_response.headers.get('Retry-After'))
             location = dss_response.headers['Location']
 
@@ -233,7 +233,7 @@ class DSSFileDownload(RepositoryFileDownload):
             self.replica = one(query['replica'])
             self.file = attrs.evolve(self.file, version=one(query['version']))
             self._retry_after = retry_after
-        elif dss_response.status_code == 302:
+        elif dss_response.status == 302:
             location = dss_response.headers['Location']
             # Remove once https://github.com/HumanCellAtlas/data-store/issues/1837 is resolved
             if True:
@@ -256,7 +256,7 @@ class DSSFileDownload(RepositoryFileDownload):
                                                          Params=params)
             self._location = location
         else:
-            dss_response.raise_for_status()
+            raise_on_status(dss_response)
             assert False
 
     @property

--- a/src/azul/service/drs_controller.py
+++ b/src/azul/service/drs_controller.py
@@ -12,6 +12,7 @@ from dataclasses import (
 from datetime import (
     datetime,
 )
+import logging
 from typing import (
     Any,
 )
@@ -27,7 +28,7 @@ from furl import (
 from more_itertools import (
     one,
 )
-import requests
+import urllib3
 
 from azul import (
     config,
@@ -37,6 +38,9 @@ from azul.drs import (
     AccessMethod,
     drs_object_uri,
     drs_object_url_path,
+)
+from azul.http import (
+    HasCachedHttpClient,
 )
 from azul.lib import (
     cached_property,
@@ -62,8 +66,10 @@ from azul.service.index_service import (
     IndexService,
 )
 
+log = logging.getLogger(__name__)
 
-class DRSController(ServiceController):
+
+class DRSController(ServiceController, HasCachedHttpClient):
 
     @cached_property
     def _service(self) -> IndexService:
@@ -207,7 +213,7 @@ class DRSController(ServiceController):
             # We only want direct URLs for Google
             extra_params = dict(query_params, directurl=access_method.replica == 'gcp')
             response = self._dss_get_file(file_uuid, access_method.replica, **extra_params)
-            if response.status_code == 301:
+            if response.status == 301:
                 retry_url = response.headers['location']
                 query = urllib.parse.urlparse(retry_url).query
                 query = urllib.parse.parse_qs(query, strict_parsing=True)
@@ -215,14 +221,14 @@ class DRSController(ServiceController):
                 # We use the encoded token string as the key for our access ID.
                 access_id = encode_access_id(token, access_method.replica)
                 drs_object.add_access_method(access_method, access_id=access_id)
-            elif response.status_code == 302:
+            elif response.status == 302:
                 retry_url = response.headers['location']
                 if access_method.replica == 'gcp':
                     assert retry_url.startswith('gs:')
                 drs_object.add_access_method(access_method, url=retry_url)
             else:
                 # For errors, just proxy DSS response
-                return Response(response.text, status_code=response.status_code)
+                return Response(response.data, status_code=response.status)
         return Response(drs_object.to_json())
 
     def get_object_access(self, access_id, file_uuid, query_params):
@@ -240,24 +246,32 @@ class DRSController(ServiceController):
                 'directurl': replica == 'gcp',
                 'token': token
             })
-            if response.status_code == 301:
-                headers = {'retry-after': response.headers['retry-after']}
+            if response.status == 301:
+                header_name = 'retry-after'
+                retry_after = response.headers[header_name]
                 # DRS says no body for 202 responses
-                return Response(body='', status_code=202, headers=headers)
-            elif response.status_code == 302:
+                return Response(body='', status_code=202, headers={header_name: retry_after})
+            elif response.status == 302:
                 retry_url = response.headers['location']
                 return Response(self._access_url(retry_url))
             else:
                 # For errors, just proxy DSS response
-                return Response(response.text, status_code=response.status_code)
+                return Response(response.data, status_code=response.status)
 
-    def _dss_get_file(self, file_uuid, replica, **kwargs):
+    def _dss_get_file(self,
+                      file_uuid,
+                      replica,
+                      **kwargs
+                      ) -> urllib3.BaseHTTPResponse:
         dss_params = {
             'replica': replica,
             **kwargs
         }
         url = self.dss_file_url(file_uuid)
-        return requests.api.get(str(url), params=dss_params, allow_redirects=False)
+        return self._http_client.request('GET',
+                                         str(url),
+                                         fields=dss_params,
+                                         redirect=False)
 
     @classmethod
     def dss_file_url(cls, file_uuid: str) -> mutable_furl:
@@ -269,7 +283,7 @@ class GatewayTimeoutError(ChaliceViewError):
 
 
 @dataclass
-class DRSObject:
+class DRSObject(HasCachedHttpClient):
     """"
     Used to build up a https://ga4gh.github.io/data-repository-service-schemas/docs/#_drsobject
     """
@@ -295,7 +309,7 @@ class DRSObject:
     def to_json(self) -> JSON:
         args = _url_query(replica='aws', version=self.version)
         url = DRSController.dss_file_url(self.uuid).add(args=args)
-        headers = requests.api.head(str(url)).headers
+        headers = self._http_client.request('HEAD', str(url)).headers
         version = headers['x-dss-version']
         if self.version is not None:
             assert version == self.version

--- a/src/humancellatlas/data/metadata/helpers/schema_validation.py
+++ b/src/humancellatlas/data/metadata/helpers/schema_validation.py
@@ -15,8 +15,11 @@ from referencing import (
     Registry,
     Resource,
 )
-import requests
 
+from azul.http import (
+    HasCachedHttpClient,
+    raise_on_status,
+)
 from azul.lib import (
     R,
     cached_property,
@@ -28,7 +31,7 @@ from azul.lib.types import (
 log = logging.getLogger(__name__)
 
 
-class SchemaValidator:
+class SchemaValidator(HasCachedHttpClient):
 
     def validate_json(self, file_json: JSON, file_name: str):
         try:
@@ -45,8 +48,8 @@ class SchemaValidator:
 
     @lru_cache(maxsize=None)
     def _download_json_file(self, file_url: str) -> JSON:
-        response = requests.get(file_url, allow_redirects=False)
-        response.raise_for_status()
+        response = self._http_client.request('GET', file_url, redirect=False)
+        raise_on_status(response)
         return response.json()
 
     def _retrieve_resource(self, resource_url: str) -> Resource:

--- a/test/app_test_case.py
+++ b/test/app_test_case.py
@@ -18,13 +18,15 @@ from chalice.local import (
 from furl import (
     furl,
 )
-import requests
-
+import urllib3
 from azul import (
     config,
 )
 from azul.chalice import (
     AzulChaliceApp,
+)
+from azul.http import (
+    raise_on_status,
 )
 from azul.lib import (
     mutable_furl,
@@ -129,7 +131,7 @@ class LocalAppTestCase(CatalogTestCase, metaclass=ABCMeta):
         while True:
             try:
                 response = self._ping()
-                response.raise_for_status()
+                raise_on_status(response)
             except Exception:
                 if time.time() > deadline:
                     raise
@@ -138,8 +140,9 @@ class LocalAppTestCase(CatalogTestCase, metaclass=ABCMeta):
             else:
                 break
 
-    def _ping(self):
-        return requests.get(str(self.base_url.set(path='/health/basic')))
+    def _ping(self) -> urllib3.BaseHTTPResponse:
+        return self._http_client.request('GET',
+                                         str(self.base_url.set(path='/health/basic')))
 
     def chalice_config(self):
         return ChaliceConfig.create(lambda_timeout=config.api_gateway_lambda_timeout)

--- a/test/azul_test_case.py
+++ b/test/azul_test_case.py
@@ -45,6 +45,7 @@ import moto.core.models
 from opensearchpy.exceptions import (
     OpenSearchWarning,
 )
+import urllib3
 
 from azul import (
     CatalogName,
@@ -53,6 +54,11 @@ from azul import (
 )
 from azul.deployment import (
     aws,
+)
+from azul.http import (
+    DefaultRetryHttpClient,
+    HasCachedHttpClient,
+    HttpClient,
 )
 from azul.logging import (
     configure_test_logging,
@@ -237,7 +243,7 @@ class AzulTestCase(TestCase):
             yield
 
 
-class AzulUnitTestCase(AzulTestCase):
+class AzulUnitTestCase(AzulTestCase, HasCachedHttpClient):
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -352,6 +358,14 @@ class AzulUnitTestCase(AzulTestCase):
         cls.addClassPatch(patch.object(target=api,
                                        attribute='valid_schema_domains',
                                        new=cls.valid_schema_domains))
+
+    def _create_http_client(self) -> HttpClient:
+        return DefaultRetryHttpClient(
+            super()._create_http_client(),
+            retries=urllib3.util.Retry(total=0,
+                                       status=0,
+                                       raise_on_status=False)
+        )
 
 
 class CatalogTestCase(AzulUnitTestCase, metaclass=ABCMeta):

--- a/test/azul_test_case.py
+++ b/test/azul_test_case.py
@@ -245,6 +245,19 @@ class AzulTestCase(TestCase):
 
 class AzulUnitTestCase(AzulTestCase, HasCachedHttpClient):
 
+    def _create_http_client(self) -> HttpClient:
+        # We don't want any retries during unit tests. Since all server fixtures
+        # run on the same machine as the tests, we don't expect any transient
+        # errors, including I/O or 500 status errors. We also require unit tests
+        # to explicitly assert the expected response status, instead of relying
+        # on the client to raise an exception.
+        return DefaultRetryHttpClient(
+            super()._create_http_client(),
+            retries=urllib3.util.Retry(total=0,
+                                       status=0,
+                                       raise_on_status=False)
+        )
+
     @classmethod
     def setUpClass(cls) -> None:
         super().setUpClass()
@@ -358,14 +371,6 @@ class AzulUnitTestCase(AzulTestCase, HasCachedHttpClient):
         cls.addClassPatch(patch.object(target=api,
                                        attribute='valid_schema_domains',
                                        new=cls.valid_schema_domains))
-
-    def _create_http_client(self) -> HttpClient:
-        return DefaultRetryHttpClient(
-            super()._create_http_client(),
-            retries=urllib3.util.Retry(total=0,
-                                       status=0,
-                                       raise_on_status=False)
-        )
 
 
 class CatalogTestCase(AzulUnitTestCase, metaclass=ABCMeta):

--- a/test/health_check_test_case.py
+++ b/test/health_check_test_case.py
@@ -18,15 +18,15 @@ from unittest.mock import (
     MagicMock,
     patch,
 )
-
 from furl import (
     furl,
 )
 from moto import (
     mock_aws,
 )
-import requests
-import responses
+from urllib3 import (
+    BaseHTTPResponse,
+)
 
 from app_test_case import (
     LocalAppTestCase,
@@ -42,6 +42,7 @@ from azul.lib.types import (
 )
 from azul.logging import (
     configure_test_logging,
+    get_test_logger,
 )
 from azul.modules import (
     load_app_module,
@@ -54,6 +55,9 @@ from service import (
 )
 from sqs_test_case import (
     SqsTestCase,
+)
+from urllib3_mock import (
+    Urllib3Mock,
 )
 
 
@@ -69,6 +73,9 @@ def setUpModule():
     configure_test_logging()
 
 
+log = get_test_logger(__name__)
+
+
 class HealthCheckTestCase(LocalAppTestCase,
                           OpenSearchTestCase,
                           StorageServiceTestCase,
@@ -76,21 +83,23 @@ class HealthCheckTestCase(LocalAppTestCase,
                           metaclass=ABCMeta):
 
     def test_basic(self):
-        response = requests.get(str(self.base_url.set(path='/health/basic')))
-        self.assertEqual(200, response.status_code)
+        response = self._http_client.request('GET',
+                                             str(self.base_url.set(path='/health/basic')))
+        self.assertEqual(200, response.status)
         self.assertEqual({'up': True}, response.json())
 
     def test_validation(self):
         for path in ['foo', 'opensearch,', ',opensearch', ',', '1']:
-            response = requests.get(str(self.base_url.set(path=('health', path))))
-            self.assertEqual(400, response.status_code)
+            response = self._http_client.request('GET',
+                                                 str(self.base_url.set(path=('health', path))))
+            self.assertEqual(400, response.status)
 
     @mock_aws
     def test_health_all_ok(self):
         self._create_mock_queues()
         with self._mock():
             response = self._test('/health/')
-        self.assertEqual(200, response.status_code)
+        self.assertEqual(200, response.status)
         self.assertEqual({
             'up': True,
             **self._expected_opensearch(up=True),
@@ -120,7 +129,7 @@ class HealthCheckTestCase(LocalAppTestCase,
             with self.subTest(keys=keys):
                 with self._mock():
                     response = self._test(f'health/{keys}')
-                self.assertEqual(200, response.status_code)
+                self.assertEqual(200, response.status)
                 self.assertEqual(expected_response, response.json())
 
     @mock_aws
@@ -128,7 +137,7 @@ class HealthCheckTestCase(LocalAppTestCase,
         # No health object is available in S3 bucket, yielding an error
         with self._mock():
             response = self._test('/health/cached')
-        self.assertEqual(404, response.status_code)
+        self.assertEqual(404, response.status)
         expected_response = {
             'Code': 'NotFoundError',
             'Message': 'Cached health object does not exist'
@@ -141,7 +150,7 @@ class HealthCheckTestCase(LocalAppTestCase,
         with self._mock():
             app.update_health_cache(MagicMock(), MagicMock())
             response = self._test('/health/cached')
-        self.assertEqual(200, response.status_code)
+        self.assertEqual(200, response.status)
 
         # Another failure is observed when the cache health object is older than
         # 2 minutes
@@ -149,7 +158,7 @@ class HealthCheckTestCase(LocalAppTestCase,
         with patch('time.time', new=lambda: future_time):
             with self._mock():
                 response = self._test('/health/cached')
-            self.assertEqual(500, response.status_code)
+            self.assertEqual(500, response.status)
             expected_response = {
                 'Code': 'ChaliceViewError',
                 'Message': 'Cached health object is stale'
@@ -164,7 +173,7 @@ class HealthCheckTestCase(LocalAppTestCase,
         # The use of subTests ensures that we see the result of both
         # assertions. In the case of the health endpoint, the body of a 503
         # may carry a body with additional information.
-        self.assertEqual(200, response.status_code)
+        self.assertEqual(200, response.status)
         expected_response = {'up': True, **self._expected_other_lambdas(up=True)}
         self.assertEqual(expected_response, response.json())
 
@@ -185,7 +194,7 @@ class HealthCheckTestCase(LocalAppTestCase,
         with patch.dict(os.environ, **mock_env):
             with self._mock():
                 response = self._test('/health/fast')
-            self.assertEqual(503, response.status_code)
+            self.assertEqual(503, response.status)
             self.assertEqual(self._expected_health(opensearch_up=False), response.json())
 
     def _expected_queues(self, *, up: bool) -> MutableJSON:
@@ -214,9 +223,9 @@ class HealthCheckTestCase(LocalAppTestCase,
             } if up else {
                 'up': up,
                 'error': (
-                    "HTTPError('503 Server Error: "
-                    "Service Unavailable for url: "
-                    f"{self._endpoint('/index/bundles?size=1')}')"
+                    ""
+                    "HTTPStatusError('Unexpected response status', 503, 'Service Unavailable', "
+                    f"'{self._endpoint('/index/bundles?size=1')}')"
                 )
             }
         }
@@ -267,38 +276,33 @@ class HealthCheckTestCase(LocalAppTestCase,
             with self._mock_service_endpoints(helper, up=endpoints_up):
                 yield
 
-    def _test(self, path: str) -> requests.Response:
-        return requests.get(str(self.base_url.set(path=path)))
+    def _test(self, path: str) -> BaseHTTPResponse:
+        return self._http_client.request('GET',
+                                         str(self.base_url.set(path=path)))
 
     def helper(self):
-        helper = responses.RequestsMock()
-        helper.add_passthru(str(self.base_url))
-        # We originally shared the Requests mock with Moto which had this set
-        # to False. Because of that, and without noticing, we ended up mocking
-        # more responses than necessary for some of the tests. Instead of
-        # rewriting the tests to only mock what is actually used, we simply
-        # disable the assertion, just like Moto did.
-        helper.assert_all_requests_are_fired = False
-        return helper
+        return Urllib3Mock(Health)
 
     def _mock_service_endpoints(self,
-                                helper: responses.RequestsMock,
+                                helper: Urllib3Mock,
                                 *,
                                 up: bool
                                 ) -> ContextManager:
-        helper.add(responses.Response(method='HEAD',
-                                      url=self._endpoint('/index/bundles?size=1'),
-                                      status=200 if up else 503,
-                                      body=''))
+        helper.add(method='HEAD',
+                   url=self._endpoint('/index/bundles?size=1'),
+                   status=200 if up else 503,
+                   reason='OK' if up else 'Service Unavailable')
         # Patching the Health class to use a random generator with a pinned
         # seed allows us to predict the service endpoint that will be picked
         # to check the health of the service REST API.
         return patch.object(Health, '_random', random.Random(x=42))
 
-    def _mock_other_lambdas(self, helper: responses.RequestsMock, *, up: bool):
+    def _mock_other_lambdas(self, helper: Urllib3Mock, *, up: bool):
         for lambda_name in self._other_lambda_names():
-            url = config.lambda_endpoint(lambda_name).set(path='/health/basic')
-            helper.add(responses.Response(method='GET',
-                                          url=str(url),
-                                          status=200 if up else 500,
-                                          json={'up': up}))
+            url = config.lambda_endpoint(lambda_name).set(path='/health/basic',
+                                                          args={'catalog': self.catalog})
+            helper.add(method='GET',
+                       url=str(url),
+                       status=200 if up else 500,
+                       reason='OK' if up else 'Internal Server Error',
+                       body={'up': up})

--- a/test/indexer/test_anvil.py
+++ b/test/indexer/test_anvil.py
@@ -42,6 +42,7 @@ from azul.lib.types import (
 )
 from azul.logging import (
     configure_test_logging,
+    get_test_logger,
 )
 from azul.plugins.repository import (
     tdr_anvil,
@@ -67,6 +68,9 @@ from indexer.test_tdr import (
 # noinspection PyPep8Naming
 def setUpModule():
     configure_test_logging()
+
+
+log = get_test_logger(__name__)
 
 
 class DUOSTestCase(TDRTestCase, ABC):

--- a/test/indexer/test_health_check.py
+++ b/test/indexer/test_health_check.py
@@ -46,7 +46,7 @@ class TestIndexerHealthCheck(DCP1TestCase, HealthCheckTestCase):
     def test_queues_down(self):
         with self._mock():
             response = self._test('/health/fast')
-        self.assertEqual(503, response.status_code)
+        self.assertEqual(503, response.status)
         self.assertEqual(self._expected_health(), response.json())
 
 

--- a/test/indexer/test_health_check.py
+++ b/test/indexer/test_health_check.py
@@ -7,6 +7,7 @@ from azul.lib.types import (
 )
 from azul.logging import (
     configure_test_logging,
+    get_test_logger,
 )
 from azul_test_case import (
     DCP1TestCase,
@@ -19,6 +20,9 @@ from health_check_test_case import (
 # noinspection PyPep8Naming
 def setUpModule():
     configure_test_logging()
+
+
+log = get_test_logger(__name__)
 
 
 class TestIndexerHealthCheck(DCP1TestCase, HealthCheckTestCase):

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -238,9 +238,6 @@ class IntegrationTestCase(AzulTestCase):
     def azul_client(self):
         return AzulClient()
 
-    def repository_plugin(self, catalog: CatalogName) -> RepositoryPlugin:
-        return self.azul_client.repository_plugin(catalog)
-
     def setUp(self) -> None:
         super().setUp()
         pinned_seed = only(
@@ -257,6 +254,12 @@ class IntegrationTestCase(AzulTestCase):
         # All random operations should be made using this seed so that test
         # results are deterministically reproducible
         self.random = Random(self.random_seed)
+
+
+class SourceSelectingIntegrationTest(IntegrationTestCase):
+
+    def repository_plugin(self, catalog: CatalogName) -> RepositoryPlugin:
+        return self.azul_client.repository_plugin(catalog)
 
     def _ma_sources(self, catalog: CatalogName) -> set[SourceSpec]:
         return set()
@@ -313,7 +316,7 @@ class IntegrationTestCase(AzulTestCase):
             return Source(ref=plugin.resolve_source(source), config=config)
 
 
-class IndexingIntegrationTest(IntegrationTestCase):
+class IndexingIntegrationTest(SourceSelectingIntegrationTest):
     """
     An integration test case that tests indexing of public and managed-access
     metadata from a random selection of bundles, and the expected effects on the
@@ -2107,7 +2110,7 @@ class AzulChaliceLocalIntegrationTest(AzulTestCase):
         self.assertEqual(200, response.status_code, response.content)
 
 
-class CanBundleScriptIntegrationTest(IntegrationTestCase):
+class CanBundleScriptIntegrationTest(SourceSelectingIntegrationTest):
 
     def _test_catalog(self, catalog: config.Catalog):
         fqid = self.bundle_fqid(catalog.name)

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -237,10 +237,16 @@ POST = 'POST'
 class IntegrationTestCase(AzulTestCase, HasCachedHttpClient):
 
     def _create_http_client(self) -> HttpClient:
+        # Since integration tests use deployed application infrastructure, we do
+        # expect transient I/O errors and rely on urllib3's defaults for
+        # handling those. However, we do not typically expect 5xx status errors
+        # as these often indicate situations in which a 4xx response would be
+        # warranted. We accept the occassional IT failure due to legitimate,
+        # transient 5xx responses. ITs are required to explicitly assert the
+        # expected response so we don't rely on the client raising an exception.
         return DefaultRetryHttpClient(
             super()._create_http_client(),
-            retries=urllib3.util.Retry(status=0,
-                                       raise_on_status=False)
+            retries=urllib3.util.Retry(status=0, raise_on_status=False)
         )
 
     @cached_property

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -233,7 +233,6 @@ POST = 'POST'
 
 
 class IntegrationTestCase(AzulTestCase):
-    min_bundles = 32
 
     @cached_property
     def azul_client(self):

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -238,20 +238,8 @@ class IntegrationTestCase(AzulTestCase):
     def azul_client(self):
         return AzulClient()
 
-    @property
-    def index_queue_service(self):
-        return self.azul_client.index_queue_service
-
-    @property
-    def repository_service(self):
-        return self.azul_client.repository_service
-
     def repository_plugin(self, catalog: CatalogName) -> RepositoryPlugin:
         return self.azul_client.repository_plugin(catalog)
-
-    @cache
-    def metadata_plugin(self, catalog: CatalogName) -> MetadataPlugin:
-        return MetadataPlugin.load(catalog).create()
 
     def setUp(self) -> None:
         super().setUp()
@@ -269,56 +257,6 @@ class IntegrationTestCase(AzulTestCase):
         # All random operations should be made using this seed so that test
         # results are deterministically reproducible
         self.random = Random(self.random_seed)
-
-    @cached_property
-    def _tdr_client(self) -> TDRClient:
-        return TDRClient.for_indexer()
-
-    @cached_property
-    def _public_tdr_client(self) -> TDRClient:
-        return TDRClient.for_anonymous_user()
-
-    @cached_property
-    def _unregistered_tdr_client(self) -> TDRClient:
-        tdr = TDRClient(
-            credentials_provider=ServiceAccountCredentialsProvider(
-                service_account=config.ServiceAccount.unregistered
-            )
-        )
-        email = tdr.credentials.service_account_email
-        self.assertFalse(tdr.is_registered(),
-                         f'The "unregistered" service account ({email!r}) has '
-                         f'been registered')
-        # The unregistered service account should not have access to any sources
-        with self.assertRaises(AssertionError) as cm:
-            tdr.list_snapshots()
-        msg = str(cm.exception)
-        expected_msg_prefix = f'The service account (SA) {email!r} is not authorized'
-        self.assertEqual(expected_msg_prefix, msg[:len(expected_msg_prefix)])
-        return tdr
-
-    @cached_property
-    def managed_access_sources_by_catalog(self
-                                          ) -> dict[CatalogName, set[TDRSourceRef]]:
-        public_sources = self._public_tdr_client.list_snapshots()
-        all_sources = self._tdr_client.list_snapshots()
-        configured_sources = {
-            catalog: self.repository_plugin(catalog).sources
-            for catalog in config.integration_test_catalogs
-            if config.is_tdr_enabled(catalog)
-        }
-        managed_access_sources = {catalog: set() for catalog in config.catalogs}
-        for catalog, sources in configured_sources.items():
-            for spec, _ in sources.items():
-                source_id = one(
-                    id
-                    for id, snapshot in all_sources.items()
-                    if snapshot['name'] == spec.name
-                )
-                if source_id not in public_sources:
-                    ref = TDRSourceRef(id=source_id, spec=spec, prefix=None)
-                    managed_access_sources[catalog].add(ref)
-        return managed_access_sources
 
     def _ma_sources(self, catalog: CatalogName) -> set[SourceSpec]:
         return set()
@@ -420,6 +358,68 @@ class IndexingIntegrationTest(IntegrationTestCase):
         super().setUp()
         self._plain_http = http_client(log)
         self._http = self._plain_http
+
+    @property
+    def index_queue_service(self):
+        return self.azul_client.index_queue_service
+
+    @property
+    def repository_service(self):
+        return self.azul_client.repository_service
+
+    @cache
+    def metadata_plugin(self, catalog: CatalogName) -> MetadataPlugin:
+        return MetadataPlugin.load(catalog).create()
+
+    @cached_property
+    def _tdr_client(self) -> TDRClient:
+        return TDRClient.for_indexer()
+
+    @cached_property
+    def _public_tdr_client(self) -> TDRClient:
+        return TDRClient.for_anonymous_user()
+
+    @cached_property
+    def _unregistered_tdr_client(self) -> TDRClient:
+        tdr = TDRClient(
+            credentials_provider=ServiceAccountCredentialsProvider(
+                service_account=config.ServiceAccount.unregistered
+            )
+        )
+        email = tdr.credentials.service_account_email
+        self.assertFalse(tdr.is_registered(),
+                         f'The "unregistered" service account ({email!r}) has '
+                         f'been registered')
+        # The unregistered service account should not have access to any sources
+        with self.assertRaises(AssertionError) as cm:
+            tdr.list_snapshots()
+        msg = str(cm.exception)
+        expected_msg_prefix = f'The service account (SA) {email!r} is not authorized'
+        self.assertEqual(expected_msg_prefix, msg[:len(expected_msg_prefix)])
+        return tdr
+
+    @cached_property
+    def managed_access_sources_by_catalog(self
+                                          ) -> dict[CatalogName, set[TDRSourceRef]]:
+        public_sources = self._public_tdr_client.list_snapshots()
+        all_sources = self._tdr_client.list_snapshots()
+        configured_sources = {
+            catalog: self.repository_plugin(catalog).sources
+            for catalog in config.integration_test_catalogs
+            if config.is_tdr_enabled(catalog)
+        }
+        managed_access_sources = {catalog: set() for catalog in config.catalogs}
+        for catalog, sources in configured_sources.items():
+            for spec, _ in sources.items():
+                source_id = one(
+                    id
+                    for id, snapshot in all_sources.items()
+                    if snapshot['name'] == spec.name
+                )
+                if source_id not in public_sources:
+                    ref = TDRSourceRef(id=source_id, spec=spec, prefix=None)
+                    managed_access_sources[catalog].add(ref)
+        return managed_access_sources
 
     def _ma_sources(self, catalog: CatalogName) -> set[SourceSpec]:
         return {

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -320,6 +320,9 @@ class IntegrationTestCase(AzulTestCase):
                     managed_access_sources[catalog].add(ref)
         return managed_access_sources
 
+    def _ma_sources(self, catalog: CatalogName) -> set[SourceSpec]:
+        return set()
+
     def _select_source(self,
                        catalog: CatalogName,
                        *,
@@ -346,17 +349,8 @@ class IntegrationTestCase(AzulTestCase):
         plugin = self.repository_plugin(catalog)
         sources = plugin.sources
 
-        if public is None:
-            ma_sources = set()
-        else:
-            ma_sources = {
-                source.spec
-                # This would raise a KeyError during the can bundle script test
-                # due to it using a mock catalog, so we only evaluate it when
-                # it's actually needed
-                for source in self.managed_access_sources_by_catalog[catalog]
-            }
-            self.assertIsSubset(ma_sources, sources.keys())
+        ma_sources = self._ma_sources(catalog)
+        self.assertIsSubset(ma_sources, sources.keys())
 
         def _filter(source: tuple[SourceSpec, SourceConfig]) -> bool:
             if public is None:
@@ -426,6 +420,12 @@ class IndexingIntegrationTest(IntegrationTestCase):
         super().setUp()
         self._plain_http = http_client(log)
         self._http = self._plain_http
+
+    def _ma_sources(self, catalog: CatalogName) -> set[SourceSpec]:
+        return {
+            source.spec
+            for source in self.managed_access_sources_by_catalog[catalog]
+        }
 
     @contextmanager
     def subTest(self, msg: Any = None, **params: Any):

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -81,7 +81,6 @@ from openapi_spec_validator import (
     validate,
 )
 import opensearchpy
-import requests
 import urllib3
 
 from azul import (
@@ -113,9 +112,12 @@ from azul.drs import (
     HostBasedDRSURI,
 )
 from azul.http import (
+    DefaultRetryHttpClient,
+    HasCachedHttpClient,
     HttpClient,
     HttpClientDecorator,
     http_client,
+    raise_on_status,
 )
 from azul.indexer import (
     SourcedBundleFQID,
@@ -232,7 +234,14 @@ PUT = 'PUT'
 POST = 'POST'
 
 
-class IntegrationTestCase(AzulTestCase):
+class IntegrationTestCase(AzulTestCase, HasCachedHttpClient):
+
+    def _create_http_client(self) -> HttpClient:
+        return DefaultRetryHttpClient(
+            super()._create_http_client(),
+            retries=urllib3.util.Retry(status=0,
+                                       raise_on_status=False)
+        )
 
     @cached_property
     def azul_client(self):
@@ -359,7 +368,7 @@ class IndexingIntegrationTest(SourceSelectingIntegrationTest):
 
     def setUp(self) -> None:
         super().setUp()
-        self._plain_http = http_client(log)
+        self._plain_http = self._http_client
         self._http = self._plain_http
 
     @property
@@ -2032,7 +2041,7 @@ class AzulClientIntegrationTest(IntegrationTestCase):
         self.assertEqual({expected}, cm.exception.args[1])
 
 
-class OpenAPIIntegrationTest(AzulTestCase):
+class OpenAPIIntegrationTest(IntegrationTestCase):
 
     def test_openapi(self):
         for component, url in [
@@ -2041,19 +2050,19 @@ class OpenAPIIntegrationTest(AzulTestCase):
         ]:
             with self.subTest(component=component):
                 url.set(path='/')
-                response = requests.get(str(url))
-                self.assertEqual(response.status_code, 200)
+                response = self._http_client.request(GET, str(url), redirect=True)
+                self.assertEqual(response.status, 200)
                 self.assertEqual(response.headers['content-type'], 'text/html')
-                self.assertGreater(len(response.content), 0)
+                self.assertGreater(len(response.data), 0)
                 # validate OpenAPI spec
                 url.set(path='/openapi.json')
-                response = requests.get(str(url))
-                response.raise_for_status()
+                response = self._http_client.request(GET, str(url))
+                raise_on_status(response)
                 spec = response.json()
                 validate(spec)
 
 
-class AzulChaliceLocalIntegrationTest(AzulTestCase):
+class AzulChaliceLocalIntegrationTest(IntegrationTestCase):
     url = furl(scheme='http', host='127.0.0.1', port=8000)
     server = None
     server_thread = None
@@ -2079,21 +2088,21 @@ class AzulChaliceLocalIntegrationTest(AzulTestCase):
         super().tearDownClass()
 
     def test_local_chalice(self):
-        response = requests.get(str(self.url))
-        self.assertEqual(200, response.status_code)
+        response = self._http_client.request(GET, str(self.url), redirect=True)
+        self.assertEqual(200, response.status)
 
     def test_local_chalice_health_endpoint(self):
         url = str(self.url.copy().set(path='health'))
-        response = requests.get(url)
-        self.assertEqual(200, response.status_code)
+        response = self._http_client.request(GET, url)
+        self.assertEqual(200, response.status)
 
     catalog = first(config.integration_test_catalogs)
 
     def test_local_chalice_index_endpoints(self):
         url = str(self.url.copy().set(path='repository/sources',
                                       query=dict(catalog=self.catalog)))
-        response = requests.get(url)
-        self.assertEqual(200, response.status_code, response.content)
+        response = self._http_client.request(GET, url)
+        self.assertEqual(200, response.status, response.data)
 
     def test_local_filtered_index_endpoints(self):
         if config.is_hca_enabled(self.catalog):
@@ -2106,8 +2115,8 @@ class AzulChaliceLocalIntegrationTest(AzulTestCase):
         url = str(self.url.copy().set(path='index/files',
                                       query=dict(filters=json.dumps(filters),
                                                  catalog=self.catalog)))
-        response = requests.get(url)
-        self.assertEqual(200, response.status_code, response.content)
+        response = self._http_client.request(GET, url)
+        self.assertEqual(200, response.status, response.data)
 
 
 class CanBundleScriptIntegrationTest(SourceSelectingIntegrationTest):
@@ -2217,10 +2226,9 @@ class CanBundleScriptIntegrationTest(SourceSelectingIntegrationTest):
         return can_bundle.main
 
 
-class SwaggerResourceIntegrationTest(AzulTestCase):
+class SwaggerResourceIntegrationTest(IntegrationTestCase):
 
     def test(self):
-        http = http_client(log)
         for component, base_url in [
             ('service', config.service_endpoint),
             ('indexer', config.indexer_endpoint)
@@ -2236,11 +2244,11 @@ class SwaggerResourceIntegrationTest(AzulTestCase):
                 ('..%2Fdoes-not-exist', 403),
             ]:
                 with self.subTest(component=component, file=file):
-                    response = http.request(GET, str(base_url / 'swagger' / file))
+                    response = self._http_client.request(GET, str(base_url / 'swagger' / file))
                     self.assertEqual(expected_status, response.status)
 
 
-class DeployedVersionIntegrationTest(AzulTestCase):
+class DeployedVersionIntegrationTest(IntegrationTestCase):
 
     def test_version(self):
         local_status = config.git_status
@@ -2249,8 +2257,8 @@ class DeployedVersionIntegrationTest(AzulTestCase):
             ('indexer', config.indexer_endpoint)
         ]:
             endpoint.set(path='/version')
-            response = requests.get(str(endpoint))
-            self.assertEqual(response.status_code, 200)
+            response = self._http_client.request(GET, str(endpoint))
+            self.assertEqual(response.status, 200)
             lambda_status = response.json()['git']
             self.assertEqual(local_status, lambda_status)
 
@@ -2270,7 +2278,7 @@ class DisableAutomaticIndexCreationTest(IntegrationTestCase):
                 opensearch.indices.delete(index=[index_name])
 
 
-class ResponseHeadersTest(AzulTestCase):
+class ResponseHeadersTest(IntegrationTestCase):
 
     def test_response_security_headers(self):
         no_cache = 'no-store'
@@ -2286,8 +2294,8 @@ class ResponseHeadersTest(AzulTestCase):
         for endpoint in (config.service_endpoint, config.indexer_endpoint):
             for path, cache_control in test_cases.items():
                 with self.subTest(endpoint=endpoint, path=path):
-                    response = requests.get(str(endpoint / path))
-                    response.raise_for_status()
+                    response = self._http_client.request(GET, str(endpoint / path))
+                    raise_on_status(response)
                     actual_csp = response.headers['Content-Security-Policy']
                     parsed_csp = CSP.parse(actual_csp)
                     parsed_csp.validate()
@@ -2311,15 +2319,16 @@ class ResponseHeadersTest(AzulTestCase):
                         # expected value.
                         'Content-Security-Policy': str(parsed_csp)
                     }
-                    self.assertIsSubset(expected_headers.items(), response.headers.items())
+                    self.assertIsSubset(expected_headers.items(),
+                                        set(list(response.headers.items())))
 
     def test_default_4xx_response_headers(self):
         for endpoint in (config.service_endpoint, config.indexer_endpoint):
             with self.subTest(endpoint=endpoint):
-                response = requests.get(str(endpoint / 'does-not-exist'))
-                self.assertEqual(403, response.status_code)
+                response = self._http_client.request(GET, str(endpoint / 'does-not-exist'))
+                self.assertEqual(403, response.status)
                 self.assertIsSubset(AzulChaliceApp.security_headers().items(),
-                                    response.headers.items())
+                                    set(list(response.headers.items())))
 
 
 class BearerTokenHttpClient(HttpClientDecorator):

--- a/test/service/test_app_logging.py
+++ b/test/service/test_app_logging.py
@@ -11,20 +11,19 @@ from unittest.mock import (
     patch,
 )
 
-import requests
-
 from azul import (
     Config,
 )
 from azul.chalice import (
     AzulChaliceApp,
-    log,
+    log as chalice_log,
 )
 from azul.lib.types import (
     JSON,
 )
 from azul.logging import (
     configure_test_logging,
+    get_test_logger,
 )
 from indexer import (
     DCP1CannedBundleTestCase,
@@ -37,6 +36,9 @@ from service import (
 # noinspection PyPep8Naming
 def setUpModule():
     configure_test_logging()
+
+
+log = get_test_logger(__name__)
 
 
 class TestServiceAppLogging(DCP1CannedBundleTestCase, WebServiceTestCase):
@@ -57,6 +59,7 @@ class TestServiceAppLogging(DCP1CannedBundleTestCase, WebServiceTestCase):
 
     def test_request_logs(self):
         prefix_len = 1024
+        http = self._http_client
 
         def filter_body(organ: str) -> JSON:
             return {'filters': json.dumps({'organ': {'is': [organ]}})}
@@ -77,25 +80,23 @@ class TestServiceAppLogging(DCP1CannedBundleTestCase, WebServiceTestCase):
                 url = self.base_url.set(path='/index/projects')
                 request_headers = {'authorization': 'Bearer ya29.foo_token'} if authenticated else {}
                 level = [INFO, DEBUG, DEBUG][debug]
-                with self.assertLogs(logger=log, level=level) as logs:
+                with self.assertLogs(logger=chalice_log, level=level) as logs:
                     with patch.object(Config, 'debug', new=PropertyMock(return_value=debug)):
                         if body:
                             request_headers = {
-                                'content-length': str(len(body)),
                                 'content-type': 'application/json',
                                 **request_headers
                             }
-                        response = requests.get(str(url),
+                        response = http.request('GET', str(url),
                                                 headers=request_headers,
-                                                json=body_json)
+                                                body=body)
                 logs = [(r.levelno, r.getMessage()) for r in logs.records]
                 body_log_level, body_log_message = logs.pop()  # asserted separately
                 request_headers = {
                     'host': url.netloc,
-                    'user-agent': 'python-requests/2.33.1',
-                    'accept-encoding': 'gzip, deflate, zstd',
-                    'accept': '*/*',
-                    'connection': 'keep-alive',
+                    'accept-encoding': 'identity',
+                    'content-length': str(len(body)),
+                    'user-agent': 'python-urllib3/2.7.0',
                     **request_headers,
                 }
                 response_headers = {
@@ -146,7 +147,7 @@ class TestServiceAppLogging(DCP1CannedBundleTestCase, WebServiceTestCase):
                     ],
                     logs
                 )
-                body = json.dumps(response.json())
+                body = json.dumps(json.loads(response.data))
                 self.assertGreater(len(body), prefix_len)
                 if debug == 0:
                     expected_log = "… with a response body of type (<class 'dict'>)"
@@ -158,4 +159,4 @@ class TestServiceAppLogging(DCP1CannedBundleTestCase, WebServiceTestCase):
                     assert False
                 self.assertEqual(expected_log, body_log_message)
                 self.assertEqual(INFO, body_log_level)
-                self.assertEqual(200, response.status_code)
+                self.assertEqual(200, response.status)

--- a/test/service/test_app_logging.py
+++ b/test/service/test_app_logging.py
@@ -94,6 +94,8 @@ class TestServiceAppLogging(DCP1CannedBundleTestCase, WebServiceTestCase):
                 body_log_level, body_log_message = logs.pop()  # asserted separately
                 request_headers = {
                     'host': url.netloc,
+                    # FIXME: Use compressed encoding
+                    #        https://github.com/DataBiosphere/azul/issues/7990
                     'accept-encoding': 'identity',
                     'content-length': str(len(body)),
                     'user-agent': 'python-urllib3/2.7.0',

--- a/test/service/test_cache_poisoning.py
+++ b/test/service/test_cache_poisoning.py
@@ -5,13 +5,15 @@ from unittest.mock import (
     patch,
 )
 
-import requests
-
 from app_test_case import (
     LocalAppTestCase,
 )
+from azul.http import (
+    raise_on_status,
+)
 from azul.logging import (
     configure_test_logging,
+    get_test_logger,
 )
 from azul.terra import (
     TDRClient,
@@ -25,6 +27,9 @@ from azul_test_case import (
 # noinspection PyPep8Naming
 def setUpModule():
     configure_test_logging()
+
+
+log = get_test_logger(__name__)
 
 
 class CachePoisoningTestCase(LocalAppTestCase, metaclass=ABCMeta):
@@ -50,8 +55,8 @@ class CachePoisoningTestCase(LocalAppTestCase, metaclass=ABCMeta):
 
     def _test(self):
         url = self.base_url.set(path='/repository/sources')
-        response = requests.get(str(url))
-        response.raise_for_status()
+        response = self._http_client.request('GET', str(url))
+        raise_on_status(response)
 
 
 # Note that the test cases are named intentionally to force the order in which

--- a/test/service/test_drs.py
+++ b/test/service/test_drs.py
@@ -22,6 +22,7 @@ from azul.lib.types import (
 )
 from azul.logging import (
     configure_test_logging,
+    get_test_logger,
 )
 from azul.service.drs_controller import (
     DRSController,
@@ -39,6 +40,9 @@ from indexer import (
 # noinspection PyPep8Naming
 def setUpModule():
     configure_test_logging()
+
+
+log = get_test_logger(__name__)
 
 
 class TestDRSEndpoint(DCP1CannedBundleTestCase, LocalAppTestCase):

--- a/test/service/test_drs.py
+++ b/test/service/test_drs.py
@@ -192,19 +192,51 @@ class TestDRSEndpoint(DCP1CannedBundleTestCase, LocalAppTestCase):
         assert redirects >= 0
         helper.add_passthru(str(self.base_url))
         if redirects == 0:
-            helper.add(self._dss_response(file_uuid, file_version, 'aws', initial=True, _301=False))
-            helper.add(self._dss_response(file_uuid, file_version, 'gcp', initial=True, _301=False))
+            helper.add(self._dss_response(file_uuid,
+                                          file_version,
+                                          'aws',
+                                          initial=True,
+                                          _301=False))
+            helper.add(self._dss_response(file_uuid,
+                                          file_version,
+                                          'gcp',
+                                          initial=True,
+                                          _301=False))
             helper.add(self._dss_response(file_uuid, file_version, 'aws', head=True))
         else:
-            helper.add(self._dss_response(file_uuid, file_version, 'aws', initial=True, _301=True))
-            helper.add(self._dss_response(file_uuid, file_version, 'gcp', initial=True, _301=True))
+            helper.add(self._dss_response(file_uuid,
+                                          file_version,
+                                          'aws',
+                                          initial=True,
+                                          _301=True))
+            helper.add(self._dss_response(file_uuid,
+                                          file_version,
+                                          'gcp',
+                                          initial=True,
+                                          _301=True))
             helper.add(self._dss_response(file_uuid, file_version, 'aws', head=True))
             redirects -= 1
             for _ in range(redirects):
-                helper.add(self._dss_response(file_uuid, file_version, 'aws', initial=False, _301=True))
-                helper.add(self._dss_response(file_uuid, file_version, 'gcp', initial=False, _301=True))
-            helper.add(self._dss_response(file_uuid, file_version, 'aws', initial=False, _301=False))
-            helper.add(self._dss_response(file_uuid, file_version, 'gcp', initial=False, _301=False))
+                helper.add(self._dss_response(file_uuid,
+                                              file_version,
+                                              'aws',
+                                              initial=False,
+                                              _301=True))
+                helper.add(self._dss_response(file_uuid,
+                                              file_version,
+                                              'gcp',
+                                              initial=False,
+                                              _301=True))
+            helper.add(self._dss_response(file_uuid,
+                                          file_version,
+                                          'aws',
+                                          initial=False,
+                                          _301=False))
+            helper.add(self._dss_response(file_uuid,
+                                          file_version,
+                                          'gcp',
+                                          initial=False,
+                                          _301=False))
 
     def test_data_object_not_found(self):
         file_uuid = 'NOT_A_GOOD_IDEA'

--- a/test/service/test_drs.py
+++ b/test/service/test_drs.py
@@ -5,9 +5,6 @@ from unittest.mock import (
 )
 import urllib.parse
 
-import requests
-import responses
-
 from app_test_case import (
     LocalAppTestCase,
 )
@@ -16,6 +13,9 @@ from azul import (
 )
 from azul.drs import (
     AccessMethod,
+)
+from azul.http import (
+    raise_on_status,
 )
 from azul.lib.types import (
     MutableJSON,
@@ -26,6 +26,7 @@ from azul.logging import (
 )
 from azul.service.drs_controller import (
     DRSController,
+    DRSObject,
     dss_drs_object_uri,
     dss_drs_object_url,
 )
@@ -34,6 +35,9 @@ from azul_test_case import (
 )
 from indexer import (
     DCP1CannedBundleTestCase,
+)
+from urllib3_mock import (
+    Urllib3Mock,
 )
 
 
@@ -71,15 +75,14 @@ class TestDRSEndpoint(DCP1CannedBundleTestCase, LocalAppTestCase):
         file_version = '2018-11-02T113344.698028Z'
         for redirects in (0, 1, 2, 6):
             with self.subTest(redirects=redirects):
-                with responses.RequestsMock() as helper:
-                    helper.add_passthru(str(self.base_url))
+                with Urllib3Mock(DRSController, DRSObject) as helper:
                     self._mock_responses(helper, redirects, file_uuid, file_version=file_version)
                     # Make first client request
                     url = dss_drs_object_url(file_uuid=file_uuid,
                                              file_version=file_version,
                                              base_url=self.base_url)
-                    drs_response = requests.get(str(url))
-                    drs_response.raise_for_status()
+                    drs_response = self._http_client.request('GET', str(url))
+                    raise_on_status(drs_response)
                     drs_object = drs_response.json()
                     uri = dss_drs_object_uri(file_uuid=file_uuid,
                                              file_version='2018-11-02T113344.698028Z')
@@ -137,16 +140,16 @@ class TestDRSEndpoint(DCP1CannedBundleTestCase, LocalAppTestCase):
                                                                     file_version=file_version,
                                                                     base_url=self.base_url,
                                                                     access_id=access_id)
-                                drs_response = requests.get(str(drs_access_url))
-                                self.assertEqual(drs_response.status_code, 202)
-                                self.assertEqual(drs_response.text, '')
+                                drs_response = self._http_client.request('GET', str(drs_access_url))
+                                self.assertEqual(drs_response.status, 202)
+                                self.assertEqual(drs_response.data.decode(), '')
                             # The final request should give us just the access URL
                             drs_access_url = dss_drs_object_url(file_uuid=file_uuid,
                                                                 file_version=file_version,
                                                                 base_url=self.base_url,
                                                                 access_id=access_id)
-                            drs_response = requests.get(str(drs_access_url))
-                            self.assertEqual(drs_response.status_code, 200)
+                            drs_response = self._http_client.request('GET', str(drs_access_url))
+                            self.assertEqual(drs_response.status, 200)
                             if method['type'] == AccessMethod.https.scheme:
                                 self.assertEqual(drs_response.json(), {'url': self.signed_url})
                             elif method['type'] == AccessMethod.gs.scheme:
@@ -155,13 +158,14 @@ class TestDRSEndpoint(DCP1CannedBundleTestCase, LocalAppTestCase):
                                 assert False, f'Access type {method["type"]} is not supported'
 
     def _dss_response(self,
+                      helper: Urllib3Mock,
                       file_uuid,
                       file_version,
                       replica,
                       head=False,
                       initial=True,
                       _301=False
-                      ):
+                      ) -> None:
         request_query = {
             'replica': replica,
             **({'version': file_version} if file_version else {}),
@@ -185,77 +189,91 @@ class TestDRSEndpoint(DCP1CannedBundleTestCase, LocalAppTestCase):
             'retry-after': '1'
         }
         if head:
-            return responses.Response(method=responses.HEAD, url=initial_url, status=200, headers=self.dss_headers)
+            helper.add(method='HEAD',
+                       url=initial_url,
+                       status=200,
+                       headers=self.dss_headers)
         else:
-            return responses.Response(method=responses.GET,
-                                      url=initial_url if initial else retry_url,
-                                      status=301 if _301 else 302,
-                                      headers=headers_301 if _301 else headers_302)
+            helper.add(method='GET',
+                       url=initial_url if initial else retry_url,
+                       status=301 if _301 else 302,
+                       headers=headers_301 if _301 else headers_302)
 
-    def _mock_responses(self, helper, redirects, file_uuid, file_version=None):
+    def _mock_responses(self,
+                        helper: Urllib3Mock,
+                        redirects,
+                        file_uuid,
+                        file_version=None):
         assert redirects >= 0
-        helper.add_passthru(str(self.base_url))
         if redirects == 0:
-            helper.add(self._dss_response(file_uuid,
-                                          file_version,
-                                          'aws',
-                                          initial=True,
-                                          _301=False))
-            helper.add(self._dss_response(file_uuid,
-                                          file_version,
-                                          'gcp',
-                                          initial=True,
-                                          _301=False))
-            helper.add(self._dss_response(file_uuid, file_version, 'aws', head=True))
+            self._dss_response(helper,
+                               file_uuid,
+                               file_version,
+                               'aws',
+                               initial=True,
+                               _301=False)
+            self._dss_response(helper,
+                               file_uuid,
+                               file_version,
+                               'gcp',
+                               initial=True,
+                               _301=False)
+            self._dss_response(helper, file_uuid, file_version, 'aws', head=True)
         else:
-            helper.add(self._dss_response(file_uuid,
-                                          file_version,
-                                          'aws',
-                                          initial=True,
-                                          _301=True))
-            helper.add(self._dss_response(file_uuid,
-                                          file_version,
-                                          'gcp',
-                                          initial=True,
-                                          _301=True))
-            helper.add(self._dss_response(file_uuid, file_version, 'aws', head=True))
+            self._dss_response(helper,
+                               file_uuid,
+                               file_version,
+                               'aws',
+                               initial=True,
+                               _301=True)
+            self._dss_response(helper,
+                               file_uuid,
+                               file_version,
+                               'gcp',
+                               initial=True,
+                               _301=True)
+            self._dss_response(helper, file_uuid, file_version, 'aws', head=True)
             redirects -= 1
             for _ in range(redirects):
-                helper.add(self._dss_response(file_uuid,
-                                              file_version,
-                                              'aws',
-                                              initial=False,
-                                              _301=True))
-                helper.add(self._dss_response(file_uuid,
-                                              file_version,
-                                              'gcp',
-                                              initial=False,
-                                              _301=True))
-            helper.add(self._dss_response(file_uuid,
-                                          file_version,
-                                          'aws',
-                                          initial=False,
-                                          _301=False))
-            helper.add(self._dss_response(file_uuid,
-                                          file_version,
-                                          'gcp',
-                                          initial=False,
-                                          _301=False))
+                self._dss_response(helper,
+                                   file_uuid,
+                                   file_version,
+                                   'aws',
+                                   initial=False,
+                                   _301=True)
+                self._dss_response(helper,
+                                   file_uuid,
+                                   file_version,
+                                   'gcp',
+                                   initial=False,
+                                   _301=True)
+            self._dss_response(helper,
+                               file_uuid,
+                               file_version,
+                               'aws',
+                               initial=False,
+                               _301=False)
+            self._dss_response(helper,
+                               file_uuid,
+                               file_version,
+                               'gcp',
+                               initial=False,
+                               _301=False)
 
     def test_data_object_not_found(self):
         file_uuid = 'NOT_A_GOOD_IDEA'
         error_body = 'DRS should just proxy the DSS for error responses'
-        with responses.RequestsMock() as helper:
-            helper.add_passthru(str(self.base_url))
-            url = f'{config.dss_endpoint}/files/{file_uuid}'
-            helper.add(responses.Response(method=responses.GET,
-                                          body=error_body,
-                                          url=url,
-                                          status=404))
+        with Urllib3Mock(DRSController, DRSObject) as helper:
+            # The controller calls dss_get_file which uses request() with
+            # fields={'replica': 'aws', 'directurl': False}. RequestMethods
+            # encodes these fields into the URL for GET requests.
+            dss_url = f'{config.dss_endpoint}/files/{file_uuid}'
+            query = urllib.parse.urlencode({'replica': 'aws', 'directurl': False})
+            helper.add(method='GET', url=f'{dss_url}?{query}', status=404, body=error_body)
             url = dss_drs_object_url(file_uuid=file_uuid, base_url=self.base_url)
-            drs_response = requests.get(str(url))
-            self.assertEqual(drs_response.status_code, 404)
-            self.assertEqual(drs_response.text, error_body)
+            drs_response = self._http_client.request('GET', str(url))
+            self.assertEqual(404, drs_response.status)
+            self.assertEqual(error_body, drs_response.data.decode())
 
 
 class TestDRSController(AzulUnitTestCase):

--- a/test/service/test_health_check.py
+++ b/test/service/test_health_check.py
@@ -7,6 +7,7 @@ from azul.lib.types import (
 )
 from azul.logging import (
     configure_test_logging,
+    get_test_logger,
 )
 from azul_test_case import (
     DCP1TestCase,
@@ -19,6 +20,9 @@ from health_check_test_case import (
 # noinspection PyPep8Naming
 def setUpModule():
     configure_test_logging()
+
+
+log = get_test_logger(__name__)
 
 
 class TestServiceHealthCheck(DCP1TestCase, HealthCheckTestCase):

--- a/test/service/test_health_check.py
+++ b/test/service/test_health_check.py
@@ -46,7 +46,7 @@ class TestServiceHealthCheck(DCP1TestCase, HealthCheckTestCase):
         self._create_mock_queues()
         with self._mock(endpoints_up=False):
             response = self._test('/health/fast')
-        self.assertEqual(503, response.status_code)
+        self.assertEqual(503, response.status)
         self.assertEqual(self._expected_health(endpoints_up=False), response.json())
 
 

--- a/test/service/test_index_projects.py
+++ b/test/service/test_index_projects.py
@@ -1,10 +1,13 @@
 from more_itertools import (
     one,
 )
-import requests
 
+from azul.http import (
+    raise_on_status,
+)
 from azul.logging import (
     configure_test_logging,
+    get_test_logger,
 )
 from indexer import (
     DCP1CannedBundleTestCase,
@@ -17,6 +20,9 @@ from service import (
 # noinspection PyPep8Naming
 def setUpModule():
     configure_test_logging()
+
+
+log = get_test_logger(__name__)
 
 
 class TestIndexProjectsEndpoint(DCP1CannedBundleTestCase, WebServiceTestCase):
@@ -43,8 +49,8 @@ class TestIndexProjectsEndpoint(DCP1CannedBundleTestCase, WebServiceTestCase):
         def get_response_json(uuid=None):
             url = self.base_url.set(path=('index', 'projects', uuid or ''),
                                     args=dict(catalog=self.catalog))
-            response = requests.get(str(url))
-            response.raise_for_status()
+            response = self._http_client.request('GET', str(url))
+            raise_on_status(response)
             return response.json()
 
         def assert_file_type_summaries(hit):

--- a/test/service/test_index_samples.py
+++ b/test/service/test_index_samples.py
@@ -1,7 +1,9 @@
-import requests
-
+from azul.http import (
+    raise_on_status,
+)
 from azul.logging import (
     configure_test_logging,
+    get_test_logger,
 )
 from indexer import (
     DCP1CannedBundleTestCase,
@@ -14,6 +16,9 @@ from service import (
 # noinspection PyPep8Naming
 def setUpModule():
     configure_test_logging()
+
+
+log = get_test_logger(__name__)
 
 
 class TestIndexSamplesEndpoint(DCP1CannedBundleTestCase, WebServiceTestCase):
@@ -31,8 +36,8 @@ class TestIndexSamplesEndpoint(DCP1CannedBundleTestCase, WebServiceTestCase):
     def test_basic_response(self):
         url = self.base_url.set(path='/index/samples',
                                 args=dict(catalog=self.catalog))
-        response = requests.get(str(url))
-        response.raise_for_status()
+        response = self._http_client.request('GET', str(url))
+        raise_on_status(response)
         response_json = response.json()
 
         def assert_file_type_summaries(hit):

--- a/test/service/test_manifest_async.py
+++ b/test/service/test_manifest_async.py
@@ -45,6 +45,7 @@ from azul.lib.types import (
 )
 from azul.logging import (
     configure_test_logging,
+    get_test_logger,
 )
 from azul.plugins import (
     ManifestFormat,
@@ -77,6 +78,9 @@ from azul_test_case import (
 # noinspection PyPep8Naming
 def setUpModule():
     configure_test_logging()
+
+
+log = get_test_logger(__name__)
 
 
 @patch.object(AsyncManifestService, '_sfn')

--- a/test/service/test_pagination.py
+++ b/test/service/test_pagination.py
@@ -14,8 +14,10 @@ import attr
 from more_itertools import (
     unzip,
 )
-import requests
 
+from azul.http import (
+    raise_on_status,
+)
 from azul.logging import (
     configure_test_logging,
     get_test_logger,
@@ -124,8 +126,8 @@ class TestPagination(DCP1CannedBundleTestCase, DocumentCloningTestCase):
             return value
 
         def fetch(url):
-            response = requests.get(str(url))
-            response.raise_for_status()
+            response = self._http_client.request('GET', str(url))
+            raise_on_status(response)
             response = response.json()
             values = tuple(map(sort_field_value, response['hits']))
             self.assertEqual(values, tuple(sorted(unique(values), reverse=reverse)))

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -25,8 +25,6 @@ from furl import (
 from google.auth.transport.urllib3 import (
     AuthorizedHttp,
 )
-import requests
-import responses
 import urllib3
 
 from app_test_case import (
@@ -45,6 +43,7 @@ from azul.drs import (
 )
 from azul.http import (
     http_client,
+    raise_on_status,
 )
 from azul.indexer.mirror_service import (
     MirrorService,
@@ -56,6 +55,9 @@ from azul.logging import (
 )
 from azul.plugins.metadata.hca import (
     HCAFile,
+)
+from azul.plugins.repository.dss import (
+    DSSFileDownload,
 )
 from azul.service.index_service import (
     IndexService,
@@ -70,6 +72,9 @@ from azul_test_case import (
 from service import (
     MirrorTestCase,
     S3TestCase,
+)
+from urllib3_mock import (
+    Urllib3Mock,
 )
 
 log = get_test_logger(__name__)
@@ -218,8 +223,7 @@ class TestRepositoryFilesWithDSS(DCP1TestCase,
                                                  ('foo bar.txt', 'grbM6udwp0n/QE/L/RYfjtQCS/U='),
                                                  ('foo&bar.txt', 'r4C8YxpJ4nXTZh+agBsfhZ2e7fI=')]:
                         with self.subTest(fetch=fetch, file_name=file_name, wait=wait):
-                            with responses.RequestsMock() as helper:
-                                helper.add_passthru(str(self.base_url))
+                            with Urllib3Mock(DSSFileDownload) as helper:
                                 fixed_time = 1547691253.07010
                                 expires = str(round(fixed_time + 3600))
                                 s3_url = furl(url=f'https://{bucket_name}.s3.amazonaws.com',
@@ -230,13 +234,13 @@ class TestRepositoryFilesWithDSS(DCP1TestCase,
                                                   'x-amz-security-token': 'SOMETOKEN',
                                                   'Expires': expires
                                               })
-                                helper.add(responses.Response(method='GET',
-                                                              url=str(dss_url),
-                                                              status=301,
-                                                              headers={
-                                                                  'Location': str(dss_url_with_token),
-                                                                  'Retry-After': '10'
-                                                              }))
+                                helper.add(method='GET',
+                                           url=str(dss_url),
+                                           status=301,
+                                           headers={
+                                               'Location': str(dss_url_with_token),
+                                               'Retry-After': '10'
+                                           })
                                 azul_url = self.base_url.set(path=['repository', 'files', file_uuid],
                                                              args=dict(catalog=self.catalog, version=file_version))
                                 if fetch:
@@ -252,16 +256,16 @@ class TestRepositoryFilesWithDSS(DCP1TestCase,
                                     before = time.monotonic()
                                     with patch.object(type(aws), 'dss_checkout_bucket', return_value=bucket_name):
                                         with patch('time.time', new=lambda: 1547691253.07010):
-                                            response = requests.get(url, allow_redirects=False)
+                                            response = self._http_client.request('GET', url, redirect=False)
                                     if wait and expect_status == 301:
                                         self.assertLess(retry_after, time.monotonic() - before)
                                     if fetch:
-                                        self.assertEqual(200, response.status_code)
+                                        self.assertEqual(200, response.status)
                                         response = response.json()
                                         self.assertEqual(expect_status, response['Status'])
                                     else:
-                                        if response.status_code != expect_status:
-                                            response.raise_for_status()
+                                        if response.status != expect_status:
+                                            raise_on_status(response)
                                         response = dict(response.headers)
                                     if expect_retry_after is None:
                                         self.assertNotIn('Retry-After', response)
@@ -285,10 +289,10 @@ class TestRepositoryFilesWithDSS(DCP1TestCase,
                                 azul_url.args['sha256'] = file.sha256
                                 self.assertUrlEqual(azul_url, location)
 
-                                helper.add(responses.Response(method='GET',
-                                                              url=str(dss_url_with_token),
-                                                              status=302,
-                                                              headers={'Location': str(s3_url)}))
+                                helper.add(method='GET',
+                                           url=str(dss_url_with_token),
+                                           status=302,
+                                           headers={'Location': str(s3_url)})
 
                                 location = request_azul(url=location, expect_status=302)
 

--- a/test/service/test_request_builder.py
+++ b/test/service/test_request_builder.py
@@ -18,6 +18,7 @@ from azul.filters import (
 )
 from azul.logging import (
     configure_test_logging,
+    get_test_logger,
 )
 from azul.plugins import (
     FieldPath,
@@ -46,6 +47,9 @@ from service import (
 # noinspection PyPep8Naming
 def setUpModule():
     configure_test_logging()
+
+
+log = get_test_logger(__name__)
 
 
 class TestRequestBuilder(DCP1CannedBundleTestCase, WebServiceTestCase):

--- a/test/service/test_request_validation.py
+++ b/test/service/test_request_validation.py
@@ -3,13 +3,11 @@ import json
 from furl import (
     furl,
 )
-import requests
-from requests import (
-    Response,
-)
+import urllib3
 
 from azul.logging import (
     configure_test_logging,
+    get_test_logger,
 )
 from azul.plugins import (
     MetadataPlugin,
@@ -28,6 +26,9 @@ from service import (
 # noinspection PyPep8Naming
 def setUpModule():
     configure_test_logging()
+
+
+log = get_test_logger(__name__)
 
 
 class RequestParameterValidationTest(DCP1CannedBundleTestCase,
@@ -57,13 +58,16 @@ class RequestParameterValidationTest(DCP1CannedBundleTestCase,
         assert isinstance(plugin, MetadataPlugin)
         return plugin
 
-    def assertResponseStatus(self, url: furl, status: int) -> Response:
+    def assertResponseStatus(self,
+                             url: furl,
+                             status: int
+                             ) -> urllib3.BaseHTTPResponse:
         if str(url.path) in {'/manifest/files', '/fetch/manifest/files'}:
             method = 'PUT'
         else:
             method = 'GET'
-        response = requests.request(method, str(url))
-        self.assertEqual(status, response.status_code, response.content)
+        response = self._http_client.request(method, str(url))
+        self.assertEqual(status, response.status, response.data)
         return response
 
     def assertErrorMessage(self, url: furl, status: int, code: str, message: str):

--- a/test/service/test_response.py
+++ b/test/service/test_response.py
@@ -33,8 +33,6 @@ from furl import (
 from more_itertools import (
     one,
 )
-import requests
-
 from app_test_case import (
     LocalAppTestCase,
 )
@@ -46,6 +44,9 @@ from azul.deployment import (
 )
 from azul.field_type import (
     null_str,
+)
+from azul.http import (
+    raise_on_status,
 )
 from azul.indexer import (
     BundleFQID,
@@ -1043,9 +1044,10 @@ class TestIndexResponse(IndexResponseTestCase):
     def test_sorting_details(self):
         for entity_type in 'files', 'samples', 'projects', 'bundles':
             with self.subTest(entity_type=entity_type):
-                response = requests.get(str(self.base_url.set(path=('index', entity_type),
-                                                              args=self._params())))
-                response.raise_for_status()
+                response = self._http_client.request('GET',
+                                                     str(self.base_url.set(path=('index', entity_type),
+                                                                           args=self._params())))
+                raise_on_status(response)
                 response_json = response.json()
                 # Verify default sort field is set correctly
                 self.assertEqual(response_json['pagination']['sort'],
@@ -1058,8 +1060,8 @@ class TestIndexResponse(IndexResponseTestCase):
         for entity_type in ('files', 'bundles'):
             with self.subTest(entity_type=entity_type):
                 url = self.base_url.set(path=('index', entity_type), args=self._params())
-                response = requests.get(str(url))
-                response.raise_for_status()
+                response = self._http_client.request('GET', str(url))
+                raise_on_status(response)
                 response_json = response.json()
                 for hit in response_json['hits']:
                     if entity_type == 'files':
@@ -1085,8 +1087,8 @@ class TestIndexResponse(IndexResponseTestCase):
             with self.subTest(test_data=test_data):
                 params = self._params(size=10, filters={'specimenDisease': {'is': test_data}})
                 url = self.base_url.set(path='/index/samples', args=params)
-                response = requests.get(str(url))
-                response.raise_for_status()
+                response = self._http_client.request('GET', str(url))
+                raise_on_status(response)
                 response_json = response.json()
                 diseases = {
                     disease
@@ -1115,8 +1117,8 @@ class TestIndexResponse(IndexResponseTestCase):
                 with self.subTest(entity_type=entity_type):
                     params = self._params(size=2, filters={'projectId': {'is': [test_data['id']]}})
                     url = self.base_url.set(path=('index', entity_type), args=params)
-                    response = requests.get(str(url))
-                    response.raise_for_status()
+                    response = self._http_client.request('GET', str(url))
+                    raise_on_status(response)
                     response_json = response.json()
                     for hit in response_json['hits']:
                         for project in hit['projects']:
@@ -1135,8 +1137,8 @@ class TestIndexResponse(IndexResponseTestCase):
                               filters={'contentDescription': {'is': ['RNA sequence']}},
                               sort='fileName',
                               order='asc')
-        response = requests.get(str(url), params=params)
-        response.raise_for_status()
+        response = self._http_client.request('GET', str(url), fields=params)
+        raise_on_status(response)
         response_json = response.json()
         expected = [
             'Cortex2.CCJ15ANXX.SM2_052318p4_D8.unmapped.1.fastq.gz',
@@ -1154,8 +1156,8 @@ class TestIndexResponse(IndexResponseTestCase):
         """
         url = self.base_url.set(path='/index/samples',
                                 args=(self._params(size=10)))
-        response = requests.get(str(url))
-        response.raise_for_status()
+        response = self._http_client.request('GET', str(url))
+        raise_on_status(response)
         response_json = response.json()
         facets = response_json['termFacets']
 
@@ -1181,8 +1183,8 @@ class TestIndexResponse(IndexResponseTestCase):
         for entity_type in 'projects', 'samples', 'files', 'bundles':
             with self.subTest(entity_type=entity_type):
                 url = self.base_url.set(path=('index', entity_type), args=self._params())
-                response = requests.get(str(url))
-                response.raise_for_status()
+                response = self._http_client.request('GET', str(url))
+                raise_on_status(response)
                 response_json = response.json()
                 if entity_type == 'samples':
                     for hit in response_json['hits']:
@@ -1203,8 +1205,8 @@ class TestIndexResponse(IndexResponseTestCase):
     def test_bundles_outer_entity(self):
         entity_type = 'bundles'
         url = self.base_url.set(path=('index', entity_type), args=self._params())
-        response = requests.get(str(url))
-        response.raise_for_status()
+        response = self._http_client.request('GET', str(url))
+        raise_on_status(response)
         response = response.json()
         indexed_bundles = set(self.bundles())
         self.assertEqual(len(self.bundles()), len(indexed_bundles))
@@ -1303,8 +1305,8 @@ class TestIndexResponse(IndexResponseTestCase):
                                           order='desc',
                                           sort='entryId')
                     url = self.base_url.set(path='/index/projects', args=params)
-                    response = requests.get(str(url))
-                    response.raise_for_status()
+                    response = self._http_client.request('GET', str(url))
+                    raise_on_status(response)
                     actual_hits = [hit['donorOrganisms'] for hit in response.json()['hits']]
                     self.assertElasticEqual(expected_hits, actual_hits)
 
@@ -1316,13 +1318,15 @@ class TestIndexResponse(IndexResponseTestCase):
 
         for sort_field, accessor in sort_fields:
             responses = {
-                order: requests.get(str(self.base_url.set(path='/index/projects',
-                                                          args=self._params(order=order, sort=sort_field))))
+                order: self._http_client.request('GET',
+                                                 str(self.base_url.set(path='/index/projects',
+                                                                       args=self._params(order=order,
+                                                                                         sort=sort_field))))
                 for order in ['asc', 'desc']
             }
             hit_sort_values = {}
             for order, response in responses.items():
-                response.raise_for_status()
+                raise_on_status(response)
                 hit_sort_values[order] = [accessor(hit) for hit in response.json()['hits']]
 
             self.assertEqual(hit_sort_values['asc'],
@@ -1360,8 +1364,8 @@ class TestIndexResponse(IndexResponseTestCase):
                                       sort='cellLineType',
                                       order='asc' if ascending else 'desc')
                 url = self.base_url.set(path='/index/projects', args=params)
-                response = requests.get(str(url))
-                response.raise_for_status()
+                response = self._http_client.request('GET', str(url))
+                raise_on_status(response)
                 response_json = response.json()
                 actual_values = list(extract_cell_line_types(response_json))
                 expected = ascending_values if ascending else list(reversed(ascending_values))
@@ -1378,8 +1382,8 @@ class TestIndexResponse(IndexResponseTestCase):
             with self.subTest(order=order, reverse=reverse):
                 params = self._params(size=15, sort='laboratory', order=order)
                 url = self.base_url.set(path='/index/projects', args=params)
-                response = requests.get(str(url))
-                response.raise_for_status()
+                response = self._http_client.request('GET', str(url))
+                raise_on_status(response)
                 response_json = response.json()
                 laboratories = []
                 for hit in response_json['hits']:
@@ -1696,8 +1700,8 @@ class TestIndexResponse(IndexResponseTestCase):
                                          sorted(expected, key=lambda x: (x[0] is None, x[0])))
                     params = self._params(size=50, sort=field, order=direction)
                     url = self.base_url.set(path=('index', entity_type), args=params)
-                    response = requests.get(str(url))
-                    response.raise_for_status()
+                    response = self._http_client.request('GET', str(url))
+                    raise_on_status(response)
                     response_json = response.json()
                     actual = [
                         (dates[field], hit['entryId'])
@@ -1870,8 +1874,8 @@ class TestIndexResponse(IndexResponseTestCase):
                     }
                     params = self._params(filters=filters, size=15, sort=field, order='asc')
                     url = self.base_url.set(path=('index', entity_type), args=params)
-                    response = requests.get(str(url))
-                    response.raise_for_status()
+                    response = self._http_client.request('GET', str(url))
+                    raise_on_status(response)
                     response_json = response.json()
                     actual = [
                         (dates[field], hit['entryId'])
@@ -1902,8 +1906,8 @@ class TestIndexResponse(IndexResponseTestCase):
 
         # Next assert the order of contributors in the service response
         url = self.base_url.set(path=('index', 'projects', project_id))
-        response = requests.get(str(url))
-        response.raise_for_status()
+        response = self._http_client.request('GET', str(url))
+        raise_on_status(response)
         response_json = response.json()
         project = one(response_json['projects'])
         actual = [r['email'] for r in project['contributors']]
@@ -1949,8 +1953,8 @@ class TestIndexResponse(IndexResponseTestCase):
         for project_id, term_facets in project_term_facets.items():
             with self.subTest(project_id=project_id):
                 params = self._params(filters={'projectId': {'is': [project_id]}})
-                response = requests.get(url, params=params)
-                response.raise_for_status()
+                response = self._http_client.request('GET', url, fields=params)
+                raise_on_status(response)
                 response_json = response.json()
                 actual_term_facets = response_json['termFacets']
                 for facet, terms in term_facets.items():
@@ -2032,11 +2036,11 @@ class TestIndexResponse(IndexResponseTestCase):
                 url = self.base_url.set(path='/index/projects',
                                         args=dict(catalog=self.catalog,
                                                   filters=json.dumps({'organismAge': filters})))
-                response = requests.get(str(url))
+                response = self._http_client.request('GET', str(url))
                 if project_id is None:
-                    self.assertTrue(response.status_code, 400)
+                    self.assertTrue(response.status, 400)
                 else:
-                    response.raise_for_status()
+                    raise_on_status(response)
                     response = response.json()
                     hit = one(response['hits'])
                     self.assertEqual(hit['entryId'], project_id)
@@ -2052,8 +2056,8 @@ class TestIndexResponse(IndexResponseTestCase):
         """
         params = self._params(size=3, sort='workflow', order='asc')
         url = self.base_url.set(path='/index/samples', args=params)
-        response = requests.get(str(url))
-        response.raise_for_status()
+        response = self._http_client.request('GET', str(url))
+        raise_on_status(response)
         response_json = response.json()
         first_page_next = parse_url_qs(response_json['pagination']['next'])
 
@@ -2075,8 +2079,8 @@ class TestIndexResponse(IndexResponseTestCase):
         self.assertEqual([None, '2d8282f0-6cbb-4d5a-822c-4b01718b4d0d'],
                          json.loads(first_page_next['search_after']))
 
-        response = requests.get(response_json['pagination']['next'])
-        response.raise_for_status()
+        response = self._http_client.request('GET', response_json['pagination']['next'])
+        raise_on_status(response)
         response_json = response.json()
         second_page_next = parse_url_qs(response_json['pagination']['next'])
         second_page_previous = parse_url_qs(response_json['pagination']['previous'])
@@ -2100,12 +2104,12 @@ class TestIndexResponse(IndexResponseTestCase):
         query_params = self._params(size=1, sort='sampleId', order='asc')
         url = self.base_url.set(path='/index/samples', args=query_params)
         # Get page 1
-        response = requests.get(str(url))
-        response.raise_for_status()
+        response = self._http_client.request('GET', str(url))
+        raise_on_status(response)
         response_json = response.json()
         # Get page 2
-        response = requests.get(response_json['pagination']['next'])
-        response.raise_for_status()
+        response = self._http_client.request('GET', response_json['pagination']['next'])
+        raise_on_status(response)
         response_json = response.json()
         test_cases = {
             'search_before': response_json['pagination']['previous'],
@@ -2114,17 +2118,17 @@ class TestIndexResponse(IndexResponseTestCase):
         for pagination_key, good_url in test_cases.items():
             with self.subTest(pagination_key=pagination_key):
                 # Verify URL works before modifying
-                response = requests.get(good_url)
-                response.raise_for_status()
+                response = self._http_client.request('GET', good_url)
+                raise_on_status(response)
                 # Modify search_… param in URL and verify expected error occurs
                 bad_url = furl(good_url)
                 self.assertIn('"', bad_url.args[pagination_key])
                 bad_url.args[pagination_key] = bad_url.args[pagination_key].replace('"', '')
-                response = requests.get(str(bad_url))
+                response = self._http_client.request('GET', str(bad_url))
                 error_msg = f'The {pagination_key!r} parameter is not valid JSON'
                 expected_text = f'{{"Code":"BadRequestError","Message":"{error_msg}"}}'
-                self.assertEqual(400, response.status_code)
-                self.assertEqual(expected_text, response.text)
+                self.assertEqual(400, response.status)
+                self.assertEqual(expected_text, response.data.decode())
 
     def test_filter_by_publication_title(self):
         cases = [
@@ -2173,8 +2177,8 @@ class TestIndexResponse(IndexResponseTestCase):
                 }
                 url = self.base_url.set(path='/index/files',
                                         args=dict(filters=json.dumps(filters)))
-                response = requests.get(str(url))
-                self.assertEqual(200, response.status_code)
+                response = self._http_client.request('GET', str(url))
+                self.assertEqual(200, response.status)
                 self.assertEqual(expected_terms,
                                  response.json()['termFacets']['publicationTitle'])
                 files = {
@@ -2196,8 +2200,8 @@ class TestIndexResponse(IndexResponseTestCase):
             with self.subTest(entity_type=entity_type,
                               expect_accessible=expect_accessible):
                 url = str(self.base_url.set(path=('index', entity_type)))
-                response = requests.get(url)
-                self.assertEqual(200, response.status_code)
+                response = self._http_client.request('GET', url)
+                self.assertEqual(200, response.status)
                 hits = response.json()['hits']
                 if expect_empty:
                     self.assertEqual([], hits)
@@ -2222,8 +2226,8 @@ class TestIndexResponse(IndexResponseTestCase):
                 }
             })
             url = self.base_url.set(path='/index/projects')
-            response = requests.get(str(url), params=params)
-            self.assertEqual(200, response.status_code)
+            response = self._http_client.request('GET', str(url), fields=params)
+            self.assertEqual(200, response.status)
             return response.json()
 
         cases = [
@@ -2272,8 +2276,8 @@ class TestIndexResponse(IndexResponseTestCase):
                                      azul_git_commit=commit,
                                      azul_git_dirty=str(int(dirty))):
                     url = self.base_url.set(path='/version')
-                    response = requests.get(str(url))
-                    response.raise_for_status()
+                    response = self._http_client.request('GET', str(url))
+                    raise_on_status(response)
                     expected_json = {
                         'commit': commit,
                         'dirty': dirty
@@ -2307,8 +2311,8 @@ class TestFileTypeSummaries(IndexResponseTestCase):
             'catalog': self.catalog,
             'filters': json.dumps(filters)
         }
-        response = requests.get(str(url), params=params)
-        response.raise_for_status()
+        response = self._http_client.request('GET', str(url), fields=params)
+        raise_on_status(response)
         response_json = response.json()
         file_type_summaries = one(response_json['hits'])['fileTypeSummaries']
         expected = [
@@ -2481,8 +2485,8 @@ class TestResponseInnerEntitySamples(IndexResponseTestCase):
                     'order': 'asc',
                 }
                 url = self.base_url.set(path='/index/projects', args=params)
-                response = requests.get(str(url))
-                response.raise_for_status()
+                response = self._http_client.request('GET', str(url))
+                raise_on_status(response)
                 response_json = response.json()
                 hits = response_json['hits']
                 self.assertEqual(expected_hits, [hit['samples'] for hit in hits])
@@ -2536,8 +2540,8 @@ class TestSchemaTestDataCannedBundle(IndexResponseTestCase):
         for entity_type in expected_cell_counts.keys():
             with self.subTest(entity_type=entity_type):
                 url = self.base_url.set(path=('index', entity_type), args=params)
-                response = requests.get(url)
-                response.raise_for_status()
+                response = self._http_client.request('GET', str(url))
+                raise_on_status(response)
                 response_json = response.json()
                 actual_cell_counts = []
                 for hit in response_json['hits']:
@@ -2549,8 +2553,8 @@ class TestSchemaTestDataCannedBundle(IndexResponseTestCase):
     def test_summary_cell_counts(self):
         url = self.base_url.set(path='/index/summary',
                                 args=dict(catalog=self.catalog))
-        response = requests.get(str(url))
-        response.raise_for_status()
+        response = self._http_client.request('GET', str(url))
+        raise_on_status(response)
         summary = response.json()
         self.assertEqual(1, summary['projectCount'])
         self.assertEqual(10, summary['fileCount'])
@@ -2578,8 +2582,8 @@ class TestSchemaTestDataCannedBundle(IndexResponseTestCase):
         """
         params = {'catalog': self.catalog}
         url = self.base_url.set(path='/index/projects', args=params)
-        response = requests.get(url)
-        response.raise_for_status()
+        response = self._http_client.request('GET', str(url))
+        raise_on_status(response)
         response_json = response.json()
         hit = one(response_json['hits'])
         expected_protocols = [
@@ -2682,8 +2686,8 @@ class TestNestedFieldAggregation(IndexResponseTestCase):
             with self.subTest(entity_type=entity_type):
                 url = self.base_url.set(path='/index/' + entity_type,
                                         args=(self._params(size=1)))
-                response = requests.get(str(url))
-                response.raise_for_status()
+                response = self._http_client.request('GET', (str(url)))
+                raise_on_status(response)
                 response_json = response.json()
                 facets = response_json['termFacets']
                 expected = []
@@ -2772,8 +2776,8 @@ class TestSortAndFilterByCellCount(IndexResponseTestCase):
                         'order': 'asc' if ascending else 'desc'
                     }
                     url = self.base_url.set(path='/index/projects', args=params)
-                    response = requests.get(str(url))
-                    response.raise_for_status()
+                    response = self._http_client.request('GET', str(url))
+                    raise_on_status(response)
                     response = response.json()
                     actual = list(map(CellCounts.from_response, response['hits']))
                     if not ascending:
@@ -2839,8 +2843,8 @@ class TestSortAndFilterByCellCount(IndexResponseTestCase):
                         'filters': json.dumps(filters)
                     }
                     url = self.base_url.set(path='/index/projects', args=params)
-                    response = requests.get(str(url))
-                    response.raise_for_status()
+                    response = self._http_client.request('GET', str(url))
+                    raise_on_status(response)
                     response = response.json()
                     actual = list(map(CellCounts.from_response, response['hits']))
                     self.assertEqual(actual, expected)
@@ -2910,8 +2914,8 @@ class TestProjectMatrices(IndexResponseTestCase):
         """
         params = self.params(project_id='8185730f-4113-40d3-9cc3-929271784c2b')
         url = self.base_url.set(path='/index/files', args=params)
-        response = requests.get(str(url))
-        response.raise_for_status()
+        response = self._http_client.request('GET', str(url))
+        raise_on_status(response)
         response_json = response.json()
         facets = response_json['termFacets']
         expected_counts = {
@@ -2937,8 +2941,8 @@ class TestProjectMatrices(IndexResponseTestCase):
         """
         params = self.params(project_id='8185730f-4113-40d3-9cc3-929271784c2b')
         url = self.base_url.set(path='/index/files', args=params)
-        response = requests.get(str(url))
-        response.raise_for_status()
+        response = self._http_client.request('GET', str(url))
+        raise_on_status(response)
         response_json = response.json()
         facets = response_json['termFacets']
         expected = [
@@ -3002,8 +3006,8 @@ class TestProjectMatrices(IndexResponseTestCase):
                                      facet=facet,
                                      value=value)
                 url = self.base_url.set(path='/index/files', args=params)
-                response = requests.get(str(url))
-                response.raise_for_status()
+                response = self._http_client.request('GET', str(url))
+                raise_on_status(response)
                 response_json = response.json()
                 actual_files = [one(hit['files'])['name'] for hit in response_json['hits']]
                 self.assertEqual(sorted(expected_files), sorted(actual_files))
@@ -3017,8 +3021,8 @@ class TestProjectMatrices(IndexResponseTestCase):
         url = self.base_url.set(path='/index/projects', args=params)
         drs_uri = furl(scheme='drs',
                        netloc=config.drs_domain or config.api_lambda_domain('service'))
-        response = requests.get(str(url))
-        response.raise_for_status()
+        response = self._http_client.request('GET', str(url))
+        raise_on_status(response)
         response_json = response.json()
         hit = one(response_json['hits'])
         self.assertEqual('8185730f-4113-40d3-9cc3-929271784c2b', hit['entryId'])
@@ -3387,8 +3391,8 @@ class TestProjectMatrices(IndexResponseTestCase):
         for endpoint in ('projects', 'samples'):
             with self.subTest(endpoint=endpoint):
                 url = self.base_url.set(path=('index', endpoint), args=params)
-                response = requests.get(str(url))
-                response.raise_for_status()
+                response = self._http_client.request('GET', str(url))
+                raise_on_status(response)
                 response_json = response.json()
                 for hit in response_json['hits']:
                     actual_counts = {
@@ -3403,8 +3407,8 @@ class TestProjectMatrices(IndexResponseTestCase):
         }
         actual_counts = Counter()
         url = self.base_url.set(path='/index/files', args=params)
-        response = requests.get(str(url))
-        response.raise_for_status()
+        response = self._http_client.request('GET', str(url))
+        raise_on_status(response)
         response_json = response.json()
         for hit in response_json['hits']:
             file = one(hit['files'])
@@ -3452,8 +3456,8 @@ class TestResponseFields(IndexResponseTestCase):
     def test_summary_response(self):
         url = self.base_url.set(path='/index/summary',
                                 args=dict(catalog=self.catalog))
-        response = requests.get(str(url))
-        response.raise_for_status()
+        response = self._http_client.request('GET', str(url))
+        raise_on_status(response)
         summary = response.json()
         self.assertEqual(1 + 1 + 1 + 1, summary['projectCount'])
         self.assertEqual(1 + 1 + 3 + 1, summary['specimenCount'])
@@ -3545,8 +3549,8 @@ class TestResponseFields(IndexResponseTestCase):
                 url = self.base_url.set(path='/index/summary',
                                         args=dict(catalog=self.catalog,
                                                   filters=json.dumps(filters)))
-                response = requests.get(str(url))
-                response.raise_for_status()
+                response = self._http_client.request('GET', str(url))
+                raise_on_status(response)
                 summary = response.json()
                 self.assertElasticEqual(expected_projects, summary['projects'])
 
@@ -3557,8 +3561,8 @@ class TestResponseFields(IndexResponseTestCase):
                 if use_filter:
                     params['filters'] = json.dumps({"organPart": {"is": [None]}})
                 url = self.base_url.set(path='/index/summary', args=params)
-                response = requests.get(str(url))
-                response.raise_for_status()
+                response = self._http_client.request('GET', str(url))
+                raise_on_status(response)
                 summary_object = response.json()
                 self.assertEqual(summary_object['labCount'], labCount)
 
@@ -3576,8 +3580,8 @@ class TestResponseFields(IndexResponseTestCase):
             })
         }
         url = self.base_url.set(path='/index/projects', args=params)
-        response = requests.get(str(url))
-        response.raise_for_status()
+        response = self._http_client.request('GET', str(url))
+        raise_on_status(response)
         response_json = response.json()
         project = one(one(response_json['hits'])['projects'])
         expected_contributors = [
@@ -3658,8 +3662,8 @@ class TestResponseFields(IndexResponseTestCase):
                 plugin = self.index_service.metadata_plugin(self.catalog)
                 for entity_type in plugin.exposed_indices:
                     url = self.base_url.set(path=('index', entity_type), args=params)
-                    response = requests.get(url)
-                    response.raise_for_status()
+                    response = self._http_client.request('GET', str(url))
+                    raise_on_status(response)
                     response = response.json()
                     if field != 'duosId':
                         facets = response['termFacets']
@@ -3721,8 +3725,8 @@ class TestUnpopulatedIndexResponse(IndexResponseTestCase):
             with self.subTest(entity_type=entity_type):
                 url = self.base_url.set(path=('index', entity_type),
                                         args=dict(order='asc'))
-                response = requests.get(str(url))
-                response.raise_for_status()
+                response = self._http_client.request('GET', str(url))
+                raise_on_status(response)
                 sort_field = self._metadata_plugin.exposed_indices[entity_type].field_name
                 expected_response = {
                     'hits': [],
@@ -3756,8 +3760,8 @@ class TestUnpopulatedIndexResponse(IndexResponseTestCase):
             with self.subTest(entity=entity_type, field=field):
                 url = self.base_url.set(path=('index', entity_type),
                                         args=dict(sort=field))
-                response = requests.get(str(url))
-                self.assertEqual(200, response.status_code)
+                response = self._http_client.request('GET', str(url))
+                self.assertEqual(200, response.status)
 
 
 class TestListCatalogsResponse(DCP1CannedBundleTestCase, LocalAppTestCase):
@@ -3768,8 +3772,9 @@ class TestListCatalogsResponse(DCP1CannedBundleTestCase, LocalAppTestCase):
         return 'service'
 
     def test(self):
-        response = requests.get(str(self.base_url.set(path='/index/catalogs')))
-        self.assertEqual(200, response.status_code)
+        response = self._http_client.request('GET',
+                                             str(self.base_url.set(path='/index/catalogs')))
+        self.assertEqual(200, response.status)
         self.assertEqual({
             'default_catalog': 'test',
             'catalogs': {
@@ -3836,8 +3841,8 @@ class TestResponseWithDCP2Cans(DCP2CannedBundleTestCase, WebServiceTestCase):
 
     def test_tdr_sources(self):
         url = self.base_url.set(path='/index/projects')
-        response = requests.get(str(url))
-        response.raise_for_status()
+        response = self._http_client.request('GET', str(url))
+        raise_on_status(response)
         response_json = response.json()
         plugin = self.index_service.metadata_plugin(self.catalog)
         special_fields = plugin.special_fields
@@ -3853,8 +3858,8 @@ class TestResponseWithDCP2Cans(DCP2CannedBundleTestCase, WebServiceTestCase):
 
     def get_file(self, entry_id: str) -> JSON:
         url = self.base_url.set(path=('index', 'files', entry_id))
-        response = requests.get(str(url))
-        response.raise_for_status()
+        response = self._http_client.request('GET', str(url))
+        raise_on_status(response)
         return one(response.json()['files'])
 
     def test_file_urls(self):
@@ -3879,8 +3884,8 @@ class TestResponseWithDCP2Cans(DCP2CannedBundleTestCase, WebServiceTestCase):
         self.maxDiff = None
         project_id = '9b876d31-0739-4e96-9846-f76e6a427279'
         url = self.base_url.set(path=('index', 'projects', project_id))
-        response = requests.get(str(url))
-        response.raise_for_status()
+        response = self._http_client.request('GET', str(url))
+        raise_on_status(response)
         response_json = response.json()
         project = one(response_json['projects'])
         file_url = str(self.base_url.set(

--- a/test/service/test_response.py
+++ b/test/service/test_response.py
@@ -68,6 +68,7 @@ from azul.lib.types import (
 )
 from azul.logging import (
     configure_test_logging,
+    get_test_logger,
 )
 from azul.plugins import (
     FieldPath,
@@ -110,6 +111,9 @@ from service import (
 # noinspection PyPep8Naming
 def setUpModule():
     configure_test_logging()
+
+
+log = get_test_logger(__name__)
 
 
 def parse_url_qs(url) -> dict[str, str]:

--- a/test/service/test_response_anvil.py
+++ b/test/service/test_response_anvil.py
@@ -1,13 +1,15 @@
-import requests
-
 from azul.deployment import (
     aws,
+)
+from azul.http import (
+    raise_on_status,
 )
 from azul.lib.types import (
     JSON,
 )
 from azul.logging import (
     configure_test_logging,
+    get_test_logger,
 )
 from azul.plugins.repository.tdr_anvil import (
     TDRAnvilBundleFQID,
@@ -23,6 +25,9 @@ from service import (
 # noinspection PyPep8Naming
 def setUpModule():
     configure_test_logging()
+
+
+log = get_test_logger(__name__)
 
 
 class TestAnvilResponse(AnvilIndexerTestCase, WebServiceTestCase):
@@ -1568,7 +1573,7 @@ class TestAnvilResponse(AnvilIndexerTestCase, WebServiceTestCase):
         self._assertResponse(url, expected_response)
 
     def _assertResponse(self, url: str, expected_response: JSON):
-        response = requests.get(url)
-        response.raise_for_status()
+        response = self._http_client.request('GET', url)
+        raise_on_status(response)
         response = response.json()
         self.assertEqual(expected_response, response)

--- a/test/test_app_logging.py
+++ b/test/test_app_logging.py
@@ -82,6 +82,8 @@ class TestAppLogging(AzulUnitTestCase):
                     self.assertEqual(5, len(azul_log.output))
                     info = {
                         'host': f'{host}:{port}',
+                        # FIXME: Use compressed encoding
+                        #        https://github.com/DataBiosphere/azul/issues/7990
                         'accept-encoding': 'identity',
                         'user-agent': 'python-urllib3/2.7.0',
                     }

--- a/test/test_app_logging.py
+++ b/test/test_app_logging.py
@@ -18,7 +18,6 @@ from chalice.config import (
 from more_itertools import (
     one,
 )
-import requests
 
 from app_test_case import (
     ChaliceServerThread,
@@ -30,6 +29,7 @@ from azul.chalice import (
 from azul.logging import (
     azul_log_level,
     configure_test_logging,
+    get_test_logger,
 )
 from azul_test_case import (
     AzulUnitTestCase,
@@ -39,6 +39,9 @@ from azul_test_case import (
 # noinspection PyPep8Naming
 def setUpModule():
     configure_test_logging()
+
+
+log = get_test_logger(__name__)
 
 
 class TestAppLogging(AzulUnitTestCase):
@@ -66,23 +69,21 @@ class TestAppLogging(AzulUnitTestCase):
                         host, port = server_thread.address
                         with self.assertLogs(app.log, level=log_level) as app_log:
                             with self.assertLogs(azul.log, level=log_level) as azul_log:
-                                response = requests.get(f'http://{host}:{port}{path}')
+                                response = self._http_client.request('GET', f'http://{host}:{port}{path}')
                     finally:
                         server_thread.kill_thread()
                         server_thread.join(timeout=10)
                         if server_thread.is_alive():
                             self.fail('Thread is still alive after joining')
 
-                    self.assertEqual(500, response.status_code)
+                    self.assertEqual(500, response.status)
 
                     # The request is always logged
                     self.assertEqual(5, len(azul_log.output))
                     info = {
                         'host': f'{host}:{port}',
-                        'user-agent': 'python-requests/2.33.1',
-                        'accept-encoding': 'gzip, deflate, zstd',
-                        'accept': '*/*',
-                        'connection': 'keep-alive'
+                        'accept-encoding': 'identity',
+                        'user-agent': 'python-urllib3/2.7.0',
                     }
                     self.assertEqual(f'INFO:azul.chalice:Received GET request for {path!r}, '
                                      f"with {json.dumps({'query': None, 'headers': info})}.",
@@ -99,7 +100,7 @@ class TestAppLogging(AzulUnitTestCase):
                     self.assertIn(magic_message, app_log.output[0])
                     self.assertIn(traceback_header, app_log.output[0])
 
-                    body = response.content.decode()
+                    body = response.data.decode()
                     if debug < 2:
                         # We don't allow stacktraces in error responses …
                         self.assertNotIn(traceback_header, body)

--- a/test/urllib3_mock.py
+++ b/test/urllib3_mock.py
@@ -1,0 +1,124 @@
+from collections import (
+    defaultdict,
+    deque,
+)
+import json
+from unittest.mock import (
+    PropertyMock,
+    patch,
+)
+
+from urllib3 import (
+    BaseHTTPResponse,
+    HTTPResponse,
+)
+
+from azul.http import (
+    HttpClient,
+)
+from azul.lib import (
+    mutable_furl,
+)
+from azul.lib.types import (
+    JSON,
+)
+
+type _QueuedResponses = dict[tuple[str, str], deque[BaseHTTPResponse]]
+
+
+class Urllib3Mock:
+    """
+    Context manager that patches the ``_http_client`` property of one or more
+    target classes with a mock client that returns previously queued mock
+    responses. Each distinct combination of HTTP method and URL has a separate
+    queue. When the patched target's mock client makes a request matching one of
+    those combinations, the mock responses are returned in the order they were
+    queued in.
+    """
+
+    def __init__(self, *targets: type) -> None:
+        """
+        Create the context manager instance that patches the given targets on
+        entry, and restores them on exit.
+        """
+        self._responses: _QueuedResponses = defaultdict(deque)
+        self._client = _MockHttpClient(self._responses)
+        self._patches = deque(
+            patch.object(target,
+                         '_http_client',
+                         new=PropertyMock(return_value=self._client))
+            for target in targets
+        )
+
+    def add(self,
+            *,
+            method: str,
+            url: str,
+            status: int,
+            headers: dict[str, str] | None = None,
+            body: bytes | str | JSON = b'',
+            reason: str | None = None,
+            ) -> None:
+        """
+        Queue a mock response for the given combination of HTTP method and URL.
+        If multiple responses are queued for the same combination, they are
+        returned in the order they were queued in.
+
+        :param method: the request method, e.g. 'GET'
+
+        :param url: the request URL
+
+        :param status: the status of the returned response
+
+        :param headers: the headers of the returned response
+
+        :param body: the body of the returned response
+
+        :param reason: optional text to follow the numeric response status
+        """
+        if headers is None:
+            headers = {}
+        if isinstance(body, dict):
+            body = json.dumps(body)
+            headers['Content-Type'] = 'application/json'
+        if isinstance(body, str):
+            body = body.encode()
+        assert isinstance(body, bytes), type(body)
+        response = HTTPResponse(body=body,
+                                headers=headers,
+                                status=status,
+                                reason=reason,
+                                request_method=method,
+                                request_url=url,
+                                preload_content=True)
+        key = (method, _normalize_url(url))
+        self._responses[key].append(response)
+
+    def __enter__(self):
+        for p in self._patches:
+            p.start()
+        return self
+
+    def __exit__(self, *_args):
+        for p in reversed(self._patches):
+            p.stop()
+        self._responses.clear()
+
+
+class _MockHttpClient(HttpClient):
+
+    def __init__(self, responses: _QueuedResponses) -> None:
+        super().__init__()
+        self._responses = responses
+
+    def urlopen(self, method: str, url: str, *args, **kwargs) -> BaseHTTPResponse:
+        key = (method, _normalize_url(url))
+        responses = self._responses[key]
+        assert responses, f'No responses queued for {key!r}'
+        return responses.popleft()
+
+
+def _normalize_url(url: str) -> str:
+    url = mutable_furl(url)
+    url.set(args=dict(sorted(url.args.items())))
+    return str(url)


### PR DESCRIPTION

Linked issues: #7633


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator and the author


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `sandbox`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilbox`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] PR is assigned to only the operator
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
