### PR TITLE
Cover query service with mypy (#6821)

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -71,6 +71,7 @@ modules =
     azul.service.manifest_service,
     azul.field_type,
     azul.source,
+    azul.service.query_service,
 
 
 packages =

--- a/src/azul/lib/types.py
+++ b/src/azul/lib/types.py
@@ -132,6 +132,11 @@ def json_items_are_sequences_of_mappings(vs: AnyJSON) -> TypeGuard[Mapping[str, 
     return True
 
 
+def json_primitive(v: AnyJSON) -> PrimitiveJSON:
+    assert v is None or isinstance(v, (str, int, float, bool)), type(v)
+    return v
+
+
 def json_dict(v: AnyMutableJSON) -> MutableJSON:
     assert isinstance(v, dict), type(v)
     return v

--- a/src/azul/lib/types.py
+++ b/src/azul/lib/types.py
@@ -132,11 +132,6 @@ def json_items_are_sequences_of_mappings(vs: AnyJSON) -> TypeGuard[Mapping[str, 
     return True
 
 
-def json_primitive(v: AnyJSON) -> PrimitiveJSON:
-    assert v is None or isinstance(v, (str, int, float, bool)), type(v)
-    return v
-
-
 def json_dict(v: AnyMutableJSON) -> MutableJSON:
     assert isinstance(v, dict), type(v)
     return v
@@ -197,6 +192,11 @@ def json_items_are_lists(vs: MutableJSON) -> TypeGuard[dict[str, MutableJSONArra
 
 def json_sorted(vs: Iterable[PrimitiveJSON]) -> MutableJSONArray:
     return sorted(vs, key=none_safe_key(none_last=True))
+
+
+def json_primitive(v: AnyJSON) -> PrimitiveJSON:
+    assert v is None or isinstance(v, (str, int, float, bool)), type(v)
+    return v
 
 
 def json_str(v: AnyMutableJSON | AnyJSON) -> str:

--- a/src/azul/service/query_service.py
+++ b/src/azul/service/query_service.py
@@ -225,7 +225,7 @@ class FilterStage(_OpenSearchStage[Response, Response]):
             translated_filters[field] = {operator: list(values)}
         return translated_filters
 
-    def prepare_query(self, skip_field_paths: tuple[FieldPath] = ()) -> Query:
+    def prepare_query(self, skip_field_paths: tuple[FieldPath, ...] = ()) -> Query:
         """
         Converts the given filters into an OpenSearch DSL Query object.
         """

--- a/src/azul/service/query_service.py
+++ b/src/azul/service/query_service.py
@@ -8,7 +8,6 @@ from collections import (
 from collections.abc import (
     Iterable,
     Mapping,
-    Sequence,
 )
 from functools import (
     partial,
@@ -66,6 +65,7 @@ from azul.lib import (
 from azul.lib.types import (
     AnyJSON,
     JSON,
+    JSONArray,
     JSONTypedDict,
     JSONs,
     MutableJSON,
@@ -168,7 +168,7 @@ class _OpenSearchStage[R1, R2](OpenSearchStage[R1, R2], metaclass=ABCMeta):
         return OpenSearchChain(inner=other, outer=self)
 
 
-TranslatedFilters = Mapping[FieldPath, Mapping[str, Sequence[PrimitiveJSON]]]
+TranslatedFilters = Mapping[FieldPath, Mapping[str, JSONArray]]
 
 
 @attr.s(frozen=True, auto_attribs=True, kw_only=True)

--- a/src/azul/service/query_service.py
+++ b/src/azul/service/query_service.py
@@ -590,8 +590,6 @@ class PaginationStage(_OpenSearchStage[JSON, ResponseTriple]):
         """
         Returns hits and pagination as dict
         """
-        # The slice is necessary because we may have fetched an extra entry to
-        # determine if there is a previous or next page.
         hits = self._extract_hits(response)
         hits = self._translate_hits(hits)
         pagination = self._process_pagination(response)
@@ -599,6 +597,8 @@ class PaginationStage(_OpenSearchStage[JSON, ResponseTriple]):
         return hits, pagination, aggregations
 
     def _extract_hits(self, response):
+        # The slice is necessary because we may have fetched an extra entry to
+        # determine if there is a previous or next page.
         hits = response['hits']['hits'][0:self.pagination.size]
         if self.pagination.search_before is not None:
             hits = reversed(hits)

--- a/src/azul/service/query_service.py
+++ b/src/azul/service/query_service.py
@@ -67,7 +67,17 @@ from azul.lib.types import (
     JSONs,
     MutableJSON,
     PrimitiveJSON,
-    json_list,
+    json_dict,
+    json_dict_of_dicts,
+    json_element_dicts,
+    json_element_strings,
+    json_int,
+    json_item_sequences,
+    json_list_of_dicts,
+    json_mapping,
+    json_primitive,
+    json_sequence,
+    json_sequence_of_mappings,
     json_str,
 )
 from azul.opensearch import (
@@ -79,6 +89,7 @@ from azul.plugins import (
     dotted,
 )
 from azul.service import (
+    FilterJSON,
     Filters,
     FiltersJSON,
 )
@@ -213,14 +224,20 @@ class FilterStage(_OpenSearchStage[Response, Response]):
         """
         catalog = self.catalog
         field_mapping = self.plugin.field_mapping
-        translated_filters = {}
-        for field, filter in filters.items():
-            field = field_mapping[field]
+
+        def translate_filter(field_name: str,
+                             filter: FilterJSON
+                             ) -> tuple[FieldPath, Mapping[str, JSONArray]]:
+            field_path = field_mapping[field_name]
             operator, values = one(filter.items())
-            field_type = self.service.field_type(catalog, field)
-            values = field_type.filter(operator, values)
-            translated_filters[field] = {operator: list(values)}
-        return translated_filters
+            field_type = self.service.field_type(catalog, field_path)
+            values: JSONArray = list(field_type.filter(operator, values))
+            return field_path, {operator: values}
+
+        return dict(
+            translate_filter(field, filter)
+            for field, filter in filters.items()
+        )
 
     def prepare_query(self, skip_field_paths: tuple[FieldPath, ...] = ()) -> Query:
         """
@@ -229,14 +246,14 @@ class FilterStage(_OpenSearchStage[Response, Response]):
         filter_list = []
         for field_path, filter in self.prepared_filters.items():
             if field_path not in skip_field_paths:
-                operator, values = one(filter.items())
+                operator, values = one(json_item_sequences(filter))
                 # Note that `is_not` is only used internally (for filtering by
                 # inaccessible sources)
                 if operator in ('is', 'is_not'):
                     field_type = self.service.field_type(self.catalog, field_path)
                     if isinstance(field_type, Nested):
                         term_queries = []
-                        for nested_field, nested_value in one(values).items():
+                        for nested_field, nested_value in json_mapping(one(values)).items():
                             nested_body = {dotted(field_path, nested_field, 'keyword'): nested_value}
                             term_queries.append(Q('term', **nested_body))
                         query = Q('nested', path=dotted(field_path), query=Q('bool', must=term_queries))
@@ -255,7 +272,7 @@ class FilterStage(_OpenSearchStage[Response, Response]):
                     filter_list.append(query)
                 elif operator in ('contains', 'within', 'intersects'):
                     for value in values:
-                        value = value | {'relation': operator}
+                        value = {**json_mapping(value), 'relation': operator}
                         filter_list.append(Q('range', **{dotted(field_path): value}))
                 else:
                     assert False
@@ -304,7 +321,7 @@ class AggregationStage(_OpenSearchStage[MutableJSON, MutableJSON]):
 
     def process_response(self, response: MutableJSON) -> MutableJSON:
         try:
-            aggs = response['aggregations']
+            aggs = json_dict(response['aggregations'])
         except KeyError:
             pass
         else:
@@ -327,7 +344,7 @@ class AggregationStage(_OpenSearchStage[MutableJSON, MutableJSON]):
             nested_agg = agg.bucket(name='nested',
                                     agg_type='nested',
                                     path=dotted(facet_path))
-            facet_path = dotted(facet_path, field_type.agg_property)
+            facet_path = (*facet_path, field_type.agg_property)
         else:
             nested_agg = agg
         # Make an inner agg that will contain the terms in question
@@ -365,9 +382,9 @@ class AggregationStage(_OpenSearchStage[MutableJSON, MutableJSON]):
             annotate(request.aggs[agg_name])
 
     def _flatten_nested_aggs(self, aggs: MutableJSON):
-        for facet, agg in aggs.items():
+        for facet, agg in json_dict_of_dicts(aggs).items():
             try:
-                nested_agg = agg.pop('nested')
+                nested_agg = json_dict(agg.pop('nested'))
             except KeyError:
                 pass
             else:
@@ -379,26 +396,27 @@ class AggregationStage(_OpenSearchStage[MutableJSON, MutableJSON]):
         OpenSearch response.
         """
 
-        def translate(k, v: MutableJSON):
+        def translate(k: str, v: MutableJSON):
             try:
                 buckets = v['buckets']
             except KeyError:
-                for k, v in v.items():
-                    if isinstance(v, dict):
-                        translate(k, v)
+                for ki, vi in v.items():
+                    if isinstance(vi, dict):
+                        translate(ki, vi)
             else:
                 try:
-                    path = v['meta']['path']
+                    path = json_dict(v['meta'])['path']
                 except KeyError:
                     pass
                 else:
-                    field_type = self.service.field_type(self.catalog, tuple(path))
-                    for bucket in buckets:
+                    field_type = self.service.field_type(self.catalog,
+                                                         tuple(json_element_strings(path)))
+                    for bucket in json_element_dicts(buckets):
                         bucket['key'] = field_type.from_index(bucket['key'])
                         translate(k, bucket)
 
         for k, v in aggs.items():
-            translate(k, v)
+            translate(k, json_dict(v))
 
     def _populate_accessible(self, aggs: MutableJSON) -> None:
         # Because the value of the `accessible` field depends on the provided
@@ -407,13 +425,13 @@ class AggregationStage(_OpenSearchStage[MutableJSON, MutableJSON]):
         source_ids = self.filter_stage.filters.source_ids
         plugin = self.service.metadata_plugin(self.catalog)
         special_fields = plugin.special_fields
-        agg = aggs.pop(special_fields.source_id.name)
+        agg = json_dict(aggs.pop(special_fields.source_id.name))
         counts_by_accessibility: dict[bool, int] = defaultdict(int)
-        terms = agg['myTerms']
-        buckets = terms['buckets']
+        terms = json_dict(agg['myTerms'])
+        buckets = json_list_of_dicts(terms['buckets'])
         for bucket in buckets:
             accessible = bucket['key'] in source_ids
-            counts_by_accessibility[accessible] += bucket['doc_count']
+            counts_by_accessibility[accessible] += json_int(bucket['doc_count'])
         terms['buckets'] = [
             {'key': accessible, 'doc_count': count}
             for accessible, count in counts_by_accessibility.items()
@@ -464,8 +482,8 @@ type SortKey = tuple[PrimitiveJSON, str]
 
 
 def sort_key_from_json(s: AnyJSON) -> SortKey:
-    a, b = json_list(s)
-    return a, json_str(b)
+    a, b = json_sequence(s)
+    return json_primitive(a), json_str(b)
 
 
 def sort_key_to_json(s: SortKey) -> AnyJSON:
@@ -592,29 +610,30 @@ class PaginationStage(_OpenSearchStage[JSON, ResponseTriple]):
         hits, total = self._extract_hits(response)
         pagination = self._process_pagination(hits, total)
         hits = self._translate_hits(hits)
-        aggregations = response.get('aggregations', {})
+        aggregations = json_mapping(response.get('aggregations', {}))
         return hits, pagination, aggregations
 
     def _extract_hits(self, response: JSON) -> tuple[JSONs, int]:
-        hits = response['hits']
-        total = hits['total']
+        hits = json_mapping(response['hits'])
+        total = json_mapping(hits['total'])
         # FIXME: Handle other relations
         #        https://github.com/DataBiosphere/azul/issues/3770
         assert total['relation'] == 'eq'
-        return hits['hits'], total['value']
+        return json_sequence_of_mappings(hits['hits']), json_int(total['value'])
 
     def _translate_hits(self, hits: JSONs) -> JSONs:
         # The slice is necessary because we may have fetched an extra entry to
         # determine if there is a previous or next page.
         hits = hits[0:self.pagination.size]
-        if self.pagination.search_before is not None:
-            hits = reversed(hits)
+        hits = iter(hits) if self.pagination.search_before is None else reversed(hits)
         return [
-            self.service.translate_fields(self.catalog, hit['_source'], forward=False)
+            self.service.translate_fields(self.catalog,
+                                          json_mapping(hit['_source']),
+                                          forward=False)
             for hit in hits
         ]
 
-    def _process_pagination(self, hits: JSONs, total: int) -> MutableJSON:
+    def _process_pagination(self, hits: JSONs, total: int) -> ResponsePagination:
         pages = -(-total // self.pagination.size)
 
         # ... else use search_after/search_before pagination
@@ -624,12 +643,12 @@ class PaginationStage(_OpenSearchStage[JSON, ResponseTriple]):
             if count > self.pagination.size:
                 # There is an extra hit, indicating a next page.
                 count -= 1
-                search_after = tuple(hits[count - 1]['sort'])
+                search_after = sort_key_from_json(hits[count - 1]['sort'])
             else:
                 # No next page
                 search_after = None
             if self.pagination.search_after is not None:
-                search_before = tuple(hits[0]['sort'])
+                search_before = sort_key_from_json(hits[0]['sort'])
             else:
                 search_before = None
         else:
@@ -637,11 +656,11 @@ class PaginationStage(_OpenSearchStage[JSON, ResponseTriple]):
             if count > self.pagination.size:
                 # There is an extra hit, indicating a previous page.
                 count -= 1
-                search_before = tuple(hits[count - 1]['sort'])
+                search_before = sort_key_from_json(hits[count - 1]['sort'])
             else:
                 # No previous page
                 search_before = None
-            search_after = tuple(hits[0]['sort'])
+            search_after = sort_key_from_json(hits[0]['sort'])
 
         pagination = self.pagination.advance(search_before=search_before,
                                              search_after=search_after)

--- a/src/azul/service/query_service.py
+++ b/src/azul/service/query_service.py
@@ -549,12 +549,12 @@ class PaginationStage(_OpenSearchStage[JSON, ResponseTriple]):
 
     def prepare_request(self, request: Search) -> Search:
         sort_order = self.pagination.order
-        sort_field = self.plugin.field_mapping[self.pagination.sort]
-        field_type = self.service.field_type(self.catalog, sort_field)
+        sort_field_path = self.plugin.field_mapping[self.pagination.sort]
+        field_type = self.service.field_type(self.catalog, sort_field_path)
         sort_mode = field_type.es_sort_mode
-        sort_field = dotted(sort_field, 'keyword')
+        sort_field = dotted(sort_field_path, 'keyword')
 
-        def sort(order):
+        def sort(order: str) -> tuple[JSON, JSON]:
             assert order in ('asc', 'desc'), order
             return (
                 {
@@ -665,7 +665,7 @@ class PaginationStage(_OpenSearchStage[JSON, ResponseTriple]):
         pagination = self.pagination.advance(search_before=search_before,
                                              search_after=search_after)
 
-        def page_link(*, previous):
+        def page_link(*, previous: bool) -> str | None:
             url = pagination.link(previous=previous,
                                   catalog=self.catalog,
                                   filters=json.dumps(self.filters.explicit))

--- a/src/azul/service/query_service.py
+++ b/src/azul/service/query_service.py
@@ -231,7 +231,9 @@ class FilterStage(_OpenSearchStage[Response, Response]):
             field_path = field_mapping[field_name]
             operator, values = one(filter.items())
             field_type = self.service.field_type(catalog, field_path)
-            values: JSONArray = list(field_type.filter(operator, values))
+            # FIXME: remove `type: ignore`
+            #        https://github.com/DataBiosphere/azul/issues/6821
+            values: JSONArray = list(field_type.filter(operator, values))  # type: ignore
             return field_path, {operator: values}
 
         return dict(

--- a/src/azul/service/query_service.py
+++ b/src/azul/service/query_service.py
@@ -53,6 +53,7 @@ from azul.field_type import (
 )
 from azul.indexer.document import (
     DocumentType,
+    FieldPath,
     IndexName,
 )
 from azul.indexer.document_service import (
@@ -77,7 +78,6 @@ from azul.opensearch import (
 )
 from azul.plugins import (
     DocumentSlice,
-    FieldPath,
     MetadataPlugin,
     dotted,
 )

--- a/src/azul/service/query_service.py
+++ b/src/azul/service/query_service.py
@@ -412,10 +412,12 @@ class AggregationStage(_OpenSearchStage[MutableJSON, MutableJSON]):
         special_fields = plugin.special_fields
         agg = aggs.pop(special_fields.source_id.name)
         counts_by_accessibility: dict[bool, int] = defaultdict(int)
-        for bucket in agg['myTerms']['buckets']:
+        terms = agg['myTerms']
+        buckets = terms['buckets']
+        for bucket in buckets:
             accessible = bucket['key'] in source_ids
             counts_by_accessibility[accessible] += bucket['doc_count']
-        agg['myTerms']['buckets'] = [
+        terms['buckets'] = [
             {'key': accessible, 'doc_count': count}
             for accessible, count in counts_by_accessibility.items()
         ]

--- a/src/azul/service/query_service.py
+++ b/src/azul/service/query_service.py
@@ -9,9 +9,6 @@ from collections.abc import (
     Iterable,
     Mapping,
 )
-from functools import (
-    partial,
-)
 import json
 import logging
 from typing import (
@@ -592,35 +589,35 @@ class PaginationStage(_OpenSearchStage[JSON, ResponseTriple]):
         """
         Returns hits and pagination as dict
         """
-        hits = self._extract_hits(response)
+        hits, total = self._extract_hits(response)
+        pagination = self._process_pagination(hits, total)
         hits = self._translate_hits(hits)
-        pagination = self._process_pagination(response)
         aggregations = response.get('aggregations', {})
         return hits, pagination, aggregations
 
-    def _extract_hits(self, response):
-        # The slice is necessary because we may have fetched an extra entry to
-        # determine if there is a previous or next page.
-        hits = response['hits']['hits'][0:self.pagination.size]
-        if self.pagination.search_before is not None:
-            hits = reversed(hits)
-        hits = [hit['_source'] for hit in hits]
-        return hits
-
-    def _translate_hits(self, hits):
-        f = partial(self.service.translate_fields, self.catalog, forward=False)
-        hits = list(map(f, hits))
-        return hits
-
-    def _process_pagination(self, response: JSON) -> MutableJSON:
-        total = response['hits']['total']
+    def _extract_hits(self, response: JSON) -> tuple[JSONs, int]:
+        hits = response['hits']
+        total = hits['total']
         # FIXME: Handle other relations
         #        https://github.com/DataBiosphere/azul/issues/3770
         assert total['relation'] == 'eq'
-        pages = -(-total['value'] // self.pagination.size)
+        return hits['hits'], total['value']
+
+    def _translate_hits(self, hits: JSONs) -> JSONs:
+        # The slice is necessary because we may have fetched an extra entry to
+        # determine if there is a previous or next page.
+        hits = hits[0:self.pagination.size]
+        if self.pagination.search_before is not None:
+            hits = reversed(hits)
+        return [
+            self.service.translate_fields(self.catalog, hit['_source'], forward=False)
+            for hit in hits
+        ]
+
+    def _process_pagination(self, hits: JSONs, total: int) -> MutableJSON:
+        pages = -(-total // self.pagination.size)
 
         # ... else use search_after/search_before pagination
-        hits: JSONs = response['hits']['hits']
         count = len(hits)
         if self.pagination.search_before is None:
             # hits are normal sorted
@@ -656,7 +653,7 @@ class PaginationStage(_OpenSearchStage[JSON, ResponseTriple]):
             return None if url is None else str(url)
 
         return ResponsePagination(count=count,
-                                  total=total['value'],
+                                  total=total,
                                   size=pagination.size,
                                   next=page_link(previous=False),
                                   previous=page_link(previous=True),


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #6821


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (mirror)

- [x] This PR is labeled `mirror:dev` <sub>or the changes introduced by it will not require mirroring of `dev`</sub>
- [x] This PR is labeled `mirror:anvildev` <sub>or the changes introduced by it will not require mirroring of `anvildev`</sub>
- [x] This PR is labeled `mirror:anvilprod` <sub>or the changes introduced by it will not require mirroring of `anvilprod`</sub>
- [x] This PR is labeled `mirror:prod` <sub>or the changes introduced by it will not require mirroring of `prod`</sub>
- [x] This PR is labeled `mirror:partial` and its description documents the specific mirroring procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full mirroring or carries none of the labels `mirror:dev`, `mirror:anvildev`, `mirror:anvilprod` and `mirror:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [ ] Actually approved the PR
- [ ] Labeled linked issues as `demo` or `no demo`
- [ ] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [ ] Decided if PR can be labeled `no sandbox`
- [ ] A comment to this PR details the completed security design review
- [ ] PR title is appropriate as title of merge commit
- [ ] `N reviews` label is accurate
- [ ] Status of PR is *Approved*
- [ ] PR is assigned to only the operator and the author


### Operator

- [ ] Checked `reindex:…` labels and `r` commit title tag
- [ ] Checked `mirror:…` labels
- [ ] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [ ] Squashed PR branch and rebased onto `develop`
- [ ] Sanity-checked history
- [ ] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [ ] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [ ] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [ ] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [ ] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [ ] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [ ] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [ ] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `sandbox`</sub>
- [ ] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilbox`</sub>
- [ ] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [ ] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [ ] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [ ] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [ ] Started mirroring in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [ ] Started mirroring in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>
- [ ] Checked for failures in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [ ] Checked for failures in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>


### Operator (merge the branch)

- [ ] All status checks passed and the PR is mergeable
- [ ] The title of the merge commit starts with the title of this PR
- [ ] Added PR # reference to merge commit title
- [ ] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [ ] Pushed merge commit to GitHub
- [ ] Status of PR is *Merged lower*
- [ ] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [ ] Pushed merge commit to GitLab `dev`
- [ ] Pushed merge commit to GitLab `anvildev`
- [ ] Build passes on GitLab `dev`
- [ ] Reviewed build logs for anomalies on GitLab `dev`
- [ ] Build passes on GitLab `anvildev`
- [ ] Reviewed build logs for anomalies on GitLab `anvildev`
- [ ] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Deleted PR branch from GitHub
- [ ] PR is assigned to only the operator
- [ ] Deleted PR branch from GitLab `dev`
- [ ] Deleted PR branch from GitLab `anvildev`
- [ ] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [ ] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [ ] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [ ] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [ ] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [ ] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [ ] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [ ] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [ ] Started mirroring in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [ ] Started mirroring in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [ ] Emptied mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [ ] Emptied mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>


### Operator

- [ ] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [ ] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [ ] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
