### PR TITLE
Move source subsetting to service layer (#7783)

### DIFF
--- a/scripts/mirror.py
+++ b/scripts/mirror.py
@@ -29,7 +29,6 @@ def mirror_catalog(azul: AzulClient,
                    catalog: CatalogName,
                    source_globs: set[str],
                    wait: bool):
-    plugin = azul.repository_plugin(catalog)
     fail_queue = config.mirror_queue.to_fail.name
     assert azul.is_queue_empty(fail_queue), R(
         'Cannot begin mirroring because a previous operation failed: '
@@ -37,7 +36,7 @@ def mirror_catalog(azul: AzulClient,
         fail_queue)
     public_sources_by_spec = {
         source.spec: source
-        for source in plugin.list_sources(authentication=None)
+        for source in azul.source_service.list_sources(catalog, authentication=None)
     }
     # When the user doesn't specify a source or provides "*" as a source glob,
     # we implicitly filter out managed-access sources. This lets us assert that

--- a/scripts/post_deploy_tdr.py
+++ b/scripts/post_deploy_tdr.py
@@ -106,8 +106,8 @@ class TerraValidator:
             require(subgraph_count <= 512, 'Common prefix is too short', ref.spec)
 
     def verify_source_access(self) -> None:
-        public_snapshots = self.public_tdr.snapshot_ids()
-        all_snapshots = self.tdr.snapshot_ids()
+        public_snapshots = self.public_tdr.list_snapshot_ids()
+        all_snapshots = self.tdr.list_snapshot_ids()
         diff = public_snapshots - all_snapshots
         require(not diff,
                 'The public service account can access snapshots that the indexer '

--- a/src/azul/azulclient.py
+++ b/src/azul/azulclient.py
@@ -70,6 +70,9 @@ from azul.plugins import (
 from azul.queues import (
     Queues,
 )
+from azul.service.source_service import (
+    SourceService,
+)
 from azul.types import (
     JSON,
     JSONs,
@@ -107,6 +110,10 @@ class AzulClient(SignatureHelper, HasCachedHttpClient):
     @cache
     def mirror_service(self, catalog: CatalogName) -> BaseMirrorService:
         return BaseMirrorService(catalog=catalog)
+
+    @cached_property
+    def source_service(self) -> SourceService:
+        return SourceService()
 
     def local_reindex(self, catalog: CatalogName, prefix: str) -> int:
         service = self.index_repository_service

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -588,8 +588,7 @@ class MirrorService(BaseMirrorService, HasCachedHttpClient):
 
     @_mirror.register
     def _(self, a: MirrorPartitionAction) -> Iterator[MirrorAction]:
-        plugin = self.repository_plugin
-        files = plugin.list_files(a.source, a.prefix)
+        files = self.repository_plugin.list_files(a.source, a.prefix)
         for file in files:
             assert file.size is not None, R('File size unknown', file)
             assert file.size <= self.max_file_size, R(

--- a/src/azul/plugins/__init__.py
+++ b/src/azul/plugins/__init__.py
@@ -680,7 +680,7 @@ class RepositoryPlugin[BUNDLE: Bundle = Bundle[SourcedBundleFQID],
     @abstractmethod
     def list_sources(self,
                      authentication: Authentication | None
-                     ) -> Iterable[SOURCE_REF]:
+                     ) -> list[SOURCE_REF]:
         """
         The sources the plugin is configured to read metadata from that are
         accessible using the provided authentication. Retrieving this

--- a/src/azul/plugins/__init__.py
+++ b/src/azul/plugins/__init__.py
@@ -653,40 +653,20 @@ class RepositoryPlugin[BUNDLE: Bundle = Bundle[SourcedBundleFQID],
         assert source.prefix is not None, source
         assert prefix in source.prefix, (source, prefix)
 
-    def _match_sources(self,
-                       source_names_by_id: Mapping[str, str]
-                       ) -> list[SOURCE_REF]:
-        """
-        Filter the given sources to only include sources that the plugin is
-        configured to read metadata from, and return a ``SourceRef`` instance
-        for each matching source.`
-        """
-        configured_specs_by_name = {spec.name: spec for spec in self.sources}
-        assert len(self.sources) == len(configured_specs_by_name), R(
-            'Source names are not unique', self.sources)
-        source_ids_by_name = {
-            name: id
-            for id, name in source_names_by_id.items()
-            if name in configured_specs_by_name
-        }
-        source_ref_cls = self.source_ref_cls
-        return [
-            source_ref_cls(id=id,
-                           spec=configured_specs_by_name[name],
-                           prefix=None)
-            for name, id in source_ids_by_name.items()
-        ]
-
     @abstractmethod
     def list_sources(self,
                      authentication: Authentication | None
                      ) -> list[SOURCE_REF]:
         """
-        The sources the plugin is configured to read metadata from that are
-        accessible using the provided authentication. Retrieving this
-        information may require a round-trip to the underlying repository.
-        Implementations should raise PermissionError if the provided
+        List the sources in the underlying repository that are accessible using
+        the provided authentication.
+
+        Retrieving this information may require a round-trip to the underlying
+        repository. Implementations should raise PermissionError if the provided
         authentication is insufficient to access the repository.
+
+        The returned set may include sources that the plugin is not configured
+        to read metadata from.
         """
         raise NotImplementedError
 

--- a/src/azul/plugins/__init__.py
+++ b/src/azul/plugins/__init__.py
@@ -701,6 +701,9 @@ class RepositoryPlugin[BUNDLE: Bundle = Bundle[SourcedBundleFQID],
         Retrieving this information may require a round-trip to the underlying
         repository. Implementations should raise PermissionError if the provided
         authentication is insufficient to access the repository.
+
+        The returned set may include the IDs of sources that the plugin is
+        not configured to read metadata from.
         """
         return {source.id for source in self.list_sources(authentication)}
 

--- a/src/azul/plugins/__init__.py
+++ b/src/azul/plugins/__init__.py
@@ -745,8 +745,8 @@ class RepositoryPlugin[BUNDLE: Bundle = Bundle[SourcedBundleFQID],
     @abstractmethod
     def _lookup_source_id(self, spec: SOURCE_SPEC) -> str:
         """
-        Return the ID of the repository source with the specified name or raise
-        an exception if no such source exists.
+        Return the ID of the specified source or raise an exception if no such
+        source exists.
         """
         raise NotImplementedError
 

--- a/src/azul/plugins/repository/tdr.py
+++ b/src/azul/plugins/repository/tdr.py
@@ -139,7 +139,7 @@ class TDRPlugin[TDR_BUNDLE: TDRBundle,
                         authentication: Authentication | None
                         ) -> set[str]:
         def list_snapshot_ids(tdr: TDRClient):
-            return tdr.snapshot_ids()
+            return tdr.list_snapshot_ids()
 
         return self._auth_fallback(authentication, list_snapshot_ids)
 

--- a/src/azul/plugins/repository/tdr.py
+++ b/src/azul/plugins/repository/tdr.py
@@ -130,7 +130,7 @@ class TDRPlugin[TDR_BUNDLE: TDRBundle,
                      authentication: Authentication | None
                      ) -> list[TDRSourceRef]:
         def list_snapshots(tdr: TDRClient):
-            return tdr.snapshot_names_by_id(filter=self._common_source_filter)
+            return tdr.list_snapshots(filter=self._common_source_filter)
 
         names_by_id = self._auth_fallback(authentication, list_snapshots)
         return self._match_sources(names_by_id)

--- a/src/azul/plugins/repository/tdr.py
+++ b/src/azul/plugins/repository/tdr.py
@@ -132,8 +132,17 @@ class TDRPlugin[TDR_BUNDLE: TDRBundle,
         def list_snapshots(tdr: TDRClient):
             return tdr.list_snapshots(filter=self._common_source_filter)
 
-        names_by_id = self._auth_fallback(authentication, list_snapshots)
-        return self._match_sources(names_by_id)
+        snapshots_by_id = self._auth_fallback(authentication, list_snapshots)
+
+        return [
+            TDRSourceRef(id=id,
+                         spec=TDRSourceSpec(name=snapshot['name'],
+                                            type=TDRSourceSpec.Type.bigquery,
+                                            domain=TDRSourceSpec.Domain.gcp,
+                                            subdomain=snapshot['dataProject']),
+                         prefix=None)
+            for id, snapshot in snapshots_by_id.items()
+        ]
 
     def list_source_ids(self,
                         authentication: Authentication | None

--- a/src/azul/plugins/repository/tdr.py
+++ b/src/azul/plugins/repository/tdr.py
@@ -99,6 +99,11 @@ class TDRPlugin[TDR_BUNDLE: TDRBundle,
                        authentication: Authentication | None,
                        tdr_callback: Callable[[TDRClient], T]
                        ) -> T:
+        """
+        Terra rejects credentials for users are not registered with Terra's SAM.
+        This method invokes the given callback with the given credentials but
+        invokes the callback again if they are rejected for that reason.
+        """
         # The line below raises UnauthorizedError for invalid tokens. We don't
         # want to fall back to anonymous authentication in that case.
         tdr = self._user_authenticated_tdr(authentication)
@@ -108,8 +113,7 @@ class TDRPlugin[TDR_BUNDLE: TDRBundle,
             if authentication is None or tdr.is_registered():
                 raise
             else:
-                log.info('Falling back to default authentication because the '
-                         'request included credentials from an unregistered account')
+                log.info('Falling back to anonymous access')
                 tdr = self._user_authenticated_tdr(None)
                 return tdr_callback(tdr)
 

--- a/src/azul/plugins/repository/tdr.py
+++ b/src/azul/plugins/repository/tdr.py
@@ -129,15 +129,19 @@ class TDRPlugin[TDR_BUNDLE: TDRBundle,
     def list_sources(self,
                      authentication: Authentication | None
                      ) -> list[TDRSourceRef]:
-        names_by_id = self._auth_fallback(authentication,
-                                          lambda tdr: tdr.snapshot_names_by_id(filter=self._common_source_filter))
+        def list_snapshots(tdr: TDRClient):
+            return tdr.snapshot_names_by_id(filter=self._common_source_filter)
+
+        names_by_id = self._auth_fallback(authentication, list_snapshots)
         return self._match_sources(names_by_id)
 
     def list_source_ids(self,
                         authentication: Authentication | None
                         ) -> set[str]:
-        return self._auth_fallback(authentication,
-                                   lambda tdr: tdr.snapshot_ids())
+        def list_snapshot_ids(tdr: TDRClient):
+            return tdr.snapshot_ids()
+
+        return self._auth_fallback(authentication, list_snapshot_ids)
 
     @property
     def tdr(self):

--- a/src/azul/service/source_service.py
+++ b/src/azul/service/source_service.py
@@ -11,6 +11,7 @@ from typing import (
 from azul import (
     CatalogName,
     NotInLambdaContextException,
+    R,
     cache,
     cached_property,
     config,
@@ -126,7 +127,29 @@ class SourceService:
                       catalog: CatalogName,
                       authentication: Authentication | None
                       ) -> Iterable[SourceRef]:
-        return self.repository_plugin(catalog).list_sources(authentication)
+        plugin = self.repository_plugin(catalog)
+        refs = plugin.list_sources(authentication)
+        specs = plugin.sources.keys()
+
+        specs_by_name = {spec.name: spec for spec in specs}
+        assert len(specs) == len(specs_by_name), R(
+            'Duplicate source names in catalog configuration', list(specs))
+
+        refs_by_name = {ref.spec.name: ref for ref in refs}
+        assert len(refs) == len(refs_by_name), R(
+            'Duplicate source names in repository', refs)
+
+        matching_refs = []
+        for ref in refs:
+            try:
+                spec = specs_by_name[ref.spec.name]
+            except KeyError:
+                pass
+            else:
+                assert spec == ref.spec, R('Misconfigured source', spec, ref)
+                matching_refs.append(ref)
+
+        return matching_refs
 
     table_name = config.dynamo_sources_cache_table_name
 

--- a/src/azul/terra.py
+++ b/src/azul/terra.py
@@ -17,6 +17,7 @@ from time import (
 from typing import (
     ClassVar,
     Self,
+    TypedDict,
 )
 
 import attrs
@@ -99,6 +100,7 @@ from azul.strings import (
 from azul.types import (
     JSON,
     MutableJSON,
+    is_of_type,
     json_dict,
     json_int,
     json_list,
@@ -553,17 +555,19 @@ class TDRClient(SAMClient, DRSClient):
     def list_snapshot_ids(self) -> set[str]:
         """
         List the IDs of the TDR snapshots accessible to the current credentials.
-        Much faster than listing the snapshots' names.
+        We were told that this is much faster than listing the snapshots.
         """
         endpoint = self._repository_endpoint('snapshots', 'roleMap')
         response = self._request('GET', endpoint, headers={'Connection': 'close'})
         response = self._check_response(endpoint, response)
         return set(json_dict(response['roleMap']).keys())
 
-    def list_snapshots(self,
-                       *,
-                       filter: str | None = None
-                       ) -> dict[str, str]:
+    class Snapshot(TypedDict):
+        id: str
+        name: str
+        dataProject: str | None  # None for Azure-backed snapshots
+
+    def list_snapshots(self, *, filter: str | None = None) -> dict[str, Snapshot]:
         """
         List the TDR snapshots accessible to the current credentials.
 
@@ -595,10 +599,9 @@ class TDRClient(SAMClient, DRSClient):
             endpoint.set(args=args)
             response = self._request('GET', endpoint)
             response = self._check_response(endpoint, response)
-            snapshots.update({
-                json_str(snapshot['id']): json_str(snapshot['name'])
-                for snapshot in map(json_dict, json_list(response['items']))
-            })
+            for snapshot in json_list(response['items']):
+                assert is_of_type(snapshot, self.Snapshot)
+                snapshots[snapshot['id']] = snapshot
             after = len(snapshots)
             total = json_int(response['filteredTotal'])
             if after == total:

--- a/src/azul/terra.py
+++ b/src/azul/terra.py
@@ -551,7 +551,7 @@ class TDRClient(SAMClient, DRSClient):
 
     page_size: ClassVar[int] = 1000
 
-    def snapshot_ids(self) -> set[str]:
+    def list_snapshot_ids(self) -> set[str]:
         """
         List the IDs of the TDR snapshots accessible to the current credentials.
         Much faster than listing the snapshots' names.

--- a/src/azul/terra.py
+++ b/src/azul/terra.py
@@ -561,10 +561,10 @@ class TDRClient(SAMClient, DRSClient):
         response = self._check_response(endpoint, response)
         return set(json_dict(response['roleMap']).keys())
 
-    def snapshot_names_by_id(self,
-                             *,
-                             filter: Optional[str] = None
-                             ) -> dict[str, str]:
+    def list_snapshots(self,
+                       *,
+                       filter: Optional[str] = None
+                       ) -> dict[str, str]:
         """
         List the TDR snapshots accessible to the current credentials.
 

--- a/src/azul/terra.py
+++ b/src/azul/terra.py
@@ -16,7 +16,6 @@ from time import (
 )
 from typing import (
     ClassVar,
-    Optional,
     Self,
 )
 
@@ -563,7 +562,7 @@ class TDRClient(SAMClient, DRSClient):
 
     def list_snapshots(self,
                        *,
-                       filter: Optional[str] = None
+                       filter: str | None = None
                        ) -> dict[str, str]:
         """
         List the TDR snapshots accessible to the current credentials.

--- a/src/azul/types.py
+++ b/src/azul/types.py
@@ -3,6 +3,7 @@ from collections.abc import (
     Sequence,
 )
 from types import (
+    GenericAlias,
     UnionType,
     get_original_bases,
 )
@@ -11,16 +12,22 @@ from typing import (
     Callable,
     ForwardRef,
     Iterable,
+    List,
     Optional,
     Protocol,
     TypeAliasType,
     TypeGuard,
+    TypeIs,
     TypeVar,
     TypedDict,
     Union,
     cast,
     get_args,
     get_origin,
+)
+
+from more_itertools import (
+    one,
 )
 
 from azul.collections import (
@@ -576,3 +583,142 @@ class SupportsLessAndGreaterThan(Protocol):
     def __lt__(self, __other: Any) -> bool: ...
 
     def __gt__(self, __other: Any) -> bool: ...
+
+
+_UnionGenericAlias = type(Union[int, str])
+_GenericAlias = type(List[int])
+_TypedDictMeta = type(JSONTypedDict)
+
+# The following serves more of a documentary purpose than for static analysis.
+# We can't include the above three types in the definition, even thought we'd
+# like to, because they are determined at runtime. Note that UnionType and
+# others are defined the same way, and it appears that mypy supports only those
+# specific cases.
+#
+type TypeExpression = Union[
+    type,
+    TypeAliasType,
+    UnionType,
+    GenericAlias,
+]
+
+
+def check_type(type_expression: TypeExpression, value: Any) -> bool:
+    """
+    CAUTION: THIS IS A PROOF OF CONCEPT. IT MAY CHANGE OR GO AWAY IN THE FUTURE.
+
+    This function resembles the ``isinstance()`` built-in but additionally
+    supports type unions, type aliases, TypedDict and certain generic
+    collections (currently any mapping or iterable). TypedDict instances and
+    collections are checked recursively, and for every item, which is why this
+    function may be slow. If the second argument is a cyclic data structure,
+    this function may never return. Another difference to ``isinstance`` is that
+    the order of the arguments is swapped: the type comes first.
+
+    >>> check_type(list, [])
+    True
+
+    >>> check_type(list, {})
+    False
+
+    >>> check_type(list[str], [1])
+    False
+
+    >>> check_type(list[str], [''])
+    True
+
+    >>> type X[T] = dict[int, set[T] | list[T|None]]
+    >>> x = {1: {'a'}, 2: [None, 'b']}
+    >>> check_type(X[str], x)
+    True
+
+    >>> check_type(X[int], x)
+    False
+
+    Assign a type variable to the value of another type variable …
+
+    … of a different name:
+
+    >>> class D[S, T](TypedDict):
+    ...     x: X[S]
+    ...     y: T
+    >>> check_type(D[str, int], {'x': x, 'y': 42})
+    True
+
+    … of the same name:
+
+    >>> class D[T, S](TypedDict):
+    ...     x: X[T]
+    ...     y: S
+    >>> check_type(D[str, int], {'x': x, 'y': 42})
+    True
+
+    >>> class C(dict[str, int]): pass
+    >>> check_type(C, C({'x': 1}))
+    True
+    >>> check_type(C, {'x': 1})
+    False
+    """
+    return _check_type(type_expression, value, {})
+
+
+def _check_type(t: TypeExpression | TypeVar,
+                x: Any,
+                tvs: dict[str, TypeExpression]
+                ) -> bool:
+    """
+    :param t: the expected type of the value
+    :param x: the value to check
+    :param tvs: the values of any type variables ocurring in the first argument
+    """
+    if isinstance(t, TypeVar):
+        return _check_type(tvs[t.__name__], x, tvs)
+    elif isinstance(t, TypeAliasType):
+        return _check_type(t.__value__, x, tvs)
+    elif isinstance(t, (UnionType, _UnionGenericAlias)):
+        ats = get_args(t)
+        return any(_check_type(at, x, tvs) for at in ats)
+    elif isinstance(t, (GenericAlias, _GenericAlias)):
+        ot, ats = not_none(get_origin(t)), get_args(t)
+        tps = getattr(ot, '__type_params__', ())
+        if tps:
+            tvs = tvs | {
+                tp.__name__: tvs[at.__name__] if isinstance(at, TypeVar) else at
+                for tp, at in zip(tps, ats, strict=True)
+            }
+            return _check_type(ot, x, tvs)
+        elif _check_type(ot, x, tvs):
+            if issubclass(ot, Mapping):
+                assert isinstance(x, Mapping)
+                kt, vt = ats
+                return all(
+                    _check_type(kt, k, tvs) and _check_type(vt, v, tvs)
+                    for k, v in x.items()
+                )
+            elif issubclass(ot, Iterable):
+                assert isinstance(x, Iterable)
+                it = one(ats)
+                return all(_check_type(it, i, tvs) for i in x)
+            else:
+                assert False, ('Unsupported generic type', ot)
+        else:
+            return False
+    elif isinstance(t, _TypedDictMeta):
+        for k, vt in t.__annotations__.items():
+            try:
+                v = x[k]
+            except KeyError:
+                if k in t.__required_keys__:
+                    return False
+            else:
+                if not _check_type(vt, v, tvs):
+                    return False
+        return True
+    elif isinstance(t, type):
+        return isinstance(x, t)
+    else:
+        assert False, ('Unsupported type', t)
+
+
+def is_of_type[T](value: Any, typ: type[T]) -> TypeIs[T]:
+    return check_type(typ, value)

--- a/test/indexer/test_tdr.py
+++ b/test/indexer/test_tdr.py
@@ -466,7 +466,8 @@ class TestTDRSourceList(AzulUnitTestCase):
     def _mock_snapshots(self, access_token: str) -> JSONs:
         return [{
             'id': 'foo',
-            'name': f'{access_token}_snapshot'
+            'name': f'{access_token}_snapshot',
+            'dataProject': 'mock_project'
         }]
 
     def _mock_tdr_enumerate_snapshots(self,
@@ -515,7 +516,7 @@ class TestTDRSourceList(AzulUnitTestCase):
                 with self._patch_urlopen(new=self._mock_google_oauth_tokeninfo()):
                     tdr_client = TDRClient.for_registered_user(OAuth2(token))
             expected_snapshots = {
-                snapshot['id']: snapshot['name']
+                snapshot['id']: snapshot
                 for snapshot in self._mock_snapshots(token)
             }
             # The patching here is deliberately "deep" into the implementation
@@ -536,13 +537,14 @@ class TestTDRSourceList(AzulUnitTestCase):
                             tdr_client = TDRClient.for_anonymous_user()
                             page_size = 1000
                             snapshots = [
-                                {'id': str(n), 'name': f'snapshot_{n}'}
+                                {
+                                    'id': str(n),
+                                    'name': f'snapshot_{n}',
+                                    'dataProject': 'mock-project'
+                                }
                                 for n in range(page_size * num_full_pages + last_page_size)
                             ]
-                            expected = {
-                                snapshot['id']: snapshot['name']
-                                for snapshot in snapshots
-                            }
+                            expected = {snapshot['id']: snapshot for snapshot in snapshots}
 
                             def responses():
                                 iterator = iter(snapshots)

--- a/test/indexer/test_tdr.py
+++ b/test/indexer/test_tdr.py
@@ -522,7 +522,7 @@ class TestTDRSourceList(AzulUnitTestCase):
             # to ensure that the proper authorization headers are being sent
             # when nothing is mocked.
             with self._patch_urlopen(new=self._mock_tdr_enumerate_snapshots(tdr_client)):
-                self.assertEqual(tdr_client.snapshot_names_by_id(), expected_snapshots)
+                self.assertEqual(tdr_client.list_snapshots(), expected_snapshots)
 
     def test_list_snapshots_paging(self):
         for page_size in [1, 10]:
@@ -561,7 +561,7 @@ class TestTDRSourceList(AzulUnitTestCase):
                                 self.assertEqual(page_size, tdr_client.page_size)
                                 with mock.patch.object(TerraClient, '_request') as _request:
                                     _request.side_effect = responses()
-                                    actual = tdr_client.snapshot_names_by_id(filter=filter)
+                                    actual = tdr_client.list_snapshots(filter=filter)
                             self.assertEqual(expected, actual)
                             num_expected_calls = max(1, num_full_pages + (1 if last_page_size else 0))
                             self.assertEqual(num_expected_calls, _request.call_count)

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -274,7 +274,7 @@ class IntegrationTestCase(AzulTestCase):
                          f'been registered')
         # The unregistered service account should not have access to any sources
         with self.assertRaises(RequirementError) as cm:
-            tdr.snapshot_names_by_id()
+            tdr.list_snapshots()
         msg = str(cm.exception)
         expected_msg_prefix = f'The service account (SA) {email!r} is not authorized'
         self.assertEqual(expected_msg_prefix, msg[:len(expected_msg_prefix)])
@@ -283,8 +283,8 @@ class IntegrationTestCase(AzulTestCase):
     @cached_property
     def managed_access_sources_by_catalog(self
                                           ) -> dict[CatalogName, set[TDRSourceRef]]:
-        public_sources = self._public_tdr_client.snapshot_names_by_id()
-        all_sources = self._tdr_client.snapshot_names_by_id()
+        public_sources = self._public_tdr_client.list_snapshots()
+        all_sources = self._tdr_client.list_snapshots()
         configured_sources = {
             catalog: self.repository_plugin(catalog).sources
             for catalog in config.integration_test_catalogs
@@ -433,8 +433,8 @@ class IndexingIntegrationTest(IntegrationTestCase):
         for page_size in 1, 2:
             with self.subTest(page_size=page_size):
                 with mock.patch.object(TDRClient, 'page_size', page_size):
-                    paged_snapshots = self._tdr_client.snapshot_names_by_id(filter=filter)
-                snapshots = self._tdr_client.snapshot_names_by_id(filter=filter)
+                    paged_snapshots = self._tdr_client.list_snapshots(filter=filter)
+                snapshots = self._tdr_client.list_snapshots(filter=filter)
                 self.assertLess(len(snapshots), 20)
                 # Show that multiple pages were fetched, via the pigeonhole
                 # principle, and under the assumption that the TDR client

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -293,7 +293,11 @@ class IntegrationTestCase(AzulTestCase):
         managed_access_sources = {catalog: set() for catalog in config.catalogs}
         for catalog, sources in configured_sources.items():
             for spec, _ in sources.items():
-                source_id = one(id for id, name in all_sources.items() if name == spec.name)
+                source_id = one(
+                    id
+                    for id, snapshot in all_sources.items()
+                    if snapshot['name'] == spec.name
+                )
                 if source_id not in public_sources:
                     ref = TDRSourceRef(id=source_id, spec=spec, prefix=None)
                     managed_access_sources[catalog].add(ref)

--- a/test/service/test_cache_poisoning.py
+++ b/test/service/test_cache_poisoning.py
@@ -34,7 +34,7 @@ class CachePoisoningTestCase(LocalAppTestCase, metaclass=ABCMeta):
     def setUpClass(cls):
         super().setUpClass()
         cls.snapshot_mock = patch.object(TDRClient,
-                                         'snapshot_names_by_id',
+                                         'list_snapshots',
                                          return_value={})
         cls.snapshot_mock.start()
 

--- a/test/service/test_source_service.py
+++ b/test/service/test_source_service.py
@@ -179,10 +179,10 @@ class TestListSources(DCP2TestCase, LocalAppTestCase):
             ]}
 
     @patch.object(SourceService, '_get')
-    @patch.object(TDRClient, 'snapshot_names_by_id')
+    @patch.object(TDRClient, 'list_snapshots')
     @patch.object(TDRClient, 'validate', new=MagicMock())
-    def test(self, mock_tdr_client__snapshot_names_by_id, mock_source_service__get):
-        mock_tdr_client__snapshot_names_by_id.return_value = self.source_names_by_id
+    def test(self, mock_tdr_client__list_snapshots, mock_source_service__get):
+        mock_tdr_client__list_snapshots.return_value = self.source_names_by_id
         client = http_client(log)
         azul_url = furl(url=self.base_url,
                         path='/repository/sources',

--- a/test/service/test_source_service.py
+++ b/test/service/test_source_service.py
@@ -198,7 +198,7 @@ class TestListSources(DCP2TestCase, LocalAppTestCase):
                     'sources': [
                         {
                             'sourceId': id,
-                            'sourceSpec': str(TDRSourceSpec.parse(self.make_spec_str(name)))
+                            'sourceSpec': self.make_spec_str(name)
                         }
                         for id, name in self.snapshots_by_id.items()
                         if name not in self.extra_sources

--- a/test/service/test_source_service.py
+++ b/test/service/test_source_service.py
@@ -31,6 +31,9 @@ from azul import (
 from azul.http import (
     http_client,
 )
+from azul.indexer import (
+    SourceConfig,
+)
 from azul.logging import (
     configure_test_logging,
     get_test_logger,
@@ -100,6 +103,13 @@ class TestPublicSources(DCP2TestCase):
 
         class MockPlugin:
 
+            @property
+            def sources(self):
+                return {
+                    TDRSourceSpec.parse(spec): SourceConfig.from_json(config)
+                    for spec, config in cls._sources().items()
+                }
+
             def list_sources(self, authentication):
                 assert authentication is None, authentication
                 return [cls.source]
@@ -141,13 +151,17 @@ class TestListSources(DCP2TestCase, LocalAppTestCase):
         return 'service'
 
     snapshot_names = ['mock_snapshot_1', 'mock_snapshot_2']
-    make_spec_str = 'tdr:bigquery:gcp:mock:{}'.format
+    make_spec_str = 'tdr:bigquery:gcp:mock-project:{}'.format
 
     # Includes extra sources to check that the endpoint only returns results
     # for the current catalog
     extra_sources = ['foo', 'bar']
     snapshots_by_id = {
-        str(i): name
+        str(i): {
+            'id': str(i),
+            'dataProject': 'mock-project',
+            'name': name
+        }
         for i, name in enumerate(snapshot_names + extra_sources)
     }
 
@@ -172,10 +186,10 @@ class TestListSources(DCP2TestCase, LocalAppTestCase):
         return {
             cls.catalog: [
                 TDRSourceRef(id=id,
-                             spec=TDRSourceSpec.parse(cls.make_spec_str(name)),
+                             spec=TDRSourceSpec.parse(cls.make_spec_str(snapshot['name'])),
                              prefix=None)
-                for id, name in cls.snapshots_by_id.items()
-                if name not in cls.extra_sources
+                for id, snapshot in cls.snapshots_by_id.items()
+                if snapshot['name'] not in cls.extra_sources
             ]}
 
     @patch.object(SourceService, '_get')
@@ -198,10 +212,10 @@ class TestListSources(DCP2TestCase, LocalAppTestCase):
                     'sources': [
                         {
                             'sourceId': id,
-                            'sourceSpec': self.make_spec_str(name)
+                            'sourceSpec': self.make_spec_str(snapshot['name'])
                         }
-                        for id, name in self.snapshots_by_id.items()
-                        if name not in self.extra_sources
+                        for id, snapshot in self.snapshots_by_id.items()
+                        if snapshot['name'] not in self.extra_sources
                     ]
                 }
                 self.assertEqual(expected, actual)

--- a/test/service/test_source_service.py
+++ b/test/service/test_source_service.py
@@ -211,7 +211,7 @@ class TestListSources(DCP2TestCase, LocalAppTestCase):
         _test(authenticate=False, cache=True)
         mock_source_service__get.return_value = None
         mock_source_service__get.side_effect = NotFound('foo_token')
-        with patch('azul.terra.TDRClient.snapshot_ids',
+        with patch('azul.terra.TDRClient.list_snapshot_ids',
                    return_value=self.source_names_by_id.keys() | {'not_indexed'}):
             _test(authenticate=True, cache=False)
             _test(authenticate=False, cache=False)

--- a/test/service/test_source_service.py
+++ b/test/service/test_source_service.py
@@ -140,22 +140,22 @@ class TestListSources(DCP2TestCase, LocalAppTestCase):
     def app_name(cls) -> str:
         return 'service'
 
-    source_names = ['mock_snapshot_1', 'mock_snapshot_2']
-    make_spec = 'tdr:bigquery:gcp:mock:{}'.format
+    snapshot_names = ['mock_snapshot_1', 'mock_snapshot_2']
+    make_spec_str = 'tdr:bigquery:gcp:mock:{}'.format
 
     # Includes extra sources to check that the endpoint only returns results
     # for the current catalog
     extra_sources = ['foo', 'bar']
-    source_names_by_id = {
+    snapshots_by_id = {
         str(i): name
-        for i, name in enumerate(source_names + extra_sources)
+        for i, name in enumerate(snapshot_names + extra_sources)
     }
 
     @classmethod
     def _sources(cls):
         return {
-            cls.make_spec(n): {'mirror': True}
-            for n in cls.source_names
+            cls.make_spec_str(n): {'mirror': True}
+            for n in cls.snapshot_names
         }
 
     @classmethod
@@ -172,9 +172,9 @@ class TestListSources(DCP2TestCase, LocalAppTestCase):
         return {
             cls.catalog: [
                 TDRSourceRef(id=id,
-                             spec=TDRSourceSpec.parse(cls.make_spec(name)),
+                             spec=TDRSourceSpec.parse(cls.make_spec_str(name)),
                              prefix=None)
-                for id, name in cls.source_names_by_id.items()
+                for id, name in cls.snapshots_by_id.items()
                 if name not in cls.extra_sources
             ]}
 
@@ -182,7 +182,7 @@ class TestListSources(DCP2TestCase, LocalAppTestCase):
     @patch.object(TDRClient, 'list_snapshots')
     @patch.object(TDRClient, 'validate', new=MagicMock())
     def test(self, mock_tdr_client__list_snapshots, mock_source_service__get):
-        mock_tdr_client__list_snapshots.return_value = self.source_names_by_id
+        mock_tdr_client__list_snapshots.return_value = self.snapshots_by_id
         client = http_client(log)
         azul_url = furl(url=self.base_url,
                         path='/repository/sources',
@@ -198,20 +198,20 @@ class TestListSources(DCP2TestCase, LocalAppTestCase):
                     'sources': [
                         {
                             'sourceId': id,
-                            'sourceSpec': str(TDRSourceSpec.parse(self.make_spec(name)))
+                            'sourceSpec': str(TDRSourceSpec.parse(self.make_spec_str(name)))
                         }
-                        for id, name in self.source_names_by_id.items()
+                        for id, name in self.snapshots_by_id.items()
                         if name not in self.extra_sources
                     ]
                 }
                 self.assertEqual(expected, actual)
 
-        mock_source_service__get.return_value = list(self.source_names_by_id.keys())
+        mock_source_service__get.return_value = list(self.snapshots_by_id.keys())
         _test(authenticate=True, cache=True)
         _test(authenticate=False, cache=True)
         mock_source_service__get.return_value = None
         mock_source_service__get.side_effect = NotFound('foo_token')
         with patch('azul.terra.TDRClient.list_snapshot_ids',
-                   return_value=self.source_names_by_id.keys() | {'not_indexed'}):
+                   return_value=self.snapshots_by_id.keys() | {'not_indexed'}):
             _test(authenticate=True, cache=False)
             _test(authenticate=False, cache=False)


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #7783


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator and the author


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `sandbox`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilbox`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] PR is assigned to only the operator
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
