### PR TITLE
Fix: Newly created GitLab instance fails to mount data volume (#4890)

### DIFF
--- a/OPERATOR.rst
+++ b/OPERATOR.rst
@@ -426,8 +426,8 @@ Finally, SSH into the instance to complete the setup of new data volume. Use the
 ``resize2fs`` to grow the size of the mounted file system so that it matches
 that of the volume. Run::
 
-    df # Verify device /dev/nvme1n1 is mounted on /mnt/gitlab, note available size
-    sudo resize2fs /dev/nvme1n1
+    df | grep /mnt/gitlab # Verify the name of the mounted device (e.g. /dev/nvme1n1) and note the available size
+    sudo resize2fs <device_name> # Match the device name emitted by the previous command
     df # Verify the new available size is larger
 
 The output of the last ``df`` command should inform of the success of these

--- a/README.md
+++ b/README.md
@@ -1979,10 +1979,14 @@ The Gitlab EC2 instance is attached to an EBS volume that contains all of
 Gitlab's data and configuration. That volume is not controlled by Terraform and
 must be created manually before terraforming the `gitlab` component for the
 first time. Details about creating and formatting the volume can be found in
-[gitlab.tf.json.template.py]. The volume is mounted at `/mnt/gitlab`. The
-configuration changes are tracked in a local Git repository on the system 
-administrator's computer. The system administrator keeps the configuration files 
-consistent between GitLab instances.
+[gitlab.tf.json.template.py]. The volume is mounted at `/mnt/gitlab`. Also, the
+volume is mounted by its filesystem UUID rather than by device path
+(e.g., `/dev/nvme1n1`), ensuring reliable mounting across different instance
+types. This is because device names can vary and volumes may be attached in a
+non-deterministic order. See [gitlab.tf.json.template.py] for details on
+obtaining the UUID. The configuration changes are tracked in a local Git
+repository on the system administrator's computer. The system administrator
+keeps the configuration files consistent between GitLab instances.
 
 When an instance boots and finds the EBS volume empty, Gitlab will initialize it
 with default configuration. That configuration is very vulnerable because the

--- a/deployments/anvildev.gitlab/environment.py
+++ b/deployments/anvildev.gitlab/environment.py
@@ -25,6 +25,7 @@ def env() -> Mapping[str, Optional[str]]:
     provide the value.
     """
     return {
+        'azul_gitlab_data_volume_id': '7ca852ee-8e69-4ce3-bb3b-a5500fbe8ce4',
         'azul_terraform_component': 'gitlab',
         'azul_vpc_cidr': '172.23.0.0/16',
         'azul_vpn_subnet': '10.44.0.0/16'

--- a/deployments/anvilprod.gitlab/environment.py
+++ b/deployments/anvilprod.gitlab/environment.py
@@ -25,6 +25,7 @@ def env() -> Mapping[str, Optional[str]]:
     provide the value.
     """
     return {
+        'azul_gitlab_data_volume_id': '652b2ce9-ed1d-4b08-a2fd-7312eb0aa576',
         'azul_terraform_component': 'gitlab',
         'azul_vpc_cidr': '172.24.0.0/16',
         'azul_vpn_subnet': '10.45.0.0/16'

--- a/deployments/dev.gitlab/environment.py
+++ b/deployments/dev.gitlab/environment.py
@@ -25,6 +25,7 @@ def env() -> Mapping[str, Optional[str]]:
     provide the value.
     """
     return {
+        'azul_gitlab_data_volume_id': 'cdd0f0f9-ebba-41cd-9b92-95f47599db1a',
         'azul_terraform_component': 'gitlab',
         'azul_vpc_cidr': '172.21.0.0/16',
         'azul_vpn_subnet': '10.42.0.0/16'

--- a/deployments/prod.gitlab/environment.py
+++ b/deployments/prod.gitlab/environment.py
@@ -25,6 +25,7 @@ def env() -> Mapping[str, Optional[str]]:
     provide the value.
     """
     return {
+        'azul_gitlab_data_volume_id': 'e690b050-64a5-4810-aa1f-85136ab02ff5',
         'azul_terraform_component': 'gitlab',
         'azul_vpc_cidr': '172.22.0.0/16',
         'azul_vpn_subnet': '10.43.0.0/16'

--- a/deployments/tempdev.gitlab/environment.py
+++ b/deployments/tempdev.gitlab/environment.py
@@ -25,6 +25,7 @@ def env() -> Mapping[str, Optional[str]]:
     provide the value.
     """
     return {
+        'azul_gitlab_data_volume_id': '6de99059-9912-4ae1-b76e-4565372a1302',
         'azul_terraform_component': 'gitlab',
         'azul_vpc_cidr': '172.25.0.0/16',
         'azul_vpn_subnet': '10.46.0.0/16'

--- a/environment.py
+++ b/environment.py
@@ -648,6 +648,13 @@ def env() -> Mapping[str, str | None]:
         #
         'azul_gitlab_access_token': None,
 
+        # The filesystem UUID of the EBS volume attached to the GitLab EC2
+        # instance. This variable is only used in the `.gitlab` component. For
+        # additional info, see section 8.5 of the README (Storage) and the
+        # comments in `terraform/gitlab/gitlab.tf.json.template.py`.
+        #
+        'azul_gitlab_data_volume_id': None,
+
         # The name of the user owning the token in `azul_gitlab_access_token`.
         #
         'azul_gitlab_user': None,

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -1672,6 +1672,10 @@ class Config:
         return self.environ.get('azul_gitlab_access_token')
 
     @property
+    def gitlab_data_volume_id(self) -> str | None:
+        return self.environ.get('azul_gitlab_data_volume_id')
+
+    @property
     def lambda_layer_key(self) -> str:
         return 'lambda_layers'
 

--- a/terraform/gitlab/gitlab.tf.json.template.py
+++ b/terraform/gitlab/gitlab.tf.json.template.py
@@ -250,6 +250,8 @@ ami_id = {
     'us-east-1': 'ami-07f8da7e8a9c81dee'
 }
 
+data_volume_device = '/dev/nvme1n1'
+
 gitlab_mount = '/mnt/gitlab'
 
 vpc_dns_servers = [
@@ -1608,7 +1610,7 @@ emit_tf({} if config.terraform_component != 'gitlab' else {
                 'user_data_replace_on_change': True,
                 'user_data': '#cloud-config\n' + yaml.dump({
                     'mounts': [
-                        ['/dev/nvme1n1', gitlab_mount, 'ext4', '']
+                        [data_volume_device, gitlab_mount, 'ext4', '']
                     ],
                     'packages': [
                         'docker',
@@ -1626,8 +1628,8 @@ emit_tf({} if config.terraform_component != 'gitlab' else {
                     'ssh_genkeytypes': ['rsa', 'dsa', 'ecdsa'],
                     'bootcmd': [
                         '; '.join([
-                            'until [ -b /dev/nvme1n1 ]',
-                            'do echo "/dev/nvme1n1 does not exist, sleeping 1s"',
+                            f'until [ -b {data_volume_device} ]',
+                            f'do echo "{data_volume_device} does not exist, sleeping 1s"',
                             'sleep 1',
                             'done'
                         ]),

--- a/terraform/gitlab/gitlab.tf.json.template.py
+++ b/terraform/gitlab/gitlab.tf.json.template.py
@@ -1631,7 +1631,7 @@ emit_tf({} if config.terraform_component != 'gitlab' else {
                             f'until [ -b {data_volume_device} ]',
                             f'do echo "{data_volume_device} does not exist, sleeping 1s"',
                             'sleep 1',
-                            'done'
+                            f'done && echo "Data volume attached to $(readlink -f {data_volume_device})"'
                         ]),
                         [
                             'cloud-init-per',

--- a/terraform/gitlab/gitlab.tf.json.template.py
+++ b/terraform/gitlab/gitlab.tf.json.template.py
@@ -152,8 +152,11 @@ from azul.terraform import (
 # To then format the volume, you can then either attach it to some other Linux
 # instance and format it there or use `make terraform` to create the actual
 # Gitlab instance and attach the volume. For the latter you would need to ssh
-# into the Gitlab instance, format `/dev/xvdf` (`/dev/nvme1n1` on newer
-# instance types) and reboot the instance. For example:
+# into the Gitlab instance, format `/dev/nvme1n1`. Occasionally, the device name
+# may be different, like `/dev/nvme0n1`. The invariant is that there should be
+# two controller devices, one for the root volume and one for the data volume.
+# Determine the controller device name to which the root volume is attached and
+# then simply use the other controller device name. For example:
 #
 # docker stop gitlab-runner
 # docker stop gitlab
@@ -161,8 +164,20 @@ from azul.terraform import (
 # sudo mv /mnt/gitlab /mnt/gitlab.deleteme
 # sudo mkdir /mnt/gitlab
 # sudo mkfs.ext4 /dev/nvme1n1
-# sudo reboot
-# sudo rm -rf /mnt/gitlab.deleteme
+#
+# After formatting the volume, obtain its UUID and set it as the value of
+# `azul_gitlab_data_volume_id` in the `.gitlab` component's `environment.py`.
+#
+# To get the UUID of an unmounted volume, run
+#
+# sudo lsblk -f
+#
+# For a mounted volume, use
+#
+# sudo blkid /dev/nvme1n1
+#
+# After setting `azul_gitlab_data_volume_id` to the obtained volume UUID,
+# terminate the instance and (re)deploy the `.gitlab` component.
 #
 # The EBS volume should be backed up (EBS snapshot) periodically. Not only does
 # it contain Gitlab's data but also its config.
@@ -250,7 +265,11 @@ ami_id = {
     'us-east-1': 'ami-07f8da7e8a9c81dee'
 }
 
-data_volume_device = '/dev/nvme1n1'
+# Cloud-init's cc_mounts module does not support the UUID=<uuid> device
+# specification format. We use the /dev/disk/by-uuid/<uuid> symlink as a
+# workaround, relying on udev to create the symlink when the volume is attached.
+#
+data_volume_device = f'/dev/disk/by-uuid/{config.gitlab_data_volume_id}'
 
 gitlab_mount = '/mnt/gitlab'
 


### PR DESCRIPTION
Linked issues: #4890


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator and the author


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `sandbox`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilbox`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] PR is assigned to only the operator
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
