### PR TITLE
Expose access to mirrored MA files via /repository/files (#7931)

### DIFF
--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -504,6 +504,14 @@ class MirrorService:
             return None
 
     def mirror_url(self, file: File) -> str | None:
+
+        # FIXME: Expose access to mirrored MA files via /repository/files
+        #        https://github.com/DataBiosphere/azul/issues/7931
+        #
+        assert file.source is not None, file
+        if not self._is_public(file.source.spec):
+            return None
+
         if self._info_exists(file):
             storage = self._storage_for_file(file)
             return storage.get_presigned_url(object_key=self._file_object_key(file),

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -358,17 +358,8 @@ class MirrorService:
         return StorageService(bucket)
 
     def _storage_for_file(self, file: File) -> StorageService:
-        # Currently, :py:attr:`source` will never be none during mirroring (see
-        # the implementations of :meth:`RepositoryPlugin.list-files`), but will
-        # always be None when downloading files via the service.
-        #
-        # FIXME: Expose access to mirrored MA files via /repository/files
-        #        https://github.com/DataBiosphere/azul/issues/7931
-        #
-        if file.source is None:
-            return self._storage
-        else:
-            return self._storage_for_source(file.source.spec)
+        assert file.source is not None, file
+        return self._storage_for_source(file.source.spec)
 
     def _storage_for_source(self, source: SourceSpec) -> StorageService:
         if self._is_public(source):
@@ -398,19 +389,7 @@ class MirrorService:
         if self.may_mirror():
             plugin = self.repository_plugin
             source_config = plugin.sources[source_spec]
-            if source_config.mirror:
-                # This method is only used by the index and manifest services
-                # to determine whether to populate a file's mirror URI in the
-                # index response/manifest or not. We deliberately return a false
-                # negative for managed-access files since we don't want the
-                # service to know about them yet.
-                #
-                # FIXME: Expose access to mirrored MA files via /repository/files
-                #        https://github.com/DataBiosphere/azul/issues/7931
-                #
-                return self._is_public(source_spec)
-            else:
-                return False
+            return source_config.mirror
         else:
             return False
 
@@ -513,7 +492,7 @@ class MirrorService:
         :param file_json: the index representation of the file
         """
         if self.may_mirror_files_from_source(source):
-            file = file_cls.from_index(file_json)
+            file = file_cls.from_index(file_json, source=None)
             if self.may_mirror(0 if file.size is None else file.size):
                 storage = self._storage_for_source(source)
                 return str(furl(scheme='s3',

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -525,7 +525,7 @@ class MirrorService:
             return None
 
     def mirror_url(self, file: File) -> str | None:
-        if self.info_exists(file):
+        if self._info_exists(file):
             storage = self._storage_for_file(file)
             return storage.get_presigned_url(object_key=self._file_object_key(file),
                                              file_name=file.name,
@@ -537,7 +537,7 @@ class MirrorService:
         storage = self._storage_for_file(file)
         return json.loads(storage.get_object(self._info_object_key(file)))
 
-    def info_exists(self, file: File) -> bool:
+    def _info_exists(self, file: File) -> bool:
         storage = self._storage_for_file(file)
         return storage.object_exists(self._info_object_key(file))
 
@@ -663,7 +663,7 @@ class MirrorWorkerService(MirrorService, HasCachedHttpClient):
     @_mirror.register
     def _(self, a: MirrorFileAction) -> Iterator[MirrorAction]:
         assert a.file.size is not None, R('File size unknown', a.file)
-        if self.info_exists(a.file):
+        if self._info_exists(a.file):
             log.info('File is already mirrored, skipping upload: %r', a.file)
             self._update_info(a.file)
         elif self._file_exists(a.file):

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -504,14 +504,6 @@ class MirrorService:
             return None
 
     def mirror_url(self, file: File) -> str | None:
-
-        # FIXME: Expose access to mirrored MA files via /repository/files
-        #        https://github.com/DataBiosphere/azul/issues/7931
-        #
-        assert file.source is not None, file
-        if not self._is_public(file.source.spec):
-            return None
-
         if self._info_exists(file):
             storage = self._storage_for_file(file)
             return storage.get_presigned_url(object_key=self._file_object_key(file),

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -524,11 +524,14 @@ class MirrorService:
         else:
             return None
 
-    def mirror_url(self, file: File) -> str:
-        storage = self._storage_for_file(file)
-        return storage.get_presigned_url(object_key=self._file_object_key(file),
-                                         file_name=file.name,
-                                         content_type=file.content_type)
+    def mirror_url(self, file: File) -> str | None:
+        if self.info_exists(file):
+            storage = self._storage_for_file(file)
+            return storage.get_presigned_url(object_key=self._file_object_key(file),
+                                             file_name=file.name,
+                                             content_type=file.content_type)
+        else:
+            return None
 
     def info(self, file: File) -> MutableJSON:
         storage = self._storage_for_file(file)

--- a/src/azul/plugins/__init__.py
+++ b/src/azul/plugins/__init__.py
@@ -969,7 +969,7 @@ class File(DiscriminatingPolymorphicSerializableAttrs,
 
     @classmethod
     @abstractmethod
-    def from_index(cls, hit: JSON) -> Self:
+    def from_index(cls, hit: JSON, *, source: SourceRef | None) -> Self:
         """
         Instantiate this class from an entity aggregate document retrieved from
         OpenSearch.

--- a/src/azul/plugins/metadata/anvil/__init__.py
+++ b/src/azul/plugins/metadata/anvil/__init__.py
@@ -90,6 +90,9 @@ from azul.plugins.metadata.anvil.service.response import (
     AnvilSearchResponseStage,
     AnvilSummaryResponseStage,
 )
+from azul.source import (
+    SourceRef,
+)
 
 
 class Plugin(MetadataPlugin[AnvilBundle]):
@@ -549,12 +552,13 @@ class AnvilFile(File):
     md5: str
 
     @classmethod
-    def from_index(cls, hit: JSON) -> Self:
+    def from_index(cls, hit: JSON, *, source: SourceRef | None) -> Self:
         return cls(uuid=json_str(hit['document_id']),
                    version=json_str(hit['version']),
                    name=json_str(hit['file_name']),
                    size=json_int(hit['file_size']),
                    drs_uri=optional(json_str, hit['drs_uri']),
+                   source=source,
                    md5=json_str(hit['file_md5sum']))
 
     @property

--- a/src/azul/plugins/metadata/hca/__init__.py
+++ b/src/azul/plugins/metadata/hca/__init__.py
@@ -498,13 +498,14 @@ class HCAFile(File):
     s3_etag: str | None = None
 
     @classmethod
-    def from_index(cls, hit: JSON) -> Self:
+    def from_index(cls, hit: JSON, *, source: SourceRef | None) -> Self:
         return cls(uuid=json_str(hit['uuid']),
                    version=json_str(hit['version']),
                    name=json_str(hit['name']),
                    size=json_int(hit['size']),
                    drs_uri=optional(json_str, hit['drs_uri']),
                    content_type=json_str(hit['content-type']),
+                   source=source,
                    sha256=json_str(hit['sha256']),
                    crc32c=json_str(hit['crc32c']),
                    sha1=optional(json_str, hit.get('sha1')),

--- a/src/azul/service/index_service.py
+++ b/src/azul/service/index_service.py
@@ -64,6 +64,7 @@ from azul.service.query_service import (
     _OpenSearchStage,
 )
 from azul.source import (
+    SourceRef,
     SourceSpec,
 )
 
@@ -355,8 +356,10 @@ class IndexService(QueryService):
             # Can't have more than one hit with the same version
             assert file_version is None, len(hits)
 
-        file = one(first(hits)['contents']['files'])
-        file = plugin.file_class.from_index(file)
+        hit = first(hits)
+        source = SourceRef.from_json(one(hit['sources']))
+        file = one(hit['contents']['files'])
+        file = plugin.file_class.from_index(file, source=source)
         if file_version is not None:
             assert file_version == file.version
         return file

--- a/src/azul/service/lambda_iam_policy.py
+++ b/src/azul/service/lambda_iam_policy.py
@@ -111,7 +111,12 @@ policy = {
             ],
             'Resource': [
                 f'arn:aws:s3:::{resource}'
-                for bucket in alist(aws.mirror_bucket, config.mirror_bucket)
+                for bucket in alist(
+                    aws.mirror_bucket,
+                    config.mirror_bucket,
+                    aws.ma_mirror_bucket,
+                    config.ma_mirror_bucket
+                )
                 for resource in [bucket, f'{bucket}/*']
             ]
         },

--- a/src/azul/service/repository_controller.py
+++ b/src/azul/service/repository_controller.py
@@ -397,9 +397,7 @@ class RepositoryController(ServiceController):
         # requests since they aren't propagated via query parameters.
         # `MirrorFileDownload` will always be ready immediately.
         if request_index == 0 and config.enable_mirroring:
-            mirror_service = self._mirror_service(catalog)
-            if mirror_service.info_exists(file):
-                mirror_url = mirror_service.mirror_url(file)
+            mirror_url = self._mirror_service(catalog).mirror_url(file)
 
         if mirror_url is None:
             download_cls = plugin.file_download_class()

--- a/src/azul/service/repository_controller.py
+++ b/src/azul/service/repository_controller.py
@@ -393,7 +393,10 @@ class RepositoryController(ServiceController):
         plugin = self._repository_plugin(catalog)
 
         mirror_url = None
-        if config.enable_mirroring:
+        # The file's content type and source would be None on subsequent
+        # requests since they aren't propagated via query parametesr.
+        # `MirrorFileDownload` will always be ready immediately.
+        if request_index == 0 and config.enable_mirroring:
             mirror_service = self._mirror_service(catalog)
             if mirror_service.info_exists(file):
                 mirror_url = mirror_service.mirror_url(file)
@@ -402,9 +405,6 @@ class RepositoryController(ServiceController):
             download_cls = plugin.file_download_class()
             download = download_cls(plugin=plugin, file=file, replica=replica, token=token)
         else:
-            # The file's content type would be None on subsequent requests since
-            # it isn't propagated via a query parameter. `MirrorFileDownload`
-            # will always be ready immediately.
             assert request_index == 0, request_index
             download = MirrorFileDownload(
                 plugin=plugin,

--- a/src/azul/service/repository_controller.py
+++ b/src/azul/service/repository_controller.py
@@ -394,7 +394,7 @@ class RepositoryController(ServiceController):
 
         mirror_url = None
         # The file's content type and source would be None on subsequent
-        # requests since they aren't propagated via query parametesr.
+        # requests since they aren't propagated via query parameters.
         # `MirrorFileDownload` will always be ready immediately.
         if request_index == 0 and config.enable_mirroring:
             mirror_service = self._mirror_service(catalog)

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -1592,16 +1592,19 @@ class IndexingIntegrationTest(IntegrationTestCase):
                 }
             })
         inner_files = [one(file['files']) for file in files]
-        mirror_limit = config.catalogs[catalog].mirror_limit
+        mirror_service = self._mirror_service(catalog)
         for file in inner_files:
             mirror_uri = file['azul_mirror_uri']
             file_size = lookup(file, 'file_size', 'size')
-            if file_size > mirror_limit or not ma_source.config.mirror:
-                self.assertIsNone(mirror_uri)
-            else:
+            if (
+                mirror_service.may_mirror_files_from_source(ma_source.spec)
+                and mirror_service.may_mirror(file_size)
+            ):
                 self.assertIsNotNone(mirror_uri)
                 mirror_uri = furl(mirror_uri)
                 self.assertEqual(aws.ma_mirror_bucket, mirror_uri.host)
+            else:
+                self.assertIsNone(mirror_uri)
         managed_access_file_urls = {
             file['azul_url']
             for file in inner_files

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -1592,8 +1592,16 @@ class IndexingIntegrationTest(IntegrationTestCase):
                 }
             })
         inner_files = [one(file['files']) for file in files]
+        mirror_limit = config.catalogs[catalog].mirror_limit
         for file in inner_files:
-            self.assertIsNone(file['azul_mirror_uri'])
+            mirror_uri = file['azul_mirror_uri']
+            file_size = lookup(file, 'file_size', 'size')
+            if file_size > mirror_limit or not ma_source.config.mirror:
+                self.assertIsNone(mirror_uri)
+            else:
+                self.assertIsNotNone(mirror_uri)
+                mirror_uri = furl(mirror_uri)
+                self.assertEqual(aws.ma_mirror_bucket, mirror_uri.host)
         managed_access_file_urls = {
             file['azul_url']
             for file in inner_files

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -105,7 +105,7 @@ class RepositoryFilesTestCase(LocalAppTestCase, metaclass=ABCMeta):
 
 class TestRepositoryFilesWithTDR(DCP2TestCase, RepositoryFilesTestCase):
 
-    @patch.object(MirrorService, 'info_exists', new=Mock(return_value=False))
+    @patch.object(MirrorService, '_info_exists', new=Mock(return_value=False))
     @patch.object(TerraClient,
                   '_http_client',
                   AuthorizedHttp(MagicMock(),
@@ -175,7 +175,7 @@ class TestRepositoryFilesWithDSS(DCP1TestCase,
                                  RepositoryFilesTestCase,
                                  S3TestCase):
 
-    @patch.object(MirrorService, 'info_exists', new=Mock(return_value=False))
+    @patch.object(MirrorService, '_info_exists', new=Mock(return_value=False))
     @patch.object(type(config), 'dss_direct_access_role', new=Mock(return_value=None))
     def test(self):
         self.maxDiff = None
@@ -325,7 +325,7 @@ class TestRepositoryFilesWithMirroring(DCP2TestCase,
                                              schema_url_func=MagicMock())
         with patch.object(MirrorWorkerService, '_download', return_value=file_content):
             mirror_service._mirror_file(file)
-        self.assertTrue(mirror_service.info_exists(file))
+        self.assertTrue(mirror_service._info_exists(file))
 
         client = http_client(log)
         args = dict(catalog=self.catalog, version=file_version)

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -123,6 +123,7 @@ class TestRepositoryFilesWithTDR(DCP2TestCase, RepositoryFilesTestCase):
                        version=file_version,
                        drs_uri=drs_uri,
                        size=1,
+                       source=self.source.ref,
                        content_type='text/plain',
                        sha256='123',
                        crc32c='abc')
@@ -196,6 +197,7 @@ class TestRepositoryFilesWithDSS(DCP1TestCase,
                        version=file_version,
                        drs_uri=f'drs://{self._drs_domain_name}/{file_uuid}?version={file_version}',
                        size=3,
+                       source=self.source.ref,
                        content_type='text/plain',
                        sha256='123',
                        crc32c='abc')
@@ -318,6 +320,7 @@ class TestRepositoryFilesWithMirroring(DCP2TestCase,
                        drs_uri=None,
                        size=len(file_content),
                        content_type='text/plain',
+                       source=self.source.ref,
                        sha256=hashlib.sha256(file_content).hexdigest(),
                        crc32c=None)
 


### PR DESCRIPTION


Linked issues: #7931


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [ ] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (mirror)

- [x] This PR is labeled `mirror:dev` <sub>or the changes introduced by it will not require mirroring of `dev`</sub>
- [x] This PR is labeled `mirror:anvildev` <sub>or the changes introduced by it will not require mirroring of `anvildev`</sub>
- [x] This PR is labeled `mirror:anvilprod` <sub>or the changes introduced by it will not require mirroring of `anvilprod`</sub>
- [x] This PR is labeled `mirror:prod` <sub>or the changes introduced by it will not require mirroring of `prod`</sub>
- [x] This PR is labeled `mirror:partial` and its description documents the specific mirroring procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full mirroring or carries none of the labels `mirror:dev`, `mirror:anvildev`, `mirror:anvilprod` and `mirror:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [ ] PR is awaiting requested review from a peer
- [ ] Status of PR is *Review requested*
- [ ] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [ ] Actually approved the PR
- [ ] PR is not a draft
- [ ] PR is awaiting requested review from system administrator
- [ ] Status of PR is *Review requested*
- [ ] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [ ] Actually approved the PR
- [ ] Labeled linked issues as `demo` or `no demo`
- [ ] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [ ] Decided if PR can be labeled `no sandbox`
- [ ] A comment to this PR details the completed security design review
- [ ] PR title is appropriate as title of merge commit
- [ ] `N reviews` label is accurate
- [ ] Status of PR is *Approved*
- [ ] PR is assigned to only the operator and the author


### Operator

- [ ] Checked `reindex:…` labels and `r` commit title tag
- [ ] Checked `mirror:…` labels
- [ ] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [ ] Squashed PR branch and rebased onto `develop`
- [ ] Sanity-checked history
- [ ] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [ ] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [ ] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [ ] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [ ] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [ ] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [ ] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [ ] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `sandbox`</sub>
- [ ] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilbox`</sub>
- [ ] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [ ] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [ ] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [ ] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [ ] Started mirroring in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [ ] Started mirroring in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>
- [ ] Checked for failures in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [ ] Checked for failures in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>


### Operator (merge the branch)

- [ ] All status checks passed and the PR is mergeable
- [ ] The title of the merge commit starts with the title of this PR
- [ ] Added PR # reference to merge commit title
- [ ] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [ ] Pushed merge commit to GitHub
- [ ] Status of PR is *Merged lower*
- [ ] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [ ] Pushed merge commit to GitLab `dev`
- [ ] Pushed merge commit to GitLab `anvildev`
- [ ] Build passes on GitLab `dev`
- [ ] Reviewed build logs for anomalies on GitLab `dev`
- [ ] Build passes on GitLab `anvildev`
- [ ] Reviewed build logs for anomalies on GitLab `anvildev`
- [ ] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Deleted PR branch from GitHub
- [ ] PR is assigned to only the operator
- [ ] Deleted PR branch from GitLab `dev`
- [ ] Deleted PR branch from GitLab `anvildev`
- [ ] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [ ] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [ ] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [ ] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [ ] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [ ] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [ ] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [ ] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [ ] Started mirroring in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [ ] Started mirroring in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [ ] Emptied mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [ ] Emptied mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>


### Operator

- [ ] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [ ] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `API`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [ ] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
