### PR TITLE
Expose mirror configuration via service (#7952)

### DIFF
--- a/scripts/mirror.py
+++ b/scripts/mirror.py
@@ -38,7 +38,7 @@ def mirror_catalog(azul: AzulClient,
         fail_queue)
     public_sources_by_spec = {
         source.spec: source
-        for source in azul.source_service.list_sources(catalog, authentication=None)
+        for source, _ in azul.source_service.list_sources(catalog, authentication=None)
     }
     # When the user doesn't specify a source or provides "*" as a source glob,
     # we implicitly filter out managed-access sources. This lets us assert that

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -370,7 +370,7 @@ class MirrorService:
                                                                    authentication=None)
                 is_public = any(
                     source_spec == source.spec
-                    for source in public_sources
+                    for source, _ in public_sources
                 )
                 return is_public
             else:

--- a/src/azul/lib/types.py
+++ b/src/azul/lib/types.py
@@ -92,6 +92,10 @@ def json_item_sequences(vs: AnyJSON) -> Iterable[tuple[str, JSONArray]]:
         yield k, json_sequence(v)
 
 
+def json_element_sequences(vs: AnyJSON) -> Iterable[JSONArray]:
+    return map(json_sequence, json_sequence(vs))
+
+
 def json_element_mappings(vs: AnyJSON) -> Iterable[JSON]:
     return map(json_mapping, json_sequence(vs))
 

--- a/src/azul/service/catalog_controller.py
+++ b/src/azul/service/catalog_controller.py
@@ -127,7 +127,10 @@ class CatalogController(ServiceController):
         if issubclass(plugin_cls, RepositoryPlugin):
             repository_plugin = plugin_cls.create(catalog)
             return {
-                'sources': list(map(str, repository_plugin.sources))
+                'sources': {
+                    str(source): cfg.to_json()
+                    for source, cfg in repository_plugin.sources.items()
+                }
             }
         elif issubclass(plugin_cls, MetadataPlugin):
             metadata_plugin = plugin_cls.create()

--- a/src/azul/service/source_controller.py
+++ b/src/azul/service/source_controller.py
@@ -63,7 +63,11 @@ class SourceController(Controller):
                 log.debug(diff)
                 raise BadGatewayError('Inconsistent response from repository')
             return [
-                {'sourceId': source.id, 'sourceSpec': str(source.spec)}
+                {
+                    'sourceId': source.id,
+                    'sourceSpec': str(source.spec),
+                    'sourceConfig': cfg.to_json()
+                }
                 for source, cfg in sources
             ]
 

--- a/src/azul/service/source_controller.py
+++ b/src/azul/service/source_controller.py
@@ -52,7 +52,7 @@ class SourceController(Controller):
         except TooManyRequestsException as e:
             raise TooManyRequestsError(*e.args)
         else:
-            authoritative_source_ids = {source.id for source in sources}
+            authoritative_source_ids = {source.id for source, _ in sources}
             cached_source_ids = self._list_source_ids(catalog, authentication)
             # For optimized performance, the cache may include source IDs that
             # are accessible but are not configured for indexing. Therefore, we
@@ -64,7 +64,7 @@ class SourceController(Controller):
                 raise BadGatewayError('Inconsistent response from repository')
             return [
                 {'sourceId': source.id, 'sourceSpec': str(source.spec)}
-                for source in sources
+                for source, cfg in sources
             ]
 
     def _list_source_ids(self,

--- a/src/azul/service/source_service.py
+++ b/src/azul/service/source_service.py
@@ -18,6 +18,9 @@ from azul.auth import (
 from azul.deployment import (
     aws,
 )
+from azul.indexer import (
+    SourceConfig,
+)
 from azul.lib import (
     R,
     cache,
@@ -26,6 +29,7 @@ from azul.lib import (
 from azul.lib.types import (
     AnyJSON,
     JSON,
+    json_element_sequences,
     json_element_strings,
     json_item_sequences,
 )
@@ -90,7 +94,7 @@ class SourceService:
         the result is then cached until the instance is destroyed.
         """
         if authentication is None:
-            source_ids = {source.id for source in self._public_sources[catalog]}
+            source_ids = {source.id for source, _ in self._public_sources[catalog]}
         else:
             plugin = self.repository_plugin(catalog)
             cache_key = (catalog, authentication.identity())
@@ -107,7 +111,7 @@ class SourceService:
     def list_sources(self,
                      catalog: CatalogName,
                      authentication: Authentication | None
-                     ) -> Iterable[SourceRef]:
+                     ) -> Iterable[tuple[SourceRef, SourceConfig]]:
         """
         List the sources in the given catalog that are accessible using the
         provided authentication.
@@ -130,12 +134,12 @@ class SourceService:
     def _list_sources(self,
                       catalog: CatalogName,
                       authentication: Authentication | None
-                      ) -> Iterable[SourceRef]:
+                      ) -> Iterable[tuple[SourceRef, SourceConfig]]:
         plugin = self.repository_plugin(catalog)
         refs = plugin.list_sources(authentication)
-        specs = plugin.sources.keys()
+        specs = plugin.sources
 
-        specs_by_name = {spec.name: spec for spec in specs}
+        specs_by_name = {spec.name: (spec, cfg) for spec, cfg in specs.items()}
         assert len(specs) == len(specs_by_name), R(
             'Duplicate source names in catalog configuration', list(specs))
 
@@ -146,12 +150,12 @@ class SourceService:
         matching_refs = []
         for ref in refs:
             try:
-                spec = specs_by_name[ref.spec.name]
+                spec, cfg = specs_by_name[ref.spec.name]
             except KeyError:
                 pass
             else:
                 assert spec == ref.spec, R('Misconfigured source', spec, ref)
-                matching_refs.append(ref)
+                matching_refs.append((ref, cfg))
 
         return matching_refs
 
@@ -199,7 +203,8 @@ class SourceService:
         return int(time())
 
     @cached_property
-    def _public_sources(self) -> Mapping[CatalogName, Iterable[SourceRef]]:
+    def _public_sources(self
+                        ) -> Mapping[CatalogName, Iterable[tuple[SourceRef, SourceConfig]]]:
         """
         The set of all sources included in any catalog in the current
         deployment that are accessible to the public service account. When
@@ -216,13 +221,16 @@ class SourceService:
             }
         else:
             return {
-                catalog: [SourceRef.from_json(source) for source in sources]
+                catalog: [
+                    (SourceRef.from_json(source), SourceConfig.from_json(cfg))
+                    for source, cfg in json_element_sequences(sources)
+                ]
                 for catalog, sources in json_item_sequences(public_sources)
             }
 
     @property
     def public_sources_for_outsourcing(self) -> JSON:
         return {
-            catalog: [source.to_json() for source in sources]
+            catalog: [[source.to_json(), cfg.to_json()] for source, cfg in sources]
             for catalog, sources in self._public_sources.items()
         }

--- a/test/azul_test_case.py
+++ b/test/azul_test_case.py
@@ -54,6 +54,9 @@ from azul import (
 from azul.deployment import (
     aws,
 )
+from azul.indexer import (
+    SourceConfig,
+)
 from azul.logging import (
     configure_test_logging,
     get_test_logger,
@@ -360,6 +363,7 @@ class AzulUnitTestCase(AzulTestCase):
 class CatalogTestCase(AzulUnitTestCase, metaclass=ABCMeta):
     catalog: CatalogName = 'test'
     source: SourceRef
+    source_config: SourceConfig = SourceConfig(mirror=True)
 
     @classmethod
     @abstractmethod
@@ -475,7 +479,7 @@ class DCP1TestCase(DSSTestCase):
                                         mirror_limit=None,
                                         plugins=dict(metadata=config.Catalog.Plugin(name='hca'),
                                                      repository=config.Catalog.Plugin(name='dss')),
-                                        sources={str(cls.source.spec): {'mirror': True}})
+                                        sources={str(cls.source.spec): cls.source_config.to_json()})
         }
 
 
@@ -499,7 +503,7 @@ class TDRTestCase(CatalogTestCase, metaclass=ABCMeta):
 
     @classmethod
     def _sources(cls):
-        return {str(cls.source.spec): {'mirror': True}}
+        return {str(cls.source.spec): cls.source_config.to_json()}
 
     @classmethod
     def _patch_source_cache(cls):
@@ -541,7 +545,7 @@ class AnvilTestCase(TDRTestCase):
                                         mirror_limit=None,
                                         plugins=dict(metadata=config.Catalog.Plugin(name='anvil'),
                                                      repository=config.Catalog.Plugin(name='tdr_anvil')),
-                                        sources={str(cls.source.spec): {'mirror': True}})
+                                        sources={str(cls.source.spec): cls.source_config.to_json()})
         }
 
 

--- a/test/azul_test_case.py
+++ b/test/azul_test_case.py
@@ -425,7 +425,7 @@ class CatalogTestCase(AzulUnitTestCase, metaclass=ABCMeta):
         cls.addClassPatch(patch.object(SourceService,
                                        '_public_sources',
                                        new_callable=PropertyMock,
-                                       return_value={cls.catalog: [cls.source]}))
+                                       return_value={cls.catalog: [(cls.source, cls.source_config)]}))
 
 
 class DSSTestCase(CatalogTestCase, metaclass=ABCMeta):

--- a/test/service/test_response.py
+++ b/test/service/test_response.py
@@ -3731,9 +3731,11 @@ class TestListCatalogsResponse(DCP1CannedBundleTestCase, LocalAppTestCase):
                         },
                         'repository': {
                             'name': 'dss',
-                            'sources': [
-                                'https://fake_dss_instance/v1'
-                            ],
+                            'sources': {
+                                'https://fake_dss_instance/v1': {
+                                    'mirror': True
+                                }
+                            },
                         }
                     }
                 }

--- a/test/service/test_source_service.py
+++ b/test/service/test_source_service.py
@@ -168,7 +168,7 @@ class TestListSources(DCP2TestCase, LocalAppTestCase):
     @classmethod
     def _sources(cls):
         return {
-            cls.make_spec_str(n): {'mirror': True}
+            cls.make_spec_str(n): cls.source_config.to_json()
             for n in cls.snapshot_names
         }
 

--- a/test/service/test_source_service.py
+++ b/test/service/test_source_service.py
@@ -215,7 +215,8 @@ class TestListSources(DCP2TestCase, LocalAppTestCase):
                     'sources': [
                         {
                             'sourceId': id,
-                            'sourceSpec': self.make_spec_str(snapshot['name'])
+                            'sourceSpec': self.make_spec_str(snapshot['name']),
+                            'sourceConfig': self.source_config.to_json()
                         }
                         for id, snapshot in self.snapshots_by_id.items()
                         if snapshot['name'] not in self.extra_sources

--- a/test/service/test_source_service.py
+++ b/test/service/test_source_service.py
@@ -141,7 +141,7 @@ class TestPublicSources(DCP2TestCase):
             test()
 
         self.assertEqual(*outsourced)
-        self.assertEqual([{self.catalog: [self.source]}] * 2, actuals)
+        self.assertEqual([{self.catalog: [(self.source, self.source_config)]}] * 2, actuals)
 
 
 class TestListSources(DCP2TestCase, LocalAppTestCase):
@@ -182,12 +182,15 @@ class TestListSources(DCP2TestCase, LocalAppTestCase):
         )
 
     @classmethod
-    def _sources_by_catalog(cls) -> dict[str, list[TDRSourceRef]]:
+    def _sources_by_catalog(cls) -> dict[str, list[tuple[TDRSourceRef, SourceConfig]]]:
         return {
             cls.catalog: [
-                TDRSourceRef(id=id,
-                             spec=TDRSourceSpec.parse(cls.make_spec_str(snapshot['name'])),
-                             prefix=None)
+                (
+                    TDRSourceRef(id=id,
+                                 spec=TDRSourceSpec.parse(cls.make_spec_str(snapshot['name'])),
+                                 prefix=None),
+                    cls.source_config
+                )
                 for id, snapshot in cls.snapshots_by_id.items()
                 if snapshot['name'] not in cls.extra_sources
             ]}


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #7952


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (mirror)

- [x] This PR is labeled `mirror:dev` <sub>or the changes introduced by it will not require mirroring of `dev`</sub>
- [x] This PR is labeled `mirror:anvildev` <sub>or the changes introduced by it will not require mirroring of `anvildev`</sub>
- [x] This PR is labeled `mirror:anvilprod` <sub>or the changes introduced by it will not require mirroring of `anvilprod`</sub>
- [x] This PR is labeled `mirror:prod` <sub>or the changes introduced by it will not require mirroring of `prod`</sub>
- [x] This PR is labeled `mirror:partial` and its description documents the specific mirroring procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full mirroring or carries none of the labels `mirror:dev`, `mirror:anvildev`, `mirror:anvilprod` and `mirror:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [ ] Actually approved the PR
- [ ] PR is not a draft
- [ ] PR is awaiting requested review from system administrator
- [ ] Status of PR is *Review requested*
- [ ] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [ ] Actually approved the PR
- [ ] Labeled linked issues as `demo` or `no demo`
- [ ] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [ ] Decided if PR can be labeled `no sandbox`
- [ ] A comment to this PR details the completed security design review
- [ ] PR title is appropriate as title of merge commit
- [ ] `N reviews` label is accurate
- [ ] Status of PR is *Approved*
- [ ] PR is assigned to only the operator and the author


### Operator

- [ ] Checked `reindex:…` labels and `r` commit title tag
- [ ] Checked `mirror:…` labels
- [ ] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [ ] Squashed PR branch and rebased onto `develop`
- [ ] Sanity-checked history
- [ ] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [ ] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [ ] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [ ] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [ ] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [ ] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [ ] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [ ] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `sandbox`</sub>
- [ ] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilbox`</sub>
- [ ] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [ ] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [ ] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [ ] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [ ] Started mirroring in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [ ] Started mirroring in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>
- [ ] Checked for failures in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [ ] Checked for failures in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>


### Operator (merge the branch)

- [ ] All status checks passed and the PR is mergeable
- [ ] The title of the merge commit starts with the title of this PR
- [ ] Added PR # reference to merge commit title
- [ ] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [ ] Pushed merge commit to GitHub
- [ ] Status of PR is *Merged lower*
- [ ] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [ ] Pushed merge commit to GitLab `dev`
- [ ] Pushed merge commit to GitLab `anvildev`
- [ ] Build passes on GitLab `dev`
- [ ] Reviewed build logs for anomalies on GitLab `dev`
- [ ] Build passes on GitLab `anvildev`
- [ ] Reviewed build logs for anomalies on GitLab `anvildev`
- [ ] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Deleted PR branch from GitHub
- [ ] PR is assigned to only the operator
- [ ] Deleted PR branch from GitLab `dev`
- [ ] Deleted PR branch from GitLab `anvildev`
- [ ] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [ ] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [ ] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [ ] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [ ] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [ ] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [ ] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [ ] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [ ] Started mirroring in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [ ] Started mirroring in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [ ] Emptied mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [ ] Emptied mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>


### Operator

- [ ] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [ ] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [ ] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
