### PR TITLE
Ensure that a file's mirror URI is correct in service responses & manifests (#7930, #7686)

### DIFF
--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -498,6 +498,8 @@ class MirrorService:
         #
         if self.will_mirror(source.spec, file_size=0):
             file = file_cls.from_index(file_json, source=source)
+            # FIXME: Remove file size default
+            #        https://github.com/DataBiosphere/azul/issues/8024
             if self.will_mirror(source.spec, 0 if file.size is None else file.size):
                 storage = self._storage_for_source(source.spec)
                 return str(furl(scheme='s3',

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -480,7 +480,7 @@ class MirrorService:
     assert 1.5 * 1024 ** 4 <= max_file_size
 
     def mirror_uri(self,
-                   source: SourceSpec,
+                   source: SourceRef,
                    file_cls: type[File],
                    file_json: JSON
                    ) -> str | None:
@@ -499,10 +499,10 @@ class MirrorService:
 
         :param file_json: the index representation of the file
         """
-        if self.may_mirror_files_from_source(source):
-            file = file_cls.from_index(file_json, source=None)
+        if self.may_mirror_files_from_source(source.spec):
+            file = file_cls.from_index(file_json, source=source)
             if self.may_mirror(0 if file.size is None else file.size):
-                storage = self._storage_for_source(source)
+                storage = self._storage_for_source(source.spec)
                 return str(furl(scheme='s3',
                                 netloc=storage.bucket_name,
                                 path=self._file_object_key(file)))

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -493,6 +493,9 @@ class MirrorService:
         # file from a source that was configured to not be mirrored because the
         # file metadata in that source is incomplete or broken.
         #
+        # FIXME: Files from 1000G snapshot in anvildev can't be mirrored
+        #        https://github.com/DataBiosphere/azul/issues/7634
+        #
         if self.will_mirror(source.spec, file_size=0):
             file = file_cls.from_index(file_json, source=source)
             if self.will_mirror(source.spec, 0 if file.size is None else file.size):

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -524,17 +524,20 @@ class MirrorService:
         else:
             return None
 
-    def mirror_url(self, file: File) -> str:
-        storage = self._storage_for_file(file)
-        return storage.get_presigned_url(object_key=self._file_object_key(file),
-                                         file_name=file.name,
-                                         content_type=file.content_type)
+    def mirror_url(self, file: File) -> str | None:
+        if self._info_exists(file):
+            storage = self._storage_for_file(file)
+            return storage.get_presigned_url(object_key=self._file_object_key(file),
+                                             file_name=file.name,
+                                             content_type=file.content_type)
+        else:
+            return None
 
     def info(self, file: File) -> MutableJSON:
         storage = self._storage_for_file(file)
         return json.loads(storage.get_object(self._info_object_key(file)))
 
-    def info_exists(self, file: File) -> bool:
+    def _info_exists(self, file: File) -> bool:
         storage = self._storage_for_file(file)
         return storage.object_exists(self._info_object_key(file))
 
@@ -660,7 +663,7 @@ class MirrorWorkerService(MirrorService, HasCachedHttpClient):
     @_mirror.register
     def _(self, a: MirrorFileAction) -> Iterator[MirrorAction]:
         assert a.file.size is not None, R('File size unknown', a.file)
-        if self.info_exists(a.file):
+        if self._info_exists(a.file):
             log.info('File is already mirrored, skipping upload: %r', a.file)
             self._update_info(a.file)
         elif self._file_exists(a.file):

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -379,37 +379,30 @@ class MirrorService:
     def _source_service(self) -> SourceService:
         return SourceService()
 
-    def will_mirror_file(self, file_size: int, source: SourceSpec) -> bool:
+    def will_mirror(self, source: SourceSpec, file_size: int) -> bool:
         """
         Test whether files from the given source, that are of the given size or
-        less, will be mirrored when :meth:``mirror_sources`` is invoked with
-        that source, or when :meth:``mirror_file`` is invoked with such a file.
+        less, will be mirrored when :meth:`mirror_sources` is invoked with
+        that source, or when :meth:`mirror_file` is invoked with such a file.
         """
-        return self.may_mirror(file_size) and self.may_mirror_files_from_source(source)
-
-    def may_mirror_files_from_source(self, source_spec: SourceSpec) -> bool:
-        """
-        Test whether it makes sense to request the mirroring of files from the
-        given source. If this method returns True, files from the source may or
-        may not be mirrored. If this method returns False, the service will
-        definitely not mirror any files from the source.
-        """
-        if self.may_mirror():
-            plugin = self.repository_plugin
-            source_config = plugin.sources[source_spec]
+        if self._may_mirror(file_size):
+            source_config = self.repository_plugin.sources[source]
             return source_config.mirror
         else:
             return False
 
-    def may_mirror(self, file_size: int = 0) -> bool:
+    def may_mirror(self) -> bool:
         """
         Test whether it makes sense to request the mirroring of files from the
-        current catalog if they are of the given size or larger. If this method
-        returns True, such files may or may not be mirrored. If this method
-        returns False, the service will definitely skip mirroring such files,
-        although it may mirror smaller files.
+        current catalog. If this method returns True, such files may or may not
+        be mirrored, depending on their size and source. If this method returns
+        False, the service will definitely skip mirroring such files.
         """
+        return self._may_mirror(0)
+
+    def _may_mirror(self, file_size: int) -> bool:
         if config.enable_mirroring:
+            # A mirror limit of -1 disables mirroring of an entire catalog
             max_size = config.catalogs[self.catalog].mirror_limit
             return max_size is None or file_size <= max_size
         else:
@@ -492,16 +485,17 @@ class MirrorService:
 
         :param source: The source of the file
 
-        :param file_cls: The type of the file. This parameter is needed in order
-                         to avoid deserializing a file from a source that was
-                         configured to not be mirrored because the file metadata
-                         in that source is incomplete or broken
+        :param file_cls: The type of the file.
 
         :param file_json: the index representation of the file
         """
-        if self.may_mirror_files_from_source(source.spec):
+        # We have to call will_mirror() twice in order to avoid deserializing a
+        # file from a source that was configured to not be mirrored because the
+        # file metadata in that source is incomplete or broken.
+        #
+        if self.will_mirror(source.spec, file_size=0):
             file = file_cls.from_index(file_json, source=source)
-            if self.may_mirror(0 if file.size is None else file.size):
+            if self.will_mirror(source.spec, 0 if file.size is None else file.size):
                 storage = self._storage_for_source(source.spec)
                 return str(furl(scheme='s3',
                                 netloc=storage.bucket_name,
@@ -648,7 +642,7 @@ class MirrorWorkerService(MirrorService, HasCachedHttpClient):
             assert file.size is not None, R('File size unknown', file)
             assert file.size <= self.max_file_size, R(
                 'File too big', file, self.max_file_size)
-            if self.may_mirror(file.size):
+            if self.will_mirror(file.source.spec, file.size):
                 yield devolve(MirrorFileAction, a, file=file)
             else:
                 log.info('Not mirroring file to save cost: %r', file)

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -515,6 +515,14 @@ class MirrorService:
             return None
 
     def mirror_url(self, file: File) -> str | None:
+
+        # FIXME: Expose access to mirrored MA files via /repository/files
+        #        https://github.com/DataBiosphere/azul/issues/7931
+        #
+        assert file.source is not None, file
+        if not self._is_public(file.source.spec):
+            return None
+
         if self._info_exists(file):
             storage = self._storage_for_file(file)
             return storage.get_presigned_url(object_key=self._file_object_key(file),

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -358,17 +358,8 @@ class MirrorService:
         return StorageService(bucket)
 
     def _storage_for_file(self, file: File) -> StorageService:
-        # Currently, :py:attr:`source` will never be none during mirroring (see
-        # the implementations of :meth:`RepositoryPlugin.list-files`), but will
-        # always be None when downloading files via the service.
-        #
-        # FIXME: Expose access to mirrored MA files via /repository/files
-        #        https://github.com/DataBiosphere/azul/issues/7931
-        #
-        if file.source is None:
-            return self._storage
-        else:
-            return self._storage_for_source(file.source.spec)
+        assert file.source is not None, file
+        return self._storage_for_source(file.source.spec)
 
     def _storage_for_source(self, source: SourceSpec) -> StorageService:
         if self._is_public(source):
@@ -388,6 +379,17 @@ class MirrorService:
     def _source_service(self) -> SourceService:
         return SourceService()
 
+    def should_mirror_file(self, file_size: int, source: SourceSpec) -> bool:
+        """
+        Test whether a file of the given size from the given source should be
+        mirrored. If this method returns True, either the file is currently
+        mirrored, or it will be mirrored the next time the mirror script is
+        run targeting the file's catalog/source. If this method returns False,
+        either the file is not currently mirrored, or it was mirrored previously
+        but ought to be deleted, and should be ignored in the meantime.
+        """
+        return self.may_mirror(file_size) and self.may_mirror_files_from_source(source)
+
     def may_mirror_files_from_source(self, source_spec: SourceSpec) -> bool:
         """
         Test whether it makes sense to request the mirroring of files from the
@@ -398,19 +400,7 @@ class MirrorService:
         if self.may_mirror():
             plugin = self.repository_plugin
             source_config = plugin.sources[source_spec]
-            if source_config.mirror:
-                # This method is only used by the index and manifest services
-                # to determine whether to populate a file's mirror URI in the
-                # index response/manifest or not. We deliberately return a false
-                # negative for managed-access files since we don't want the
-                # service to know about them yet.
-                #
-                # FIXME: Expose access to mirrored MA files via /repository/files
-                #        https://github.com/DataBiosphere/azul/issues/7931
-                #
-                return self._is_public(source_spec)
-            else:
-                return False
+            return source_config.mirror
         else:
             return False
 
@@ -513,7 +503,7 @@ class MirrorService:
         :param file_json: the index representation of the file
         """
         if self.may_mirror_files_from_source(source):
-            file = file_cls.from_index(file_json)
+            file = file_cls.from_index(file_json, source=None)
             if self.may_mirror(0 if file.size is None else file.size):
                 storage = self._storage_for_source(source)
                 return str(furl(scheme='s3',

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -379,14 +379,11 @@ class MirrorService:
     def _source_service(self) -> SourceService:
         return SourceService()
 
-    def should_mirror_file(self, file_size: int, source: SourceSpec) -> bool:
+    def will_mirror_file(self, file_size: int, source: SourceSpec) -> bool:
         """
-        Test whether a file of the given size from the given source should be
-        mirrored. If this method returns True, either the file is currently
-        mirrored, or it will be mirrored the next time the mirror script is
-        run targeting the file's catalog/source. If this method returns False,
-        either the file is not currently mirrored, or it was mirrored previously
-        but ought to be deleted, and should be ignored in the meantime.
+        Test whether files from the given source, that are of the given size or
+        less, will be mirrored when :meth:``mirror_sources`` is invoked with
+        that source, or when :meth:``mirror_file`` is invoked with such a file.
         """
         return self.may_mirror(file_size) and self.may_mirror_files_from_source(source)
 

--- a/src/azul/lib/__init__.py
+++ b/src/azul/lib/__init__.py
@@ -1,7 +1,5 @@
 import functools
 from typing import (
-    Callable,
-    Hashable,
     TYPE_CHECKING,
     final,
 )
@@ -20,19 +18,7 @@ cached_property = CachedProperty
 
 lru_cache = functools.lru_cache
 
-if TYPE_CHECKING:
-    # Work around https://github.com/python/typeshed/issues/15139
-    @final
-    class CacheWrapper[_T]:
-
-        def __call__(self, *args: Hashable, **kwargs: Hashable) -> _T:
-            ...
-
-
-    def cache[_T](f: Callable[..., _T], /) -> CacheWrapper[_T]:  # noqa: E303
-        ...
-else:
-    cache = functools.cache
+cache = functools.cache
 
 
 def cache_per_thread(f, /):

--- a/src/azul/lib/collections.py
+++ b/src/azul/lib/collections.py
@@ -605,6 +605,18 @@ class LookupDefault(Enum):
     RAISE = 0
 
 
+@overload
+def lookup[K, V](d: Mapping[K, V], k: K, *ks: K, default: V | LookupDefault) -> V: ...
+
+
+@overload
+def lookup[K, V](d: Mapping[K, V], k: K, *ks: K, default: None) -> V | None: ...
+
+
+@overload
+def lookup[K, V](d: Mapping[K, V], k: K, *ks: K) -> V | None: ...
+
+
 def lookup[K, V](d: Mapping[K, V],
                  k: K,
                  *ks: K,

--- a/src/azul/plugins/__init__.py
+++ b/src/azul/plugins/__init__.py
@@ -969,7 +969,7 @@ class File(DiscriminatingPolymorphicSerializableAttrs,
 
     @classmethod
     @abstractmethod
-    def from_index(cls, hit: JSON) -> Self:
+    def from_index(cls, hit: JSON, *, source: SourceRef | None) -> Self:
         """
         Instantiate this class from an entity aggregate document retrieved from
         OpenSearch.

--- a/src/azul/plugins/metadata/anvil/__init__.py
+++ b/src/azul/plugins/metadata/anvil/__init__.py
@@ -90,6 +90,9 @@ from azul.plugins.metadata.anvil.service.response import (
     AnvilSearchResponseStage,
     AnvilSummaryResponseStage,
 )
+from azul.source import (
+    SourceRef,
+)
 
 
 class Plugin(MetadataPlugin[AnvilBundle]):
@@ -549,12 +552,13 @@ class AnvilFile(File):
     md5: str
 
     @classmethod
-    def from_index(cls, hit: JSON) -> Self:
+    def from_index(cls, hit: JSON, *, source: SourceRef | None) -> Self:
         return cls(uuid=json_str(hit['document_id']),
                    version=json_str(hit['version']),
                    name=json_str(hit['file_name']),
                    size=json_int(hit['file_size']),
                    drs_uri=optional(json_str, hit['drs_uri']),
+                   source=source,
                    md5=json_str(hit['file_md5sum']))
 
     @property

--- a/src/azul/plugins/metadata/anvil/service/response.py
+++ b/src/azul/plugins/metadata/anvil/service/response.py
@@ -46,7 +46,6 @@ from azul.service.query_service import (
 )
 from azul.source import (
     SourceRef,
-    SourceSpec,
 )
 
 
@@ -179,7 +178,7 @@ class AnvilSearchResponseStage(SearchResponseStage):
         contents = json_mapping(es_hit['contents'])
         sources = json_sequence_of_mappings(es_hit['sources'])
         bundles = json_element_mappings(es_hit['bundles'])
-        source = SourceRef[SourceSpec].from_json(one(sources)).spec
+        source: SourceRef = SourceRef.from_json(one(sources))
         return {
             'entryId': json_str(es_hit['entity_id']),
             # Note that there is a brittle coupling that must be maintained
@@ -207,7 +206,7 @@ class AnvilSearchResponseStage(SearchResponseStage):
             self._special_fields.bundle_version.name_in_hit: json_str(es_bundle['version'])
         }
 
-    def _make_contents(self, source: SourceSpec, es_contents: JSON) -> MutableJSON:
+    def _make_contents(self, source: SourceRef, es_contents: JSON) -> MutableJSON:
         return {
             inner_entity_type: (
                 [
@@ -222,7 +221,7 @@ class AnvilSearchResponseStage(SearchResponseStage):
         }
 
     def _pivotal_entity(self,
-                        source: SourceSpec,
+                        source: SourceRef,
                         inner_entity_type: str,
                         inner_entity: JSON,
                         ) -> MutableJSON:

--- a/src/azul/plugins/metadata/hca/__init__.py
+++ b/src/azul/plugins/metadata/hca/__init__.py
@@ -498,13 +498,14 @@ class HCAFile(File):
     s3_etag: str | None = None
 
     @classmethod
-    def from_index(cls, hit: JSON) -> Self:
+    def from_index(cls, hit: JSON, *, source: SourceRef | None) -> Self:
         return cls(uuid=json_str(hit['uuid']),
                    version=json_str(hit['version']),
                    name=json_str(hit['name']),
                    size=json_int(hit['size']),
                    drs_uri=optional(json_str, hit['drs_uri']),
                    content_type=json_str(hit['content-type']),
+                   source=source,
                    sha256=json_str(hit['sha256']),
                    crc32c=json_str(hit['crc32c']),
                    sha1=optional(json_str, hit.get('sha1')),

--- a/src/azul/plugins/metadata/hca/service/response.py
+++ b/src/azul/plugins/metadata/hca/service/response.py
@@ -57,7 +57,6 @@ from azul.service.query_service import (
 )
 from azul.source import (
     SourceRef,
-    SourceSpec,
 )
 
 log = logging.getLogger(__name__)
@@ -349,7 +348,7 @@ class HCASearchResponseStage(SearchResponseStage):
             for dates in entry['contents']['dates']
         ]
 
-    def make_projects(self, source: SourceSpec, entry) -> MutableJSONs:
+    def make_projects(self, source: SourceRef, entry) -> MutableJSONs:
         projects = []
         contents = entry['contents']
         for project in contents['projects']:
@@ -389,7 +388,7 @@ class HCASearchResponseStage(SearchResponseStage):
     # FIXME: Move this to during aggregation
     #        https://github.com/DataBiosphere/azul/issues/2415
 
-    def make_matrices_(self, source: SourceSpec, matrices: JSONs) -> JSON:
+    def make_matrices_(self, source: SourceRef, matrices: JSONs) -> JSON:
         files: list[JSON] = []
         if matrices:
             for file in json_element_mappings(one(matrices)['file']):
@@ -400,14 +399,14 @@ class HCASearchResponseStage(SearchResponseStage):
                 files.append(translated_file)
         return make_stratification_tree(files)
 
-    def make_files(self, source: SourceSpec, entry: JSON) -> JSONs:
+    def make_files(self, source: SourceRef, entry: JSON) -> JSONs:
         files = []
         for _file in json_element_mappings(json_mapping(entry['contents'])['files']):
             translated_file = self.make_file(source, _file)
             files.append(translated_file)
         return files
 
-    def make_file(self, source: SourceSpec, file: JSON) -> JSON:
+    def make_file(self, source: SourceRef, file: JSON) -> JSON:
         translated_file = {
             'contentDescription': file.get('content_description'),
             'format': file.get('file_format'),
@@ -517,7 +516,7 @@ class HCASearchResponseStage(SearchResponseStage):
         return list(map(self.make_hit, hits))
 
     def make_hit(self, es_hit) -> SummarizedHit | CompleteHit:
-        source: SourceSpec = SourceRef.from_json(one(es_hit['sources'])).spec
+        source: SourceRef = SourceRef.from_json(one(es_hit['sources']))
         hit = Hit(protocols=self.make_protocols(es_hit),
                   entryId=es_hit['entity_id'],
                   sources=self.make_sources(es_hit),

--- a/src/azul/service/index_service.py
+++ b/src/azul/service/index_service.py
@@ -65,7 +65,6 @@ from azul.service.query_service import (
 )
 from azul.source import (
     SourceRef,
-    SourceSpec,
 )
 
 log = logging.getLogger(__name__)
@@ -96,7 +95,7 @@ class SearchResponseStage(_OpenSearchStage[ResponseTriple, MutableJSON],
                                           file_uuid=uuid,
                                           version=version))
 
-    def _file_mirror_uri(self, source: SourceSpec, file: JSON) -> str | None:
+    def _file_mirror_uri(self, source: SourceRef, file: JSON) -> str | None:
         file_cls = self.plugin.file_class
         mirror_service = self.service.mirror_service(self.catalog)
         return mirror_service.mirror_uri(source, file_cls, file)

--- a/src/azul/service/index_service.py
+++ b/src/azul/service/index_service.py
@@ -64,6 +64,7 @@ from azul.service.query_service import (
     _OpenSearchStage,
 )
 from azul.source import (
+    SourceRef,
     SourceSpec,
 )
 
@@ -355,8 +356,10 @@ class IndexService(QueryService):
             # Can't have more than one hit with the same version
             assert file_version is None, len(hits)
 
-        file = one(first(hits)['contents']['files'])
-        file = plugin.file_class.from_index(file)
+        hit = first(hits)
+        source = SourceRef.from_json(one(hit['sources']))
+        file = one(hit['contents']['files'])
+        file = plugin.file_class.from_index(file, source=source)
         if file_version is not None:
             assert file_version == file.version
         return file

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -1595,9 +1595,9 @@ class CurlManifestGenerator(PagedManifestGenerator):
                 # ensure that the signed URL of the manifest expired after one
                 # hour.
                 #
-                if not config.is_anvil_enabled(self.catalog) or (
-                    self.mirror_service.may_mirror_files_from_source(source.spec)
-                    and self.mirror_service.may_mirror(json_int(file['file_size']))
+                if (
+                    not config.is_anvil_enabled(self.catalog)
+                    or self.mirror_service.will_mirror(source.spec, json_int(file['file_size']))
                 ):
                     _write(file)
                     if config.is_hca_enabled(self.catalog):

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -189,7 +189,6 @@ from azul.service.storage_service import (
 from azul.source import (
     Prefix,
     SourceRef,
-    SourceSpec,
 )
 from azul.vendored.frozendict import (
     frozendict,
@@ -1154,7 +1153,7 @@ class ManifestGenerator(metaclass=ABCMeta):
                                           fetch=False,
                                           **args))
 
-    def _azul_mirror_uri(self, source: SourceSpec, file: JSON) -> str | None:
+    def _azul_mirror_uri(self, source: SourceRef, file: JSON) -> str | None:
         file_cls = self.metadata_plugin.file_class
         return self.mirror_service.mirror_uri(source, file_cls, file)
 
@@ -1748,7 +1747,7 @@ class CompactManifestGenerator(PagedManifestGenerator):
                 assert isinstance(doc, dict)
                 contents = json_mapping(doc['contents'])
                 sources = json_element_mappings(doc['sources'])
-                source: SourceSpec = SourceRef.from_json(one(sources)).spec
+                source: SourceRef = SourceRef.from_json(one(sources))
                 if len(project_short_names) < 2 and 'projects' in contents:
                     project = one(json_sequence_of_mappings(contents['projects']))
                     short_names = json_element_strings(project['project_short_name'])

--- a/src/azul/service/repository_controller.py
+++ b/src/azul/service/repository_controller.py
@@ -397,9 +397,7 @@ class RepositoryController(ServiceController):
         # requests since they aren't propagated via query parameters.
         # `MirrorFileDownload` will always be ready immediately.
         if request_index == 0 and config.enable_mirroring:
-            mirror_service = self._mirror_service(catalog)
-            if mirror_service.info_exists(file):
-                mirror_url = mirror_service.mirror_url(file)
+            mirror_url = self._mirror_service(catalog).mirror_url(file)
 
         if mirror_url is None:
             download_cls = plugin.file_download_class()

--- a/src/azul/service/repository_controller.py
+++ b/src/azul/service/repository_controller.py
@@ -393,7 +393,10 @@ class RepositoryController(ServiceController):
         plugin = self._repository_plugin(catalog)
 
         mirror_url = None
-        if config.enable_mirroring:
+        # The file's content type and source would be None on subsequent
+        # requests since they aren't propagated via query parameters.
+        # `MirrorFileDownload` will always be ready immediately.
+        if request_index == 0 and config.enable_mirroring:
             mirror_service = self._mirror_service(catalog)
             if mirror_service.info_exists(file):
                 mirror_url = mirror_service.mirror_url(file)
@@ -402,9 +405,6 @@ class RepositoryController(ServiceController):
             download_cls = plugin.file_download_class()
             download = download_cls(plugin=plugin, file=file, replica=replica, token=token)
         else:
-            # The file's content type would be None on subsequent requests since
-            # it isn't propagated via a query parameter. `MirrorFileDownload`
-            # will always be ready immediately.
             assert request_index == 0, request_index
             download = MirrorFileDownload(
                 plugin=plugin,

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -1596,7 +1596,7 @@ class IndexingIntegrationTest(IntegrationTestCase):
         for file in inner_files:
             mirror_uri = file['azul_mirror_uri']
             file_size = lookup(file, 'file_size', 'size')
-            if mirror_service.should_mirror_file(file_size, ma_source.spec):
+            if mirror_service.will_mirror_file(file_size, ma_source.spec):
                 self.assertIsNotNone(mirror_uri)
                 mirror_uri = furl(mirror_uri)
                 self.assertEqual(aws.ma_mirror_bucket, mirror_uri.host)

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -1603,7 +1603,7 @@ class IndexingIntegrationTest(IntegrationTestCase):
         for file in inner_files:
             mirror_uri = optional(json_str, file['azul_mirror_uri'])
             file_size = json_int(lookup(file, 'file_size', 'size'))
-            if mirror_service.will_mirror_file(file_size, ma_source.spec):
+            if mirror_service.will_mirror(ma_source.spec, file_size):
                 self.assertIsNotNone(mirror_uri)
                 mirror_uri = furl(mirror_uri)
                 self.assertEqual(aws.ma_mirror_bucket, mirror_uri.host)
@@ -1788,9 +1788,10 @@ class IndexingIntegrationTest(IntegrationTestCase):
 
             service_by_catalog = {}
             for catalog in config.catalogs.values():
-                service = self._mirror_service(catalog.name)
-                if catalog.is_integration_test_catalog and service.may_mirror():
-                    service_by_catalog[catalog.name] = service
+                if catalog.is_integration_test_catalog:
+                    service = self._mirror_service(catalog.name)
+                    if service.may_mirror():
+                        service_by_catalog[catalog.name] = service
 
             sources_by_catalog = {
                 catalog: list(filter(is_not_none, (

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -1592,8 +1592,16 @@ class IndexingIntegrationTest(IntegrationTestCase):
                 }
             })
         inner_files = [one(file['files']) for file in files]
+        mirror_service = self._mirror_service(catalog)
         for file in inner_files:
-            self.assertIsNone(file['azul_mirror_uri'])
+            mirror_uri = file['azul_mirror_uri']
+            file_size = lookup(file, 'file_size', 'size')
+            if mirror_service.should_mirror_file(file_size, ma_source.spec):
+                self.assertIsNotNone(mirror_uri)
+                mirror_uri = furl(mirror_uri)
+                self.assertEqual(aws.ma_mirror_bucket, mirror_uri.host)
+            else:
+                self.assertIsNone(mirror_uri)
         managed_access_file_urls = {
             file['azul_url']
             for file in inner_files

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -137,6 +137,10 @@ from azul.lib.types import (
     JSONs,
     MutableJSON,
     MutableJSONs,
+    json_int,
+    json_list_of_dicts,
+    json_str,
+    optional,
 )
 from azul.logging import (
     configure_test_logging,
@@ -1129,7 +1133,10 @@ class IndexingIntegrationTest(IntegrationTestCase):
             fields_expected = set(f['name'] for f in fields)
             self.assertEqual(fields_present, fields_expected)
             for relation in cast(MutableJSONs, record['relations']):
-                relations.add((relation['dst_name'], relation['dst_id']))
+                relations.add((
+                    json_str(relation['dst_name']),
+                    json_str(relation['dst_id'])
+                ))
         # We expect to observe the special `Metadata` entity record and at least
         # one additional entity record
         self.assertGreater(len(record_fqids), 1)
@@ -1591,11 +1598,11 @@ class IndexingIntegrationTest(IntegrationTestCase):
                     'is': [ma_source.id]
                 }
             })
-        inner_files = [one(file['files']) for file in files]
+        inner_files = [one(json_list_of_dicts(file['files'])) for file in files]
         mirror_service = self._mirror_service(catalog)
         for file in inner_files:
-            mirror_uri = file['azul_mirror_uri']
-            file_size = lookup(file, 'file_size', 'size')
+            mirror_uri = optional(json_str, file['azul_mirror_uri'])
+            file_size = json_int(lookup(file, 'file_size', 'size'))
             if mirror_service.will_mirror_file(file_size, ma_source.spec):
                 self.assertIsNotNone(mirror_uri)
                 mirror_uri = furl(mirror_uri)
@@ -1603,7 +1610,7 @@ class IndexingIntegrationTest(IntegrationTestCase):
             else:
                 self.assertIsNone(mirror_uri)
         managed_access_file_urls = {
-            file['azul_url']
+            json_str(file['azul_url'])
             for file in inner_files
         }
         file_url = furl(self.random.choice(sorted(managed_access_file_urls)))

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -105,7 +105,7 @@ class RepositoryFilesTestCase(LocalAppTestCase, metaclass=ABCMeta):
 
 class TestRepositoryFilesWithTDR(DCP2TestCase, RepositoryFilesTestCase):
 
-    @patch.object(MirrorService, 'info_exists', new=Mock(return_value=False))
+    @patch.object(MirrorService, '_info_exists', new=Mock(return_value=False))
     @patch.object(TerraClient,
                   '_http_client',
                   AuthorizedHttp(MagicMock(),
@@ -175,7 +175,7 @@ class TestRepositoryFilesWithDSS(DCP1TestCase,
                                  RepositoryFilesTestCase,
                                  S3TestCase):
 
-    @patch.object(MirrorService, 'info_exists', new=Mock(return_value=False))
+    @patch.object(MirrorService, '_info_exists', new=Mock(return_value=False))
     @patch.object(type(config), 'dss_direct_access_role', new=Mock(return_value=None))
     def test(self):
         self.maxDiff = None
@@ -325,7 +325,7 @@ class TestRepositoryFilesWithMirroring(DCP2TestCase,
                                              schema_url_func=MagicMock())
         with patch.object(MirrorWorkerService, '_download', return_value=file_content):
             mirror_service._mirror_file(file)
-        self.assertTrue(mirror_service.info_exists(file))
+        self.assertTrue(mirror_service._info_exists(file))
 
         client = http_client(log)
         args = dict(catalog=self.catalog, version=file_version)

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -123,6 +123,7 @@ class TestRepositoryFilesWithTDR(DCP2TestCase, RepositoryFilesTestCase):
                        version=file_version,
                        drs_uri=drs_uri,
                        size=1,
+                       source=self.source.ref,
                        content_type='text/plain',
                        sha256='123',
                        crc32c='abc')
@@ -196,6 +197,7 @@ class TestRepositoryFilesWithDSS(DCP1TestCase,
                        version=file_version,
                        drs_uri=f'drs://{self._drs_domain_name}/{file_uuid}?version={file_version}',
                        size=3,
+                       source=self.source.ref,
                        content_type='text/plain',
                        sha256='123',
                        crc32c='abc')
@@ -318,6 +320,7 @@ class TestRepositoryFilesWithMirroring(DCP2TestCase,
                        drs_uri=None,
                        size=len(file_content),
                        content_type='text/plain',
+                       source=self.source.ref,
                        sha256=hashlib.sha256(file_content).hexdigest(),
                        crc32c=None)
 


### PR DESCRIPTION
Linked issues: #7930, #7686


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (mirror)

- [x] This PR is labeled `mirror:dev` <sub>or the changes introduced by it will not require mirroring of `dev`</sub>
- [x] This PR is labeled `mirror:anvildev` <sub>or the changes introduced by it will not require mirroring of `anvildev`</sub>
- [x] This PR is labeled `mirror:anvilprod` <sub>or the changes introduced by it will not require mirroring of `anvilprod`</sub>
- [x] This PR is labeled `mirror:prod` <sub>or the changes introduced by it will not require mirroring of `prod`</sub>
- [x] This PR is labeled `mirror:partial` and its description documents the specific mirroring procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full mirroring or carries none of the labels `mirror:dev`, `mirror:anvildev`, `mirror:anvilprod` and `mirror:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator and the author


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked `mirror:…` labels
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `sandbox`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilbox`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Started mirroring in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [x] Started mirroring in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] PR is assigned to only the operator
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>


### Operator

- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>

### Author

- [x] Author to perform a dry run of the demo against dev and anvildev
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
