### PR TITLE
Improve caching of furl instances (#7801)

### DIFF
--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -43,9 +43,6 @@ from attrs import (
     field,
     frozen,
 )
-from furl import (
-    furl,
-)
 from more_itertools import (
     first,
     one,
@@ -75,6 +72,15 @@ from azul.vendored.frozendict import (
     frozendict,
 )
 
+if TYPE_CHECKING:
+    from furl import (
+        _mutable_furl as mutable_furl,
+    )
+else:
+    from furl import (
+        furl as mutable_furl,
+    )
+
 log = _logging.getLogger(__name__)
 
 Netloc = tuple[str, int]
@@ -102,13 +108,6 @@ else:
 
 def cache_per_thread(f, /):
     return azul.caching.lru_cache_per_thread(maxsize=None)(f)
-
-
-#: A type alias for annotating the return value of methods that return a
-#: ``furl`` instance that can be modified without side effects in the object
-#: whose method returned it.
-#:
-mutable_furl = furl
 
 
 @final
@@ -411,20 +410,20 @@ class Config:
 
     @property
     def tdr_service_url(self) -> mutable_furl:
-        return furl(self.environ['AZUL_TDR_SERVICE_URL'])
+        return mutable_furl(self.environ['AZUL_TDR_SERVICE_URL'])
 
     @property
     def sam_service_url(self) -> mutable_furl:
-        return furl(self.environ['AZUL_SAM_SERVICE_URL'])
+        return mutable_furl(self.environ['AZUL_SAM_SERVICE_URL'])
 
     @property
     def duos_service_url(self) -> mutable_furl | None:
         url = self.environ.get('AZUL_DUOS_SERVICE_URL')
-        return None if url is None else furl(url)
+        return None if url is None else mutable_furl(url)
 
     @property
     def terra_service_url(self) -> mutable_furl:
-        return furl(self.environ['AZUL_TERRA_SERVICE_URL'])
+        return mutable_furl(self.environ['AZUL_TERRA_SERVICE_URL'])
 
     @property
     def dss_query_prefix(self) -> str:
@@ -742,7 +741,7 @@ class Config:
         return [self.drs_domain] if lambda_name == 'service' and self.drs_domain else []
 
     def lambda_endpoint(self, lambda_name: str) -> mutable_furl:
-        return furl(scheme='https', netloc=self.api_lambda_domain(lambda_name))
+        return mutable_furl(scheme='https', netloc=self.api_lambda_domain(lambda_name))
 
     @property
     def indexer_endpoint(self) -> mutable_furl:
@@ -755,7 +754,7 @@ class Config:
     @property
     def drs_endpoint(self) -> mutable_furl:
         if self.drs_domain:
-            return furl(scheme='https', netloc=self.drs_domain)
+            return mutable_furl(scheme='https', netloc=self.drs_domain)
         else:
             return self.service_endpoint
 

--- a/src/azul/chalice.py
+++ b/src/azul/chalice.py
@@ -425,14 +425,15 @@ class AzulChaliceApp(Chalice):
             else:
                 # Invocation via API Gateway
                 pass
-            self_url = furl(scheme=scheme, netloc=self.current_request.headers['host'])
+            self_url = mutable_furl(scheme=scheme,
+                                    netloc=self.current_request.headers['host'])
         else:
             assert False, self.current_request
         return self_url
 
     @property
     def is_running_locally(self) -> bool:
-        host = self.base_url.netloc.partition(':')[0]
+        host = not_none(self.base_url.netloc).partition(':')[0]
         return host in ('localhost', '127.0.0.1')
 
     def _register_spec(self,
@@ -763,8 +764,8 @@ class AzulChaliceApp(Chalice):
             file_name = 'swagger-initializer.js.template.mustache'
             template = self.load_static_resource('swagger', file_name)
             base_url = self.base_url
-            redirect_url = furl(base_url).add(path='swagger/oauth2-redirect.html')
-            openapi_spec = furl(base_url).add(path='openapi.json')
+            redirect_url = mutable_furl(base_url).add(path='swagger/oauth2-redirect.html')
+            openapi_spec = mutable_furl(base_url).add(path='openapi.json')
             body = chevron.render(template, {
                 'OPENAPI_SPEC': json.dumps(str(openapi_spec.path)),
                 'OAUTH2_CLIENT_ID': json.dumps(config.google_oauth2_client_id),

--- a/src/azul/drs.py
+++ b/src/azul/drs.py
@@ -47,6 +47,7 @@ from azul.types import (
     json_dict,
     json_list,
     json_str,
+    not_none,
 )
 
 log = logging.getLogger(__name__)
@@ -57,8 +58,8 @@ def drs_object_uri(*,
                    path: Sequence[str],
                    params: Mapping[str, str]
                    ) -> mutable_furl:
-    assert ':' not in base_url.netloc
-    return furl(url=base_url, scheme='drs', path=path, args=params)
+    assert ':' not in not_none(base_url.netloc)
+    return mutable_furl(url=base_url, scheme='drs', path=path, args=params)
 
 
 def drs_object_url_path(*, object_id: str, access_id: str | None = None) -> str:
@@ -218,7 +219,7 @@ class HostBasedDRSURI(DRSURI):
         assert not parsed_uri.fragment, R('Fragment is disallowed in a DRS URI')
         path = parsed_uri.path.segments
         assert len(path) == 1, R('Invalid path', drs_uri)
-        return cls(server=parsed_uri.netloc, object_id=path[0])
+        return cls(server=not_none(parsed_uri.netloc), object_id=path[0])
 
     def to_url(self) -> furl:
         path = drs_object_url_path(object_id=self.object_id)
@@ -327,7 +328,7 @@ class IdentifiersDotOrgClient(_BaseClient):
         assert placeholder in url_pattern, R(
             'Missing accession placeholder in URL pattern', url_pattern)
         url = url_pattern.replace(placeholder, accession)
-        return furl(url)
+        return mutable_furl(url)
 
     _api_url = 'https://registry.api.identifiers.org/restApi/'
 
@@ -346,7 +347,7 @@ class IdentifiersDotOrgClient(_BaseClient):
         return json_str(resource['name']), json_str(resource['urlPattern'])
 
     def _api_request(self, path: str, **args) -> MutableJSON:
-        url = furl(self._api_url).add(path=path, args=args)
+        url = mutable_furl(self._api_url).add(path=path, args=args)
         response = self._http_client.request('GET', str(url))
         if response.status == 200:
             return json.loads(response.data)
@@ -413,7 +414,7 @@ class DRSObject:
             response = self._request(url)
             if response.status == 200:
                 response_data = json_dict(json.loads(response.data))
-                scheme = furl(response_data['url']).scheme
+                scheme = furl(json_str(response_data['url'])).scheme
                 assert scheme == access_method.scheme, R(
                     'Unexpected access URL scheme', scheme)
                 access_url = json_str(response_data['url'])

--- a/src/azul/oauth2.py
+++ b/src/azul/oauth2.py
@@ -141,7 +141,7 @@ class OAuth2Client(HasCachedHttpClient):
         """
         credentials = self.credentials
         url = furl(url='https://www.googleapis.com/oauth2/v3/tokeninfo',
-                   args=dict(access_token=credentials.token))
+                   args=dict(access_token=str(credentials.token)))
         response = self._http_client_without_credentials.request('GET', str(url))
         reject(response.status == 400,
                'The token is not valid')

--- a/src/azul/terra.py
+++ b/src/azul/terra.py
@@ -590,8 +590,8 @@ class TDRClient(SAMClient, DRSClient):
         snapshots = {}
         before = 0
         while True:
-            args = dict(offset=before,
-                        limit=self.page_size,
+            args = dict(offset=str(before),
+                        limit=str(self.page_size),
                         sort='created_date',
                         direction='asc')
             if filter is not None:

--- a/stubs/furl.pyi
+++ b/stubs/furl.pyi
@@ -1,0 +1,143 @@
+"""
+Bare-bones typing stubs for furl. The distinction between mutable and immutable
+instances is completely made up. In reality, every instance of furl.furl is
+mutable. The main motivation behind creating these stubs is to enlist mypy's
+support in enforcing immutability when mutablility is not needed, as that lets
+us more aggressively cache `furl` instances.
+
+Furthermore, these stubs only represent current usage of `furl` in Azul. If you
+want to use an aspect of `furl` that's not yet stubbed, feel free to add it.
+Note however, that we intentionally do not stub many of the mostly superfluous
+convenience features offered by `furl` such as converting non-string values to
+strings on the fly, and the implicit handling of lists of values for the
+mappings that back the query and fragment parts of a URL. These conveniences
+would complicate the signatures, making them harder to read and maintain,
+outweighing the value they might add.
+"""
+
+import abc
+from typing import (
+    Iterable,
+    Mapping,
+    MutableMapping,
+    Self,
+    Sequence,
+    Union,
+)
+
+type _Args = Union[
+    str,
+    Mapping[str, str],
+    Mapping[str, Sequence[str]],
+    Sequence[tuple[str, str]]
+]
+type _Path = Union[
+    str,
+    Path,
+    Sequence[str]
+]
+type _Fragment = _Args
+
+
+class MultiMapping[K, V](
+    Mapping[K, V],
+    metaclass=abc.ABCMeta
+):
+    def getlist(self, k: K) -> Sequence[V]: ...
+
+    def allitems(self) -> Iterable[tuple[K, V]]: ...
+
+
+class MutableMultiMapping[K, V](
+    MultiMapping[K, V],
+    MutableMapping[K, V],
+    metaclass=abc.ABCMeta
+):
+    def setlist(self, k: K, vs: Iterable[V]) -> Self: ...
+
+    def addlist(self, k: K, vs: Iterable[V]) -> Self: ...
+
+
+class Query:
+    params: MultiMapping[str, str]
+
+
+class MutableQuery(Query):
+    params: MutableMultiMapping[str, str]
+
+    def add(self, args: _Args): ...
+
+
+class Path:
+    segments: Sequence[str]
+
+
+class MutablePath(Path):
+    segments: list[str]
+
+    def add(self, path: _Path): ...
+
+
+class Fragment:
+    pass
+
+
+class MutableFragment(Fragment):
+    pass
+
+
+class furl:
+    scheme: str | None
+    netloc: str | None
+    host: str | None
+    port: int | None
+    path: Path
+    args: MultiMapping[str, str]
+    query: Query
+    fragment: Fragment
+
+    def __init__(self,
+                 url: furl | str | None = None,
+                 *,
+                 scheme: str | None = None,
+                 netloc: str | None = None,
+                 host: str | None = None,
+                 port: int | None = None,
+                 path: _Path | None = None,
+                 args: _Args | None = None,
+                 query: _Args | None = None,
+                 fragment: _Fragment | None = None,
+                 ): ...
+
+    def copy(self) -> _mutable_furl: ...
+
+    def __truediv__(self, path: _Path) -> _mutable_furl: ...
+
+
+class _mutable_furl(furl):
+    path: MutablePath
+    args: MutableMultiMapping[str, str]
+    query: MutableQuery
+    fragment: MutableFragment
+
+    def add(self,
+            *,
+            path: _Path | None = None,
+            args: _Args | None = None,
+            query: _Args | None = None,
+            fragment: _Fragment | None = None,
+            ) -> Self: ...
+
+    def set(self,
+            *,
+            scheme: str | None = None,
+            netloc: str | None = None,
+            host: str | None = None,
+            port: int | None = None,
+            path: _Path | None = None,
+            args: _Args | None = None,
+            query: _Args | None = None,
+            fragment: _Fragment | None = None,
+            ) -> Self: ...
+
+    def join(self, *urls: str | furl) -> Self: ...


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #7801


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator and the author


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `sandbox`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilbox`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] PR is assigned to only the operator
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR does not require mirroring `dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR does not require mirroring `anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod` and `reindex:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
