### PR TITLE
Fix: Redundant implementations of file URLs and mirror URIs (#8042)

### DIFF
--- a/src/azul/plugins/metadata/anvil/service/response.py
+++ b/src/azul/plugins/metadata/anvil/service/response.py
@@ -32,7 +32,6 @@ from azul.lib.types import (
     json_sequence_of_mappings,
     json_str,
     json_untyped_dict,
-    optional,
 )
 from azul.plugins import (
     SpecialFields,
@@ -229,9 +228,7 @@ class AnvilSearchResponseStage(SearchResponseStage):
                         ) -> MutableJSON:
         inner_entity = copy_json(inner_entity)
         if inner_entity_type == 'files':
-            inner_entity['azul_url'] = self._file_url(uuid=json_str(inner_entity['document_id']),
-                                                      version=json_str(inner_entity['version']),
-                                                      drs_uri=optional(json_str, inner_entity['drs_uri']))
+            inner_entity['azul_url'] = self._file_url(inner_entity)
             inner_entity['azul_mirror_uri'] = self._file_mirror_uri(source, inner_entity)
             inner_entity.pop('version', None)
         return inner_entity

--- a/src/azul/plugins/metadata/hca/service/response.py
+++ b/src/azul/plugins/metadata/hca/service/response.py
@@ -424,9 +424,7 @@ class HCASearchResponseStage(SearchResponseStage):
             'version': file.get('version'),
             'matrixCellCount': file.get('matrix_cell_count'),
             'drs_uri': file.get('drs_uri'),
-            'azul_url': self._file_url(uuid=json_str(file['uuid']),
-                                       version=json_str(file['version']),
-                                       drs_uri=optional(json_str, file['drs_uri'])),
+            'azul_url': self._file_url(file),
             'azul_mirror_uri': self._file_mirror_uri(source, file),
         }
         return translated_file

--- a/src/azul/service/drs_controller.py
+++ b/src/azul/service/drs_controller.py
@@ -73,7 +73,7 @@ class DRSController(ServiceController, HasCachedHttpClient):
 
     @cached_property
     def _service(self) -> IndexService:
-        return IndexService()
+        return IndexService(file_url_func=self._file_url)
 
     _drs_spec_description = fd('''
         This is a partial implementation of the [DRS 1.0.0 spec][1]. Not all

--- a/src/azul/service/index_controller.py
+++ b/src/azul/service/index_controller.py
@@ -70,7 +70,7 @@ class IndexController(QueryController):
 
     @cached_property
     def _service(self) -> IndexService:
-        return IndexService()
+        return IndexService(file_url_func=self._file_url)
 
     _min_page_size = 1
 
@@ -371,7 +371,6 @@ class IndexController(QueryController):
         try:
             response = self._service.search(catalog=self.app.catalog,
                                             entity_type=entity_type,
-                                            file_url_func=self._file_url,
                                             item_id=entity_id,
                                             filters=filters,
                                             pagination=pagination)

--- a/src/azul/service/index_service.py
+++ b/src/azul/service/index_service.py
@@ -77,13 +77,13 @@ class SearchResponseStage(_OpenSearchStage[ResponseTriple, MutableJSON],
     def prepare_request(self, request: Search) -> Search:
         return request
 
-    def _file_url(self, *, uuid: str, version: str, drs_uri: str | None) -> str | None:
+    def _file_url(self, file: JSON) -> str | None:
         # FIXME: Redundant implementations of file URLs and mirror URIs
         #        https://github.com/DataBiosphere/azul/issues/8042
-        if drs_uri is None:
+        if file['drs_uri'] is None:
             # To download a file we need its DRS URI
             return None
-        elif drs_uri.startswith('drs://dg.4503'):
+        elif file['drs_uri'].startswith('drs://dg.4503'):
             # LungMAP contains files not hosted on TDR. Downloading these files
             # requires authentication that can't be provided by Azul.
             #
@@ -91,10 +91,11 @@ class SearchResponseStage(_OpenSearchStage[ResponseTriple, MutableJSON],
             #        https://github.com/DataBiosphere/azul/issues/8236
             return None
         else:
+            special_fields = self.plugin.special_fields
             return str(self.service.file_url_func(catalog=self.catalog,
                                                   fetch=False,
-                                                  file_uuid=uuid,
-                                                  version=version))
+                                                  file_uuid=file[special_fields.file_uuid.name_in_hit],
+                                                  version=file['version']))
 
     def _file_mirror_uri(self, source: SourceRef, file: JSON) -> str | None:
         # FIXME: Redundant implementations of file URLs and mirror URIs

--- a/src/azul/service/index_service.py
+++ b/src/azul/service/index_service.py
@@ -32,12 +32,6 @@ from azul import (
 from azul.filters import (
     Filters,
 )
-from azul.indexer.mirror_service import (
-    MirrorService,
-)
-from azul.lib import (
-    cache,
-)
 from azul.lib.types import (
     JSON,
     MutableJSON,
@@ -51,14 +45,13 @@ from azul.plugins import (
 )
 from azul.service import (
     BadArgumentException,
-    FileUrlFunc,
 )
 from azul.service.query_service import (
+    FileUrlService,
     IndexNotFoundError,
     OpenSearchStage,
     Pagination,
     PaginationStage,
-    QueryService,
     ResponseTriple,
     ToDictStage,
     _OpenSearchStage,
@@ -124,12 +117,7 @@ class SummaryResponseStage(OpenSearchStage[JSON, MutableJSON],
 
 
 @attrs.frozen(auto_attribs=True, kw_only=True)
-class IndexService(QueryService):
-    file_url_func: FileUrlFunc
-
-    @cache
-    def mirror_service(self, catalog: CatalogName) -> MirrorService:
-        return MirrorService(catalog=catalog)
+class IndexService(FileUrlService):
 
     def search(self,
                *,

--- a/src/azul/service/index_service.py
+++ b/src/azul/service/index_service.py
@@ -35,6 +35,9 @@ from azul.filters import (
 from azul.indexer.mirror_service import (
     MirrorService,
 )
+from azul.lib import (
+    cache,
+)
 from azul.lib.types import (
     JSON,
     MutableJSON,
@@ -104,7 +107,7 @@ class SearchResponseStage(_OpenSearchStage[ResponseTriple, MutableJSON],
         # FIXME: Redundant implementations of file URLs and mirror URIs
         #        https://github.com/DataBiosphere/azul/issues/8042
         file_cls = self.plugin.file_class
-        mirror_service = MirrorService.for_catalog(self.catalog)
+        mirror_service = self.service.mirror_service(self.catalog)
         return mirror_service.mirror_uri(source, file_cls, file)
 
 
@@ -123,6 +126,10 @@ class SummaryResponseStage(OpenSearchStage[JSON, MutableJSON],
 @attrs.frozen(auto_attribs=True, kw_only=True)
 class IndexService(QueryService):
     file_url_func: FileUrlFunc
+
+    @cache
+    def mirror_service(self, catalog: CatalogName) -> MirrorService:
+        return MirrorService(catalog=catalog)
 
     def search(self,
                *,

--- a/src/azul/service/index_service.py
+++ b/src/azul/service/index_service.py
@@ -77,7 +77,6 @@ class EntityNotFoundError(Exception):
 class SearchResponseStage(_OpenSearchStage[ResponseTriple, MutableJSON],
                           metaclass=ABCMeta):
     service: IndexService
-    file_url_func: FileUrlFunc
 
     def prepare_request(self, request: Search) -> Search:
         return request
@@ -96,10 +95,10 @@ class SearchResponseStage(_OpenSearchStage[ResponseTriple, MutableJSON],
             #        https://github.com/DataBiosphere/azul/issues/8236
             return None
         else:
-            return str(self.file_url_func(catalog=self.catalog,
-                                          fetch=False,
-                                          file_uuid=uuid,
-                                          version=version))
+            return str(self.service.file_url_func(catalog=self.catalog,
+                                                  fetch=False,
+                                                  file_uuid=uuid,
+                                                  version=version))
 
     def _file_mirror_uri(self, source: SourceRef, file: JSON) -> str | None:
         # FIXME: Redundant implementations of file URLs and mirror URIs
@@ -121,13 +120,14 @@ class SummaryResponseStage(OpenSearchStage[JSON, MutableJSON],
         return request
 
 
+@attrs.frozen(auto_attribs=True, kw_only=True)
 class IndexService(QueryService):
+    file_url_func: FileUrlFunc
 
     def search(self,
                *,
                catalog: CatalogName,
                entity_type: str,
-               file_url_func: FileUrlFunc,
                item_id: str | None,
                filters: Filters,
                pagination: Pagination
@@ -139,9 +139,6 @@ class IndexService(QueryService):
         :param pagination: A dictionary with pagination information as return from `_get_pagination()`
         :param filters: parsed JSON filters from the request
         :param item_id: If item_id is specified, only a single item is searched for
-        :param file_url_func: A function that is used only when getting a *list* of files data.
-        It creates the files URL based on info from the request. It should have the type
-        signature `(uuid: str, **params) -> str`
         :return: The OpenSearch JSON response
         """
         if item_id is not None:
@@ -152,8 +149,7 @@ class IndexService(QueryService):
                                 filters=filters,
                                 pagination=pagination,
                                 aggregate=item_id is None,
-                                entity_type=entity_type,
-                                file_url_func=file_url_func)
+                                entity_type=entity_type)
 
         special_fields = self.metadata_plugin(catalog).special_fields
         for hit in response['hits']:
@@ -173,7 +169,6 @@ class IndexService(QueryService):
                 aggregate: bool,
                 filters: Filters,
                 pagination: Pagination,
-                file_url_func: FileUrlFunc
                 ) -> MutableJSON:
         """
         This function does the whole transformation process. It takes the path
@@ -229,8 +224,7 @@ class IndexService(QueryService):
         response_stage_cls = plugin.search_response_stage
         chain = response_stage_cls(service=self,
                                    catalog=catalog,
-                                   entity_type=entity_type,
-                                   file_url_func=file_url_func).wrap(chain)
+                                   entity_type=entity_type).wrap(chain)
 
         request = self.create_request(catalog, entity_type)
         request = chain.prepare_request(request)

--- a/src/azul/service/index_service.py
+++ b/src/azul/service/index_service.py
@@ -78,31 +78,10 @@ class SearchResponseStage(_OpenSearchStage[ResponseTriple, MutableJSON],
         return request
 
     def _file_url(self, file: JSON) -> str | None:
-        # FIXME: Redundant implementations of file URLs and mirror URIs
-        #        https://github.com/DataBiosphere/azul/issues/8042
-        if file['drs_uri'] is None:
-            # To download a file we need its DRS URI
-            return None
-        elif file['drs_uri'].startswith('drs://dg.4503'):
-            # LungMAP contains files not hosted on TDR. Downloading these files
-            # requires authentication that can't be provided by Azul.
-            #
-            # FIXME: We shouldn't hard-code compact identifier namespaces
-            #        https://github.com/DataBiosphere/azul/issues/8236
-            return None
-        else:
-            special_fields = self.plugin.special_fields
-            return str(self.service.file_url_func(catalog=self.catalog,
-                                                  fetch=False,
-                                                  file_uuid=file[special_fields.file_uuid.name_in_hit],
-                                                  version=file['version']))
+        return self.service.azul_file_url(self.catalog, file)
 
     def _file_mirror_uri(self, source: SourceRef, file: JSON) -> str | None:
-        # FIXME: Redundant implementations of file URLs and mirror URIs
-        #        https://github.com/DataBiosphere/azul/issues/8042
-        file_cls = self.plugin.file_class
-        mirror_service = self.service.mirror_service(self.catalog)
-        return mirror_service.mirror_uri(source, file_cls, file)
+        return self.service.azul_mirror_uri(self.catalog, source, file)
 
 
 class SummaryResponseStage(OpenSearchStage[JSON, MutableJSON],

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -573,6 +573,10 @@ class CachedManifestNotFound(Exception):
 class ManifestService(QueryService):
     file_url_func: FileUrlFunc
 
+    @cache
+    def mirror_service(self, catalog: CatalogName) -> MirrorService:
+        return MirrorService(catalog=catalog)
+
     @cached_property
     def storage_service(self) -> StorageService:
         return StorageService()
@@ -807,9 +811,9 @@ class ManifestGenerator(metaclass=ABCMeta):
     def metadata_plugin(self) -> MetadataPlugin:
         return self.service.metadata_plugin(self.catalog)
 
-    @cached_property
+    @property
     def mirror_service(self) -> MirrorService:
-        return MirrorService.for_catalog(self.catalog)
+        return self.service.mirror_service(self.catalog)
 
     @classmethod
     @abstractmethod

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -167,17 +167,16 @@ from azul.plugins import (
     manifest_config_to_json,
 )
 from azul.service import (
-    FileUrlFunc,
     avro_pfb,
 )
 from azul.service.avro_pfb import (
     PFBRelation,
 )
 from azul.service.query_service import (
+    FileUrlService,
     OpenSearchChain,
     Pagination,
     PaginationStage,
-    QueryService,
     SortKey,
     ToDictStage,
     sort_key_from_json,
@@ -570,12 +569,7 @@ class CachedManifestNotFound(Exception):
 
 
 @attrs.frozen(kw_only=True)
-class ManifestService(QueryService):
-    file_url_func: FileUrlFunc
-
-    @cache
-    def mirror_service(self, catalog: CatalogName) -> MirrorService:
-        return MirrorService(catalog=catalog)
+class ManifestService(FileUrlService):
 
     @cached_property
     def storage_service(self) -> StorageService:

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -959,7 +959,6 @@ class ManifestGenerator(metaclass=ABCMeta):
         self.service = service
         self.catalog = catalog
         self.filters = filters
-        self.file_url_func = service.file_url_func
 
     manifest_namespace = UUID('ca1df635-b42c-4671-9322-b0a7209f0235')
 
@@ -1137,31 +1136,10 @@ class ManifestGenerator(metaclass=ABCMeta):
                        file: JSON,
                        args: Mapping = frozendict()
                        ) -> str | None:
-        # FIXME: Redundant implementations of file URLs and mirror URIs
-        #        https://github.com/DataBiosphere/azul/issues/8042
-        if file['drs_uri'] is None:
-            # To download a file we need its DRS URI
-            return None
-        elif json_str(file['drs_uri']).startswith('drs://dg.4503'):
-            # LungMAP contains files not hosted on TDR. Downloading these files
-            # requires authentication that can't be provided by Azul.
-            #
-            # FIXME: We shouldn't hard-code compact identifier namespaces
-            #        https://github.com/DataBiosphere/azul/issues/8236
-            return None
-        else:
-            special_fields = self.metadata_plugin.special_fields
-            return str(self.file_url_func(catalog=self.catalog,
-                                          file_uuid=json_str(file[special_fields.file_uuid.name_in_hit]),
-                                          version=json_str(file['version']),
-                                          fetch=False,
-                                          **args))
+        return self.service.azul_file_url(self.catalog, file, args)
 
     def _azul_mirror_uri(self, source: SourceRef, file: JSON) -> str | None:
-        # FIXME: Redundant implementations of file URLs and mirror URIs
-        #        https://github.com/DataBiosphere/azul/issues/8042
-        file_cls = self.metadata_plugin.file_class
-        return self.mirror_service.mirror_uri(source, file_cls, file)
+        return self.service.azul_mirror_uri(self.catalog, source, file)
 
     @cache
     def _content_hash(self, *, by_bundle: bool) -> str:

--- a/src/azul/service/query_service.py
+++ b/src/azul/service/query_service.py
@@ -63,8 +63,12 @@ from azul.indexer.document import (
 from azul.indexer.document_service import (
     DocumentService,
 )
+from azul.indexer.mirror_service import (
+    MirrorService,
+)
 from azul.lib import (
     R,
+    cache,
     cached_property,
 )
 from azul.lib.types import (
@@ -86,6 +90,9 @@ from azul.plugins import (
     MetadataPlugin,
     dotted,
     undotted,
+)
+from azul.service import (
+    FileUrlFunc,
 )
 
 log = logging.getLogger(__name__)
@@ -812,3 +819,12 @@ class QueryService(DocumentService):
                       index=str(IndexName.create(catalog=catalog,
                                                  qualifier=entity_type,
                                                  doc_type=doc_type)))
+
+
+@attrs.frozen(kw_only=True)
+class FileUrlService(QueryService):
+    file_url_func: FileUrlFunc
+
+    @cache
+    def mirror_service(self, catalog: CatalogName) -> MirrorService:
+        return MirrorService(catalog=catalog)

--- a/src/azul/service/query_service.py
+++ b/src/azul/service/query_service.py
@@ -79,6 +79,7 @@ from azul.lib.types import (
     MutableJSON,
     PrimitiveJSON,
     json_str,
+    optional,
 )
 from azul.opensearch import (
     OpenSearchClientFactory,
@@ -93,6 +94,12 @@ from azul.plugins import (
 )
 from azul.service import (
     FileUrlFunc,
+)
+from azul.source import (
+    SourceRef,
+)
+from azul.vendored.frozendict import (
+    frozendict,
 )
 
 log = logging.getLogger(__name__)
@@ -828,3 +835,38 @@ class FileUrlService(QueryService):
     @cache
     def mirror_service(self, catalog: CatalogName) -> MirrorService:
         return MirrorService(catalog=catalog)
+
+    def azul_mirror_uri(self,
+                        catalog: CatalogName,
+                        source: SourceRef,
+                        file: JSON
+                        ) -> str | None:
+        file_cls = self.metadata_plugin(catalog).file_class
+        return self.mirror_service(catalog).mirror_uri(source, file_cls, file)
+
+    def azul_file_url(self,
+                      catalog: CatalogName,
+                      file: JSON,
+                      args: Mapping = frozendict()
+                      ) -> str | None:
+        drs_uri = optional(json_str, file['drs_uri'])
+        if drs_uri is None:
+            # To download a file we need its DRS URI
+            return None
+        elif (
+            config.catalogs[catalog].atlas == 'lungmap'
+            and file['drs_uri'].startswith('drs://dg.4503:')
+        ):
+            # LungMAP contains files not hosted on TDR. Downloading these files
+            # requires authentication that can't be provided by Azul.
+            #
+            # FIXME: We shouldn't hard-code compact identifier namespaces
+            #        https://github.com/DataBiosphere/azul/issues/8236
+            return None
+        else:
+            special_fields = self.metadata_plugin(catalog).special_fields
+            return str(self.file_url_func(catalog=catalog,
+                                          file_uuid=json_str(file[special_fields.file_uuid.name_in_hit]),
+                                          version=json_str(file['version']),
+                                          fetch=False,
+                                          **args))

--- a/src/azul/service/repository_controller.py
+++ b/src/azul/service/repository_controller.py
@@ -89,7 +89,7 @@ class RepositoryController(ServiceController):
 
     @cached_property
     def _index_service(self) -> IndexService:
-        return IndexService()
+        return IndexService(file_url_func=self._file_url)
 
     def _mirror_service(self, catalog: CatalogName) -> MirrorService:
         return MirrorService.for_catalog(catalog)

--- a/test/service/test_response.py
+++ b/test/service/test_response.py
@@ -217,8 +217,7 @@ class TestIndexResponse(IndexResponseTestCase):
     def _response_stage(self, entity_type: str) -> HCASearchResponseStage:
         return HCASearchResponseStage(service=self._service_index_service,
                                       entity_type=entity_type,
-                                      catalog=self.catalog,
-                                      file_url_func=self.file_url_func)
+                                      catalog=self.catalog)
 
     @property
     def paginations(self):


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #8042


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [ ] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (mirror)

- [x] This PR is labeled `mirror:dev` <sub>or the changes introduced by it will not require mirroring of `dev`</sub>
- [x] This PR is labeled `mirror:anvildev` <sub>or the changes introduced by it will not require mirroring of `anvildev`</sub>
- [x] This PR is labeled `mirror:anvilprod` <sub>or the changes introduced by it will not require mirroring of `anvilprod`</sub>
- [x] This PR is labeled `mirror:prod` <sub>or the changes introduced by it will not require mirroring of `prod`</sub>
- [x] This PR is labeled `mirror:partial` and its description documents the specific mirroring procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full mirroring or carries none of the labels `mirror:dev`, `mirror:anvildev`, `mirror:anvilprod` and `mirror:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [ ] PR is awaiting requested review from a peer
- [ ] Status of PR is *Review requested*
- [ ] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [ ] Actually approved the PR
- [ ] PR is not a draft
- [ ] PR is awaiting requested review from system administrator
- [ ] Status of PR is *Review requested*
- [ ] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [ ] Actually approved the PR
- [ ] Labeled linked issues as `demo` or `no demo`
- [ ] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [ ] Decided if PR can be labeled `no sandbox`
- [ ] A comment to this PR details the completed security design review
- [ ] PR title is appropriate as title of merge commit
- [ ] `N reviews` label is accurate
- [ ] Status of PR is *Approved*
- [ ] PR is assigned to only the operator and the author


### Operator

- [ ] Checked `reindex:…` labels and `r` commit title tag
- [ ] Checked `mirror:…` labels
- [ ] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [ ] Squashed PR branch and rebased onto `develop`
- [ ] Sanity-checked history
- [ ] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [ ] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [ ] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [ ] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [ ] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [ ] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [ ] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [ ] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [ ] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [ ] Applied upgrade instructions from UPGRADING.rst to `sandbox` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `sandbox`</sub>
- [ ] Applied upgrade instructions from UPGRADING.rst to `anvilbox` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `anvilbox`</sub>
- [ ] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `sandbox`</sub>
- [ ] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilbox`</sub>
- [ ] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [ ] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [ ] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [ ] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [ ] Started mirroring in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [ ] Started mirroring in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>
- [ ] Checked for failures in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [ ] Checked for failures in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>


### Operator (merge the branch)

- [ ] All status checks passed and the PR is mergeable
- [ ] The title of the merge commit starts with the title of this PR
- [ ] Added PR # reference to merge commit title
- [ ] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [ ] Pushed merge commit to GitHub
- [ ] Status of PR is *Merged lower*
- [ ] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [ ] Pushed merge commit to GitLab `dev`
- [ ] Pushed merge commit to GitLab `anvildev`
- [ ] Build passes on GitLab `dev`
- [ ] Reviewed build logs for anomalies on GitLab `dev`
- [ ] Build passes on GitLab `anvildev`
- [ ] Reviewed build logs for anomalies on GitLab `anvildev`
- [ ] Applied upgrade instructions from UPGRADING.rst to `dev` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `dev`</sub>
- [ ] Applied upgrade instructions from UPGRADING.rst to `anvildev` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `anvildev`</sub>
- [ ] Notified developers to apply upgrade instructions from UPGRADING.rst to their personal deployments <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to personal deployments</sub>
- [ ] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [ ] Deleted PR branch from GitHub
- [ ] PR is assigned to only the operator
- [ ] Deleted PR branch from GitLab `dev`
- [ ] Deleted PR branch from GitLab `anvildev`
- [ ] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [ ] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [ ] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [ ] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [ ] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [ ] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [ ] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [ ] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [ ] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [ ] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [ ] Started mirroring in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [ ] Started mirroring in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [ ] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [ ] Emptied mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [ ] Emptied mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>


### Operator

- [ ] Propagated the `upgrade` and `API` labels to the next promotion PRs <sub>or this PR carries neither of these labels</sub>
- [ ] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [ ] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [ ] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
