### PR TITLE
Use `SourceService.public_sources` in `.list…` methods (#7761)

### DIFF
--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -356,9 +356,11 @@ class BaseMirrorService:
             plugin = self.repository_plugin
             source_config = plugin.sources[source_spec]
             if source_config.mirror:
+                public_sources = self._source_service.list_sources(self.catalog,
+                                                                   authentication=None)
                 is_public = any(
                     source_spec == source.spec
-                    for source in self._source_service.public_sources[self.catalog]
+                    for source in public_sources
                 )
                 return is_public
             else:

--- a/src/azul/service/source_service.py
+++ b/src/azul/service/source_service.py
@@ -65,26 +65,38 @@ class SourceService:
                         authentication: Authentication | None
                         ) -> set[str]:
         """
-        List source IDs in the underlying repository that are accessible using
-        the provided authentication. Source IDs may be included even if they are
-        not included in the given catalog. May require a roundtrip to the
-        underlying repository, but results are cached in DynamoDB for a short
-        time.
-        """
-        plugin = self.repository_plugin(catalog)
+        List the IDs of the sources in the underlying repository that are
+        accessible using the provided authentication, or the public service
+        account if no authentication is provided. The result may contain the IDs
+        of sources that are not included in the given catalog.
 
-        cache_key = (
-            catalog,
-            '' if authentication is None else authentication.identity()
-        )
-        joiner = ':'
-        assert not any(joiner in c for c in cache_key), cache_key
-        cache_key = joiner.join(cache_key)
-        try:
-            source_ids = set(json_element_strings(self._get(cache_key)))
-        except CacheMiss:
-            source_ids = plugin.list_source_ids(authentication)
-            self._put(cache_key, list(source_ids))
+        This method may require a roundtrip to the underlying repository, but
+        results are cached for a certain amount of time, depending on the
+        context and whether authentication is provided.
+
+        If authentication is provided, the result is cached for a few minutes,
+        and the cached result is shared between all instances of this class in a
+        single deployment, in the context of a Lambda function and outside.
+
+        If no authentication (``None``) was provided, the caching depends on the
+        context: calls within a Lambda context use the result determined at
+        deployment time. Outside of that context, the first call of this method
+        per instance of this class incurs a round trip to the repository, and
+        the result is then cached until the instance is destroyed.
+        """
+        if authentication is None:
+            source_ids = {source.id for source in self._public_sources[catalog]}
+        else:
+            plugin = self.repository_plugin(catalog)
+            cache_key = (catalog, authentication.identity())
+            joiner = ':'
+            assert not any(joiner in c for c in cache_key), cache_key
+            cache_key = joiner.join(cache_key)
+            try:
+                source_ids = set(json_element_strings(self._get(cache_key)))
+            except CacheMiss:
+                source_ids = plugin.list_source_ids(authentication)
+                self._put(cache_key, list(source_ids))
         return source_ids
 
     def list_sources(self,
@@ -92,9 +104,28 @@ class SourceService:
                      authentication: Authentication | None
                      ) -> Iterable[SourceRef]:
         """
-        List sources in the given catalog that are accessible using the provided
-        authentication. May require a roundtrip to the underlying repository.
+        List the sources in the given catalog that are accessible using the
+        provided authentication.
+
+        If authentication is provided, this method requires a roundtrip to the
+        underlying repository.
+
+        If no authentication (``None``) was provided, the caching depends on the
+        context: calls within a Lambda context use the result determined at
+        deployment time. Outside of that context, the first call of this method
+        per instance of this class incurs a round trip to the repository, and
+        the result is then cached until the instance is destroyed.
+
         """
+        if authentication is None:
+            return self._public_sources[catalog]
+        else:
+            return self._list_sources(catalog, authentication)
+
+    def _list_sources(self,
+                      catalog: CatalogName,
+                      authentication: Authentication | None
+                      ) -> Iterable[SourceRef]:
         return self.repository_plugin(catalog).list_sources(authentication)
 
     table_name = config.dynamo_sources_cache_table_name
@@ -141,22 +172,19 @@ class SourceService:
         return int(time())
 
     @cached_property
-    def public_sources(self) -> Mapping[CatalogName, Iterable[SourceRef]]:
+    def _public_sources(self) -> Mapping[CatalogName, Iterable[SourceRef]]:
         """
         The set of all sources included in any catalog in the current
         deployment that are accessible to the public service account. When
-        invoked from a lambda function, this will never make a roundtrip to the
-        underlying repository. Unlike :meth:`list_sources`, if the public
-        service account gains or loses access to a source, that change will not
-        be reflected in the return value until the lambda function is
-        re-deployed.
+        invoked from a Lambda function, this will never make a roundtrip to the
+        underlying repository.
         """
         try:
             with open_resource('public_sources.json') as f:
                 public_sources = json.load(f)
         except NotInLambdaContextException:
             return {
-                catalog.name: self.list_sources(catalog.name, authentication=None)
+                catalog.name: self._list_sources(catalog.name, authentication=None)
                 for catalog in config.catalogs.values()
             }
         else:
@@ -169,5 +197,5 @@ class SourceService:
     def public_sources_for_outsourcing(self) -> JSON:
         return {
             catalog: [source.to_json() for source in sources]
-            for catalog, sources in self.public_sources.items()
+            for catalog, sources in self._public_sources.items()
         }

--- a/test/azul_test_case.py
+++ b/test/azul_test_case.py
@@ -414,7 +414,7 @@ class CatalogTestCase(AzulUnitTestCase, metaclass=ABCMeta):
     @classmethod
     def _patch_public_sources(cls):
         cls.addClassPatch(patch.object(SourceService,
-                                       'public_sources',
+                                       '_public_sources',
                                        new_callable=PropertyMock,
                                        return_value={cls.catalog: [cls.source]}))
 

--- a/test/azul_test_case.py
+++ b/test/azul_test_case.py
@@ -273,6 +273,14 @@ class AzulUnitTestCase(AzulTestCase):
                                      AZUL_AWS_ACCOUNT_ID=moto.core.models.DEFAULT_ACCOUNT_ID,
                                      azul_aws_account_name=cls._aws_account_name))
 
+    # These must match what `moto` uses to mock the instance metadata
+    # response (see InstanceMetadataResponse.metadata_response() in
+    # moto.instance_metadata.responses).
+
+    mock_boto_credentials = Credentials(access_key='test-key',
+                                        secret_key='test-secret-key',
+                                        token='test-session-token')
+
     @classmethod
     def _patch_aws_credentials(cls):
         # Discard cached Boto3/botocore clients, resources and sessions
@@ -294,21 +302,16 @@ class AzulUnitTestCase(AzulTestCase):
         # test to leak into a mocked use of boto3. The latter was the reason for
         # https://github.com/DataBiosphere/azul/issues/668.
 
-        def dummy_get_credentials(_self):
-            # These must match what `moto` uses to mock the instance metadata
-            # response (see InstanceMetadataResponse.metadata_response() in
-            # moto.instance_metadata.responses).
-            return Credentials(access_key='test-key',
-                               secret_key='test-secret-key',
-                               token='test-session-token')
+        def mock_get_credentials(_self):
+            return cls.mock_boto_credentials
 
         cls.addClassPatch(patch.object(botocore.session.Session,
                                        'get_credentials',
-                                       dummy_get_credentials))
+                                       mock_get_credentials))
 
         cls.addClassPatch(patch.object(boto3.session.Session,
                                        'get_credentials',
-                                       dummy_get_credentials))
+                                       mock_get_credentials))
 
     # We almost certainly won't have access to this region
     _aws_test_region = 'us-gov-west-1'

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -191,9 +191,7 @@ class TestListSources(DCP2TestCase, RepositoryFilesTestCase):
             for n in cls.mock_source_names
         }
 
-    @patch.object(SourceService, '_put', new=MagicMock())
     @patch.object(SourceService, '_get')
-    @patch.object(BaseMirrorService, 'info_exists', new=Mock(return_value=False))
     @patch.object(TDRClient, 'snapshot_names_by_id')
     @patch.object(TDRClient, 'validate', new=MagicMock())
     def test_list_sources(self,

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -200,7 +200,10 @@ class TestListSources(DCP2TestCase, RepositoryFilesTestCase):
 
     @classmethod
     def _sources(cls):
-        return {cls.make_mock_source_spec(n): {'mirror': True} for n in cls.mock_source_names}
+        return {
+            cls.make_mock_source_spec(n): {'mirror': True}
+            for n in cls.mock_source_names
+        }
 
     @mock.patch.object(TDRClient, 'snapshot_names_by_id')
     @mock.patch.object(TDRClient, 'validate', new=MagicMock())

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -9,11 +9,9 @@ import time
 from typing import (
     Union,
 )
-from unittest import (
-    mock,
-)
 from unittest.mock import (
     MagicMock,
+    patch,
 )
 
 import attr
@@ -116,17 +114,17 @@ class RepositoryFilesTestCase(LocalAppTestCase, metaclass=ABCMeta):
 
 class TestRepositoryFilesWithTDR(DCP2TestCase, RepositoryFilesTestCase):
 
-    @mock.patch.object(SourceService, '_put', new=MagicMock())
-    @mock.patch.object(SourceService, '_get')
-    @mock.patch.object(BaseMirrorService,
-                       'info_exists',
-                       new=MagicMock(return_value=False))
-    @mock.patch.dict(os.environ,
-                     AZUL_TDR_SERVICE_URL=str(DCP2TestCase.mock_tdr_service_url))
-    @mock.patch.object(TerraClient,
-                       '_http_client',
-                       AuthorizedHttp(MagicMock(),
-                                      urllib3.PoolManager(ca_certs=certifi.where())))
+    @patch.object(SourceService, '_put', new=MagicMock())
+    @patch.object(SourceService, '_get')
+    @patch.object(BaseMirrorService,
+                  'info_exists',
+                  new=MagicMock(return_value=False))
+    @patch.dict(os.environ,
+                AZUL_TDR_SERVICE_URL=str(DCP2TestCase.mock_tdr_service_url))
+    @patch.object(TerraClient,
+                  '_http_client',
+                  AuthorizedHttp(MagicMock(),
+                                 urllib3.PoolManager(ca_certs=certifi.where())))
     def test_repository_files(self, mock_get_cached_sources):
         mock_get_cached_sources.return_value = []
         client = http_client(log)
@@ -146,9 +144,9 @@ class TestRepositoryFilesWithTDR(DCP2TestCase, RepositoryFilesTestCase):
                        crc32c='abc')
         for fetch in True, False:
             with self.subTest(fetch=fetch):
-                with mock.patch.object(RepositoryService,
-                                       'get_data_file',
-                                       return_value=file):
+                with patch.object(RepositoryService,
+                                  'get_data_file',
+                                  return_value=file):
                     azul_url = self.base_url.set(path=['repository', 'files', file_uuid],
                                                  args=dict(catalog=self.catalog, version=file_version))
                     if fetch:
@@ -169,7 +167,7 @@ class TestRepositoryFilesWithTDR(DCP2TestCase, RepositoryFilesTestCase):
                                              'X-Goog-Signature': 'SOMESIGNATURE',
                                          })
                     access = Access(method=AccessMethod.https, url=str(pre_signed_gs))
-                    with mock.patch.object(DRSObject, 'get', return_value=access):
+                    with patch.object(DRSObject, 'get', return_value=access):
                         response = client.request('GET', str(azul_url), redirect=False)
                         self.assertEqual(200 if fetch else 302, response.status)
                         if fetch:
@@ -182,9 +180,9 @@ class TestRepositoryFilesWithTDR(DCP2TestCase, RepositoryFilesTestCase):
 
         file = attr.evolve(file, drs_uri=None)
         with self.subTest('phantom'):
-            with mock.patch.object(RepositoryService,
-                                   'get_data_file',
-                                   return_value=file):
+            with patch.object(RepositoryService,
+                              'get_data_file',
+                              return_value=file):
                 response = client.request('GET', str(azul_url), redirect=False)
             self.assertEqual(response.status, 404)
 
@@ -200,13 +198,13 @@ class TestListSources(DCP2TestCase, RepositoryFilesTestCase):
             for n in cls.mock_source_names
         }
 
-    @mock.patch.object(SourceService, '_put', new=MagicMock())
-    @mock.patch.object(SourceService, '_get')
-    @mock.patch.object(BaseMirrorService,
-                       'info_exists',
-                       new=MagicMock(return_value=False))
-    @mock.patch.object(TDRClient, 'snapshot_names_by_id')
-    @mock.patch.object(TDRClient, 'validate', new=MagicMock())
+    @patch.object(SourceService, '_put', new=MagicMock())
+    @patch.object(SourceService, '_get')
+    @patch.object(BaseMirrorService,
+                  'info_exists',
+                  new=MagicMock(return_value=False))
+    @patch.object(TDRClient, 'snapshot_names_by_id')
+    @patch.object(TDRClient, 'validate', new=MagicMock())
     def test_list_sources(self,
                           mock_list_snapshots,
                           mock_get_cached_sources,
@@ -251,8 +249,8 @@ class TestListSources(DCP2TestCase, RepositoryFilesTestCase):
         _test(authenticate=False, cache=True)
         mock_get_cached_sources.return_value = None
         mock_get_cached_sources.side_effect = NotFound('foo_token')
-        with mock.patch('azul.terra.TDRClient.snapshot_ids',
-                        return_value=mock_source_names_by_id.keys() | {'not_indexed'}):
+        with patch('azul.terra.TDRClient.snapshot_ids',
+                   return_value=mock_source_names_by_id.keys() | {'not_indexed'}):
             _test(authenticate=True, cache=False)
             _test(authenticate=False, cache=False)
 
@@ -276,14 +274,14 @@ class TestRepositoryFilesWithDSS(DCP1TestCase,
     mock_secret_access_key = 'test-secret-key'  # @mock_sts uses wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY
     mock_session_token = 'test-session-token'  # @mock_sts token starts with AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk
 
-    @mock.patch.object(BaseMirrorService,
-                       'info_exists',
-                       new=MagicMock(return_value=False))
-    @mock.patch.dict(os.environ,
-                     AWS_ACCESS_KEY_ID=mock_access_key_id,
-                     AWS_SECRET_ACCESS_KEY=mock_secret_access_key,
-                     AWS_SESSION_TOKEN=mock_session_token)
-    @mock.patch.object(type(config), 'dss_direct_access_role')
+    @patch.object(BaseMirrorService,
+                  'info_exists',
+                  new=MagicMock(return_value=False))
+    @patch.dict(os.environ,
+                AWS_ACCESS_KEY_ID=mock_access_key_id,
+                AWS_SECRET_ACCESS_KEY=mock_secret_access_key,
+                AWS_SESSION_TOKEN=mock_session_token)
+    @patch.object(type(config), 'dss_direct_access_role')
     def test_repository_files(self, dss_direct_access_role):
         dss_direct_access_role.return_value = None
         self.maxDiff = None
@@ -307,7 +305,7 @@ class TestRepositoryFilesWithDSS(DCP1TestCase,
                        content_type='text/plain',
                        sha256='123',
                        crc32c='abc')
-        with mock.patch.object(RepositoryService, 'get_data_file', return_value=file):
+        with patch.object(RepositoryService, 'get_data_file', return_value=file):
             args = {
                 'replica': 'aws',
                 'version': file_version
@@ -356,8 +354,8 @@ class TestRepositoryFilesWithDSS(DCP1TestCase,
                                     retry_after = 1
                                     expect_retry_after = None if wait or expect_status == 302 else retry_after
                                     before = time.monotonic()
-                                    with mock.patch.object(type(aws), 'dss_checkout_bucket', return_value=bucket_name):
-                                        with mock.patch('time.time', new=lambda: 1547691253.07010):
+                                    with patch.object(type(aws), 'dss_checkout_bucket', return_value=bucket_name):
+                                        with patch('time.time', new=lambda: 1547691253.07010):
                                             response = requests.get(url, allow_redirects=False)
                                     if wait and expect_status == 301:
                                         self.assertLess(retry_after, time.monotonic() - before)
@@ -431,14 +429,14 @@ class TestRepositoryFilesWithMirroring(DCP2TestCase,
 
         mirror_service = MirrorService(catalog=self.catalog,
                                        schema_url_func=MagicMock())
-        with mock.patch.object(MirrorService, '_download', return_value=file_content):
+        with patch.object(MirrorService, '_download', return_value=file_content):
             mirror_service._mirror_file(file)
         self.assertTrue(mirror_service.info_exists(file))
 
         client = http_client(log)
         args = dict(catalog=self.catalog, version=file_version)
         azul_url = self.base_url.set(path=['repository', 'files', file_uuid], args=args)
-        with mock.patch.object(RepositoryService, 'get_data_file', return_value=file):
+        with patch.object(RepositoryService, 'get_data_file', return_value=file):
             response = client.request('GET', str(azul_url), redirect=False)
         self.assertEqual(302, response.status)
 

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -119,7 +119,7 @@ class TestRepositoryFilesWithTDR(DCP2TestCase, RepositoryFilesTestCase):
                   '_http_client',
                   AuthorizedHttp(MagicMock(),
                                  urllib3.PoolManager(ca_certs=certifi.where())))
-    def test_repository_files(self):
+    def test(self):
         client = http_client(log)
 
         file_uuid = '701c9a63-23da-4978-946b-7576b6ad088a'
@@ -194,10 +194,7 @@ class TestListSources(DCP2TestCase, RepositoryFilesTestCase):
     @patch.object(SourceService, '_get')
     @patch.object(TDRClient, 'snapshot_names_by_id')
     @patch.object(TDRClient, 'validate', new=MagicMock())
-    def test_list_sources(self,
-                          mock_list_snapshots,
-                          mock_get_cached_sources,
-                          ):
+    def test(self, mock_list_snapshots, mock_get_cached_sources):
         # Includes extra sources to check that the endpoint only returns results
         # for the current catalog
         extra_sources = ['foo', 'bar']
@@ -250,7 +247,7 @@ class TestRepositoryFilesWithDSS(DCP1TestCase,
 
     @patch.object(BaseMirrorService, 'info_exists', new=Mock(return_value=False))
     @patch.object(type(config), 'dss_direct_access_role', new=Mock(return_value=None))
-    def test_repository_files(self):
+    def test(self):
         self.maxDiff = None
         key = ('blobs/6929799f227ae5f0b3e0167a6cf2bd683db097848af6ccde6329185212598779'
                '.f2237ad0a776fd7057eb3d3498114c85e2f521d7'
@@ -380,7 +377,7 @@ class TestRepositoryFilesWithMirroring(DCP2TestCase,
                                        RepositoryFilesTestCase,
                                        MirrorTestCase):
 
-    def test_repository_files(self):
+    def test(self):
         file_content = b'Contents of foo'
         file_uuid = '701c9a63-23da-4978-946b-7576b6ad088a'
         file_version = '2018-09-12T12:11:54.054628Z'

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -11,6 +11,7 @@ from typing import (
 )
 from unittest.mock import (
     MagicMock,
+    Mock,
     patch,
 )
 
@@ -116,9 +117,7 @@ class TestRepositoryFilesWithTDR(DCP2TestCase, RepositoryFilesTestCase):
 
     @patch.object(SourceService, '_put', new=MagicMock())
     @patch.object(SourceService, '_get')
-    @patch.object(BaseMirrorService,
-                  'info_exists',
-                  new=MagicMock(return_value=False))
+    @patch.object(BaseMirrorService, 'info_exists', new=Mock(return_value=False))
     @patch.dict(os.environ,
                 AZUL_TDR_SERVICE_URL=str(DCP2TestCase.mock_tdr_service_url))
     @patch.object(TerraClient,
@@ -200,9 +199,7 @@ class TestListSources(DCP2TestCase, RepositoryFilesTestCase):
 
     @patch.object(SourceService, '_put', new=MagicMock())
     @patch.object(SourceService, '_get')
-    @patch.object(BaseMirrorService,
-                  'info_exists',
-                  new=MagicMock(return_value=False))
+    @patch.object(BaseMirrorService, 'info_exists', new=Mock(return_value=False))
     @patch.object(TDRClient, 'snapshot_names_by_id')
     @patch.object(TDRClient, 'validate', new=MagicMock())
     def test_list_sources(self,
@@ -274,9 +271,7 @@ class TestRepositoryFilesWithDSS(DCP1TestCase,
     mock_secret_access_key = 'test-secret-key'  # @mock_sts uses wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY
     mock_session_token = 'test-session-token'  # @mock_sts token starts with AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk
 
-    @patch.object(BaseMirrorService,
-                  'info_exists',
-                  new=MagicMock(return_value=False))
+    @patch.object(BaseMirrorService, 'info_exists', new=Mock(return_value=False))
     @patch.dict(os.environ,
                 AWS_ACCESS_KEY_ID=mock_access_key_id,
                 AWS_SECRET_ACCESS_KEY=mock_secret_access_key,

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -4,7 +4,6 @@ from abc import (
 import hashlib
 import io
 import json
-import os
 import time
 from typing import (
     Union,
@@ -115,17 +114,12 @@ class RepositoryFilesTestCase(LocalAppTestCase, metaclass=ABCMeta):
 
 class TestRepositoryFilesWithTDR(DCP2TestCase, RepositoryFilesTestCase):
 
-    @patch.object(SourceService, '_put', new=MagicMock())
-    @patch.object(SourceService, '_get')
     @patch.object(BaseMirrorService, 'info_exists', new=Mock(return_value=False))
-    @patch.dict(os.environ,
-                AZUL_TDR_SERVICE_URL=str(DCP2TestCase.mock_tdr_service_url))
     @patch.object(TerraClient,
                   '_http_client',
                   AuthorizedHttp(MagicMock(),
                                  urllib3.PoolManager(ca_certs=certifi.where())))
-    def test_repository_files(self, mock_get_cached_sources):
-        mock_get_cached_sources.return_value = []
+    def test_repository_files(self):
         client = http_client(log)
 
         file_uuid = '701c9a63-23da-4978-946b-7576b6ad088a'

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -188,6 +188,13 @@ class TestRepositoryFilesWithTDR(DCP2TestCase, RepositoryFilesTestCase):
                 response = client.request('GET', str(azul_url), redirect=False)
             self.assertEqual(response.status, 404)
 
+
+@mock.patch.object(SourceService, '_put', new=MagicMock())
+@mock.patch.object(SourceService, '_get')
+@mock.patch.object(BaseMirrorService,
+                   'info_exists',
+                   new=MagicMock(return_value=False))
+class TestListSources(DCP2TestCase, RepositoryFilesTestCase):
     mock_source_names = ['mock_snapshot_1', 'mock_snapshot_2']
     make_mock_source_spec = 'tdr:bigquery:gcp:mock:{}'.format
 

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -255,27 +255,7 @@ class TestListSources(DCP2TestCase, RepositoryFilesTestCase):
 class TestRepositoryFilesWithDSS(DCP1TestCase,
                                  RepositoryFilesTestCase,
                                  S3TestCase):
-    # These are the credentials defined in
-    #
-    # moto.instance_metadata.responses.InstanceMetadataResponse
-    #
-    # which, for reasons yet to be determined, is used on Travis but not when I
-    # run this locally. Maybe it's the absence of ~/.aws/credentials. The
-    # credentials that @mock_sts provides look more realistic but boto3's STS
-    # credential provider would be skipped on CI because the lack of
-    # ~/.aws/credentials there implies that AssumeRole credentials aren't
-    # configured, causing boto3 to default to use credentials from mock instance
-    # metadata.
-    #
-    mock_access_key_id = 'test-key'  # @mock_sts uses AKIAIOSFODNN7EXAMPLE
-    mock_secret_access_key = 'test-secret-key'  # @mock_sts uses wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY
-    mock_session_token = 'test-session-token'  # @mock_sts token starts with AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk
-
     @patch.object(BaseMirrorService, 'info_exists', new=Mock(return_value=False))
-    @patch.dict(os.environ,
-                AWS_ACCESS_KEY_ID=mock_access_key_id,
-                AWS_SECRET_ACCESS_KEY=mock_secret_access_key,
-                AWS_SESSION_TOKEN=mock_session_token)
     @patch.object(type(config), 'dss_direct_access_role')
     def test_repository_files(self, dss_direct_access_role):
         dss_direct_access_role.return_value = None
@@ -393,10 +373,10 @@ class TestRepositoryFilesWithDSS(DCP1TestCase,
 
                                 args = {
                                     'response-content-disposition': f'attachment;filename={file_name}',
-                                    'AWSAccessKeyId': self.mock_access_key_id,
+                                    'AWSAccessKeyId': self.mock_boto_credentials.access_key,
                                     'Signature': signature,
                                     'Expires': expires,
-                                    'x-amz-security-token': self.mock_session_token
+                                    'x-amz-security-token': self.mock_boto_credentials.token
                                 }
                                 re_pre_signed_s3_url = furl(url=f'https://{bucket_name}.s3.amazonaws.com',
                                                             path=key,

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -180,7 +180,12 @@ class TestRepositoryFilesWithTDR(DCP2TestCase, RepositoryFilesTestCase):
             self.assertEqual(response.status, 404)
 
 
-class TestListSources(DCP2TestCase, RepositoryFilesTestCase):
+class TestListSources(DCP2TestCase, LocalAppTestCase):
+
+    @classmethod
+    def app_name(cls) -> str:
+        return 'service'
+
     mock_source_names = ['mock_snapshot_1', 'mock_snapshot_2']
     make_mock_source_spec = 'tdr:bigquery:gcp:mock:{}'.format
 

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -114,13 +114,13 @@ class RepositoryFilesTestCase(LocalAppTestCase, metaclass=ABCMeta):
         self.assertEqual(sorted(a.args.allitems()), sorted(b.args.allitems()))
 
 
-@mock.patch.object(SourceService, '_put', new=MagicMock())
-@mock.patch.object(SourceService, '_get')
-@mock.patch.object(BaseMirrorService,
-                   'info_exists',
-                   new=MagicMock(return_value=False))
 class TestRepositoryFilesWithTDR(DCP2TestCase, RepositoryFilesTestCase):
 
+    @mock.patch.object(SourceService, '_put', new=MagicMock())
+    @mock.patch.object(SourceService, '_get')
+    @mock.patch.object(BaseMirrorService,
+                       'info_exists',
+                       new=MagicMock(return_value=False))
     @mock.patch.dict(os.environ,
                      AZUL_TDR_SERVICE_URL=str(DCP2TestCase.mock_tdr_service_url))
     @mock.patch.object(TerraClient,
@@ -189,11 +189,6 @@ class TestRepositoryFilesWithTDR(DCP2TestCase, RepositoryFilesTestCase):
             self.assertEqual(response.status, 404)
 
 
-@mock.patch.object(SourceService, '_put', new=MagicMock())
-@mock.patch.object(SourceService, '_get')
-@mock.patch.object(BaseMirrorService,
-                   'info_exists',
-                   new=MagicMock(return_value=False))
 class TestListSources(DCP2TestCase, RepositoryFilesTestCase):
     mock_source_names = ['mock_snapshot_1', 'mock_snapshot_2']
     make_mock_source_spec = 'tdr:bigquery:gcp:mock:{}'.format
@@ -205,6 +200,11 @@ class TestListSources(DCP2TestCase, RepositoryFilesTestCase):
             for n in cls.mock_source_names
         }
 
+    @mock.patch.object(SourceService, '_put', new=MagicMock())
+    @mock.patch.object(SourceService, '_get')
+    @mock.patch.object(BaseMirrorService,
+                       'info_exists',
+                       new=MagicMock(return_value=False))
     @mock.patch.object(TDRClient, 'snapshot_names_by_id')
     @mock.patch.object(TDRClient, 'validate', new=MagicMock())
     def test_list_sources(self,
@@ -257,9 +257,6 @@ class TestListSources(DCP2TestCase, RepositoryFilesTestCase):
             _test(authenticate=False, cache=False)
 
 
-@mock.patch.object(BaseMirrorService,
-                   'info_exists',
-                   new=MagicMock(return_value=False))
 class TestRepositoryFilesWithDSS(DCP1TestCase,
                                  RepositoryFilesTestCase,
                                  S3TestCase):
@@ -279,6 +276,9 @@ class TestRepositoryFilesWithDSS(DCP1TestCase,
     mock_secret_access_key = 'test-secret-key'  # @mock_sts uses wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY
     mock_session_token = 'test-session-token'  # @mock_sts token starts with AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk
 
+    @mock.patch.object(BaseMirrorService,
+                       'info_exists',
+                       new=MagicMock(return_value=False))
     @mock.patch.dict(os.environ,
                      AWS_ACCESS_KEY_ID=mock_access_key_id,
                      AWS_SECRET_ACCESS_KEY=mock_secret_access_key,

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -60,17 +60,8 @@ from azul.plugins.metadata.hca import (
 from azul.service.repository_service import (
     RepositoryService,
 )
-from azul.service.source_service import (
-    NotFound,
-    SourceService,
-)
 from azul.terra import (
-    TDRClient,
-    TDRSourceSpec,
     TerraClient,
-)
-from azul.types import (
-    JSON,
 )
 from azul_test_case import (
     DCP1TestCase,
@@ -178,72 +169,6 @@ class TestRepositoryFilesWithTDR(DCP2TestCase, RepositoryFilesTestCase):
                               return_value=file):
                 response = client.request('GET', str(azul_url), redirect=False)
             self.assertEqual(response.status, 404)
-
-
-class TestListSources(DCP2TestCase, LocalAppTestCase):
-
-    @classmethod
-    def app_name(cls) -> str:
-        return 'service'
-
-    mock_source_names = ['mock_snapshot_1', 'mock_snapshot_2']
-    make_mock_source_spec = 'tdr:bigquery:gcp:mock:{}'.format
-
-    @classmethod
-    def _sources(cls):
-        return {
-            cls.make_mock_source_spec(n): {'mirror': True}
-            for n in cls.mock_source_names
-        }
-
-    @patch.object(SourceService, '_get')
-    @patch.object(TDRClient, 'snapshot_names_by_id')
-    @patch.object(TDRClient, 'validate', new=MagicMock())
-    def test(self, mock_tdr_client__snapshot_names_by_id, mock_source_service__get):
-        # Includes extra sources to check that the endpoint only returns results
-        # for the current catalog
-        extra_sources = ['foo', 'bar']
-        mock_source_names_by_id = {
-            str(i): source_name
-            for i, source_name in enumerate(self.mock_source_names + extra_sources)
-        }
-        mock_tdr_client__snapshot_names_by_id.return_value = mock_source_names_by_id
-        client = http_client(log)
-        azul_url = furl(url=self.base_url,
-                        path='/repository/sources',
-                        query_params=dict(catalog=self.catalog))
-
-        def _list_sources(headers) -> JSON:
-            response = client.request('GET',
-                                      str(azul_url),
-                                      headers=headers)
-            self.assertEqual(response.status, 200)
-            return json.loads(response.data)
-
-        def _test(*, authenticate: bool, cache: bool):
-            with self.subTest(authenticate=authenticate, cache=cache):
-                response = _list_sources({'Authorization': 'Bearer foo_token'}
-                                         if authenticate else {})
-                self.assertEqual(response, {
-                    'sources': [
-                        {
-                            'sourceId': id,
-                            'sourceSpec': str(TDRSourceSpec.parse(self.make_mock_source_spec(name)))
-                        }
-                        for id, name in mock_source_names_by_id.items()
-                        if name not in extra_sources
-                    ]
-                })
-
-        mock_source_service__get.return_value = list(mock_source_names_by_id.keys())
-        _test(authenticate=True, cache=True)
-        _test(authenticate=False, cache=True)
-        mock_source_service__get.return_value = None
-        mock_source_service__get.side_effect = NotFound('foo_token')
-        with patch('azul.terra.TDRClient.snapshot_ids',
-                   return_value=mock_source_names_by_id.keys() | {'not_indexed'}):
-            _test(authenticate=True, cache=False)
-            _test(authenticate=False, cache=False)
 
 
 class TestRepositoryFilesWithDSS(DCP1TestCase,

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -255,10 +255,10 @@ class TestListSources(DCP2TestCase, RepositoryFilesTestCase):
 class TestRepositoryFilesWithDSS(DCP1TestCase,
                                  RepositoryFilesTestCase,
                                  S3TestCase):
+
     @patch.object(BaseMirrorService, 'info_exists', new=Mock(return_value=False))
-    @patch.object(type(config), 'dss_direct_access_role')
-    def test_repository_files(self, dss_direct_access_role):
-        dss_direct_access_role.return_value = None
+    @patch.object(type(config), 'dss_direct_access_role', new=Mock(return_value=None))
+    def test_repository_files(self):
         self.maxDiff = None
         key = ('blobs/6929799f227ae5f0b3e0167a6cf2bd683db097848af6ccde6329185212598779'
                '.f2237ad0a776fd7057eb3d3498114c85e2f521d7'

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -194,7 +194,7 @@ class TestListSources(DCP2TestCase, RepositoryFilesTestCase):
     @patch.object(SourceService, '_get')
     @patch.object(TDRClient, 'snapshot_names_by_id')
     @patch.object(TDRClient, 'validate', new=MagicMock())
-    def test(self, mock_list_snapshots, mock_get_cached_sources):
+    def test(self, mock_tdr_client__snapshot_names_by_id, mock_source_service__get):
         # Includes extra sources to check that the endpoint only returns results
         # for the current catalog
         extra_sources = ['foo', 'bar']
@@ -202,7 +202,7 @@ class TestListSources(DCP2TestCase, RepositoryFilesTestCase):
             str(i): source_name
             for i, source_name in enumerate(self.mock_source_names + extra_sources)
         }
-        mock_list_snapshots.return_value = mock_source_names_by_id
+        mock_tdr_client__snapshot_names_by_id.return_value = mock_source_names_by_id
         client = http_client(log)
         azul_url = furl(url=self.base_url,
                         path='/repository/sources',
@@ -230,11 +230,11 @@ class TestListSources(DCP2TestCase, RepositoryFilesTestCase):
                     ]
                 })
 
-        mock_get_cached_sources.return_value = list(mock_source_names_by_id.keys())
+        mock_source_service__get.return_value = list(mock_source_names_by_id.keys())
         _test(authenticate=True, cache=True)
         _test(authenticate=False, cache=True)
-        mock_get_cached_sources.return_value = None
-        mock_get_cached_sources.side_effect = NotFound('foo_token')
+        mock_source_service__get.return_value = None
+        mock_source_service__get.side_effect = NotFound('foo_token')
         with patch('azul.terra.TDRClient.snapshot_ids',
                    return_value=mock_source_names_by_id.keys() | {'not_indexed'}):
             _test(authenticate=True, cache=False)

--- a/test/service/test_response.py
+++ b/test/service/test_response.py
@@ -75,6 +75,9 @@ from azul.plugins.metadata.hca.service.response import (
 from azul.service.elasticsearch_service import (
     ResponsePagination,
 )
+from azul.service.source_service import (
+    SourceService,
+)
 from azul.terra import (
     TDRSourceRef,
     TDRSourceSpec,
@@ -2187,8 +2190,7 @@ class TestIndexResponse(IndexResponseTestCase):
         for entity_type in filtered_entity_types:
             _test(entity_type, expect_empty=False, expect_accessible=True)
 
-        with mock.patch('azul.plugins.repository.dss.Plugin.list_sources',
-                        return_value=[]):
+        with mock.patch.object(SourceService, 'list_source_ids', return_value=set()):
             for entity_type, is_filtered in filtered_entity_types.items():
                 _test(entity_type, expect_empty=is_filtered, expect_accessible=False)
 

--- a/test/service/test_response.py
+++ b/test/service/test_response.py
@@ -2170,7 +2170,8 @@ class TestIndexResponse(IndexResponseTestCase):
 
         def _test(entity_type: str, expect_empty: bool, expect_accessible: bool):
             accessible_field = self._metadata_plugin.special_fields.accessible.name_in_hit
-            with self.subTest(entity_type=entity_type, access=expect_accessible):
+            with self.subTest(entity_type=entity_type,
+                              expect_accessible=expect_accessible):
                 url = str(self.base_url.set(path=('index', entity_type)))
                 response = requests.get(url)
                 self.assertEqual(200, response.status_code)

--- a/test/service/test_source_service.py
+++ b/test/service/test_source_service.py
@@ -6,7 +6,14 @@ from typing import (
 from unittest import (
     mock,
 )
+from unittest.mock import (
+    MagicMock,
+    patch,
+)
 
+from furl import (
+    furl,
+)
 from moto import (
     mock_aws,
 )
@@ -14,13 +21,28 @@ from mypy_boto3_dynamodb.literals import (
     ScalarAttributeTypeType,
 )
 
+from app_test_case import (
+    LocalAppTestCase,
+)
 from azul import (
+    JSON,
     NotInLambdaContextException,
+)
+from azul.http import (
+    http_client,
+)
+from azul.logging import (
+    configure_test_logging,
+    get_test_logger,
 )
 from azul.service.source_service import (
     Expired,
     NotFound,
     SourceService,
+)
+from azul.terra import (
+    TDRClient,
+    TDRSourceSpec,
 )
 from azul_test_case import (
     DCP2TestCase,
@@ -28,6 +50,13 @@ from azul_test_case import (
 from dynamodb_test_case import (
     DynamoDBTestCase,
 )
+
+log = get_test_logger(__name__)
+
+
+# noinspection PyPep8Naming
+def setUpModule():
+    configure_test_logging(log)
 
 
 @mock_aws
@@ -102,3 +131,69 @@ class TestPublicSources(DCP2TestCase):
 
         self.assertEqual(*outsourced)
         self.assertEqual([{self.catalog: [self.source]}] * 2, actuals)
+
+
+class TestListSources(DCP2TestCase, LocalAppTestCase):
+
+    @classmethod
+    def app_name(cls) -> str:
+        return 'service'
+
+    mock_source_names = ['mock_snapshot_1', 'mock_snapshot_2']
+    make_mock_source_spec = 'tdr:bigquery:gcp:mock:{}'.format
+
+    @classmethod
+    def _sources(cls):
+        return {
+            cls.make_mock_source_spec(n): {'mirror': True}
+            for n in cls.mock_source_names
+        }
+
+    @patch.object(SourceService, '_get')
+    @patch.object(TDRClient, 'snapshot_names_by_id')
+    @patch.object(TDRClient, 'validate', new=MagicMock())
+    def test(self, mock_tdr_client__snapshot_names_by_id, mock_source_service__get):
+        # Includes extra sources to check that the endpoint only returns results
+        # for the current catalog
+        extra_sources = ['foo', 'bar']
+        mock_source_names_by_id = {
+            str(i): source_name
+            for i, source_name in enumerate(self.mock_source_names + extra_sources)
+        }
+        mock_tdr_client__snapshot_names_by_id.return_value = mock_source_names_by_id
+        client = http_client(log)
+        azul_url = furl(url=self.base_url,
+                        path='/repository/sources',
+                        query_params=dict(catalog=self.catalog))
+
+        def _list_sources(headers) -> JSON:
+            response = client.request('GET',
+                                      str(azul_url),
+                                      headers=headers)
+            self.assertEqual(response.status, 200)
+            return json.loads(response.data)
+
+        def _test(*, authenticate: bool, cache: bool):
+            with self.subTest(authenticate=authenticate, cache=cache):
+                response = _list_sources({'Authorization': 'Bearer foo_token'}
+                                         if authenticate else {})
+                self.assertEqual(response, {
+                    'sources': [
+                        {
+                            'sourceId': id,
+                            'sourceSpec': str(TDRSourceSpec.parse(self.make_mock_source_spec(name)))
+                        }
+                        for id, name in mock_source_names_by_id.items()
+                        if name not in extra_sources
+                    ]
+                })
+
+        mock_source_service__get.return_value = list(mock_source_names_by_id.keys())
+        _test(authenticate=True, cache=True)
+        _test(authenticate=False, cache=True)
+        mock_source_service__get.return_value = None
+        mock_source_service__get.side_effect = NotFound('foo_token')
+        with patch('azul.terra.TDRClient.snapshot_ids',
+                   return_value=mock_source_names_by_id.keys() | {'not_indexed'}):
+            _test(authenticate=True, cache=False)
+            _test(authenticate=False, cache=False)

--- a/test/service/test_source_service.py
+++ b/test/service/test_source_service.py
@@ -168,9 +168,7 @@ class TestListSources(DCP2TestCase, LocalAppTestCase):
                         query_params=dict(catalog=self.catalog))
 
         def _list_sources(headers) -> JSON:
-            response = client.request('GET',
-                                      str(azul_url),
-                                      headers=headers)
+            response = client.request('GET', str(azul_url), headers=headers)
             self.assertEqual(response.status, 200)
             return json.loads(response.data)
 

--- a/test/service/test_source_service.py
+++ b/test/service/test_source_service.py
@@ -8,6 +8,7 @@ from unittest import (
 )
 from unittest.mock import (
     MagicMock,
+    PropertyMock,
     patch,
 )
 
@@ -41,6 +42,7 @@ from azul.service.source_service import (
 )
 from azul.terra import (
     TDRClient,
+    TDRSourceRef,
     TDRSourceSpec,
 )
 from azul_test_case import (
@@ -111,7 +113,7 @@ class TestPublicSources(DCP2TestCase):
 
         def test():
             service = SourceService()
-            actuals.append(service.public_sources)
+            actuals.append(service._public_sources)
             outsourced.append(service.public_sources_for_outsourcing)
             mock_open_resource.assert_called_once()
 
@@ -155,6 +157,26 @@ class TestListSources(DCP2TestCase, LocalAppTestCase):
             cls.make_spec(n): {'mirror': True}
             for n in cls.source_names
         }
+
+    @classmethod
+    def _patch_public_sources(cls):
+        cls.addClassPatch(
+            patch.object(SourceService,
+                         '_public_sources',
+                         new_callable=PropertyMock,
+                         return_value=cls._sources_by_catalog())
+        )
+
+    @classmethod
+    def _sources_by_catalog(cls) -> dict[str, list[TDRSourceRef]]:
+        return {
+            cls.catalog: [
+                TDRSourceRef(id=id,
+                             spec=TDRSourceSpec.parse(cls.make_spec(name)),
+                             prefix=None)
+                for id, name in cls.source_names_by_id.items()
+                if name not in cls.extra_sources
+            ]}
 
     @patch.object(SourceService, '_get')
     @patch.object(TDRClient, 'snapshot_names_by_id')

--- a/test/service/test_source_service.py
+++ b/test/service/test_source_service.py
@@ -139,29 +139,29 @@ class TestListSources(DCP2TestCase, LocalAppTestCase):
     def app_name(cls) -> str:
         return 'service'
 
-    mock_source_names = ['mock_snapshot_1', 'mock_snapshot_2']
-    make_mock_source_spec = 'tdr:bigquery:gcp:mock:{}'.format
+    source_names = ['mock_snapshot_1', 'mock_snapshot_2']
+    make_spec = 'tdr:bigquery:gcp:mock:{}'.format
 
     # Includes extra sources to check that the endpoint only returns results
     # for the current catalog
     extra_sources = ['foo', 'bar']
-    mock_source_names_by_id = {
-        str(i): source_name
-        for i, source_name in enumerate(mock_source_names + extra_sources)
+    source_names_by_id = {
+        str(i): name
+        for i, name in enumerate(source_names + extra_sources)
     }
 
     @classmethod
     def _sources(cls):
         return {
-            cls.make_mock_source_spec(n): {'mirror': True}
-            for n in cls.mock_source_names
+            cls.make_spec(n): {'mirror': True}
+            for n in cls.source_names
         }
 
     @patch.object(SourceService, '_get')
     @patch.object(TDRClient, 'snapshot_names_by_id')
     @patch.object(TDRClient, 'validate', new=MagicMock())
     def test(self, mock_tdr_client__snapshot_names_by_id, mock_source_service__get):
-        mock_tdr_client__snapshot_names_by_id.return_value = self.mock_source_names_by_id
+        mock_tdr_client__snapshot_names_by_id.return_value = self.source_names_by_id
         client = http_client(log)
         azul_url = furl(url=self.base_url,
                         path='/repository/sources',
@@ -182,19 +182,19 @@ class TestListSources(DCP2TestCase, LocalAppTestCase):
                     'sources': [
                         {
                             'sourceId': id,
-                            'sourceSpec': str(TDRSourceSpec.parse(self.make_mock_source_spec(name)))
+                            'sourceSpec': str(TDRSourceSpec.parse(self.make_spec(name)))
                         }
-                        for id, name in self.mock_source_names_by_id.items()
+                        for id, name in self.source_names_by_id.items()
                         if name not in self.extra_sources
                     ]
                 })
 
-        mock_source_service__get.return_value = list(self.mock_source_names_by_id.keys())
+        mock_source_service__get.return_value = list(self.source_names_by_id.keys())
         _test(authenticate=True, cache=True)
         _test(authenticate=False, cache=True)
         mock_source_service__get.return_value = None
         mock_source_service__get.side_effect = NotFound('foo_token')
         with patch('azul.terra.TDRClient.snapshot_ids',
-                   return_value=self.mock_source_names_by_id.keys() | {'not_indexed'}):
+                   return_value=self.source_names_by_id.keys() | {'not_indexed'}):
             _test(authenticate=True, cache=False)
             _test(authenticate=False, cache=False)

--- a/test/service/test_source_service.py
+++ b/test/service/test_source_service.py
@@ -182,7 +182,7 @@ class TestListSources(DCP2TestCase, LocalAppTestCase):
                         if name not in self.extra_sources
                     ]
                 }
-                self.assertEqual(response, expected)
+                self.assertEqual(expected, response)
 
         mock_source_service__get.return_value = list(self.source_names_by_id.keys())
         _test(authenticate=True, cache=True)

--- a/test/service/test_source_service.py
+++ b/test/service/test_source_service.py
@@ -171,7 +171,7 @@ class TestListSources(DCP2TestCase, LocalAppTestCase):
                 headers = {'Authorization': 'Bearer foo_token'} if authenticate else {}
                 response = client.request('GET', str(azul_url), headers=headers)
                 self.assertEqual(response.status, 200)
-                response = json.loads(response.data)
+                actual = json.loads(response.data)
                 expected = {
                     'sources': [
                         {
@@ -182,7 +182,7 @@ class TestListSources(DCP2TestCase, LocalAppTestCase):
                         if name not in self.extra_sources
                     ]
                 }
-                self.assertEqual(expected, response)
+                self.assertEqual(expected, actual)
 
         mock_source_service__get.return_value = list(self.source_names_by_id.keys())
         _test(authenticate=True, cache=True)

--- a/test/service/test_source_service.py
+++ b/test/service/test_source_service.py
@@ -172,7 +172,7 @@ class TestListSources(DCP2TestCase, LocalAppTestCase):
                 response = client.request('GET', str(azul_url), headers=headers)
                 self.assertEqual(response.status, 200)
                 response = json.loads(response.data)
-                self.assertEqual(response, {
+                expected = {
                     'sources': [
                         {
                             'sourceId': id,
@@ -181,7 +181,8 @@ class TestListSources(DCP2TestCase, LocalAppTestCase):
                         for id, name in self.source_names_by_id.items()
                         if name not in self.extra_sources
                     ]
-                })
+                }
+                self.assertEqual(response, expected)
 
         mock_source_service__get.return_value = list(self.source_names_by_id.keys())
         _test(authenticate=True, cache=True)

--- a/test/service/test_source_service.py
+++ b/test/service/test_source_service.py
@@ -142,6 +142,14 @@ class TestListSources(DCP2TestCase, LocalAppTestCase):
     mock_source_names = ['mock_snapshot_1', 'mock_snapshot_2']
     make_mock_source_spec = 'tdr:bigquery:gcp:mock:{}'.format
 
+    # Includes extra sources to check that the endpoint only returns results
+    # for the current catalog
+    extra_sources = ['foo', 'bar']
+    mock_source_names_by_id = {
+        str(i): source_name
+        for i, source_name in enumerate(mock_source_names + extra_sources)
+    }
+
     @classmethod
     def _sources(cls):
         return {
@@ -153,14 +161,7 @@ class TestListSources(DCP2TestCase, LocalAppTestCase):
     @patch.object(TDRClient, 'snapshot_names_by_id')
     @patch.object(TDRClient, 'validate', new=MagicMock())
     def test(self, mock_tdr_client__snapshot_names_by_id, mock_source_service__get):
-        # Includes extra sources to check that the endpoint only returns results
-        # for the current catalog
-        extra_sources = ['foo', 'bar']
-        mock_source_names_by_id = {
-            str(i): source_name
-            for i, source_name in enumerate(self.mock_source_names + extra_sources)
-        }
-        mock_tdr_client__snapshot_names_by_id.return_value = mock_source_names_by_id
+        mock_tdr_client__snapshot_names_by_id.return_value = self.mock_source_names_by_id
         client = http_client(log)
         azul_url = furl(url=self.base_url,
                         path='/repository/sources',
@@ -183,17 +184,17 @@ class TestListSources(DCP2TestCase, LocalAppTestCase):
                             'sourceId': id,
                             'sourceSpec': str(TDRSourceSpec.parse(self.make_mock_source_spec(name)))
                         }
-                        for id, name in mock_source_names_by_id.items()
-                        if name not in extra_sources
+                        for id, name in self.mock_source_names_by_id.items()
+                        if name not in self.extra_sources
                     ]
                 })
 
-        mock_source_service__get.return_value = list(mock_source_names_by_id.keys())
+        mock_source_service__get.return_value = list(self.mock_source_names_by_id.keys())
         _test(authenticate=True, cache=True)
         _test(authenticate=False, cache=True)
         mock_source_service__get.return_value = None
         mock_source_service__get.side_effect = NotFound('foo_token')
         with patch('azul.terra.TDRClient.snapshot_ids',
-                   return_value=mock_source_names_by_id.keys() | {'not_indexed'}):
+                   return_value=self.mock_source_names_by_id.keys() | {'not_indexed'}):
             _test(authenticate=True, cache=False)
             _test(authenticate=False, cache=False)

--- a/test/service/test_source_service.py
+++ b/test/service/test_source_service.py
@@ -25,7 +25,6 @@ from app_test_case import (
     LocalAppTestCase,
 )
 from azul import (
-    JSON,
     NotInLambdaContextException,
 )
 from azul.http import (
@@ -167,15 +166,12 @@ class TestListSources(DCP2TestCase, LocalAppTestCase):
                         path='/repository/sources',
                         query_params=dict(catalog=self.catalog))
 
-        def _list_sources(headers) -> JSON:
-            response = client.request('GET', str(azul_url), headers=headers)
-            self.assertEqual(response.status, 200)
-            return json.loads(response.data)
-
         def _test(*, authenticate: bool, cache: bool):
             with self.subTest(authenticate=authenticate, cache=cache):
-                response = _list_sources({'Authorization': 'Bearer foo_token'}
-                                         if authenticate else {})
+                headers = {'Authorization': 'Bearer foo_token'} if authenticate else {}
+                response = client.request('GET', str(azul_url), headers=headers)
+                self.assertEqual(response.status, 200)
+                response = json.loads(response.data)
                 self.assertEqual(response, {
                     'sources': [
                         {


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #7761


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator and the author


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `sandbox`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilbox`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] PR is assigned to only the operator
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
