### PR TITLE
Enable cURL manifest for AnVIL (#7653)

### DIFF
--- a/src/azul/plugins/__init__.py
+++ b/src/azul/plugins/__init__.py
@@ -227,6 +227,7 @@ class SpecialFields:
     bundle_uuid: SpecialField
     bundle_version: SpecialField
     file_uuid: SpecialField
+    file_name: SpecialField
 
 
 class ManifestFormat(SerializableEnum):

--- a/src/azul/plugins/metadata/anvil/__init__.py
+++ b/src/azul/plugins/metadata/anvil/__init__.py
@@ -110,6 +110,9 @@ class Plugin(MetadataPlugin[AnvilBundle]):
         return [
             ManifestFormat.compact,
             ManifestFormat.terra_pfb,
+            *iif(config.enable_mirroring, [
+                ManifestFormat.curl
+            ]),
             *iif(config.enable_replicas, [
                 ManifestFormat.verbatim_jsonl,
                 ManifestFormat.verbatim_pfb

--- a/src/azul/plugins/metadata/anvil/__init__.py
+++ b/src/azul/plugins/metadata/anvil/__init__.py
@@ -275,7 +275,8 @@ class Plugin(MetadataPlugin[AnvilBundle]):
         source_prefix=SpecialField.symmetric('source_prefix'),
         bundle_uuid=SpecialField.symmetric('bundle_uuid'),
         bundle_version=SpecialField.symmetric('bundle_version'),
-        file_uuid=SpecialField(name='files.document_id', name_in_hit='document_id')
+        file_uuid=SpecialField(name='files.document_id', name_in_hit='document_id'),
+        file_name=SpecialField(name='files.file_name', name_in_hit='file_name'),
     )
 
     @property

--- a/src/azul/plugins/metadata/hca/__init__.py
+++ b/src/azul/plugins/metadata/hca/__init__.py
@@ -311,7 +311,8 @@ class Plugin(MetadataPlugin[HCABundle]):
         source_prefix=SpecialField.symmetric('sourcePrefix'),
         bundle_uuid=SpecialField.symmetric('bundleUuid'),
         bundle_version=SpecialField.symmetric('bundleVersion'),
-        file_uuid=SpecialField(name='fileId', name_in_hit='uuid')
+        file_uuid=SpecialField(name='fileId', name_in_hit='uuid'),
+        file_name=SpecialField(name='fileName', name_in_hit='name')
     )
 
     @property

--- a/src/azul/service/manifest_controller.py
+++ b/src/azul/service/manifest_controller.py
@@ -546,26 +546,31 @@ class ManifestController(QueryController):
             }
         else:
             assert manifest.manifest_key == manifest_key
+
             # The manifest is ultimately downloaded via a signed URL that points
-            # to the storage bucket. This signed URL expires after one hour,
-            # which is desirable because it is a client and its short lifespan
-            # reduces the risk of it being shared. However, this also makes it
-            # unsuitable for cURL downloads that may need to be retried over
-            # longer timespans (https://github.com/DataBiosphere/azul/issues/2875)
-            # To allow for cURL manifests to remain valid for longer than 1
-            # hour, we instead return a 301 redirect to the non-fetch
-            # `/manifest/files` endpoint with the object key of the cached
-            # manifest specified as a query parameter. This object key is also a
-            # client secret; it is mutually exclusive with OAuth tokens and
-            # allows for the cached manifest to be downloaded without
-            # authentication for as long as the cached manifest persists in S3.
-            # This increases the risk of the secret being shared, but is
-            # necessary to preserve the functionality of the cURL download.
+            # to the storage bucket. This URL expires after one hour. The signed
+            # URL is a client-side secret and a short expiration reduces the
+            # impact of it being accidentially shared with unauthorized parties.
+            #
+            # A short expiration, however, is unsuitable for cURL downloads that
+            # may need to be retried over a longer time period. To allow for
+            # cURL manifests to remain valid for longer than one hour, we
+            # instead return a 301 redirect to the non-fetch `/manifest/files`
+            # endpoint with the object key of the cached manifest specified as a
+            # query parameter. This object key is also a client secret; it is
+            # mutually exclusive with OAuth tokens and allows for the cached
+            # manifest to be downloaded without authentication for as long as
+            # the cached manifest persists in S3. This increases the risk of the
+            # secret being shared, but is necessary to preserve the utility of
+            # the cURL download feature in general.
+            #
+            # Note that on AnVIL, we are prohibited from exposing manifest URLs
+            # that remain valid for longer than one hour, if those manifests
+            # contain managed-access data or metadata. Fortunately, there's
+            # currently no need to enforce this here because the AnVIL plugin's
+            # cURL-format manifest never includes managed-access files.
+            #
             if fetch and manifest.format is ManifestFormat.curl:
-                # For AnVIL, we are prohibited from exposing a manifest URL that
-                # remains valid for longer than 1 hour. Currently, the AnVIL
-                # plugin does not support cURL-format manifests.
-                assert not config.is_anvil_enabled(manifest_key.catalog)
                 manifest_key = self._service.sign_manifest_key(manifest_key)
                 url = self._manifest_url(fetch=False, token_or_key=manifest_key.encode())
             else:

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -138,6 +138,7 @@ from azul.lib.types import (
     json_element_mappings,
     json_element_strings,
     json_elements_are_mappings,
+    json_int,
     json_list_of_dicts,
     json_mapping,
     json_sequence,
@@ -1578,10 +1579,29 @@ class CurlManifestGenerator(PagedManifestGenerator):
                 contents = json_mapping(doc['contents'])
                 files = json_sequence(contents['files'])
                 file = json_mapping(one(files))
-                _write(file)
-                if config.is_hca_enabled(self.catalog):
-                    for related_file in json_element_mappings(file['related_files']):
-                        _write(related_file, is_related_file=True)
+                source: JSON = one(json_sequence_of_mappings(doc['sources']))
+                source: SourceRef = SourceRef.from_json(source)
+
+                # On AnVIL, and for political reasons, we are not permitted to
+                # include managed-access files, even if they are accessible to
+                # the requesting user. Because we only mirror open-access files,
+                # we can use the mirrorability of a file as a proxy condition
+                # for excluding managed-access files. It is possible that the
+                # condition is true for a file that has yet to be mirrored.
+                # Until the mirrored copy exists, the download will fall back to
+                # TDR's original. We accept that caveat. Also note that if
+                # managed-access files were to be included, we would need to
+                # ensure that the signed URL of the manifest expired after one
+                # hour.
+                #
+                if not config.is_anvil_enabled(self.catalog) or (
+                    self.mirror_service.may_mirror_files_from_source(source.spec)
+                    and self.mirror_service.may_mirror(json_int(file['file_size']))
+                ):
+                    _write(file)
+                    if config.is_hca_enabled(self.catalog):
+                        for related_file in json_element_mappings(file['related_files']):
+                            _write(related_file, is_related_file=True)
             assert hit is not None
             return partition.next_page(file_name=None,
                                        search_after=self._search_after(hit))

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -50,7 +50,6 @@ from typing import (
     IO,
     Protocol,
     Self,
-    cast,
 )
 import unicodedata
 from uuid import (
@@ -142,6 +141,7 @@ from azul.lib.types import (
     json_list_of_dicts,
     json_mapping,
     json_sequence,
+    json_sequence_of_mappings,
     json_str,
     not_none,
     optional,
@@ -1722,7 +1722,7 @@ class CompactManifestGenerator(PagedManifestGenerator):
                 sources = json_element_mappings(doc['sources'])
                 source: SourceSpec = SourceRef.from_json(one(sources)).spec
                 if len(project_short_names) < 2 and 'projects' in contents:
-                    project = one(cast(JSONs, contents['projects']))
+                    project = one(json_sequence_of_mappings(contents['projects']))
                     short_names = json_element_strings(project['project_short_name'])
                     project_short_names.update(short_names)
                 row: Cells = {}

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -1518,6 +1518,7 @@ class CurlManifestGenerator(PagedManifestGenerator):
                       ) -> ManifestPartition:
 
         def _write(file: JSON, is_related_file: bool = False):
+            file_name = json_str(file['name'])
             # Related files are indexed differently than normal files (they
             # don't have their own document but are listed inside the main
             # file's document), so to ensure that the /repository/files
@@ -1526,7 +1527,7 @@ class CurlManifestGenerator(PagedManifestGenerator):
             # need to query the index for that information.
             args = {
                 'requestIndex': 1,
-                'fileName': file['name'],
+                'fileName': file_name,
                 'drsUri': file['drs_uri']
             } if is_related_file else {
             }
@@ -1542,7 +1543,7 @@ class CurlManifestGenerator(PagedManifestGenerator):
                 # the one with the most recent version.
                 bundle = max(json_element_mappings(doc['bundles']),
                              key=itemgetter('version', 'uuid'))
-                output_name = json_str(bundle['uuid']) + '/' + json_str(file['name'])
+                output_name = json_str(bundle['uuid']) + '/' + file_name
                 output_name = self._sanitize_path(output_name)
                 output.write(f'url={self._option(file_url)}\n'
                              f'output={self._option(output_name)}\n\n')

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -1518,7 +1518,11 @@ class CurlManifestGenerator(PagedManifestGenerator):
                       ) -> ManifestPartition:
 
         def _write(file: JSON, is_related_file: bool = False):
-            file_name = json_str(file['name'])
+            special_fields = self.metadata_plugin.special_fields
+            file_name_field = special_fields.file_name.name_in_hit
+            file_uuid_field = special_fields.file_uuid.name_in_hit
+
+            file_name = json_str(file[file_name_field])
             # Related files are indexed differently than normal files (they
             # don't have their own document but are listed inside the main
             # file's document), so to ensure that the /repository/files
@@ -1534,8 +1538,8 @@ class CurlManifestGenerator(PagedManifestGenerator):
 
             file_url = self._azul_file_url(file, args)
             if file_url is None:
-                output.write(f"# File {file['uuid']!r}, version {file['version']!r} is "
-                             f"currently not available in catalog {self.catalog!r}.\n\n")
+                output.write(f"# File {file[file_uuid_field]!r}, version {file['version']!r} "
+                             f"is currently not available in catalog {self.catalog!r}.\n\n")
             else:
                 # To prevent overwriting one file with another one of the same name
                 # but different content we nest each file in a folder using the
@@ -1575,8 +1579,9 @@ class CurlManifestGenerator(PagedManifestGenerator):
                 files = json_sequence(contents['files'])
                 file = json_mapping(one(files))
                 _write(file)
-                for related_file in json_element_mappings(file['related_files']):
-                    _write(related_file, is_related_file=True)
+                if config.is_hca_enabled(self.catalog):
+                    for related_file in json_element_mappings(file['related_files']):
+                        _write(related_file, is_related_file=True)
             assert hit is not None
             return partition.next_page(file_name=None,
                                        search_after=self._search_after(hit))

--- a/test/indexer/__init__.py
+++ b/test/indexer/__init__.py
@@ -210,6 +210,25 @@ class AnvilCannedBundleTestCase(AnvilTestCase,
                                   table_name=table_name,
                                   batch_prefix='' if BundleType.is_batched(table_name) else None)
 
+    @classmethod
+    def primary_bundle(cls) -> TDRAnvilBundleFQID:
+        return cls.bundle_fqid(uuid='826dea02-e274-affe-aabc-eb3db63ad068')
+
+    @classmethod
+    def supplementary_bundle(cls) -> TDRAnvilBundleFQID:
+        return cls.bundle_fqid(uuid='595c469e-604d-ab34-af39-f5b9f5d61818',
+                               table_name=BundleType.supplementary.value)
+
+    @classmethod
+    def duos_bundle(cls) -> TDRAnvilBundleFQID:
+        return cls.bundle_fqid(uuid='2370f948-2783-aeb6-afea-e022897f4dcf',
+                               table_name=BundleType.duos.value)
+
+    @classmethod
+    def replica_bundle(cls) -> TDRAnvilBundleFQID:
+        return cls.bundle_fqid(uuid='f4b39881-d519-ab6f-99a0-7cc5089caee6',
+                               table_name='non_schema_orphan_table')
+
 
 class IndexerTestCase(CatalogTestCase,
                       OpenSearchTestCase,

--- a/test/indexer/test_anvil.py
+++ b/test/indexer/test_anvil.py
@@ -47,9 +47,7 @@ from azul.plugins.repository import (
     tdr_anvil,
 )
 from azul.plugins.repository.tdr_anvil import (
-    BundleType,
     TDRAnvilBundle,
-    TDRAnvilBundleFQID,
 )
 from azul.terra import (
     TDRClient,
@@ -107,25 +105,7 @@ class DUOSTestCase(TDRTestCase, ABC):
 
 
 class AnvilIndexerTestCase(AnvilCannedBundleTestCase, IndexerTestCase):
-
-    @classmethod
-    def primary_bundle(cls) -> TDRAnvilBundleFQID:
-        return cls.bundle_fqid(uuid='826dea02-e274-affe-aabc-eb3db63ad068')
-
-    @classmethod
-    def supplementary_bundle(cls) -> TDRAnvilBundleFQID:
-        return cls.bundle_fqid(uuid='595c469e-604d-ab34-af39-f5b9f5d61818',
-                               table_name=BundleType.supplementary.value)
-
-    @classmethod
-    def duos_bundle(cls) -> TDRAnvilBundleFQID:
-        return cls.bundle_fqid(uuid='2370f948-2783-aeb6-afea-e022897f4dcf',
-                               table_name=BundleType.duos.value)
-
-    @classmethod
-    def replica_bundle(cls) -> TDRAnvilBundleFQID:
-        return cls.bundle_fqid(uuid='f4b39881-d519-ab6f-99a0-7cc5089caee6',
-                               table_name='non_schema_orphan_table')
+    pass
 
 
 class TestAnvilIndexer(AnvilIndexerTestCase,

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -318,15 +318,8 @@ class TestMirrorController(DCP2TestCase,
             messages = self._mirror_sources(SourceConfig(mirror=False))
             self.assertEqual([], messages)
 
-        catalog = config.catalogs[self.catalog]
-
-        def patch_mirror_limit(size):
-            return patch.dict(config.catalogs, {
-                self.catalog: attrs.evolve(catalog, mirror_limit=size)
-            })
-
         with self.subTest(mirror_limit=-1):
-            with patch_mirror_limit(-1):
+            with self._patch_mirror_limit(self.catalog, -1):
                 messages = self._mirror_sources()
                 self.assertEqual([], messages)
 
@@ -336,7 +329,7 @@ class TestMirrorController(DCP2TestCase,
                                    size=self._file.size + 1)
             source_message = self._test_mirror_sources()
             partition_message = self._test_mirror_source(source_message)
-            with patch_mirror_limit(self._file.size):
+            with self._patch_mirror_limit(self.catalog, self._file.size):
                 self._test_mirror_partition(partition_message, [too_big, self._file])
 
     def test_multi_part_upload(self):

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -1729,7 +1729,7 @@ class IndexingIntegrationTest(IntegrationTestCase):
             # Create a single-file curl manifest and verify that the OAuth2
             # token is present on the command line
             managed_access_file = one(self.random.choice(files)['files'])
-            managed_access_file_id = managed_access_file['uuid']
+            managed_access_file_id = lookup(managed_access_file, 'document_id', 'uuid')
             filters = {metadata_plugin.special_fields.file_uuid.name: {'is': [managed_access_file_id]}}
             manifest_url.set(args=dict(catalog=catalog,
                                        filters=json.dumps(filters),

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -1728,7 +1728,8 @@ class IndexingIntegrationTest(IntegrationTestCase):
         if ManifestFormat.curl in metadata_plugin.manifest_formats:
             # Create a single-file curl manifest and verify that the OAuth2
             # token is present on the command line
-            managed_access_file_id = one(self.random.choice(files)['files'])['uuid']
+            managed_access_file = one(self.random.choice(files)['files'])
+            managed_access_file_id = managed_access_file['uuid']
             filters = {metadata_plugin.special_fields.file_uuid.name: {'is': [managed_access_file_id]}}
             manifest_url.set(args=dict(catalog=catalog,
                                        filters=json.dumps(filters),

--- a/test/service/__init__.py
+++ b/test/service/__init__.py
@@ -26,6 +26,7 @@ from warnings import (
     deprecated,
 )
 
+import attrs
 from more_itertools import (
     flatten,
     one,
@@ -44,6 +45,7 @@ from app_test_case import (
     LocalAppTestCase,
 )
 from azul import (
+    CatalogName,
     config,
 )
 from azul.deployment import (
@@ -252,6 +254,16 @@ class MirrorTestCase(S3TestCase):
                                    'mirror_bucket',
                                    new=PropertyMock(return_value=self.mirror_bucket)))
         self._create_test_bucket(self.mirror_bucket)
+
+    @classmethod
+    def _patch_mirror_limit(cls,
+                            catalog: CatalogName,
+                            size: int | None
+                            ) -> patch.dict:
+        catalogs = config.catalogs
+        return patch.dict(catalogs, {
+            catalog: attrs.evolve(catalogs[catalog], mirror_limit=size)
+        })
 
 
 # FIXME: Remove deprecation, convert doctests, prevent use as decorator

--- a/test/service/test_filters.py
+++ b/test/service/test_filters.py
@@ -36,7 +36,8 @@ class TestFilterReification(AzulTestCase):
         source_prefix=MagicMock(),
         bundle_uuid=MagicMock(),
         bundle_version=MagicMock(),
-        file_uuid=MagicMock()
+        file_uuid=MagicMock(),
+        file_name=MagicMock()
     )
 
     @property

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -60,6 +60,7 @@ from requests import (
 
 from azul import (
     config,
+    iif,
 )
 from azul.http import (
     parse_header,
@@ -1799,6 +1800,44 @@ class TestAnvilManifests(AnvilManifestTestCase):
             )
         ]
         self._assert_tsv(expected, response)
+
+    def test_curl_manifest(self):
+        file_size_1 = 15079345
+        file_size_2 = 213021639
+        file_size_3 = 3306845592
+        cases = [-1, file_size_1, file_size_2, file_size_3]
+        for i, mirror_limit in enumerate(cases, start=1):
+            with self.subTest(mirror_limit=mirror_limit):
+                with self._patch_mirror_limit(self.catalog, mirror_limit):
+                    response = self._get_manifest(ManifestFormat.curl,
+                                                  # Redundant filter to avoid caching
+                                                  filters={'source_id': {'is': [self.source.id] * i}})
+                self.assertEqual(200, response.status_code)
+                base_url = str(self.base_url.set(path='/repository/files'))
+                expected_body = [
+                    *iif(file_size_2 <= mirror_limit, [[
+                        f'url="{base_url}/15b76f9c-6b46-433f-851d-34e89f1b9ba6' +
+                        '?catalog=test&version=2022-06-01T00%3A00%3A00.000000Z"',
+                        'output="826dea02-e274-affe-aabc-eb3db63ad068/' +
+                        '307500.merged.matefixed.sorted.markeddups.recal.g.vcf.gz"',
+                        ''
+                    ]]),
+                    *iif(file_size_3 <= mirror_limit, [[
+                        f'url="{base_url}/3b17377b-16b1-431c-9967-e5d01fc5923f' +
+                        '?catalog=test&version=2022-06-01T00%3A00%3A00.000000Z"',
+                        'output="826dea02-e274-affe-aabc-eb3db63ad068/' +
+                        '307500.merged.matefixed.sorted.markeddups.recal.bam"',
+                        ''
+                    ]]),
+                    *iif(file_size_1 <= mirror_limit, [[
+                        f'url="{base_url}/6b0f6c0f-5d80-4242-accb-840921351cd5' +
+                        '?catalog=test&version=2022-06-01T00%3A00%3A00.000000Z"',
+                        'output="595c469e-604d-ab34-af39-f5b9f5d61818/' +
+                        'CCDG_13607_B01_GRM_WGS_2019-02-19_chr15.recalibrated_variants.annotated.coding.txt"',
+                        ''
+                    ]])
+                ]
+                self._assert_curl(expected_body, response)
 
     def test_verbatim_jsonl_manifest(self):
         base_path = ['verbatim', 'jsonl', 'anvil']

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -1347,10 +1347,10 @@ class AnvilManifestTestCase(ManifestTestCase, AnvilCannedBundleTestCase):
     @classmethod
     def bundles(cls) -> list[SourcedBundleFQID]:
         return [
-            cls.bundle_fqid(uuid='2370f948-2783-aeb6-afea-e022897f4dcf'),
-            cls.bundle_fqid(uuid='595c469e-604d-ab34-af39-f5b9f5d61818'),
-            cls.bundle_fqid(uuid='826dea02-e274-affe-aabc-eb3db63ad068'),
-            cls.bundle_fqid(uuid='f4b39881-d519-ab6f-99a0-7cc5089caee6'),
+            cls.duos_bundle(),
+            cls.supplementary_bundle(),
+            cls.primary_bundle(),
+            cls.replica_bundle()
         ]
 
     source_id_filters: FiltersJSON = {

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -346,6 +346,24 @@ class ManifestTestCase(WebServiceTestCase,
         actual[1:], expected[1:] = sorted(actual[1:]), sorted(expected[1:])
         self.assertEqual(expected, actual)
 
+    def _assert_curl(self, expected_body: list[list[str]], actual: Response):
+        expected_header = [
+            '--http1.1', '',
+            '--create-dirs', '',
+            '--compressed', '',
+            '--location', '',
+            '--globoff', '',
+            '--fail', '',
+            '--fail-early', '',
+            '--continue-at -', '',
+            '--write-out "Downloading to: %{filename_effective}\\n\\n"', '',
+        ]
+        lines = actual.content.decode().splitlines()
+        header_length = len(expected_header)
+        header, body = lines[:header_length], lines[header_length:]
+        self.assertEqual(expected_header, header)
+        self.assertEqual(expected_body, sorted(chunked(body, 3)))
+
     def _file_url(self, file_id, version):
         return str(self.base_url.set(path='/repository/files/' + file_id,
                                      args=dict(catalog=self.catalog,
@@ -872,21 +890,6 @@ class TestManifests(DCP1ManifestTestCase):
         filters = {'fileFormat': {'is': ['pdf']}}
         response = self._get_manifest(ManifestFormat.curl, filters)
         self.assertEqual(200, response.status_code)
-        lines = response.content.decode().splitlines()
-        expected_header = [
-            '--http1.1', '',
-            '--create-dirs', '',
-            '--compressed', '',
-            '--location', '',
-            '--globoff', '',
-            '--fail', '',
-            '--fail-early', '',
-            '--continue-at -', '',
-            '--write-out "Downloading to: %{filename_effective}\\n\\n"', '',
-        ]
-        header_length = len(expected_header)
-        header, body = lines[:header_length], lines[header_length:]
-        self.assertEqual(expected_header, header)
         base_url = str(self.base_url.set(path='/repository/files'))
         expected_body = [
             [
@@ -908,7 +911,7 @@ class TestManifests(DCP1ManifestTestCase):
                 ''
             ],
         ]
-        self.assertEqual(expected_body, sorted(chunked(body, 3)))
+        self._assert_curl(expected_body, response)
 
     def test_manifest_format_validation(self):
         url = self.base_url.set(path='/manifest/files',

--- a/test/service/test_manifest.py
+++ b/test/service/test_manifest.py
@@ -874,24 +874,15 @@ class TestManifests(DCP1ManifestTestCase):
         self.assertEqual(200, response.status_code)
         lines = response.content.decode().splitlines()
         expected_header = [
-            '--http1.1',
-            '',
-            '--create-dirs',
-            '',
-            '--compressed',
-            '',
-            '--location',
-            '',
-            '--globoff',
-            '',
-            '--fail',
-            '',
-            '--fail-early',
-            '',
-            '--continue-at -',
-            '',
-            '--write-out "Downloading to: %{filename_effective}\\n\\n"',
-            '',
+            '--http1.1', '',
+            '--create-dirs', '',
+            '--compressed', '',
+            '--location', '',
+            '--globoff', '',
+            '--fail', '',
+            '--fail-early', '',
+            '--continue-at -', '',
+            '--write-out "Downloading to: %{filename_effective}\\n\\n"', '',
         ]
         header_length = len(expected_header)
         header, body = lines[:header_length], lines[header_length:]


### PR DESCRIPTION
Linked issues: #7653


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (mirror)

- [x] This PR is labeled `mirror:dev` <sub>or the changes introduced by it will not require mirroring of `dev`</sub>
- [x] This PR is labeled `mirror:anvildev` <sub>or the changes introduced by it will not require mirroring of `anvildev`</sub>
- [x] This PR is labeled `mirror:anvilprod` <sub>or the changes introduced by it will not require mirroring of `anvilprod`</sub>
- [x] This PR is labeled `mirror:prod` <sub>or the changes introduced by it will not require mirroring of `prod`</sub>
- [x] This PR is labeled `mirror:partial` and its description documents the specific mirroring procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full mirroring or carries none of the labels `mirror:dev`, `mirror:anvildev`, `mirror:anvilprod` and `mirror:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator and the author


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked `mirror:…` labels
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `sandbox`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilbox`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Started mirroring in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [x] Started mirroring in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] PR is assigned to only the operator
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
