### PR TITLE
Fix: Excessive number of false positives for AccessDenied alarm (DataBiosphere/azul-private#299)

### DIFF
--- a/src/azul/bigquery.py
+++ b/src/azul/bigquery.py
@@ -42,7 +42,7 @@ def backtick(table_name: str) -> str:
     >>> backtick('foo-2.bar`s.my_table')
     Traceback (most recent call last):
     ...
-    azul.RequirementError: ('`', 'must not occur in', 'foo-2.bar`s.my_table')
+    AssertionError: R('`', 'must not occur in', 'foo-2.bar`s.my_table')
     """
     if table_name_re.fullmatch(table_name):
         return table_name

--- a/src/azul/strings.py
+++ b/src/azul/strings.py
@@ -9,7 +9,7 @@ from more_itertools import (
 )
 
 from azul import (
-    reject,
+    R,
 )
 
 
@@ -282,9 +282,9 @@ def delimit(s: str, delimiter: str) -> str:
     >>> delimit("foo's", "'")
     Traceback (most recent call last):
     ...
-    azul.RequirementError: ("'", 'must not occur in', "foo's")
+    AssertionError: R("'", 'must not occur in', "foo's")
     """
-    reject(delimiter in s, delimiter, 'must not occur in', s)
+    assert delimiter not in s, R(delimiter, 'must not occur in', s)
     return delimiter + s + delimiter
 
 
@@ -302,7 +302,7 @@ def back_quote(*words: str) -> str:
     >>> back_quote('foo`s')
     Traceback (most recent call last):
     ...
-    azul.RequirementError: ('`', 'must not occur in', 'foo`s')
+    AssertionError: R('`', 'must not occur in', 'foo`s')
     """
     return delimit(join_words(*words), '`')
 
@@ -321,7 +321,7 @@ def single_quote(*words: str) -> str:
     >>> single_quote("foo", "bar's")
     Traceback (most recent call last):
     ...
-    azul.RequirementError: ("'", 'must not occur in', "foo bar's")
+    AssertionError: R("'", 'must not occur in', "foo bar's")
     """
     return delimit(join_words(*words), "'")
 
@@ -340,6 +340,6 @@ def double_quote(*words: str) -> str:
     >>> double_quote('foo', 'b"a"r')
     Traceback (most recent call last):
     ...
-    azul.RequirementError: ('"', 'must not occur in', 'foo b"a"r')
+    AssertionError: R('"', 'must not occur in', 'foo b"a"r')
     """
     return delimit(join_words(*words), '"')

--- a/src/azul/strings.py
+++ b/src/azul/strings.py
@@ -288,6 +288,67 @@ def delimit(s: str, delimiter: str) -> str:
     return delimiter + s + delimiter
 
 
+def parenthesize(s: str, parens: str = "()"):
+    """
+    >>> parenthesize('foo')
+    '(foo)'
+
+    >>> parenthesize('(foo)')
+    '((foo))'
+
+    >>> parenthesize('foo)')
+    Traceback (most recent call last):
+    ...
+    AssertionError: R('Extra closing construct in input')
+
+    >>> parenthesize('(foo')
+    Traceback (most recent call last):
+    ...
+    AssertionError: R('Missing closing construct in input')
+
+    >>> parenthesize('foo)', '{}')
+    '{foo)}'
+
+    >>> parenthesize('foo', '{)')
+    '{foo)'
+
+    >>> parenthesize(123, '()')
+    Traceback (most recent call last):
+    ...
+    AssertionError: R('First argument must be string')
+
+    >>> parenthesize('foo', 123)
+    Traceback (most recent call last):
+    ...
+    AssertionError: R('Second argument must be string')
+
+    >>> parenthesize('foo', '(')
+    Traceback (most recent call last):
+    ...
+    AssertionError: R('Second argument must be two characters', '(')
+
+    >>> parenthesize('foo', '||')
+    Traceback (most recent call last):
+    ...
+    AssertionError: R('Second argument must be two different characters', '||')
+    """
+    assert isinstance(s, str), R('First argument must be string')
+    assert isinstance(parens, str), R('Second argument must be string')
+    assert len(parens) == 2, R('Second argument must be two characters', parens)
+    open, close = iter(parens)
+    assert open != close, R("Second argument must be two different characters", parens)
+
+    i = 0
+    for c in s:
+        if c == open:
+            i += 1
+        elif c == close:
+            i -= 1
+        assert i >= 0, R('Extra closing construct in input')
+    assert i == 0, R('Missing closing construct in input')
+    return open + s + close
+
+
 def back_quote(*words: str) -> str:
     """
     Join the arguments with a space character and enclose the result in back

--- a/terraform/shared/shared.tf.json.template.py
+++ b/terraform/shared/shared.tf.json.template.py
@@ -44,7 +44,7 @@ trail_alarms = [
     # https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html#cloudwatch-2
     CloudTrailAlarm(name='api_unauthorized',
                     statistic='Sum',
-                    filter_pattern='{($.errorCode="*UnauthorizedOperation") || ($.errorCode="AccessDenied*")}'),
+                    filter_pattern='{($.errorCode = "*UnauthorizedOperation") || ($.errorCode = "AccessDenied*")}'),
     # [CloudWatch.3] Ensure a log metric filter and alarm exist for Management Console sign-in without MFA
     # https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html#cloudwatch-3
     CloudTrailAlarm(name='console_no_mfa',

--- a/terraform/shared/shared.tf.json.template.py
+++ b/terraform/shared/shared.tf.json.template.py
@@ -12,7 +12,6 @@ from azul.deployment import (
     aws,
 )
 from azul.strings import (
-    delimit,
     parenthesize as _parens,
 )
 from azul.terraform import (
@@ -28,8 +27,8 @@ def _curly(s: str) -> str:
     return _parens(s, '{}')
 
 
-def _padded_curly(s: str) -> str:
-    return _curly(delimit(s, ' '))
+def _curly_padded(s: str) -> str:
+    return _curly((f' {s} '))
 
 
 def _or(*terms: str) -> str:
@@ -38,6 +37,10 @@ def _or(*terms: str) -> str:
 
 def _and(*terms: str) -> str:
     return ' && '.join(map(_parens, terms))
+
+
+def _and_no_parens(*terms: str) -> str:
+    return ' && '.join(terms)
 
 
 class CloudTrailAlarm(NamedTuple):
@@ -74,7 +77,7 @@ trail_alarms = [
     # https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html#cloudwatch-3
     CloudTrailAlarm(name='console_no_mfa',
                     statistic='Sum',
-                    filter_pattern=_padded_curly(
+                    filter_pattern=_curly_padded(
                         _and(
                             '$.eventName = "ConsoleLogin"',
                             '$.additionalEventData.MFAUsed != "Yes"',
@@ -87,7 +90,7 @@ trail_alarms = [
     CloudTrailAlarm(name='root_usage',
                     statistic='Sum',
                     filter_pattern=_curly(
-                        _and(
+                        _and_no_parens(
                             '$.userIdentity.type="Root"',
                             '$.userIdentity.invokedBy NOT EXISTS',
                             '$.eventType !="AwsServiceEvent"'

--- a/terraform/shared/shared.tf.json.template.py
+++ b/terraform/shared/shared.tf.json.template.py
@@ -65,12 +65,25 @@ def conformance_pack(name: str) -> str:
 trail_alarms = [
     # [CloudWatch.2] Ensure a log metric filter and alarm exist for unauthorized API calls
     # https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html#cloudwatch-2
+    #
+    # Note that this event the filter pattern intentionally deviates from what
+    # the control mandates.
+    #
     CloudTrailAlarm(name='api_unauthorized',
                     statistic='Sum',
                     filter_pattern=_curly(
-                        _or(
-                            '$.errorCode = "*UnauthorizedOperation"',
-                            '$.errorCode = "AccessDenied*"'
+                        _and(
+                            _or(
+                                '$.errorCode = "*UnauthorizedOperation"',
+                                '$.errorCode = "AccessDenied*"'
+                            ),
+                            _or(
+                                '$.userIdentity.invokedBy NOT EXISTS',
+                                _and(
+                                    '$.userIdentity.invokedBy != "config.amazonaws.com"',
+                                    '$.userIdentity.invokedBy != "resource-explorer-2.amazonaws.com"'
+                                )
+                            )
                         )
                     )),
     # [CloudWatch.3] Ensure a log metric filter and alarm exist for Management Console sign-in without MFA

--- a/terraform/shared/shared.tf.json.template.py
+++ b/terraform/shared/shared.tf.json.template.py
@@ -11,6 +11,10 @@ from azul import (
 from azul.deployment import (
     aws,
 )
+from azul.strings import (
+    delimit,
+    parenthesize as _parens,
+)
 from azul.terraform import (
     block_public_s3_bucket_access,
     emit_tf,
@@ -18,6 +22,22 @@ from azul.terraform import (
     set_empty_s3_bucket_lifecycle_config,
     vpc,
 )
+
+
+def _curly(s: str) -> str:
+    return _parens(s, '{}')
+
+
+def _padded_curly(s: str) -> str:
+    return _curly(delimit(s, ' '))
+
+
+def _or(*terms: str) -> str:
+    return ' || '.join(map(_parens, terms))
+
+
+def _and(*terms: str) -> str:
+    return ' && '.join(map(_parens, terms))
 
 
 class CloudTrailAlarm(NamedTuple):
@@ -44,74 +64,140 @@ trail_alarms = [
     # https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html#cloudwatch-2
     CloudTrailAlarm(name='api_unauthorized',
                     statistic='Sum',
-                    filter_pattern='{($.errorCode = "*UnauthorizedOperation") || ($.errorCode = "AccessDenied*")}'),
+                    filter_pattern=_curly(
+                        _or(
+                            '$.errorCode = "*UnauthorizedOperation"',
+                            '$.errorCode = "AccessDenied*"'
+                        )
+                    )),
     # [CloudWatch.3] Ensure a log metric filter and alarm exist for Management Console sign-in without MFA
     # https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html#cloudwatch-3
     CloudTrailAlarm(name='console_no_mfa',
                     statistic='Sum',
-                    filter_pattern='{ ($.eventName = "ConsoleLogin") && ($.additionalEventData.MFAUsed != "Yes") && '
-                                   '($.userIdentity.type = "IAMUser") && '
-                                   '($.responseElements.ConsoleLogin = "Success") }'),
+                    filter_pattern=_padded_curly(
+                        _and(
+                            '$.eventName = "ConsoleLogin"',
+                            '$.additionalEventData.MFAUsed != "Yes"',
+                            '$.userIdentity.type = "IAMUser"',
+                            '$.responseElements.ConsoleLogin = "Success"'
+                        )
+                    )),
     # [CloudWatch.1] A log metric filter and alarm should exist for usage of the "root" user
     # https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html#cloudwatch-1
     CloudTrailAlarm(name='root_usage',
                     statistic='Sum',
-                    filter_pattern='{$.userIdentity.type="Root" && $.userIdentity.invokedBy NOT EXISTS && $.eventType '
-                                   '!="AwsServiceEvent"}'),
+                    filter_pattern=_curly(
+                        _and(
+                            '$.userIdentity.type="Root"',
+                            '$.userIdentity.invokedBy NOT EXISTS',
+                            '$.eventType !="AwsServiceEvent"'
+                        )
+                    )),
     # [CloudWatch.4] Ensure a log metric filter and alarm exist for IAM policy changes
     # https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html#cloudwatch-4
     CloudTrailAlarm(name='iam_policy_change',
                     statistic='Sum',
-                    filter_pattern='{($.eventName=DeleteGroupPolicy) || ($.eventName=DeleteRolePolicy) || '
-                                   '($.eventName=DeleteUserPolicy) || ($.eventName=PutGroupPolicy) || '
-                                   '($.eventName=PutRolePolicy) || ($.eventName=PutUserPolicy) || '
-                                   '($.eventName=CreatePolicy) || ($.eventName=DeletePolicy) || '
-                                   '($.eventName=CreatePolicyVersion) || ($.eventName=DeletePolicyVersion) || '
-                                   '($.eventName=AttachRolePolicy) || ($.eventName=DetachRolePolicy) || '
-                                   '($.eventName=AttachUserPolicy) || ($.eventName=DetachUserPolicy) || '
-                                   '($.eventName=AttachGroupPolicy) || ($.eventName=DetachGroupPolicy)}'),
+                    filter_pattern=_curly(
+                        _or(
+                            '$.eventName=DeleteGroupPolicy',
+                            '$.eventName=DeleteRolePolicy',
+                            '$.eventName=DeleteUserPolicy',
+                            '$.eventName=PutGroupPolicy',
+                            '$.eventName=PutRolePolicy',
+                            '$.eventName=PutUserPolicy',
+                            '$.eventName=CreatePolicy',
+                            '$.eventName=DeletePolicy',
+                            '$.eventName=CreatePolicyVersion',
+                            '$.eventName=DeletePolicyVersion',
+                            '$.eventName=AttachRolePolicy',
+                            '$.eventName=DetachRolePolicy',
+                            '$.eventName=AttachUserPolicy',
+                            '$.eventName=DetachUserPolicy',
+                            '$.eventName=AttachGroupPolicy',
+                            '$.eventName=DetachGroupPolicy'
+                        )
+                    )),
     # [CloudWatch.5] Ensure a log metric filter and alarm exist for CloudTrail AWS Configuration changes
     # https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html#cloudwatch-5
     CloudTrailAlarm(name='cloudtrail_config_change',
                     statistic='Sum',
-                    filter_pattern='{($.eventName=CreateTrail) || ($.eventName=UpdateTrail) || '
-                                   '($.eventName=DeleteTrail) || ($.eventName=StartLogging) || '
-                                   '($.eventName=StopLogging)}'),
+                    filter_pattern=_curly(
+                        _or(
+                            '$.eventName=CreateTrail',
+                            '$.eventName=UpdateTrail',
+                            '$.eventName=DeleteTrail',
+                            '$.eventName=StartLogging',
+                            '$.eventName=StopLogging'
+                        )
+                    )),
     # [CloudWatch.8] Ensure a log metric filter and alarm exist for S3 bucket policy changes
     # https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html#cloudwatch-8
     CloudTrailAlarm(name='s3_policy_change',
                     statistic='Sum',
-                    filter_pattern='{($.eventSource=s3.amazonaws.com) && (($.eventName=PutBucketAcl) || '
-                                   '($.eventName=PutBucketPolicy) || ($.eventName=PutBucketCors) || '
-                                   '($.eventName=PutBucketLifecycle) || ($.eventName=PutBucketReplication) || '
-                                   '($.eventName=DeleteBucketPolicy) || ($.eventName=DeleteBucketCors) || '
-                                   '($.eventName=DeleteBucketLifecycle) || ($.eventName=DeleteBucketReplication))}'),
+                    filter_pattern=_curly(
+                        _and(
+                            '$.eventSource=s3.amazonaws.com',
+                            _or(
+                                '$.eventName=PutBucketAcl',
+                                '$.eventName=PutBucketPolicy',
+                                '$.eventName=PutBucketCors',
+                                '$.eventName=PutBucketLifecycle',
+                                '$.eventName=PutBucketReplication',
+                                '$.eventName=DeleteBucketPolicy',
+                                '$.eventName=DeleteBucketCors',
+                                '$.eventName=DeleteBucketLifecycle',
+                                '$.eventName=DeleteBucketReplication'
+                            )
+                        )
+                    )),
     # [CloudWatch.12] Ensure a log metric filter and alarm exist for changes to network gateways
     # https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html#cloudwatch-12
     CloudTrailAlarm(name='network_gateway_change',
                     statistic='Sum',
-                    filter_pattern='{($.eventName=CreateCustomerGateway) || ($.eventName=DeleteCustomerGateway) || '
-                                   '($.eventName=AttachInternetGateway) || ($.eventName=CreateInternetGateway) || '
-                                   '($.eventName=DeleteInternetGateway) || ($.eventName=DetachInternetGateway)}'),
+                    filter_pattern=_curly(
+                        _or(
+                            '$.eventName=CreateCustomerGateway',
+                            '$.eventName=DeleteCustomerGateway',
+                            '$.eventName=AttachInternetGateway',
+                            '$.eventName=CreateInternetGateway',
+                            '$.eventName=DeleteInternetGateway',
+                            '$.eventName=DetachInternetGateway'
+                        )
+                    )),
     # [CloudWatch.13] Ensure a log metric filter and alarm exist for route table changes
     # https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html#cloudwatch-13
     CloudTrailAlarm(name='route_table_change',
                     statistic='Sum',
-                    filter_pattern='{($.eventName=CreateRoute) || ($.eventName=CreateRouteTable) || '
-                                   '($.eventName=ReplaceRoute) || ($.eventName=ReplaceRouteTableAssociation) || '
-                                   '($.eventName=DeleteRouteTable) || ($.eventName=DeleteRoute) || '
-                                   '($.eventName=DisassociateRouteTable)}'),
+                    filter_pattern=_curly(
+                        _or(
+                            '$.eventName=CreateRoute',
+                            '$.eventName=CreateRouteTable',
+                            '$.eventName=ReplaceRoute',
+                            '$.eventName=ReplaceRouteTableAssociation',
+                            '$.eventName=DeleteRouteTable',
+                            '$.eventName=DeleteRoute',
+                            '$.eventName=DisassociateRouteTable'
+                        )
+                    )),
     # [CloudWatch.14] Ensure a log metric filter and alarm exist for VPC changes
     # https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html#cloudwatch-14
     CloudTrailAlarm(name='vpc_change',
                     statistic='Sum',
-                    filter_pattern='{($.eventName=CreateVpc) || ($.eventName=DeleteVpc) || '
-                                   '($.eventName=ModifyVpcAttribute) || ($.eventName=AcceptVpcPeeringConnection) || '
-                                   '($.eventName=CreateVpcPeeringConnection) || '
-                                   '($.eventName=DeleteVpcPeeringConnection) || '
-                                   '($.eventName=RejectVpcPeeringConnection) || ($.eventName=AttachClassicLinkVpc) || '
-                                   '($.eventName=DetachClassicLinkVpc) || ($.eventName=DisableVpcClassicLink) || '
-                                   '($.eventName=EnableVpcClassicLink)}'),
+                    filter_pattern=_curly(
+                        _or(
+                            '$.eventName=CreateVpc',
+                            '$.eventName=DeleteVpc',
+                            '$.eventName=ModifyVpcAttribute',
+                            '$.eventName=AcceptVpcPeeringConnection',
+                            '$.eventName=CreateVpcPeeringConnection',
+                            '$.eventName=DeleteVpcPeeringConnection',
+                            '$.eventName=RejectVpcPeeringConnection',
+                            '$.eventName=AttachClassicLinkVpc',
+                            '$.eventName=DetachClassicLinkVpc',
+                            '$.eventName=DisableVpcClassicLink',
+                            '$.eventName=EnableVpcClassicLink'
+                        )
+                    )),
 ]
 
 # The deployment and/or backup of the GitLab instance requires a reboot, which


### PR DESCRIPTION
Linked issues: DataBiosphere/azul-private#299


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator and the author


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `sandbox`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilbox`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] PR is assigned to only the operator
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
