### PR TITLE
Fix: Multi-part mirroring not covered by unit tests (#7753)

### DIFF
--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -768,4 +768,4 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
         actual_digest_value = hasher.hexdigest()
         assert expected_digest.value == actual_digest_value, R(
             'File digest value does not match its contents',
-            expected_digest, file)
+            actual_digest_value, file)

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -16,6 +16,7 @@ from typing import (
     Iterator,
     Protocol,
     Self,
+    TYPE_CHECKING,
     final,
 )
 from uuid import (
@@ -90,6 +91,11 @@ from azul.types import (
     JSON,
     json_element_strings,
 )
+
+if TYPE_CHECKING:
+    from mypy_boto3_sqs.service_resource import (
+        Queue,
+    )
 
 log = logging.getLogger(__name__)
 
@@ -409,7 +415,7 @@ class BaseMirrorService:
 
         self._queue_actions(actions())
 
-    def _mirror_queue(self):
+    def _mirror_queue(self) -> 'Queue':
         name = config.mirror_queue.name
         return aws.sqs_queue(name)
 

--- a/test/indexer/test_index_controller.py
+++ b/test/indexer/test_index_controller.py
@@ -463,3 +463,6 @@ class TestIndexerApp(LocalAppTestCase,
         method = 'DELETE' if delete else 'POST'
         request = Request(method=method, url=str(url), json=body)
         return request
+
+    def _create_mock_notifications_queue(self):
+        self._create_mock_queues([config.notifications_queue.name])

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -21,6 +21,9 @@ from azul import (
     R,
     config,
 )
+from azul.deployment import (
+    aws,
+)
 from azul.http import (
     http_client,
 )
@@ -31,6 +34,7 @@ from azul.indexer.mirror_controller import (
     MirrorController,
 )
 from azul.indexer.mirror_service import (
+    FilePart,
     MirrorAction,
     MirrorService,
 )
@@ -43,6 +47,9 @@ from azul.logging import (
 )
 from azul.plugins.metadata.hca import (
     HCAFile,
+)
+from azul.queues import (
+    SQSFifoMessage,
 )
 from azul.service.source_service import (
     SourceService,
@@ -111,6 +118,11 @@ class TestMirrorController(DCP2TestCase,
 
     def _read_mirror_queue(self) -> MutableJSONs:
         return self._read_queue(self.service._mirror_queue())
+
+    def _send_mirror_message(self, body: JSON):
+        record = self._mock_sqs_record(body, fifo=True)
+        message = SQSFifoMessage.from_record(record)
+        self.queues.send_messages(self.service._mirror_queue(), [message])
 
     def _validate_file_contents(self, file: HCAFile, contents: bytes):
         response = self._s3.get_object(Bucket=self.mirror_bucket,
@@ -282,3 +294,28 @@ class TestMirrorController(DCP2TestCase,
             partition_message = self._test_mirror_source(source_message)
             with patch_mirror_limit(self._file.size):
                 self._test_mirror_partition(partition_message, [too_big, self._file])
+
+    def test_multi_part_upload(self):
+        self._create_mock_queues(config.mirror_queue_names)
+        min_size = aws.s3_min_part_size
+        file_size = min_size + 1
+
+        big_contents = self._file_contents + (b'0' * (file_size - len(self._file_contents)))
+        assert len(big_contents) == file_size
+        big_file = attrs.evolve(self._file,
+                                size=file_size,
+                                sha256=hashlib.sha256(big_contents).hexdigest())
+
+        def download(_self, _file, part: FilePart | None = None) -> bytes:
+            return big_contents[part.offset:part.offset + part.size]
+
+        # Skip over mirror_source and mirror_partition to keep things simple
+        self._send_mirror_message(self._mirror_file_message(big_file))
+        with patch.object(FilePart, 'default_size', new=min_size):
+            with patch.object(MirrorService, '_download', new=download):
+                for action in ['MirrorFileAction', 'MirrorPartAction', 'FinalizeFileAction']:
+                    message = one(self._read_mirror_queue())
+                    event = self._mirror_event(message)
+                    self.assertEqual(action, json.loads(one(event).body)['action'])
+                    self.mirror_controller.mirror(event)
+        self._validate_file_contents(big_file, big_contents)

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -49,6 +49,7 @@ from azul.service.source_service import (
 )
 from azul.types import (
     JSON,
+    MutableJSON,
     MutableJSONs,
 )
 from azul_test_case import (
@@ -100,6 +101,23 @@ class TestMirrorController(DCP2TestCase,
                     content_type='text/plain',
                     sha256=hashlib.sha256(_file_contents).hexdigest())
 
+    def _mirror_file_message(self, file: HCAFile) -> MutableJSON:
+        return dict(action='MirrorFileAction',
+                    catalog=self.catalog,
+                    operation_id=self.operation_id,
+                    source=self.source.to_json(),
+                    prefix='00',
+                    file=file.to_json())
+
+    def _read_mirror_queue(self) -> MutableJSONs:
+        return self._read_queue(self.service._mirror_queue())
+
+    def _validate_file_contents(self, file: HCAFile, contents: bytes):
+        response = self._s3.get_object(Bucket=self.mirror_bucket,
+                                       Key=self.service._file_object_key(file))
+        mirrored_file_contents = response['Body'].read()
+        self.assertEqual(mirrored_file_contents, contents)
+
     def test_mirroring(self):
         self._create_mock_queues(config.mirror_queue_names)
         file = self._file
@@ -140,7 +158,7 @@ class TestMirrorController(DCP2TestCase,
 
     def _mirror_sources(self, source_config=SourceConfig(mirror=True)) -> MutableJSONs:
         self.service.mirror_sources([(self.source, source_config)])
-        return self._read_queue(self.service._mirror_queue())
+        return self._read_mirror_queue()
 
     def _test_mirror_sources(self):
         source_message = one(self._mirror_sources())
@@ -154,7 +172,7 @@ class TestMirrorController(DCP2TestCase,
     def _test_mirror_source(self, source_message):
         event = self._mirror_event(source_message)
         self.mirror_controller.mirror(event)
-        partition_messages = self._read_queue(self.service._mirror_queue())
+        partition_messages = self._read_mirror_queue()
         partition_message = copy_json(partition_messages[0])
         partitions = []
         for message in partition_messages:
@@ -172,13 +190,8 @@ class TestMirrorController(DCP2TestCase,
         plugin_cls = type(self.service.repository_plugin)
         with patch.object(plugin_cls, 'list_files', return_value=files):
             self.mirror_controller.mirror(event)
-        file_message = one(self._read_queue(self.service._mirror_queue()))
-        expected_message = dict(action='MirrorFileAction',
-                                catalog=self.catalog,
-                                operation_id=self.operation_id,
-                                source=self.source.to_json(),
-                                prefix='00',
-                                file=self._file.to_json())
+        file_message = one(self._read_mirror_queue())
+        expected_message = self._mirror_file_message(self._file)
         self.assertEqual(expected_message, file_message)
         return file_message
 
@@ -186,10 +199,7 @@ class TestMirrorController(DCP2TestCase,
         event = self._mirror_event(file_message)
         with patch.object(MirrorService, '_download', return_value=self._file_contents):
             self.mirror_controller.mirror(event)
-        response = self._s3.get_object(Bucket=self.mirror_bucket,
-                                       Key=self.service._file_object_key(file))
-        mirrored_file_contents = response['Body'].read()
-        self.assertEqual(mirrored_file_contents, self._file_contents)
+        self._validate_file_contents(file, self._file_contents)
 
     def _test_corrupted_download(self, file_message):
         event = self._mirror_event(file_message)

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -115,8 +115,8 @@ class TestMirrorController(DCP2TestCase,
     def _validate_file_contents(self, file: HCAFile, contents: bytes):
         response = self._s3.get_object(Bucket=self.mirror_bucket,
                                        Key=self.service._file_object_key(file))
-        mirrored_file_contents = response['Body'].read()
-        self.assertEqual(mirrored_file_contents, contents)
+        file_contents = response['Body'].read()
+        self.assertEqual(file_contents, contents)
 
     def test_mirroring(self):
         self._create_mock_queues(config.mirror_queue_names)

--- a/test/sqs_test_case.py
+++ b/test/sqs_test_case.py
@@ -46,9 +46,6 @@ class SqsTestCase(AzulUnitTestCase):
             sqs.create_queue(QueueName=queue_name,
                              Attributes=dict(FifoQueue='true') if queue_name.endswith('.fifo') else {})
 
-    def _create_mock_notifications_queue(self):
-        self._create_mock_queues([config.notifications_queue.name])
-
 
 class WorkQueueTestCase(SqsTestCase):
 


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #7753


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator and the author


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `sandbox`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilbox`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] PR is assigned to only the operator
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem

