### PR TITLE
Fix: Locally-run ITs are slow due to WAF rate limiting (#8066)

### DIFF
--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -1752,6 +1752,8 @@ class Config:
 
     allowed_v4_ips_term = 'allowed_v4_ips'
 
+    it_ips_term = 'it_v4_ips'
+
     blocked_user_agents_regex_term = 'blocked_user_agents'
 
     blocked_user_agents_custom_regex_term = 'blocked_user_agents_custom'

--- a/terraform/api_gateway.tf.json.template.py
+++ b/terraform/api_gateway.tf.json.template.py
@@ -16,7 +16,6 @@ from azul.chalice import (
 )
 from azul.deployment import (
     aws,
-    public_ip,
 )
 from azul.infra.terraform import (
     chalice,
@@ -338,21 +337,19 @@ emit_tf({
             'aws_wafv2_ip_set': {
                 # The IPs in this set are exempt from the rate limit on service
                 # API requests so as to prevent integration tests from tripping
-                # them. In the set, we include the IP of the GitLab instance and
-                # that of the machine deploying the set because those are the
-                # machines most likely to run integration tests.
+                # them. In the set, we include the public IPs of the GitLab
+                # instance. The integration test will also dynamically add the
+                # IP of the machine running the IT during setup, and remove it
+                # again during teardown, unless the IT is run on GitLab.
                 #
                 config.it_ips_term: {
                     'name': config.qualified_resource_name(config.it_ips_term),
                     'scope': 'REGIONAL',
                     'ip_address_version': 'IPV4',
                     'addresses': [
-                        f'{public_ip()}/32',
-                        *[
-                            # Data source defined in data_sources.tf.json
-                            f'${{data.aws_nat_gateway.gitlab_{zone}.public_ip}}/32'
-                            for zone in range(vpc.num_zones)
-                        ]
+                        # Data source defined in data_sources.tf.json
+                        f'${{data.aws_nat_gateway.gitlab_{zone}.public_ip}}/32'
+                        for zone in range(vpc.num_zones)
                     ]
                 }
             },

--- a/terraform/api_gateway.tf.json.template.py
+++ b/terraform/api_gateway.tf.json.template.py
@@ -342,8 +342,8 @@ emit_tf({
                 # that of the machine deploying the set because those are the
                 # machines most likely to run integration tests.
                 #
-                'it_v4_ips': {
-                    'name': config.qualified_resource_name('it_v4_ips'),
+                config.it_ips_term: {
+                    'name': config.qualified_resource_name(config.it_ips_term),
                     'scope': 'REGIONAL',
                     'ip_address_version': 'IPV4',
                     'addresses': [
@@ -651,7 +651,7 @@ emit_tf({
                                 ]
                             ],
                             {
-                                # See it_v4_ips above
+                                # See aws_wafv2_ip_set.{config.it_ips_term} above
                                 'name': 'allow_it_requests',
                                 'statement': {
                                     'and_statement': [
@@ -659,7 +659,7 @@ emit_tf({
                                             'statement': [
                                                 {
                                                     'ip_set_reference_statement': {
-                                                        'arn': '${aws_wafv2_ip_set.%s.arn}' % 'it_v4_ips'
+                                                        'arn': '${aws_wafv2_ip_set.%s.arn}' % config.it_ips_term
                                                     }
                                                 },
                                                 waf_match_method('PUT'),

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -104,6 +104,7 @@ from azul.csp import (
 )
 from azul.deployment import (
     aws,
+    public_ip,
 )
 from azul.drs import (
     AccessMethod,
@@ -409,6 +410,14 @@ class IndexingIntegrationTest(IntegrationTestCase):
         # more information.
         if 'unattended' not in config.it_flags:
             cls._user_access_token = cls.__user_access_token()
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        # On GitLab, the runner's NAT gateway IPs are already in the WAF IP set
+        # by virtue of Terraform, so no on-the-fly exemption is needed.
+        if 'CI_JOB_TOKEN' not in os.environ:
+            cls.enterClassContext(IntegrationTestRateLimitExemption())
 
     def setUp(self) -> None:
         super().setUp()
@@ -2299,3 +2308,61 @@ class BearerTokenHttpClient(HttpClientDecorator):
             headers = {}
         headers = {**headers, 'Authorization': f'Bearer {self._token}'}
         return super().urlopen(method, url, body=body, headers=headers, **kwargs)
+
+
+class IntegrationTestRateLimitExemption:
+    """
+    An idempotent context manager that adds the local machine's public IP to
+    the WAF IP set exempting integration test runners from the API rate limit
+    on entry, and removes it again on exit. Entering an already-entered or
+    exiting an already-exited instance is a no-op.
+    """
+
+    _scope = 'REGIONAL'
+
+    @property
+    def _wafv2(self):
+        return aws.client('wafv2')
+
+    @cached_property
+    def _address(self) -> str:
+        return f'{public_ip()}/32'
+
+    @cached_property
+    def _qualified_name(self) -> str:
+        return config.qualified_resource_name(config.it_ips_term)
+
+    def __init__(self) -> None:
+        response = self._wafv2.list_ip_sets(Scope=self._scope)
+        self._set_id = one(
+            s['Id'] for s in response['IPSets']
+            if s['Name'] == self._qualified_name
+        )
+
+    def __enter__(self) -> IntegrationTestRateLimitExemption:
+        self._update_ip_set(lambda current: current | {self._address})
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self._update_ip_set(lambda current: current - {self._address})
+
+    type _Updater = Callable[[set[str]], set[str]]
+
+    def _update_ip_set(self, update: _Updater) -> None:
+        response = self._wafv2.get_ip_set(Name=self._qualified_name,
+                                          Scope=self._scope,
+                                          Id=self._set_id)
+        current = set(response['IPSet']['Addresses'])
+        desired = update(current)
+        if current == desired:
+            log.info('No need to modify WAF IP set %r as it already is %r',
+                     self._qualified_name, desired)
+        else:
+            additions, deletions = desired - current, current - desired
+            log.info('Updating WAF IP set %r, adding %r, removing %r.',
+                     self._qualified_name, additions, deletions)
+            self._wafv2.update_ip_set(Name=self._qualified_name,
+                                      Scope=self._scope,
+                                      Id=self._set_id,
+                                      Addresses=list(desired),
+                                      LockToken=response['LockToken'])


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #8066


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (mirror)

- [x] This PR is labeled `mirror:dev` <sub>or the changes introduced by it will not require mirroring of `dev`</sub>
- [x] This PR is labeled `mirror:anvildev` <sub>or the changes introduced by it will not require mirroring of `anvildev`</sub>
- [x] This PR is labeled `mirror:anvilprod` <sub>or the changes introduced by it will not require mirroring of `anvilprod`</sub>
- [x] This PR is labeled `mirror:prod` <sub>or the changes introduced by it will not require mirroring of `prod`</sub>
- [x] This PR is labeled `mirror:partial` and its description documents the specific mirroring procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full mirroring or carries none of the labels `mirror:dev`, `mirror:anvildev`, `mirror:anvilprod` and `mirror:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator and the author


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked `mirror:…` labels
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Applied upgrade instructions from UPGRADING.rst to `sandbox` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `sandbox`</sub>
- [x] Applied upgrade instructions from UPGRADING.rst to `anvilbox` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `anvilbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `sandbox`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilbox`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Started mirroring in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [x] Started mirroring in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Applied upgrade instructions from UPGRADING.rst to `dev` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `dev`</sub>
- [x] Applied upgrade instructions from UPGRADING.rst to `anvildev` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `anvildev`</sub>
- [x] Notified developers to apply upgrade instructions from UPGRADING.rst to their personal deployments <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to personal deployments</sub>
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] PR is assigned to only the operator
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>


### Operator

- [x] Propagated the `upgrade` and `API` labels to the next promotion PRs <sub>or this PR carries neither of these labels</sub>
- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem