### PR TITLE
Validate info object schemas during unit and integration tests (#7752)

### DIFF
--- a/lambdas/indexer/openapi.json
+++ b/lambdas/indexer/openapi.json
@@ -1128,21 +1128,44 @@
                                 "schema": {
                                     "type": "object",
                                     "properties": {
-                                        "schema": {
-                                            "type": "string"
+                                        "$schema": {
+                                            "type": "string",
+                                            "format": "url"
                                         },
-                                        "id": {
-                                            "type": "string"
+                                        "$id": {
+                                            "type": "string",
+                                            "format": "url"
                                         },
                                         "type": {
-                                            "type": "string"
+                                            "type": "object"
                                         }
                                     },
-                                    "required": [
-                                        "schema",
-                                        "id",
-                                        "type"
-                                    ],
+                                    "example": {
+                                        "$schema": "https://json-schema.org/draft/2020-12/schema",
+                                        "title": "info",
+                                        "description": "Information describing a file mirrored by Azul",
+                                        "type": "object",
+                                        "properties": {
+                                            "content-type": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "description": "Content types associated with the mirrored file, as defined for the HTTP response header of the same name"
+                                            },
+                                            "$schema": {
+                                                "type": "string",
+                                                "format": "uri",
+                                                "pattern": "^https?://.*/info/v[1-9][0-9]*\\.json$",
+                                                "description": "URL of a JSON schema the document containing this property is valid against"
+                                            }
+                                        },
+                                        "required": [
+                                            "content-type",
+                                            "$schema"
+                                        ],
+                                        "$id": "http://localhost/schemas/mirror/info/v2.json"
+                                    },
                                     "additionalProperties": true
                                 }
                             }
@@ -1160,7 +1183,8 @@
                         "required": true,
                         "schema": {
                             "type": "string"
-                        }
+                        },
+                        "example": "mirror"
                     },
                     {
                         "name": "name",
@@ -1168,7 +1192,8 @@
                         "required": true,
                         "schema": {
                             "type": "string"
-                        }
+                        },
+                        "example": "info"
                     },
                     {
                         "name": "version_and_extension",
@@ -1176,8 +1201,9 @@
                         "required": true,
                         "schema": {
                             "type": "string",
-                            "pattern": "v\\d+\\.json"
-                        }
+                            "pattern": "v([1-9][0-9]*)\\.json"
+                        },
+                        "example": "v2.json"
                     }
                 ],
                 "description": "\n[JSON Schemas](https://json-schema.org/docs) for various Azul facilities.\n"

--- a/lambdas/indexer/openapi.json
+++ b/lambdas/indexer/openapi.json
@@ -1100,7 +1100,7 @@
                 ]
             }
         },
-        "/schemas/{facility}/{schema_name}/{version_and_extension}": {
+        "/schemas/{facility}/{name}/{version_and_extension}": {
             "get": {
                 "responses": {
                     "400": {
@@ -1163,7 +1163,7 @@
                         }
                     },
                     {
-                        "name": "schema_name",
+                        "name": "name",
                         "in": "path",
                         "required": true,
                         "schema": {

--- a/resources/static/schemas/mirror/info/v1.json
+++ b/resources/static/schemas/mirror/info/v1.json
@@ -11,8 +11,8 @@
         "$schema": {
             "type": "string",
             "format": "uri",
-            "pattern": "^https?://.*/info/v\\d+\\.json$",
-            "description": "URL of a JSON schema the JSON containing this property is valid against"
+            "pattern": "^https?://.*/info/v[1-9][0-9]*\\.json$",
+            "description": "URL of a JSON schema the document containing this property is valid against"
         }
     },
     "required": [

--- a/resources/static/schemas/mirror/info/v2.json
+++ b/resources/static/schemas/mirror/info/v2.json
@@ -14,8 +14,8 @@
         "$schema": {
             "type": "string",
             "format": "uri",
-            "pattern": "^https?://.*/info/v\\d+\\.json$",
-            "description": "URL of a JSON schema the JSON containing this property is valid against"
+            "pattern": "^https?://.*/info/v[1-9][0-9]*\\.json$",
+            "description": "URL of a JSON schema the document containing this property is valid against"
         }
     },
     "required": [

--- a/scripts/generate_openapi_document.py
+++ b/scripts/generate_openapi_document.py
@@ -61,7 +61,8 @@ def main():
         lambda_endpoint = furl('http://localhost')
         with patch.object(target=AzulChaliceApp,
                           attribute='base_url',
-                          new=lambda_endpoint):
+                          new_callable=PropertyMock,
+                          side_effect=lambda_endpoint.copy):
             app_module = load_app_module(app_name)
             assert app_module.app.base_url == lambda_endpoint
             app_spec = app_module.app.spec()

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -191,7 +191,7 @@ class MirrorFileDownload(RepositoryFileDownload):
 
 class SchemaUrlFunc(Protocol):
 
-    def __call__(self, *, schema_name: str, version: int) -> mutable_furl: ...
+    def __call__(self, *, name: str, version: int) -> mutable_furl: ...
 
 
 @attrs.frozen(kw_only=True)
@@ -723,7 +723,7 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
             content_types.add(file.content_type)
         return {
             content_type: sorted(content_types),
-            '$schema': str(self._schema_url_func(schema_name='info',
+            '$schema': str(self._schema_url_func(name='info',
                                                  version=self.info_schema_version)),
         }
 

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -89,6 +89,7 @@ from azul.service.storage_service import (
 )
 from azul.types import (
     JSON,
+    MutableJSON,
     json_element_strings,
 )
 
@@ -482,6 +483,9 @@ class BaseMirrorService:
         return self._storage.get_presigned_url(object_key=self._file_object_key(file),
                                                file_name=file.name,
                                                content_type=file.content_type)
+
+    def info(self, file: File) -> MutableJSON:
+        return json.loads(self._storage.get_object(self._info_object_key(file)))
 
     def info_exists(self, file: File) -> bool:
         return self._storage.object_exists(self._info_object_key(file))

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -332,6 +332,8 @@ class BaseMirrorService:
 
     catalog: CatalogName
 
+    info_schema_version = 2
+
     @cached_property
     def _queues(self) -> Queues:
         return Queues()
@@ -717,7 +719,8 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
             content_types.add(file.content_type)
         return {
             content_type: sorted(content_types),
-            '$schema': str(self._schema_url_func(schema_name='info', version=2))
+            '$schema': str(self._schema_url_func(schema_name='info',
+                                                 version=self.info_schema_version)),
         }
 
     def _update_info(self, file: File):

--- a/src/azul/openapi/schema.py
+++ b/src/azul/openapi/schema.py
@@ -263,6 +263,14 @@ def pattern(regex: str | re.Pattern, _type: Form = str) -> JSON:
     }
 
 
+def format(name: str, **kwargs) -> JSON:
+    return {
+        **schema(str),
+        'format': name,
+        **kwargs
+    }
+
+
 def default(default: PrimitiveJSON, /, form: Form = None) -> JSON:
     """
     Add a documented default value to the type schema.

--- a/src/azul/schemas.py
+++ b/src/azul/schemas.py
@@ -24,16 +24,11 @@ class SchemaController(AppController):
     """
     A controller for serving JSON schemas relating to an Azul facility
     """
-    schema_url_path = '/schemas/{facility}/{schema_name}/{version_and_extension}'
+    schema_url_path = '/schemas/{facility}/{name}/{version_and_extension}'
 
-    def schema_url(self,
-                   *,
-                   facility: str,
-                   schema_name: str,
-                   version: int
-                   ) -> mutable_furl:
+    def schema_url(self, *, facility: str, name: str, version: int) -> mutable_furl:
         path = self.schema_url_path.format(facility=facility,
-                                           schema_name=schema_name,
+                                           name=name,
                                            version_and_extension=f'v{version}.json')
         return self.app.base_url.set(path=path)
 
@@ -52,7 +47,7 @@ class SchemaController(AppController):
                 'tags': ['Auxiliary'],
                 'parameters': [
                     params.path('facility', str),
-                    params.path('schema_name', str),
+                    params.path('name', str),
                     params.path('version_and_extension', schema.pattern(r'v\d+\.json')),
                 ],
                 'description': fd(
@@ -76,10 +71,10 @@ class SchemaController(AppController):
             }
         )
         def get_schema(facility: str,
-                       schema_name: str,
+                       name: str,
                        version_and_extension: str
                        ) -> JSON:
-            path = 'schemas', facility, schema_name, version_and_extension
+            path = 'schemas', facility, name, version_and_extension
             schema = json.loads(self.app.load_static_resource(*path))
             schema['$id'] = str(self.app.self_url)
             return schema

--- a/src/azul/schemas.py
+++ b/src/azul/schemas.py
@@ -1,6 +1,11 @@
 import json
+import re
 from typing import (
     Any,
+)
+
+from chalice import (
+    BadRequestError,
 )
 
 from azul import (
@@ -24,12 +29,24 @@ class SchemaController(AppController):
     """
     A controller for serving JSON schemas relating to an Azul facility
     """
-    schema_url_path = '/schemas/{facility}/{name}/{version_and_extension}'
+    _schema_route = '/schemas/{facility}/{name}/{version_and_extension}'
 
-    def schema_url(self, *, facility: str, name: str, version: int) -> mutable_furl:
-        path = self.schema_url_path.format(facility=facility,
-                                           name=name,
-                                           version_and_extension=f'v{version}.json')
+    version_and_extension_re = re.compile(r'v([1-9][0-9]*)\.json')
+
+    def _parse_version(self, version_and_extension: str):
+        match = self.version_and_extension_re.match(version_and_extension)
+        if match:
+            return match.group(1)
+        else:
+            raise BadRequestError('Invalid version and extension', version_and_extension)
+
+    def _format_version(self, version: int) -> str:
+        return f'v{version}.json'
+
+    def schema_url(self, facility: str, name: str, version: int) -> mutable_furl:
+        path = self._schema_route.format(facility=facility,
+                                         name=name,
+                                         version_and_extension=self._format_version(version))
         return self.app.base_url.set(path=path)
 
     def handlers(self) -> dict[str, Any]:
@@ -39,16 +56,18 @@ class SchemaController(AppController):
         """
 
         @self.app.route(
-            self.schema_url_path,
+            self._schema_route,
             methods=['GET'],
             cors=True,
             spec={
                 'summary': 'Retrieve JSON schemas',
                 'tags': ['Auxiliary'],
                 'parameters': [
-                    params.path('facility', str),
-                    params.path('name', str),
-                    params.path('version_and_extension', schema.pattern(r'v\d+\.json')),
+                    params.path('facility', str, example='mirror'),
+                    params.path('name', str, example='info'),
+                    params.path('version_and_extension',
+                                schema.pattern(self.version_and_extension_re.pattern),
+                                example='v2.json'),
                 ],
                 'description': fd(
                     '''
@@ -60,23 +79,27 @@ class SchemaController(AppController):
                         'description': 'Contents of the schema',
                         **responses.json_content(
                             schema.object(
-                                schema=str,
-                                id=str,
-                                type=str,
-                                additionalProperties=True
+                                properties={
+                                    '$schema': schema.format('url'),
+                                    '$id': schema.format('url'),
+                                    'type': schema.schema(JSON)
+                                },
+                                additionalProperties=True,
+                                example=self.get_schema('mirror', 'info', 2)
                             )
                         )
                     }
                 }
             }
         )
-        def get_schema(facility: str,
-                       name: str,
-                       version_and_extension: str
-                       ) -> JSON:
-            path = 'schemas', facility, name, version_and_extension
-            schema = json.loads(self.app.load_static_resource(*path))
-            schema['$id'] = str(self.app.self_url)
-            return schema
+        def get_schema(facility: str, name: str, version_and_extension: str) -> JSON:
+            version = self._parse_version(version_and_extension)
+            return self.get_schema(facility, name, version)
 
         return locals()
+
+    def get_schema(self, facility: str, name: str, version: int) -> JSON:
+        path = 'schemas', facility, name, self._format_version(version)
+        schema = json.loads(self.app.load_static_resource(*path))
+        schema['$id'] = str(self.schema_url(facility, name, version))
+        return schema

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -262,7 +262,8 @@ class TestMirrorController(DCP2TestCase,
         client = http_client(log)
         file = MagicMock(content_type='text/plain')
         info = self.service._info(file)
-        response = client.request('GET', info['$schema'])
+        schema_url = info['$schema']
+        response = client.request('GET', schema_url)
         self.assertEqual(200, response.status, response.data)
         schema = json.loads(response.data)
         jsonschema.validate(info, schema)

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -19,6 +19,7 @@ from app_test_case import (
 )
 from azul import (
     R,
+    cached_property,
     config,
 )
 from azul.deployment import (
@@ -212,6 +213,8 @@ class TestMirrorController(DCP2TestCase,
         with patch.object(MirrorService, '_download', return_value=self._file_contents):
             self.mirror_controller.mirror(event)
         self._validate_file_contents(file, self._file_contents)
+        content_types = self._get_content_types_from_info_object(file)
+        self.assertEqual([file.content_type], content_types)
 
     def _test_corrupted_download(self, file_message):
         event = self._mirror_event(file_message)
@@ -250,9 +253,16 @@ class TestMirrorController(DCP2TestCase,
             else:
                 self.assertIn(content_type, new_content_types)
 
+    @cached_property
+    def _info_schema(self) -> JSON:
+        basename = f'v{self.service.info_schema_version}.json'
+        path = ['schemas', 'mirror', 'info', basename]
+        return json.loads(self._app.load_static_resource(*path))
+
     def _get_content_types_from_info_object(self, file) -> list[str]:
         service = self.service
         info = json.loads(service._storage.get_object(service._info_object_key(file)))
+        jsonschema.validate(info, self._info_schema)
         content_types = info['content-type']
         self.assertIsInstance(content_types, list)
         self.assertEqual(sorted(set(content_types)), content_types)
@@ -267,6 +277,10 @@ class TestMirrorController(DCP2TestCase,
         self.assertEqual(200, response.status, response.data)
         schema = json.loads(response.data)
         jsonschema.validate(info, schema)
+        # The $id field is injected into the response by the controller, and is
+        # not present in the serialized schema definition
+        self.assertEqual(schema_url, schema.pop('$id'))
+        self.assertEqual(self._info_schema, schema)
 
     def test_files_not_mirrored(self):
         self._create_mock_queues(config.mirror_queue_names)

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -258,7 +258,7 @@ class TestMirrorController(DCP2TestCase,
         self.assertEqual(sorted(set(content_types)), content_types)
         return content_types
 
-    def test_info_schema(self):
+    def test_info_schema_response(self):
         client = http_client(log)
         file = MagicMock(content_type='text/plain')
         info = self.service._info(file)

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -255,9 +255,9 @@ class TestMirrorController(DCP2TestCase,
 
     @cached_property
     def _info_schema(self) -> JSON:
-        basename = f'v{self.service.info_schema_version}.json'
-        path = ['schemas', 'mirror', 'info', basename]
-        return json.loads(self._app.load_static_resource(*path))
+        version = self.service.info_schema_version
+        schema = self.mirror_controller.get_schema('mirror', 'info', version)
+        return schema
 
     def _get_content_types_from_info_object(self, file) -> list[str]:
         service = self.service
@@ -276,11 +276,32 @@ class TestMirrorController(DCP2TestCase,
         response = client.request('GET', schema_url)
         self.assertEqual(200, response.status, response.data)
         schema = json.loads(response.data)
-        jsonschema.validate(info, schema)
-        # The $id field is injected into the response by the controller, and is
-        # not present in the serialized schema definition
-        self.assertEqual(schema_url, schema.pop('$id'))
         self.assertEqual(self._info_schema, schema)
+        jsonschema.validate(info, schema)
+
+    def test_info_schema(self):
+        schema = self._info_schema
+        instance = {
+            'content-type': ['application/binary'],
+            '$schema': 'https://localhost/schemas/mirror/info/v2.json'
+        }
+        jsonschema.validate(instance, schema)
+        invalid_instances = [
+            {
+                'content-type': ['application/binary'],
+                '$schema': 'https://localhost/schemas/mirror/info/v0.json'
+            },
+            {
+                'content-type': 'application/binary',
+                '$schema': 'https://localhost/schemas/mirror/info/v3.json'
+            },
+            {
+                '$schema': 'https://localhost/schemas/mirror/info/v4.json'
+            }
+        ]
+        for instance in invalid_instances:
+            with self.assertRaises(jsonschema.exceptions.ValidationError):
+                jsonschema.validate(instance, schema)
 
     def test_files_not_mirrored(self):
         self._create_mock_queues(config.mirror_queue_names)

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -60,6 +60,7 @@ from google.cloud import (
 from google.oauth2 import (
     service_account,
 )
+import jsonschema
 from more_itertools import (
     first,
     grouper,
@@ -1834,6 +1835,18 @@ class IndexingIntegrationTest(IntegrationTestCase):
                         self.assertIsNotNone(actual_url)
                         actual_url.set(args=None)
                         self.assertEqual(expected_url, actual_url)
+
+                with self.subTest('validate_info_schemas'):
+                    service = self._mirror_service(catalog)
+                    info_objects = [service.info(file) for file in indexed_files.keys()]
+                    schema_url = info_objects[0]['$schema']
+                    self.assertTrue(schema_url.endswith(f'/v{service.info_schema_version}.json'))
+                    schema_response = self._get_url_json('GET', furl(schema_url))
+                    self.assertEqual(schema_url, schema_response['$id'])
+                    for info_object in info_objects:
+                        self.assertEqual(schema_url, info_object['$schema'])
+                        jsonschema.validate(info_object, schema_response)
+
             _delete()
 
 


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #7752 


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator and the author


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `sandbox`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilbox`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] PR is assigned to only the operator
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
