### PR TITLE
Fix: Manifest IT fails with pinned seed (#7835)

### DIFF
--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -524,11 +524,7 @@ class MirrorService:
         """
         assert self.catalog in config.integration_test_catalogs, R(
             'Not an IT catalog', self.catalog)
-        prefix = self._mirror_prefix
-        assert len(prefix) > 1 and prefix.endswith('/'), prefix
-        object_keys = self._storage.list_objects(prefix)
-        assert len(object_keys) <= 300, R('Too many objects', len(object_keys))
-        self._storage.delete_objects(object_keys, batch_size=100)
+        self._storage.delete_prefix(self._mirror_prefix)
 
 
 @attrs.frozen(kw_only=True, slots=False)

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -790,6 +790,14 @@ type Cells = dict[str, str]
 
 
 class ManifestAccessor:
+    service: BaseManifestService
+
+    def __init__(self, service: BaseManifestService):
+        self.service = service
+
+    @property
+    def storage(self) -> StorageService:
+        return self.service.storage_service
 
     @classmethod
     def _manifest_prefix(cls, is_it: bool) -> str:
@@ -807,6 +815,8 @@ class ManifestGenerator(ManifestAccessor, metaclass=ABCMeta):
     # Note to implementors: all property getters in this class and its
     # descendants must be inexpensive. If a property getter performs and
     # expensive computation or I/O, it should cache its return value.
+
+    service: ManifestService
 
     @classmethod
     @abstractmethod
@@ -970,8 +980,7 @@ class ManifestGenerator(ManifestAccessor, metaclass=ABCMeta):
 
         :param service: the service to use when querying the index
         """
-        super().__init__()
-        self.service = service
+        super().__init__(service)
         self.catalog = catalog
         self.filters = filters
         self.file_url_func = service.file_url_func
@@ -1275,10 +1284,6 @@ class ManifestGenerator(ManifestAccessor, metaclass=ABCMeta):
         :param partition: The partition to write.
         """
         raise NotImplementedError
-
-    @property
-    def storage(self) -> StorageService:
-        return self.service.storage_service
 
 
 class ClientSidePagingManifestGenerator(ManifestGenerator, metaclass=ABCMeta):

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -571,13 +571,16 @@ class CachedManifestNotFound(Exception):
     manifest_key: ManifestKey
 
 
-@attrs.frozen(kw_only=True)
-class ManifestService(QueryService):
-    file_url_func: FileUrlFunc
+class BaseManifestService:
 
     @cached_property
     def storage_service(self) -> StorageService:
         return StorageService()
+
+
+@attrs.frozen(kw_only=True)
+class ManifestService(BaseManifestService, QueryService):
+    file_url_func: FileUrlFunc
 
     def get_manifest(self,
                      *,
@@ -785,7 +788,14 @@ class ManifestService(QueryService):
 type Cells = dict[str, str]
 
 
-class ManifestGenerator(metaclass=ABCMeta):
+class ManifestAccessor:
+
+    @classmethod
+    def _manifest_prefix(cls) -> str:
+        return 'manifests/'
+
+
+class ManifestGenerator(ManifestAccessor, metaclass=ABCMeta):
     """
     A generator for manifests. A manifest is an exhaustive representation of
     the documents in the aggregate index for a particular entity type. The
@@ -1004,10 +1014,6 @@ class ManifestGenerator(metaclass=ABCMeta):
                            format=format,
                            manifest_hash=manifest_hash,
                            source_hash=source_hash)
-
-    @classmethod
-    def _manifest_prefix(cls) -> str:
-        return 'manifests/'
 
     @classmethod
     def s3_object_key(cls, manifest_key: ManifestKey) -> str:

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -803,6 +803,9 @@ class ManifestAccessor:
     def _manifest_prefix(cls, is_it: bool) -> str:
         return 'manifests/' + iif(is_it, '_it/')
 
+    def delete_it_files(self):
+        self.storage.delete_prefix(self._manifest_prefix(is_it=True))
+
 
 class ManifestGenerator(ManifestAccessor, metaclass=ABCMeta):
     """

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -1006,8 +1006,12 @@ class ManifestGenerator(metaclass=ABCMeta):
                            source_hash=source_hash)
 
     @classmethod
+    def _manifest_prefix(cls) -> str:
+        return 'manifests/'
+
+    @classmethod
     def s3_object_key(cls, manifest_key: ManifestKey) -> str:
-        return 'manifests' + '/' + cls.s3_object_key_base(manifest_key)
+        return cls._manifest_prefix() + cls.s3_object_key_base(manifest_key)
 
     @classmethod
     def s3_object_key_base(cls, manifest_key: ManifestKey) -> str:

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -121,6 +121,7 @@ from azul.lib.collections import (
 )
 from azul.lib.functions import (
     compose,
+    iif,
 )
 from azul.lib.json import (
     copy_json,
@@ -791,8 +792,8 @@ type Cells = dict[str, str]
 class ManifestAccessor:
 
     @classmethod
-    def _manifest_prefix(cls) -> str:
-        return 'manifests/'
+    def _manifest_prefix(cls, is_it: bool) -> str:
+        return 'manifests/' + iif(is_it, '_it/')
 
 
 class ManifestGenerator(ManifestAccessor, metaclass=ABCMeta):
@@ -1017,7 +1018,8 @@ class ManifestGenerator(ManifestAccessor, metaclass=ABCMeta):
 
     @classmethod
     def s3_object_key(cls, manifest_key: ManifestKey) -> str:
-        return cls._manifest_prefix() + cls.s3_object_key_base(manifest_key)
+        is_it = config.catalogs[manifest_key.catalog].is_integration_test_catalog
+        return cls._manifest_prefix(is_it) + cls.s3_object_key_base(manifest_key)
 
     @classmethod
     def s3_object_key_base(cls, manifest_key: ManifestKey) -> str:

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -206,6 +206,12 @@ class StorageService:
             self._s3.delete_objects(**request)
         log.info('Deleted %d objects overall', num_keys)
 
+    def delete_prefix(self, prefix: str) -> None:
+        assert len(prefix) > 1 and prefix.endswith('/'), prefix
+        object_keys = self.list_objects(prefix)
+        assert len(object_keys) <= 300, R('Too many objects', len(object_keys))
+        self.delete_objects(object_keys, batch_size=100)
+
     def list_objects(self, prefix: str) -> OrderedSet[str]:
         keys: OrderedSet[str] = OrderedSet()
         num_keys = 0

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -169,6 +169,8 @@ from azul.service.async_manifest_service import (
     Token,
 )
 from azul.service.manifest_service import (
+    BaseManifestService,
+    ManifestAccessor,
     ManifestFormat,
     ManifestGenerator,
 )
@@ -470,6 +472,8 @@ class IndexingIntegrationTest(IntegrationTestCase):
             for flag in ['index', 'delete', 'mirror']
         ]
 
+        manifest_accessor = ManifestAccessor(BaseManifestService())
+
         self._assert_queues_empty(config.indexer_fail_queue_names)
         if index:
             self._reset_indexer()
@@ -518,6 +522,12 @@ class IndexingIntegrationTest(IntegrationTestCase):
                                               bundle_fqids=catalog.bundles)
                 self._test_single_entity_response(catalog=catalog.name)
 
+        # `test_manifest` and `test_manifest_tagging_race` assert how many times
+        # the step function is executed when retrieving the manifests, with the
+        # expectation that there are no pre-existing cached manifests. This
+        # deletion is necessary to enforce that expectation, especially when
+        # performing consecutive IT runs with the same seed.
+        manifest_accessor.delete_it_files()
         for catalog in catalogs:
             self._test_manifest(catalog.name)
             self._test_manifest_tagging_race(catalog.name)
@@ -526,6 +536,9 @@ class IndexingIntegrationTest(IntegrationTestCase):
             self._test_managed_access(catalog=catalog.name,
                                       public_source=catalog.public_source,
                                       ma_source=catalog.ma_source)
+
+        if delete:
+            manifest_accessor.delete_it_files()
 
         if mirror and config.enable_mirroring:
             self._test_mirroring(delete=delete)

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -618,6 +618,7 @@ class IndexingIntegrationTest(IntegrationTestCase):
             filters = self._manifest_filters(catalog)
             execution_ids = set()
             coin_flip = bool(self.random.getrandbits(1))
+            num_old_executions = 0
             for i, fetch in enumerate([coin_flip, coin_flip, not coin_flip]):
                 with self.subTest('manifest', catalog=catalog, format=format, i=i, fetch=fetch):
                     args = dict(catalog=catalog, filters=json.dumps(filters))
@@ -655,15 +656,18 @@ class IndexingIntegrationTest(IntegrationTestCase):
                     bucket, key = one(self._manifest_objects(responses))
                     if i == 0:
                         aws.s3.delete_object(Bucket=bucket, Key=key)
-                        # One execution to generate the manifest
-                        self.assertEqual(1, len(execution_ids))
+                        # One execution to generate the manifest. However, if
+                        # this test was recently run using the same seed,
+                        # previous executions will be tracked in the token.
+                        self.assertLessEqual(1, len(execution_ids))
+                        num_old_executions = len(execution_ids) - 1
                     elif i == 1:
                         # One more execution to re-generate the manifest
-                        self.assertEqual(2, len(execution_ids))
+                        self.assertEqual(num_old_executions + 2, len(execution_ids))
                     elif i == 2:
                         # Only fetch mode changed, cached manifest will be used,
                         # and no additional executions are expected
-                        self.assertEqual(2, len(execution_ids))
+                        self.assertEqual(num_old_executions + 2, len(execution_ids))
                     else:
                         assert False
 

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -649,7 +649,7 @@ class IndexingIntegrationTest(IntegrationTestCase):
                         self.assertEqual(2, len(execution_ids))
                     elif i == 2:
                         # Only fetch mode changed, cached manifest will be used,
-                        # and no additional executions are expectect
+                        # and no additional executions are expected
                         self.assertEqual(2, len(execution_ids))
                     else:
                         assert False


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #7835 


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (mirror)

- [x] This PR is labeled `mirror:dev` <sub>or the changes introduced by it will not require mirroring of `dev`</sub>
- [x] This PR is labeled `mirror:anvildev` <sub>or the changes introduced by it will not require mirroring of `anvildev`</sub>
- [x] This PR is labeled `mirror:anvilprod` <sub>or the changes introduced by it will not require mirroring of `anvilprod`</sub>
- [x] This PR is labeled `mirror:prod` <sub>or the changes introduced by it will not require mirroring of `prod`</sub>
- [x] This PR is labeled `mirror:partial` and its description documents the specific mirroring procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full mirroring or carries none of the labels `mirror:dev`, `mirror:anvildev`, `mirror:anvilprod` and `mirror:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [ ] Actually approved the PR
- [ ] Labeled linked issues as `demo` or `no demo`
- [ ] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [ ] Decided if PR can be labeled `no sandbox`
- [ ] A comment to this PR details the completed security design review
- [ ] PR title is appropriate as title of merge commit
- [ ] `N reviews` label is accurate
- [ ] Status of PR is *Approved*
- [ ] PR is assigned to only the operator and the author


### Operator

- [ ] Checked `reindex:…` labels and `r` commit title tag
- [ ] Checked `mirror:…` labels
- [ ] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [ ] Squashed PR branch and rebased onto `develop`
- [ ] Sanity-checked history
- [ ] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [ ] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [ ] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [ ] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [ ] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [ ] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [ ] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [ ] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `sandbox`</sub>
- [ ] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilbox`</sub>
- [ ] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [ ] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [ ] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [ ] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [ ] Started mirroring in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [ ] Started mirroring in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>
- [ ] Checked for failures in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [ ] Checked for failures in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>


### Operator (merge the branch)

- [ ] All status checks passed and the PR is mergeable
- [ ] The title of the merge commit starts with the title of this PR
- [ ] Added PR # reference to merge commit title
- [ ] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [ ] Pushed merge commit to GitHub
- [ ] Status of PR is *Merged lower*
- [ ] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [ ] Pushed merge commit to GitLab `dev`
- [ ] Pushed merge commit to GitLab `anvildev`
- [ ] Build passes on GitLab `dev`
- [ ] Reviewed build logs for anomalies on GitLab `dev`
- [ ] Build passes on GitLab `anvildev`
- [ ] Reviewed build logs for anomalies on GitLab `anvildev`
- [ ] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Deleted PR branch from GitHub
- [ ] PR is assigned to only the operator
- [ ] Deleted PR branch from GitLab `dev`
- [ ] Deleted PR branch from GitLab `anvildev`
- [ ] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [ ] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [ ] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [ ] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [ ] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [ ] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [ ] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [ ] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [ ] Started mirroring in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [ ] Started mirroring in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [ ] Emptied mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [ ] Emptied mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>


### Operator

- [ ] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [ ] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [ ] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
