### PR TITLE
Fix: OpenSearch queries are huge (azul-private#316)

### DIFF
--- a/src/azul/es.py
+++ b/src/azul/es.py
@@ -43,6 +43,9 @@ from azul.deployment import (
 from azul.http import (
     HttpClient,
 )
+from azul.json import (
+    copy_json,
+)
 from azul.logging import (
     es_log,
     http_body_log_message,
@@ -273,7 +276,7 @@ class TemplateSearchJSONEncoder(json.JSONEncoder):
 
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
-        self.params: MutableJSON = {}
+        self.params: dict[str, AnyJSON] = {}
 
     def default(self, obj: Any) -> Any:
         if isinstance(obj, Template):
@@ -299,10 +302,15 @@ class TemplateSearch(Search):
         encoder = TemplateSearchJSONEncoder(sort_keys=True)
         return {
             'source': encoder.encode(super().to_dict(count=count, **kwargs)),
-            'params': encoder.params,
+            'params': copy_json(encoder.params),
         }
 
     def execute(self, ignore_cache: bool = False) -> Any:
+        # The body of this method is mostly copied from the superclass, with the
+        # only change being switching `search` for `search_template`. We could
+        # also monkeypatch that method, but this approach is more robust because
+        # we retain control over which arguments are passed. Note that `search`
+        # supports many parameters that `search_template` currently does not.
         if ignore_cache or not hasattr(self, '_response'):
             opensearch = get_connection(self._using)
             self._response = self._response_class(

--- a/src/azul/es.py
+++ b/src/azul/es.py
@@ -4,6 +4,7 @@ from abc import (
 )
 from collections.abc import (
     Collection,
+    Iterator,
 )
 import json
 import logging
@@ -12,6 +13,7 @@ from typing import (
     Mapping,
     cast,
 )
+import unittest.mock
 from urllib.parse import (
     urlencode,
 )
@@ -272,6 +274,29 @@ class Template(metaclass=ABCMeta):
         raise NotImplementedError
 
 
+class RawStr(str):
+    """
+    Instances of this class will not be surrounded by quotes when encoded as
+    JSON using a :class:`TemplateSearchJSONEncoder`.
+    """
+
+
+@attrs.frozen(auto_attribs=True, kw_only=True)
+class ToJsonTemplate(Template):
+
+    def to_source(self) -> RawStr:
+        return RawStr('{{#toJson}}' + self.param_name + '{{/toJson}}')
+
+
+_original = json.encoder.py_encode_basestring_ascii
+
+
+def _encode_basestring_ascii(s: str) -> str:
+    result = _original(s)
+    assert result[0] == result[-1] == '"', result
+    return result[1:-1] if isinstance(s, RawStr) else result
+
+
 class TemplateSearchJSONEncoder(json.JSONEncoder):
 
     def __init__(self, **kwargs) -> None:
@@ -293,6 +318,11 @@ class TemplateSearchJSONEncoder(json.JSONEncoder):
             return obj.to_source()
         else:
             return super().default(obj)
+
+    def iterencode(self, o: AnyJSON, _one_shot: bool = False) -> Iterator[str]:
+        with unittest.mock.patch('json.encoder.encode_basestring_ascii',
+                                 wraps=_encode_basestring_ascii):
+            return super().iterencode(o, _one_shot=_one_shot)
 
 
 class TemplateSearch(Search):

--- a/src/azul/es.py
+++ b/src/azul/es.py
@@ -1,6 +1,11 @@
+from abc import (
+    ABCMeta,
+    abstractmethod,
+)
 from collections.abc import (
     Collection,
 )
+import json
 import logging
 from typing import (
     Any,
@@ -11,13 +16,18 @@ from urllib.parse import (
     urlencode,
 )
 
+import attrs
 from aws_requests_auth.boto_utils import (
     BotoAWSRequestsAuth,
 )
 from opensearchpy import (
     Connection,
     OpenSearch,
+    Search,
     Urllib3HttpConnection,
+)
+from opensearchpy.connection.connections import (
+    get_connection,
 )
 import requests
 import requests.auth
@@ -36,6 +46,10 @@ from azul.http import (
 from azul.logging import (
     es_log,
     http_body_log_message,
+)
+from azul.types import (
+    AnyJSON,
+    MutableJSON,
 )
 
 log = logging.getLogger(__name__)
@@ -243,3 +257,58 @@ class ESClientFactory:
         else:
             return OpenSearch(connection_class=AzulUrllib3HttpConnection,
                               **common_params)
+
+
+@attrs.frozen(auto_attribs=True, kw_only=True)
+class Template(metaclass=ABCMeta):
+    param_name: str
+    value: AnyJSON
+
+    @abstractmethod
+    def to_source(self) -> AnyJSON:
+        raise NotImplementedError
+
+
+class TemplateSearchJSONEncoder(json.JSONEncoder):
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.params: MutableJSON = {}
+
+    def default(self, obj: Any) -> Any:
+        if isinstance(obj, Template):
+            try:
+                old_value = self.params[obj.param_name]
+            except KeyError:
+                self.params[obj.param_name] = obj.value
+            else:
+                # If two parameters have the same name, they ought to come from
+                # the same template object. Having two template objects with the
+                # same name probably indicates a bug even if they happen to use
+                # the same value.
+                assert obj.value is old_value, (obj, old_value)
+            return obj.to_source()
+        else:
+            return super().default(obj)
+
+
+class TemplateSearch(Search):
+
+    def to_dict(self, count: bool = False, **kwargs) -> MutableJSON:
+        # Sorting ensures consistent output for unit tests
+        encoder = TemplateSearchJSONEncoder(sort_keys=True)
+        return {
+            'source': encoder.encode(super().to_dict(count=count, **kwargs)),
+            'params': encoder.params,
+        }
+
+    def execute(self, ignore_cache: bool = False) -> Any:
+        if ignore_cache or not hasattr(self, '_response'):
+            opensearch = get_connection(self._using)
+            self._response = self._response_class(
+                self,
+                opensearch.search_template(
+                    index=self._index, body=self.to_dict(), **self._params
+                ),
+            )
+        return self._response

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -1314,6 +1314,25 @@ class ClientSidePagingManifestGenerator(ManifestGenerator, metaclass=ABCMeta):
             else:
                 break
 
+    def _paginate_hits_sorted(self,
+                              request: Search,
+                              sort: SortKey
+                              ) -> Iterable[Hit]:
+        """
+        Wrapper around :meth:`_paginate_hits` for simple cases where the request
+        does not require any additional setup between pages
+        """
+        request = request.extra(size=self.page_size)
+        request = request.sort(*sort)
+
+        def request_factory(search_after: SortKey | None) -> Search:
+            if search_after is None:
+                return request
+            else:
+                return request.extra(search_after=search_after)
+
+        return self._paginate_hits(request_factory)
+
     def _create_paged_request(self, search_after: SortKey | None) -> Search:
         pagination = Pagination(sort='entryId',
                                 order='asc',
@@ -1986,7 +2005,6 @@ class VerbatimManifestGenerator(ClientSidePagingManifestGenerator,
             {'terms': {'hub_ids.keyword': list(hub_ids)}},
             {'terms': {'entity_id.keyword': list(replica_ids)}}
         ]))
-        request = request.extra(size=self.page_size)
 
         # `_id` is currently the only index field that is unique to each replica
         # document (and thus results in an unambiguous total ordering). However,
@@ -1998,15 +2016,8 @@ class VerbatimManifestGenerator(ClientSidePagingManifestGenerator,
         # FIXME: ES DeprecationWarning for using _id as sort key
         #        https://github.com/DataBiosphere/azul/issues/7290
         #
-        request = request.sort('entity_id.keyword', '_id')
-
-        def request_factory(search_after: SortKey | None) -> Search:
-            if search_after is None:
-                return request
-            else:
-                return request.extra(search_after=search_after)
-
-        return self._paginate_hits(request_factory)
+        sort = ('entity_id.keyword', '_id')
+        return self._paginate_hits_sorted(request, sort)
 
 
 class JSONLVerbatimManifestGenerator(PagedManifestGenerator,

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -1835,7 +1835,8 @@ Bundle = dict[Qualifier, Groups]
 Bundles = dict[FQID, Bundle]
 
 
-class PFBManifestGenerator(FileBasedManifestGenerator):
+class PFBManifestGenerator(FileBasedManifestGenerator,
+                           ClientSidePagingManifestGenerator):
 
     @classmethod
     def format(cls) -> ManifestFormat:
@@ -1863,10 +1864,10 @@ class PFBManifestGenerator(FileBasedManifestGenerator):
 
     def _all_docs_sorted(self) -> Iterable[JSON]:
         request = self._create_request(self.entity_type)
-        request = request.params(preserve_order=True).sort('entity_id.keyword')
-        for hit in request.scan():
-            doc = self._hit_to_doc(hit)
-            yield doc
+        # Need two sort fields to satisfy type constraints
+        sort = ('entity_id.keyword',) * 2
+        hits = self._paginate_hits_sorted(request, sort)
+        return map(self._hit_to_doc, hits)
 
     def create_file(self) -> tuple[str, str | None]:
         transformers = self.service.transformer_types(self.catalog)

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -1286,6 +1286,34 @@ class ClientSidePagingManifestGenerator(ManifestGenerator, metaclass=ABCMeta):
     """
     page_size = 500
 
+    def _paginate_hits(self,
+                       request_factory: Callable[[SortKey | None], Search]
+                       ) -> Iterable[Hit]:
+        """
+        Yield all hits in every page of Elasticsearch hits in responses to
+        requests that use client-side paging.
+
+        :param request_factory:  A callable that returns a prepared Elasticsearch
+                                 request for the given search-after key, with the
+                                 appropriate filters and sorting applied. The
+                                 returned request should yield one page worth of
+                                 hits, starting at the first page (if the argument
+                                 is None), or the hit right after the hit with
+                                 given search-after key
+        """
+        search_after = None
+        while True:
+            request = request_factory(search_after)
+            response = request.execute()
+            if response.hits:
+                hit = None
+                for hit in response.hits:
+                    yield hit
+                assert hit is not None
+                search_after = self._search_after(hit)
+            else:
+                break
+
     def _create_paged_request(self, search_after: SortKey | None) -> Search:
         pagination = Pagination(sort='entryId',
                                 order='asc',
@@ -1912,34 +1940,6 @@ class VerbatimManifestGenerator(ClientSidePagingManifestGenerator,
         """
         hub_id: str
         replica_ids: list[str]
-
-    def _paginate_hits(self,
-                       request_factory: Callable[[SortKey | None], Search]
-                       ) -> Iterable[Hit]:
-        """
-        Yield all hits in every page of Elasticsearch hits in responses to
-        requests that use client-side paging.
-
-        :param request_factory:  A callable that returns a prepared Elasticsearch
-                                 request for the given search-after key, with the
-                                 appropriate filters and sorting applied. The
-                                 returned request should yield one page worth of
-                                 hits, starting at the first page (if the argument
-                                 is None), or the hit right after the hit with
-                                 given search-after key
-        """
-        search_after = None
-        while True:
-            request = request_factory(search_after)
-            response = request.execute()
-            if response.hits:
-                hit = None
-                for hit in response.hits:
-                    yield hit
-                assert hit is not None
-                search_after = self._search_after(hit)
-            else:
-                break
 
     def _list_replica_keys(self) -> Iterable[ReplicaKeys]:
         for hit in self._paginate_hits(self._create_paged_request):

--- a/src/azul/service/query_service.py
+++ b/src/azul/service/query_service.py
@@ -52,6 +52,7 @@ from azul import (
 from azul.es import (
     ESClientFactory,
     TemplateSearch,
+    ToJsonTemplate,
 )
 from azul.indexer.document import (
     DocumentType,
@@ -232,23 +233,30 @@ class FilterStage(_ElasticsearchStage[Response, Response]):
         Converts the given filters into an Elasticsearch DSL Query object.
         """
         filter_list = []
+        plugin = self.plugin
+        source_id_field_name = plugin.special_fields.source_id.name
+        source_id_field_path = plugin.field_mapping[source_id_field_name]
         for field_path, filter in self.prepared_filters.items():
             if field_path not in skip_field_paths:
+                values: Sequence[PrimitiveJSON] | ToJsonTemplate
                 operator, values = one(filter.items())
+                original_values = values
                 # Note that `is_not` is only used internally (for filtering by
                 # inaccessible sources)
                 if operator in ('is', 'is_not'):
                     field_type = self.service.field_type(self.catalog, field_path)
+                    if field_path == source_id_field_path:
+                        values = ToJsonTemplate(param_name=source_id_field_name, value=values)
                     if isinstance(field_type, Nested):
                         term_queries = []
-                        for nested_field, nested_value in one(values).items():
+                        for nested_field, nested_value in one(original_values).items():
                             nested_body = {dotted(field_path, nested_field, 'keyword'): nested_value}
                             term_queries.append(Q('term', **nested_body))
                         query = Q('nested', path=dotted(field_path), query=Q('bool', must=term_queries))
                     else:
                         query = Q('terms', **{dotted(field_path, 'keyword'): values})
                         translated_none = field_type.to_index(None)
-                        if translated_none in values:
+                        if translated_none in original_values:
                             # Note that at this point None values in filters have already
                             # been translated e.g. {'is': ['~null']} and if the filter has a
                             # None our query needs to find fields with None values as well

--- a/src/azul/service/query_service.py
+++ b/src/azul/service/query_service.py
@@ -32,9 +32,6 @@ from opensearchpy import (
     Q,
     Search,
 )
-from opensearchpy.connection.connections import (
-    get_connection,
-)
 from opensearchpy.helpers.aggs import (
     Agg,
     Terms,
@@ -54,6 +51,7 @@ from azul import (
 )
 from azul.es import (
     ESClientFactory,
+    TemplateSearch,
 )
 from azul.indexer.document import (
     DocumentType,
@@ -76,7 +74,6 @@ from azul.service import (
     FiltersJSON,
 )
 from azul.types import (
-    AnyJSON,
     JSON,
     JSONTypedDict,
     JSONs,
@@ -656,61 +653,6 @@ class PaginationStage(_ElasticsearchStage[JSON, ResponseTriple]):
                                   pages=pages,
                                   sort=pagination.sort,
                                   order=pagination.order)
-
-
-@attr.s(frozen=True, auto_attribs=True, kw_only=True)
-class Template(metaclass=ABCMeta):
-    param_name: str
-    value: AnyJSON
-
-    @abstractmethod
-    def to_source(self) -> AnyJSON:
-        raise NotImplementedError
-
-
-class TemplateSearchJSONEncoder(json.JSONEncoder):
-
-    def __init__(self, **kwargs) -> None:
-        super().__init__(**kwargs)
-        self.params: MutableJSON = {}
-
-    def default(self, obj: Any) -> Any:
-        if isinstance(obj, Template):
-            try:
-                old_value = self.params[obj.param_name]
-            except KeyError:
-                self.params[obj.param_name] = obj.value
-            else:
-                # If two parameters have the same name, they ought to come from
-                # the same template object. Having two template objects with the
-                # same name probably indicates a bug even if they happen to use
-                # the same value.
-                assert obj.value is old_value, (obj, old_value)
-            return obj.to_source()
-        else:
-            return super().default(obj)
-
-
-class TemplateSearch(Search):
-
-    def to_dict(self, count: bool = False, **kwargs) -> MutableJSON:
-        # Sorting ensures consistent output for unit tests
-        encoder = TemplateSearchJSONEncoder(sort_keys=True)
-        return {
-            'source': encoder.encode(super().to_dict(count=count, **kwargs)),
-            'params': encoder.params,
-        }
-
-    def execute(self, ignore_cache: bool = False) -> Any:
-        if ignore_cache or not hasattr(self, '_response'):
-            opensearch = get_connection(self._using)
-            self._response = self._response_class(
-                self,
-                opensearch.search_template(
-                    index=self._index, body=self.to_dict(), **self._params
-                ),
-            )
-        return self._response
 
 
 class QueryService(DocumentService):

--- a/src/azul/service/query_service.py
+++ b/src/azul/service/query_service.py
@@ -32,6 +32,9 @@ from opensearchpy import (
     Q,
     Search,
 )
+from opensearchpy.connection.connections import (
+    get_connection,
+)
 from opensearchpy.helpers.aggs import (
     Agg,
     Terms,
@@ -73,6 +76,7 @@ from azul.service import (
     FiltersJSON,
 )
 from azul.types import (
+    AnyJSON,
     JSON,
     JSONTypedDict,
     JSONs,
@@ -654,6 +658,61 @@ class PaginationStage(_ElasticsearchStage[JSON, ResponseTriple]):
                                   order=pagination.order)
 
 
+@attr.s(frozen=True, auto_attribs=True, kw_only=True)
+class Template(metaclass=ABCMeta):
+    param_name: str
+    value: AnyJSON
+
+    @abstractmethod
+    def to_source(self) -> AnyJSON:
+        raise NotImplementedError
+
+
+class TemplateSearchJSONEncoder(json.JSONEncoder):
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.params: MutableJSON = {}
+
+    def default(self, obj: Any) -> Any:
+        if isinstance(obj, Template):
+            try:
+                old_value = self.params[obj.param_name]
+            except KeyError:
+                self.params[obj.param_name] = obj.value
+            else:
+                # If two parameters have the same name, they ought to come from
+                # the same template object. Having two template objects with the
+                # same name probably indicates a bug even if they happen to use
+                # the same value.
+                assert obj.value is old_value, (obj, old_value)
+            return obj.to_source()
+        else:
+            return super().default(obj)
+
+
+class TemplateSearch(Search):
+
+    def to_dict(self, count: bool = False, **kwargs) -> MutableJSON:
+        # Sorting ensures consistent output for unit tests
+        encoder = TemplateSearchJSONEncoder(sort_keys=True)
+        return {
+            'source': encoder.encode(super().to_dict(count=count, **kwargs)),
+            'params': encoder.params,
+        }
+
+    def execute(self, ignore_cache: bool = False) -> Any:
+        if ignore_cache or not hasattr(self, '_response'):
+            opensearch = get_connection(self._using)
+            self._response = self._response_class(
+                self,
+                opensearch.search_template(
+                    index=self._index, body=self.to_dict(), **self._params
+                ),
+            )
+        return self._response
+
+
 class QueryService(DocumentService):
 
     @cached_property
@@ -691,12 +750,12 @@ class QueryService(DocumentService):
                        catalog: CatalogName,
                        entity_type: str,
                        doc_type: DocumentType = DocumentType.aggregate
-                       ) -> Search:
+                       ) -> TemplateSearch:
         """
         Create an Elasticsearch request against the index containing documents
         of the given entity and document types, in the given catalog.
         """
-        return Search(using=self._es_client,
-                      index=str(IndexName.create(catalog=catalog,
-                                                 qualifier=entity_type,
-                                                 doc_type=doc_type)))
+        return TemplateSearch(using=self._es_client,
+                              index=str(IndexName.create(catalog=catalog,
+                                                         qualifier=entity_type,
+                                                         doc_type=doc_type)))

--- a/test/es_test_case.py
+++ b/test/es_test_case.py
@@ -72,7 +72,17 @@ class ElasticsearchTestCase(DockerContainerTestCase):
                     # indices in a single request. Speeds up deletion of indices
                     # between tests.
                     #
-                    'action.destructive_requires_name': False
+                    'action.destructive_requires_name': False,
+
+                    # The service uses template queries when reading from the
+                    # index which, during tests, can far exceed the default
+                    # script compilation rate of 75/5m. Rendering a template
+                    # query using mustache is a very cheap operation compared to
+                    # other compilation contexts (e.g. generating bytecode for a
+                    # painless script), so performance shouldn't be
+                    # significantly affected.
+                    #
+                    'script.context.template.max_compilations_rate': 'unlimited'
                 }
             })
         except BaseException:  # no coverage

--- a/test/es_test_case.py
+++ b/test/es_test_case.py
@@ -67,6 +67,11 @@ class ElasticsearchTestCase(DockerContainerTestCase):
                     # failure modes that are harder to diagnose.
                     #
                     'action.auto_create_index': False,
+
+                    # Allow wildcard deletions, making it possible to delete all
+                    # indices in a single request. Speeds up deletion of indices
+                    # between tests.
+                    #
                     'action.destructive_requires_name': False
                 }
             })

--- a/test/es_test_case.py
+++ b/test/es_test_case.py
@@ -57,15 +57,15 @@ class ElasticsearchTestCase(DockerContainerTestCase):
             cls.es_client = ESClientFactory.get()
             cls._wait_for_es()
 
-            # Disable the automatic creation of indexes when documents are
-            # indexed. We create indexes explicitly before any documents are
-            # indexed so a missing index would be indicative of some sort of
-            # bug. We want to fail early in that situation. Automatically
-            # created indices have a only a default mapping, resulting in
-            # failure modes that are harder to diagnose.
-            #
             cls.es_client.cluster.put_settings(body={
                 'persistent': {
+                    # Disable the automatic creation of indexes when documents are
+                    # indexed. We create indexes explicitly before any documents are
+                    # indexed so a missing index would be indicative of some sort of
+                    # bug. We want to fail early in that situation. Automatically
+                    # created indices have a only a default mapping, resulting in
+                    # failure modes that are harder to diagnose.
+                    #
                     'action.auto_create_index': False,
                     'action.destructive_requires_name': False
                 }

--- a/test/service/test_request_builder.py
+++ b/test/service/test_request_builder.py
@@ -338,7 +338,7 @@ class TestRequestBuilder(DCP1CannedBundleTestCase, WebServiceTestCase):
         request = self._prepare_request(filters, post_filter, service)
         expected_output = json.dumps(expected_output, sort_keys=True)
         actual_output = json.dumps(request.to_dict(), sort_keys=True)
-        self.assertEqual(actual_output, expected_output)
+        self.assertEqual(expected_output, actual_output)
 
     def _prepare_request(self,
                          filters: Filters,

--- a/test/service/test_request_builder.py
+++ b/test/service/test_request_builder.py
@@ -5,9 +5,13 @@ from collections.abc import (
 import json
 
 import attr
+from opensearchpy import (
+    Search,
+)
 
 from azul import (
     CatalogName,
+    JSON,
 )
 from azul.indexer.field import (
     FieldTypes,
@@ -314,9 +318,9 @@ class TestRequestBuilder(DCP1CannedBundleTestCase, WebServiceTestCase):
         self._test_create_request(expected_output, sample_filter)
 
     def _test_create_request(self,
-                             expected_output,
-                             sample_filter,
-                             post_filter=True
+                             expected_output: JSON,
+                             sample_filter: JSON,
+                             post_filter: bool = True
                              ):
         service = self.Service(self.MockPlugin())
         filters = Filters(explicit=sample_filter, source_ids=set())
@@ -325,7 +329,11 @@ class TestRequestBuilder(DCP1CannedBundleTestCase, WebServiceTestCase):
         actual_output = json.dumps(request.to_dict(), sort_keys=True)
         self.assertEqual(actual_output, expected_output)
 
-    def _prepare_request(self, filters, post_filter, service):
+    def _prepare_request(self,
+                         filters: Filters,
+                         post_filter: bool,
+                         service: Service
+                         ) -> Search:
         entity_type = 'files'
         pipeline = service.create_chain(catalog=self.catalog,
                                         entity_type=entity_type,

--- a/test/service/test_request_builder.py
+++ b/test/service/test_request_builder.py
@@ -2,6 +2,7 @@ from collections.abc import (
     Mapping,
     Sequence,
 )
+import json
 
 import attr
 from opensearchpy import (
@@ -299,8 +300,12 @@ class TestRequestBuilder(DCP1CannedBundleTestCase, WebServiceTestCase):
                                           ):
         filters = Filters(explicit=sample_filter, source_ids=set())
         request = self._prepare_request(filters, post_filter, service)
-        actual_output = request.to_dict()
-        self.assertEqual(expected_output, actual_output)
+        expected_output = {
+            'source': json.dumps(expected_output, sort_keys=True),
+            'params': {}
+        }
+        actual_request_body = request.to_dict()
+        self.assertEqual(expected_output, actual_request_body)
 
     def _prepare_request(self,
                          filters: Filters,

--- a/test/service/test_request_builder.py
+++ b/test/service/test_request_builder.py
@@ -100,7 +100,7 @@ class TestRequestBuilder(DCP1CannedBundleTestCase, WebServiceTestCase):
         'constant_score': {
             'filter': {
                 'terms': {
-                    'sources.id.keyword': []
+                    'sources.id.keyword': '{{#toJson}}sourceId{{/toJson}}'
                 }
             }
         }
@@ -301,8 +301,12 @@ class TestRequestBuilder(DCP1CannedBundleTestCase, WebServiceTestCase):
         filters = Filters(explicit=sample_filter, source_ids=set())
         request = self._prepare_request(filters, post_filter, service)
         expected_output = {
-            'source': json.dumps(expected_output, sort_keys=True),
-            'params': {}
+            'source': (
+                json.dumps(expected_output, sort_keys=True)
+                .replace('"{{#toJson}}', '{{#toJson}}')
+                .replace('{{/toJson}}"', '{{/toJson}}')
+            ),
+            'params': {'sourceId': []}
         }
         actual_request_body = request.to_dict()
         self.assertEqual(expected_output, actual_request_body)

--- a/test/service/test_request_builder.py
+++ b/test/service/test_request_builder.py
@@ -352,7 +352,7 @@ class TestRequestBuilder(DCP1CannedBundleTestCase, WebServiceTestCase):
         Tests creation of an ES aggregate
         """
         expected_output = {
-            'filter': {
+            'post_filter': {
                 'bool': {
                     'must': [
                         self.sources_filter
@@ -360,18 +360,29 @@ class TestRequestBuilder(DCP1CannedBundleTestCase, WebServiceTestCase):
                 }
             },
             'aggs': {
-                'myTerms': {
-                    'terms': {
-                        'field': 'path.to.foo.keyword',
-                        'size': 99999
+                'foo': {
+                    'filter': {
+                        'bool': {
+                            'must': [
+                                self.sources_filter
+                            ]
+                        }
                     },
-                    'meta': {
-                        'path': ['path', 'to', 'foo']
-                    }
-                },
-                'untagged': {
-                    'missing': {
-                        'field': 'path.to.foo.keyword'
+                    'aggs': {
+                        'myTerms': {
+                            'terms': {
+                                'field': 'path.to.foo.keyword',
+                                'size': 99999
+                            },
+                            'meta': {
+                                'path': ['path', 'to', 'foo']
+                            }
+                        },
+                        'untagged': {
+                            'missing': {
+                                'field': 'path.to.foo.keyword'
+                            }
+                        }
                     }
                 }
             }
@@ -403,7 +414,6 @@ class TestRequestBuilder(DCP1CannedBundleTestCase, WebServiceTestCase):
         filters = Filters(explicit={}, source_ids=set())
         post_filter = True
         request = self._prepare_request(filters, post_filter, service)
-        aggregation = request.aggs['foo']
         expected_output = json.dumps(expected_output, sort_keys=True)
-        actual_output = json.dumps(aggregation.to_dict(), sort_keys=True)
+        actual_output = json.dumps(request.to_dict(), sort_keys=True)
         self.assertEqual(actual_output, expected_output)

--- a/test/service/test_request_builder.py
+++ b/test/service/test_request_builder.py
@@ -130,10 +130,6 @@ class TestRequestBuilder(DCP1CannedBundleTestCase, WebServiceTestCase):
             }
         }
         sample_filter = {'entity_id': {'is': ['cbb998ce-ddaf-34fa-e163-d14b399c6b34']}}
-        # Need to work on a couple cases:
-        # - The empty case
-        # - The 1 filter case
-        # - The complex multiple filters case
         self._test_create_request(expected_output, sample_filter)
 
     def test_create_request_empty(self):

--- a/test/service/test_request_builder.py
+++ b/test/service/test_request_builder.py
@@ -152,38 +152,6 @@ class TestRequestBuilder(DCP1CannedBundleTestCase, WebServiceTestCase):
         sample_filter = {}
         self._test_create_request(expected_output, sample_filter, post_filter=False)
 
-    def test_create_request_complex(self):
-        """
-        Tests creation of a complex request.
-        """
-        expected_output = {
-            'post_filter': {
-                'bool': {
-                    'must': [
-                        {
-                            'constant_score': {
-                                'filter': {
-                                    'terms': {
-                                        'entity_id.keyword': [
-                                            'cbb998ce-ddaf-34fa-e163-d14b399c6b34'
-                                        ]
-                                    }
-                                }
-                            }
-                        },
-                        self.sources_filter
-                    ]
-                }
-            }
-        }
-        sample_filter = {
-            'entity_id':
-                {
-                    'is': ['cbb998ce-ddaf-34fa-e163-d14b399c6b34']
-                }
-        }
-        self._test_create_request(expected_output, sample_filter)
-
     def test_create_request_missing_values(self):
         """
         Tests creation of a request for facets that do not have a value

--- a/test/service/test_request_builder.py
+++ b/test/service/test_request_builder.py
@@ -2,7 +2,6 @@ from collections.abc import (
     Mapping,
     Sequence,
 )
-import json
 
 import attr
 from opensearchpy import (
@@ -336,8 +335,7 @@ class TestRequestBuilder(DCP1CannedBundleTestCase, WebServiceTestCase):
                                           ):
         filters = Filters(explicit=sample_filter, source_ids=set())
         request = self._prepare_request(filters, post_filter, service)
-        expected_output = json.dumps(expected_output, sort_keys=True)
-        actual_output = json.dumps(request.to_dict(), sort_keys=True)
+        actual_output = request.to_dict()
         self.assertEqual(expected_output, actual_output)
 
     def _prepare_request(self,

--- a/test/service/test_request_builder.py
+++ b/test/service/test_request_builder.py
@@ -323,6 +323,17 @@ class TestRequestBuilder(DCP1CannedBundleTestCase, WebServiceTestCase):
                              post_filter: bool = True
                              ):
         service = self.Service(self.MockPlugin())
+        self._test_create_request_with_service(service,
+                                               expected_output,
+                                               sample_filter,
+                                               post_filter)
+
+    def _test_create_request_with_service(self,
+                                          service: Service,
+                                          expected_output: JSON,
+                                          sample_filter: JSON,
+                                          post_filter: bool = True
+                                          ):
         filters = Filters(explicit=sample_filter, source_ids=set())
         request = self._prepare_request(filters, post_filter, service)
         expected_output = json.dumps(expected_output, sort_keys=True)
@@ -410,10 +421,5 @@ class TestRequestBuilder(DCP1CannedBundleTestCase, WebServiceTestCase):
                 return ['foo']
 
         service = Service(MockPlugin())
-
-        filters = Filters(explicit={}, source_ids=set())
-        post_filter = True
-        request = self._prepare_request(filters, post_filter, service)
-        expected_output = json.dumps(expected_output, sort_keys=True)
-        actual_output = json.dumps(request.to_dict(), sort_keys=True)
-        self.assertEqual(actual_output, expected_output)
+        sample_filter = {}
+        self._test_create_request_with_service(service, expected_output, sample_filter)


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: https://github.com/DataBiosphere/azul-private/issues/316
## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [ ] Actually approved the PR
- [ ] Labeled linked issues as `demo` or `no demo`
- [ ] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [ ] Decided if PR can be labeled `no sandbox`
- [ ] A comment to this PR details the completed security design review
- [ ] PR title is appropriate as title of merge commit
- [ ] `N reviews` label is accurate
- [ ] Status of PR is *Approved*
- [ ] PR is assigned to only the operator and the author


### Operator

- [ ] Checked `reindex:…` labels and `r` commit title tag
- [ ] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [ ] Squashed PR branch and rebased onto `develop`
- [ ] Sanity-checked history
- [ ] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [ ] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [ ] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [ ] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [ ] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [ ] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [ ] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [ ] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `sandbox`</sub>
- [ ] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilbox`</sub>
- [ ] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [ ] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [ ] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [ ] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [ ] All status checks passed and the PR is mergeable
- [ ] The title of the merge commit starts with the title of this PR
- [ ] Added PR # reference to merge commit title
- [ ] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [ ] Pushed merge commit to GitHub
- [ ] Status of PR is *Merged lower*
- [ ] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [ ] Pushed merge commit to GitLab `dev`
- [ ] Pushed merge commit to GitLab `anvildev`
- [ ] Build passes on GitLab `dev`
- [ ] Reviewed build logs for anomalies on GitLab `dev`
- [ ] Build passes on GitLab `anvildev`
- [ ] Reviewed build logs for anomalies on GitLab `anvildev`
- [ ] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Deleted PR branch from GitHub
- [ ] PR is assigned to only the operator
- [ ] Deleted PR branch from GitLab `dev`
- [ ] Deleted PR branch from GitLab `anvildev`
- [ ] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [ ] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [ ] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [ ] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [ ] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [ ] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [ ] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [ ] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [ ] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [ ] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [ ] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [ ] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [ ] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [ ] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [ ] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
