### PR TITLE
Fix: Security tokens are logged verbatim (DataBiosphere/azul-private#377)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         with:
           name: 'coverage-file'
 
-      - uses: 'codecov/codecov-action@v5'
+      - uses: 'codecov/codecov-action@v7'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: 'coverage.xml'

--- a/scripts/pull_request.py
+++ b/scripts/pull_request.py
@@ -47,6 +47,7 @@ log = logging.getLogger(__name__)
 _project_root = Path(__file__).resolve().parent.parent
 _template_dir = _project_root / '.github' / 'PULL_REQUEST_TEMPLATE'
 _project_owner = 'DataBiosphere'
+_project_repos = ['azul', 'azul-private']
 _project_title = 'Azul'
 
 
@@ -114,7 +115,7 @@ def main(argv):
         fix = issue.type == 'Defect'
     else:
         fix = args.fix
-    title = _pr_title(issue_number, issue.title, fix, suffix=title_suffix)
+    title = _pr_title(issue.ref, issue.title, fix, suffix=title_suffix)
 
     log.info('Checking for existing PR …')
     existing_pr = _existing_pr()
@@ -131,7 +132,7 @@ def main(argv):
     # Normalize line endings from GitHub API responses
     body = '\n'.join(body.splitlines())
 
-    body = _reference_issue_in_body(body, issue_number)
+    body = _reference_issue_in_body(body, issue.ref)
 
     m = re.search(r'^- \[[ x]] Target branch is `(.+?)`$',
                   template, flags=re.MULTILINE)
@@ -343,26 +344,66 @@ class _IssueInfo:
     type: str
     url: str
 
+    @property
+    def ref(self) -> str:
+        segments = furl(self.url).path.segments
+        owner, repo, _, number = segments[0], segments[1], segments[2], segments[3]
+        if repo == 'azul':
+            return f'#{number}'
+        else:
+            return f'{owner}/{repo}#{number}'
+
 
 def _issue_info(issue_number: int) -> _IssueInfo:
+    repo_queries = '\n'.join(
+        fd(
+            '''
+            {alias}: repository(owner: "{owner}", name: "{repo}") {{
+                issue(number: {number}) {{
+                    title
+                    url
+                    state
+                    issueType {{ name }}
+                }}
+            }}
+            ''',
+            alias=repo.replace('-', '_'),
+            owner=_project_owner,
+            repo=repo,
+            number=issue_number
+        )
+        for repo in _project_repos
+    )
     result = subprocess.run(
         [
             'gh', 'api', 'graphql',
-            '-f', 'query=' + fd('''
-                {{
-                    repository(owner: "{owner}", name: "azul") {{
-                        issue(number: {number}) {{
-                            title
-                            url
-                            issueType {{ name }}
-                        }}
-                    }}
-                }}
-            ''', owner=_project_owner, number=issue_number),
+            '-f', 'query={ ' + repo_queries + ' }',
         ],
-        capture_output=True, text=True, check=True
+        capture_output=True, text=True
     )
-    issue = json.loads(result.stdout)['data']['repository']['issue']
+    response = json.loads(result.stdout)
+    data = response['data']
+    issues = [
+        repo_data['issue']
+        for repo_data in data.values()
+        if repo_data['issue'] is not None
+    ]
+    open_issues = [i for i in issues if i['state'] == 'OPEN']
+    if len(open_issues) == 1:
+        issue = open_issues[0]
+    elif len(open_issues) > 1:
+        assert False, R(
+            'Multiple open issues with the same number',
+            [i['url'] for i in open_issues])
+    elif len(issues) == 1:
+        issue = issues[0]
+    elif len(issues) > 1:
+        assert False, R(
+            'Multiple closed issues with the same number',
+            [i['url'] for i in issues])
+    else:
+        assert False, R(
+            'Issue not found in any repository', issue_number)
     issue_type = issue['issueType']
     return _IssueInfo(
         title=issue['title'],
@@ -371,13 +412,13 @@ def _issue_info(issue_number: int) -> _IssueInfo:
     )
 
 
-def _pr_title(issue_number: int,
+def _pr_title(issue_ref: str,
               issue_title: str,
               fix: bool,
               suffix: str = ''
               ) -> str:
     prefix = 'Fix: ' if fix else ''
-    return f'{prefix}{issue_title}{suffix} (#{issue_number})'
+    return f'{prefix}{issue_title}{suffix} ({issue_ref})'
 
 
 def _existing_pr() -> dict | None:
@@ -390,9 +431,9 @@ def _existing_pr() -> dict | None:
     return json.loads(result.stdout)
 
 
-def _reference_issue_in_body(body: str, issue_number: int) -> str:
-    body, n = re.subn(r'^(Linked issues?: *)#\d{1,5}',
-                      rf'\1#{issue_number}',
+def _reference_issue_in_body(body: str, issue_ref: str) -> str:
+    body, n = re.subn(r'^(Linked issues?: *)\S+',
+                      rf'\1{issue_ref}',
                       body, flags=re.MULTILINE)
     assert n > 0, R('Linked issues reference not found in body')
     assert n < 2, R('Multiple linked issues references found in body')

--- a/src/azul/auth.py
+++ b/src/azul/auth.py
@@ -40,8 +40,15 @@ class Authentication(metaclass=ABCMeta):
         """
         raise NotImplementedError
 
-    def redacted(self) -> str:
-        return redact(self.identity())
+    @abstractmethod
+    def __str__(self) -> str:
+        """
+        A redacted string representation that's safe to use in logs. Clients
+        shouldn't call this method directly but use ``str()`` instead. To obtain
+        an unredacted string representation, clients should use ``repr()``.
+        Concrete subclasses must implement this method.
+        """
+        raise NotImplementedError
 
 
 @attr.s(auto_attribs=True, frozen=True)
@@ -63,6 +70,9 @@ class BearerTokenAuthentication(Authentication, metaclass=ABCMeta):
     def as_http_header(self) -> str:
         return f'Authorization: Bearer {self.token}'
 
+    def __str__(self) -> str:
+        return f'{type(self).__name__}(token={redact(self.token)!r})'
+
 
 class AccessTokenAuthentication(BearerTokenAuthentication):
     pass
@@ -82,6 +92,10 @@ class HMACAuthentication(Authentication):
     def as_http_header(self) -> str:
         raise NotImplementedError
 
+    def __str__(self) -> str:
+        # Nothing to redact
+        return repr(self)
+
 
 class _IndexerAuthentication(Authentication):
 
@@ -90,6 +104,13 @@ class _IndexerAuthentication(Authentication):
 
     def as_http_header(self) -> str:
         raise NotImplementedError
+
+    def __repr__(self) -> str:
+        return f'{type(self).__name__}(identity={self.identity()!r})'
+
+    def __str__(self) -> str:
+        # Nothing to redact
+        return repr(self)
 
 
 indexer_authentication: Final = _IndexerAuthentication()

--- a/src/azul/auth.py
+++ b/src/azul/auth.py
@@ -21,7 +21,6 @@ from azul.lib.strings import (
 )
 
 
-@attr.s(auto_attribs=True, frozen=True)
 class Authentication(metaclass=ABCMeta):
 
     @abstractmethod

--- a/src/azul/auth.py
+++ b/src/azul/auth.py
@@ -71,7 +71,7 @@ class BearerTokenAuthentication(Authentication, metaclass=ABCMeta):
         return f'Authorization: Bearer {self.token}'
 
     def __str__(self) -> str:
-        return f'{type(self).__name__}(token={redact(self.token)!r})'
+        return f'{type(self).__name__}(token={redact(self.token, fullmatch=True)!r})'
 
 
 class AccessTokenAuthentication(BearerTokenAuthentication):

--- a/src/azul/auth.py
+++ b/src/azul/auth.py
@@ -15,9 +15,9 @@ from azul.lib import (
     R,
 )
 from azul.lib.strings import (
+    looks_like_access_token,
+    looks_like_redactable_jwt,
     redact,
-    redactable_access_token,
-    redactable_jwt,
 )
 
 
@@ -57,9 +57,9 @@ class BearerTokenAuthentication(Authentication, metaclass=ABCMeta):
 
     @classmethod
     def for_token(cls, token: str) -> BearerTokenAuthentication:
-        if redactable_jwt(token):
+        if looks_like_redactable_jwt(token):
             return PersonalAccessTokenAuthentication(token)
-        elif redactable_access_token(token):
+        elif looks_like_access_token(token):
             return AccessTokenAuthentication(token)
         else:
             assert False, R('Unexpected token syntax')

--- a/src/azul/chalice.py
+++ b/src/azul/chalice.py
@@ -485,6 +485,8 @@ class AzulChaliceApp(Chalice):
         if auth is None:
             log.info('Did not authenticate request.')
         else:
+            # FIXME: Logs unredacted APATs and access tokens
+            #        https://github.com/DataBiosphere/azul-private/issues/377
             log.info('Authenticated request as %r', auth)
 
     def _log_request(self, request: Request) -> None:
@@ -493,8 +495,13 @@ class AzulChaliceApp(Chalice):
             'headers': request.headers
         }
         info = json.dumps(info, cls=self._LogJSONEncoder)
+        # FIXME: Logs unredacted APATs, access tokens, and authorization
+        #        codes in request headers
+        #        https://github.com/DataBiosphere/azul-private/issues/377
         log.info('Received %s request for %r, with %s.',
                  request.context['httpMethod'], request.context['path'], info)
+        # FIXME: Logs unredacted authorization codes in request body
+        #        https://github.com/DataBiosphere/azul-private/issues/377
         log.info(http_body_log_message('request', request.raw_body))
 
     def _log_response(self, response: Response) -> None:
@@ -504,6 +511,8 @@ class AzulChaliceApp(Chalice):
         info = json.dumps(info, cls=self._LogJSONEncoder)
         log.info('Returning %i response with headers %s.',
                  response.status_code, info)
+        # FIXME: Logs unredacted APATs and authorization codes in response body
+        #        https://github.com/DataBiosphere/azul-private/issues/377
         log.info(http_body_log_message('response', response.body))
 
     absent = object()

--- a/src/azul/chalice.py
+++ b/src/azul/chalice.py
@@ -485,9 +485,7 @@ class AzulChaliceApp(Chalice):
         if auth is None:
             log.info('Did not authenticate request.')
         else:
-            # FIXME: Logs unredacted APATs and access tokens
-            #        https://github.com/DataBiosphere/azul-private/issues/377
-            log.info('Authenticated request as %r', auth)
+            log.info('Authenticated request as %s', auth)
 
     def _log_request(self, request: Request) -> None:
         info = {

--- a/src/azul/chalice.py
+++ b/src/azul/chalice.py
@@ -71,6 +71,7 @@ from azul.lib.json import (
 from azul.lib.strings import (
     format_and_dedent,
     join_words as jw,
+    redact,
 )
 from azul.lib.types import (
     JSON,
@@ -460,10 +461,13 @@ class AzulChaliceApp(Chalice):
     class _LogJSONEncoder(json.JSONEncoder):
 
         def default(self, o: Any) -> Any:
+            def _redact(v):
+                return redact(v, fullmatch=True) if isinstance(v, str) else v
+
             if isinstance(o, MultiDict):
-                # Convert to dict and flatten the singleton values.
+                # Convert to dict, flatten the singleton values, redact strings
                 return {
-                    k: v[0] if len(v) == 1 else v
+                    k: _redact(v[0]) if len(v) == 1 else list(map(_redact, v))
                     for k, v in ((k, o.getlist(k)) for k in o.keys())
                 }
             elif isinstance(o, CaseInsensitiveMapping):
@@ -493,9 +497,6 @@ class AzulChaliceApp(Chalice):
             'headers': request.headers
         }
         info = json.dumps(info, cls=self._LogJSONEncoder)
-        # FIXME: Logs unredacted APATs, access tokens, and authorization
-        #        codes in request headers
-        #        https://github.com/DataBiosphere/azul-private/issues/377
         log.info('Received %s request for %r, with %s.',
                  request.context['httpMethod'], request.context['path'], info)
         # FIXME: Logs unredacted authorization codes in request body

--- a/src/azul/chalice.py
+++ b/src/azul/chalice.py
@@ -499,8 +499,6 @@ class AzulChaliceApp(Chalice):
         info = json.dumps(info, cls=self._LogJSONEncoder)
         log.info('Received %s request for %r, with %s.',
                  request.context['httpMethod'], request.context['path'], info)
-        # FIXME: Logs unredacted authorization codes in request body
-        #        https://github.com/DataBiosphere/azul-private/issues/377
         log.info(http_body_log_message('request', request.raw_body))
 
     def _log_response(self, response: Response) -> None:
@@ -510,8 +508,6 @@ class AzulChaliceApp(Chalice):
         info = json.dumps(info, cls=self._LogJSONEncoder)
         log.info('Returning %i response with headers %s.',
                  response.status_code, info)
-        # FIXME: Logs unredacted APATs and authorization codes in response body
-        #        https://github.com/DataBiosphere/azul-private/issues/377
         log.info(http_body_log_message('response', response.body))
 
     absent = object()

--- a/src/azul/deployment.py
+++ b/src/azul/deployment.py
@@ -557,9 +557,6 @@ class AWS:
                        event_name,
                        request.method,
                        request.url)
-        # FIXME: Logs unredacted access tokens and refresh tokens in
-        #        DynamoDB request body
-        #        https://github.com/DataBiosphere/azul-private/issues/377
         message = http_body_log_message('request', request.body)
         boto3_log.info('%s:\t%s', event_name, message)
         return None
@@ -576,9 +573,6 @@ class AWS:
                 boto3_log.info('%s:\tGot no response', event_name)
             else:
                 boto3_log.info('%s:\tGot %s response', event_name, response['status_code'])
-                # FIXME: Logs unredacted access tokens and refresh tokens in
-                #        DynamoDB response body
-                #        https://github.com/DataBiosphere/azul-private/issues/377
                 message = http_body_log_message('response', response['body'])
                 boto3_log.info('%s:\t%s', event_name, message)
         else:

--- a/src/azul/deployment.py
+++ b/src/azul/deployment.py
@@ -557,6 +557,9 @@ class AWS:
                        event_name,
                        request.method,
                        request.url)
+        # FIXME: Logs unredacted access tokens and refresh tokens in
+        #        DynamoDB request body
+        #        https://github.com/DataBiosphere/azul-private/issues/377
         message = http_body_log_message('request', request.body)
         boto3_log.info('%s:\t%s', event_name, message)
         return None
@@ -573,6 +576,9 @@ class AWS:
                 boto3_log.info('%s:\tGot no response', event_name)
             else:
                 boto3_log.info('%s:\tGot %s response', event_name, response['status_code'])
+                # FIXME: Logs unredacted access tokens and refresh tokens in
+                #        DynamoDB response body
+                #        https://github.com/DataBiosphere/azul-private/issues/377
                 message = http_body_log_message('response', response['body'])
                 boto3_log.info('%s:\t%s', event_name, message)
         else:

--- a/src/azul/http.py
+++ b/src/azul/http.py
@@ -63,6 +63,29 @@ class HttpClientDecorator(HttpClient):
                 return None
 
 
+def _redact_headers(headers) -> list[tuple[str, str]]:
+    # urllib3's HTTPHeaderDict.items() can yield multiple entries for the
+    # same key, or a key only different in case
+    return [
+        (k, _redact_header(k, v))
+        for k, v in headers.items()
+    ]
+
+
+def _redact_header(name: str, value: str) -> str:
+    result = redact(value, fullmatch=True)
+    if result == value:
+        # Our standard, pattern-based approach didn't redact anything …
+        if name.lower() == 'authorization':
+            # … but the header most definitely contains a secret. We don't know
+            # what type of secret we're dealing with, so we redact it entirely.
+            return 'REDACTED'
+        else:
+            return value
+    else:
+        return result
+
+
 class LoggingHttpClient(HttpClientDecorator):
     """
     An HTTP client that logs every request and response to the given logger.
@@ -127,7 +150,8 @@ class LoggingHttpClient(HttpClientDecorator):
         assert isinstance(response, urllib3.HTTPResponse), type(response)
         log.info('Got %s response after %.3fs from %s to %s',
                  response.status, duration, method, redacted_url)
-        log.info('… with response headers %r', response.headers)
+        log.info('… with response headers %r',
+                 _redact_headers(response.headers))
         if response.isclosed():
             log.info(http_body_log_message('response', response.data))
         else:
@@ -147,22 +171,10 @@ class _LoggingConnectionPool(urllib3.connectionpool.HTTPConnectionPool):
         if headers is None or len(headers) == 0:
             log.info('… without request headers')
         else:
-            # urllib3's HTTPHeaderDict.items() can yield multiple entries for
-            # the same key, or a key only different in case
-            headers = [
-                (k, self._redact(v) if k.lower() == 'authorization' else v)
-                for k, v in headers.items()
-            ]
-            log.info('… with request headers %r', headers)
+            log.info('… with request headers %r',
+                     _redact_headers(headers))
         # The stubs for urllib3 v1.x don't declare any protected methods
         return super()._make_request(*args, **kwargs)  # type: ignore[misc]
-
-    def _redact(self, authorization: str) -> str:
-        result = redact(authorization, fullmatch=True)
-        if result == authorization:
-            return 'REDACTED'
-        else:
-            return result
 
 
 class DisableCrossHostRedirectClient(HttpClientDecorator):

--- a/src/azul/http.py
+++ b/src/azul/http.py
@@ -169,13 +169,11 @@ class _LoggingConnectionPool(urllib3.connectionpool.HTTPConnectionPool):
         return super()._make_request(*args, **kwargs)  # type: ignore[misc]
 
     def _redact(self, authorization: str) -> str:
-        # First, try a more surgical redaction for bearer tokens
-        authorization = authorization.split()
-        if len(authorization) == 2:
-            bearer, token = authorization
-            if bearer.lower() == 'bearer':
-                return bearer + ' ' + redact(token)
-        return 'REDACTED'
+        result = redact(authorization, fullmatch=True)
+        if result == authorization:
+            return 'REDACTED'
+        else:
+            return result
 
 
 class DisableCrossHostRedirectClient(HttpClientDecorator):

--- a/src/azul/http.py
+++ b/src/azul/http.py
@@ -118,20 +118,15 @@ class LoggingHttpClient(HttpClientDecorator):
 
     def urlopen(self, method, url, *args, body=None, **kwargs) -> urllib3.HTTPResponse:
         log = self._log
-        # FIXME: Logs unredacted access tokens and URL signatures in
-        #        request URL
-        #        https://github.com/DataBiosphere/azul-private/issues/377
-        log.info('Making %s request to %r', method, url)
+        redacted_url = redact(url)
+        log.info('Making %s request to %r', method, redacted_url)
         log.info(http_body_log_message('request', body))
         start = time.monotonic()
         response = super().urlopen(method, url, *args, body=body, **kwargs)
         duration = time.monotonic() - start
         assert isinstance(response, urllib3.HTTPResponse), type(response)
-        # FIXME: Logs unredacted access tokens and URL signatures in
-        #        response URL
-        #        https://github.com/DataBiosphere/azul-private/issues/377
         log.info('Got %s response after %.3fs from %s to %s',
-                 response.status, duration, method, url)
+                 response.status, duration, method, redacted_url)
         log.info('… with response headers %r', response.headers)
         if response.isclosed():
             log.info(http_body_log_message('response', response.data))

--- a/src/azul/http.py
+++ b/src/azul/http.py
@@ -122,9 +122,6 @@ class LoggingHttpClient(HttpClientDecorator):
         #        request URL
         #        https://github.com/DataBiosphere/azul-private/issues/377
         log.info('Making %s request to %r', method, url)
-        # FIXME: Logs unredacted APATs, access tokens, and refresh tokens
-        #        in request body
-        #        https://github.com/DataBiosphere/azul-private/issues/377
         log.info(http_body_log_message('request', body))
         start = time.monotonic()
         response = super().urlopen(method, url, *args, body=body, **kwargs)
@@ -137,9 +134,6 @@ class LoggingHttpClient(HttpClientDecorator):
                  response.status, duration, method, url)
         log.info('… with response headers %r', response.headers)
         if response.isclosed():
-            # FIXME: Logs unredacted APATs, access tokens, refresh tokens,
-            #        and URL signatures in response body
-            #        https://github.com/DataBiosphere/azul-private/issues/377
             log.info(http_body_log_message('response', response.data))
         else:
             log.info('… with a streamed response body')

--- a/src/azul/http.py
+++ b/src/azul/http.py
@@ -118,16 +118,28 @@ class LoggingHttpClient(HttpClientDecorator):
 
     def urlopen(self, method, url, *args, body=None, **kwargs) -> urllib3.HTTPResponse:
         log = self._log
+        # FIXME: Logs unredacted access tokens and URL signatures in
+        #        request URL
+        #        https://github.com/DataBiosphere/azul-private/issues/377
         log.info('Making %s request to %r', method, url)
+        # FIXME: Logs unredacted APATs, access tokens, and refresh tokens
+        #        in request body
+        #        https://github.com/DataBiosphere/azul-private/issues/377
         log.info(http_body_log_message('request', body))
         start = time.monotonic()
         response = super().urlopen(method, url, *args, body=body, **kwargs)
         duration = time.monotonic() - start
         assert isinstance(response, urllib3.HTTPResponse), type(response)
+        # FIXME: Logs unredacted access tokens and URL signatures in
+        #        response URL
+        #        https://github.com/DataBiosphere/azul-private/issues/377
         log.info('Got %s response after %.3fs from %s to %s',
                  response.status, duration, method, url)
         log.info('… with response headers %r', response.headers)
         if response.isclosed():
+            # FIXME: Logs unredacted APATs, access tokens, refresh tokens,
+            #        and URL signatures in response body
+            #        https://github.com/DataBiosphere/azul-private/issues/377
             log.info(http_body_log_message('response', response.data))
         else:
             log.info('… with a streamed response body')

--- a/src/azul/lib/json.py
+++ b/src/azul/lib/json.py
@@ -370,7 +370,7 @@ def redact_json(v: AnyJSON) -> AnyJSON:
     Return a copy of the given JSON with confidential string values redacted.
     """
     if isinstance(v, str):
-        return redact(v)
+        return redact(v, fullmatch=True)
     elif isinstance(v, dict):
         return {k: redact_json(v) for k, v in v.items()}
     elif isinstance(v, list):

--- a/src/azul/lib/strings.py
+++ b/src/azul/lib/strings.py
@@ -508,6 +508,11 @@ def _redact_groups(m: re.Match) -> str:
     return result
 
 
+def assert_redactable(secret: str) -> None:
+    assert redact(secret, fullmatch=True) != secret, R(
+        'Secret not matched by redaction regex')
+
+
 def redactable_access_token(s: str) -> bool:
     return s.startswith('ya29.')
 

--- a/src/azul/lib/strings.py
+++ b/src/azul/lib/strings.py
@@ -1,3 +1,4 @@
+import re
 from textwrap import (
     dedent,
 )
@@ -436,22 +437,63 @@ def double_quote(*words: str) -> str:
     return delimit(join_words(*words), '"')
 
 
-def redact(s: str) -> str:
+_base64url = r'[A-Za-z0-9_-]'
+
+_secret_re = re.compile('|'.join([
+    rf'(?i:bearer )?ey[IJ]{_base64url}+\.({_base64url}+)\.({_base64url}+)',
+    rf'(?i:bearer )?ya29\.({_base64url}+)',
+]))
+
+
+def redact(s: str, *, fullmatch: bool = False) -> str:
     """
-    Redact the given string if it appears to be a secret. Only works with whole
-    secrets: 1) it does not detect secrets that are preceded by other text, and
-    2) it will redact any other text following the secret.
+    Find and redact secrets in the given string. Every captured group in a
+    match of ``_secret_re`` is redacted; the rest of the match and the
+    surrounding text are preserved.
+
+    >>> redact('token=ya29.some_access_token!')
+    'token=ya29.sREDACTED!'
+
+    >>> redact('token=eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature123!')
+    'token=eyJhbGciOiJSUzI1NiJ9.eREDACTED0.sREDACTED!'
+
+    >>> redact('no secrets here')
+    'no secrets here'
+
+    >>> redact('Authorization: Bearer ya29.some_access_token')
+    'Authorization: Bearer ya29.sREDACTED'
+
+    With ``fullmatch=True``, only strings that are entirely a secret are
+    redacted:
+
+    >>> redact('token=ya29.some_access_token!', fullmatch=True)
+    'token=ya29.some_access_token!'
+
+    >>> redact('ya29.some_access_token', fullmatch=True)
+    'ya29.sREDACTED'
+
+    >>> redact('Bearer ya29.some_access_token', fullmatch=True)
+    'Bearer ya29.sREDACTED'
     """
-    if redactable_access_token(s):
-        return _redact(s)
-    elif redactable_jwt(s):
-        token = s.split('.')
-        if len(token) == 3:
-            return '.'.join((token[0], _redact(token[1]), _redact(token[2])))
+    if fullmatch:
+        m = _secret_re.fullmatch(s)
+        if m is None:
+            return s
         else:
-            return _redact(s)
+            return _redact_groups(m)
     else:
-        return s
+        return _secret_re.sub(_redact_groups, s)
+
+
+def _redact_groups(m: re.Match) -> str:
+    result = m.group(0)
+    start = m.start()
+    for i in reversed(range(1, len(m.groups()) + 1)):
+        if m.group(i) is not None:
+            g_start = m.start(i) - start
+            g_end = m.end(i) - start
+            result = result[:g_start] + _redact(m.group(i)) + result[g_end:]
+    return result
 
 
 def redactable_access_token(s: str) -> bool:

--- a/src/azul/lib/strings.py
+++ b/src/azul/lib/strings.py
@@ -440,8 +440,14 @@ def double_quote(*words: str) -> str:
 _base64url = r'[A-Za-z0-9_-]'
 
 _secret_re = re.compile('|'.join([
+    # JSON Web Token (JWT)
     rf'(?i:bearer )?ey[IJ]{_base64url}+\.({_base64url}+)\.({_base64url}+)',
+    # Google OAuth2 access token
     rf'(?i:bearer )?ya29\.({_base64url}+)',
+    # Google OAuth2 refresh token
+    rf'1//[0-9]{{2}}({_base64url}{{98}})',
+    # Google OAuth2 authorization code
+    rf'4/[0-9]({_base64url}{{70}})',
 ]))
 
 
@@ -462,6 +468,12 @@ def redact(s: str, *, fullmatch: bool = False) -> str:
 
     >>> redact('Authorization: Bearer ya29.some_access_token')
     'Authorization: Bearer ya29.sREDACTED'
+
+    >>> redact('refresh=1//09' + 'a' * 98 + '!')
+    'refresh=1//09aaaREDACTEDaaa!'
+
+    >>> redact('code=4/0' + 'b' * 70 + '!')
+    'code=4/0bbbREDACTEDbbb!'
 
     With ``fullmatch=True``, only strings that are entirely a secret are
     redacted:

--- a/src/azul/lib/strings.py
+++ b/src/azul/lib/strings.py
@@ -451,6 +451,14 @@ _secret_re = re.compile('|'.join([
 ]))
 
 
+def looks_like_access_token(s: str) -> bool:
+    return s.startswith('ya29.')
+
+
+def looks_like_redactable_jwt(s: str) -> bool:
+    return s[:3] in ('eyI', 'eyJ')
+
+
 def redact(s: str, *, fullmatch: bool = False) -> str:
     """
     Find and redact secrets in the given string. Every captured group in a
@@ -511,14 +519,6 @@ def _redact_groups(m: re.Match) -> str:
 def assert_redactable(secret: str) -> None:
     assert redact(secret, fullmatch=True) != secret, R(
         'Secret not matched by redaction regex')
-
-
-def looks_like_access_token(s: str) -> bool:
-    return s.startswith('ya29.')
-
-
-def looks_like_redactable_jwt(s: str) -> bool:
-    return s[:3] in ('eyI', 'eyJ')
 
 
 def _redact(secret: str, *, num_show: int = 3, mask='REDACTED'):

--- a/src/azul/lib/strings.py
+++ b/src/azul/lib/strings.py
@@ -513,11 +513,11 @@ def assert_redactable(secret: str) -> None:
         'Secret not matched by redaction regex')
 
 
-def redactable_access_token(s: str) -> bool:
+def looks_like_access_token(s: str) -> bool:
     return s.startswith('ya29.')
 
 
-def redactable_jwt(s: str) -> bool:
+def looks_like_redactable_jwt(s: str) -> bool:
     return s[:3] in ('eyI', 'eyJ')
 
 

--- a/src/azul/logging.py
+++ b/src/azul/logging.py
@@ -19,7 +19,7 @@ from azul.lib.json import (
     json_head,
 )
 from azul.lib.strings import (
-    redact,
+    redact as _redact,
     trunc_ellipses,
 )
 from azul.lib.types import (
@@ -210,7 +210,11 @@ max_log_arg_len = 1024 * 1024
 empty_bodies = ('', b'', bytearray())
 
 
-def http_body_log_message(kind: Literal['request', 'response'], body: Any) -> str:
+def http_body_log_message(kind: Literal['request', 'response'],
+                          body: Any,
+                          *,
+                          redact: bool = True
+                          ) -> str:
     """
     Returns a log message suitable for logging the given HTTP request or
     response body. The level set in AZUL_DEBUG determines whether the body is
@@ -220,7 +224,13 @@ def http_body_log_message(kind: Literal['request', 'response'], body: Any) -> st
     :param kind: wether the given body represents a request or a response
 
     :param body: the request or response body to be logged
+
+    :param redact: whether to redact secrets in the body
     """
+
+    def __redact(s: str) -> str:
+        return _redact(s) if redact else s
+
     debug = azul.config.debug
     max_len = max_log_arg_len if debug > 1 else 1024
     assert debug >= 0, debug
@@ -231,19 +241,19 @@ def http_body_log_message(kind: Literal['request', 'response'], body: Any) -> st
         if debug == 0:
             return f'… with a {kind} body of length {body_len} and type {type(body)!r}'
         elif body_len <= max_len:
-            body = redact(repr(body))
+            body = __redact(repr(body))
             return f'… with a {kind} body of length {body_len} being {body}'
         else:
             # https://github.com/python/typing/discussions/1911
             prefix = trunc_ellipses(body, max_len)  # type: ignore[type-var]
-            prefix = redact(repr(prefix))
+            prefix = __redact(repr(prefix))
             return f'… with a {kind} body of length {body_len} starting in {prefix}'
     elif isinstance(body, json_body_types):
         if debug == 0:
             pass  # fall through to the default
         else:
             head, is_complete = json_head(max_len, body)
-            body_len, head = len(head), redact(head)
+            body_len, head = len(head), __redact(head)
             if is_complete:
                 return f'… with a {kind} body of length {body_len} being {head}'
             else:

--- a/src/azul/logging.py
+++ b/src/azul/logging.py
@@ -19,6 +19,7 @@ from azul.lib.json import (
     json_head,
 )
 from azul.lib.strings import (
+    redact,
     trunc_ellipses,
 )
 from azul.lib.types import (
@@ -226,21 +227,25 @@ def http_body_log_message(kind: Literal['request', 'response'], body: Any) -> st
     if body is None or body in empty_bodies:
         return f'… without a {kind} body'
     elif isinstance(body, string_types):
+        body_len = len(body)
         if debug == 0:
-            return f'… with a {kind} body of length {len(body)} and type {type(body)!r}'
-        elif len(body) <= max_len:
-            return f'… with a {kind} body of length {len(body)} being {body !r}'
+            return f'… with a {kind} body of length {body_len} and type {type(body)!r}'
+        elif body_len <= max_len:
+            body = redact(repr(body))
+            return f'… with a {kind} body of length {body_len} being {body}'
         else:
             # https://github.com/python/typing/discussions/1911
             prefix = trunc_ellipses(body, max_len)  # type: ignore[type-var]
-            return f'… with a {kind} body of length {len(body)} starting in {prefix!r}'
+            prefix = redact(repr(prefix))
+            return f'… with a {kind} body of length {body_len} starting in {prefix}'
     elif isinstance(body, json_body_types):
         if debug == 0:
             pass  # fall through to the default
         else:
             head, is_complete = json_head(max_len, body)
+            body_len, head = len(head), redact(head)
             if is_complete:
-                return f'… with a {kind} body of length {len(head)} being {head}'
+                return f'… with a {kind} body of length {body_len} being {head}'
             else:
                 return f'… with a {kind} body starting in {head}'
     return f'… with a {kind} body of type ({type(body)!r})'

--- a/src/azul/logging.py
+++ b/src/azul/logging.py
@@ -238,9 +238,9 @@ def http_body_log_message(kind: Literal['request', 'response'], body: Any) -> st
         if debug == 0:
             pass  # fall through to the default
         else:
-            repr, is_complete = json_head(max_len, body)
+            head, is_complete = json_head(max_len, body)
             if is_complete:
-                return f'… with a {kind} body of length {len(repr)} being {repr}'
+                return f'… with a {kind} body of length {len(head)} being {head}'
             else:
-                return f'… with a {kind} body starting in {repr}'
+                return f'… with a {kind} body starting in {head}'
     return f'… with a {kind} body of type ({type(body)!r})'

--- a/src/azul/oauth2.py
+++ b/src/azul/oauth2.py
@@ -34,6 +34,9 @@ from azul.lib import (
     R,
     cached_property,
 )
+from azul.lib.strings import (
+    assert_redactable,
+)
 from azul.lib.types import (
     JSONTypedDict,
     is_of_type,
@@ -146,6 +149,9 @@ class OAuth2Client(HasCachedHttpClient):
         response = json.loads(response.data)
         assert is_of_type(response, TokenForCodeResponse)
         assert response['token_type'] == 'Bearer'
+        assert_redactable(authorization_code)
+        assert_redactable(response['access_token'])
+        assert_redactable(response['refresh_token'])
         return response
 
     def token_for_refresh(self,
@@ -167,6 +173,8 @@ class OAuth2Client(HasCachedHttpClient):
         response = json.loads(response.data)
         assert is_of_type(response, TokenResponse)
         assert response['token_type'] == 'Bearer'
+        assert_redactable(refresh_token)
+        assert_redactable(response['access_token'])
         return response
 
     def token_info(self, access_token: str) -> TokenInfoResponse:

--- a/src/azul/opensearch.py
+++ b/src/azul/opensearch.py
@@ -97,7 +97,8 @@ class AzulUrllib3HttpConnection(Urllib3HttpConnection):
     def _log_request(self, method, full_url, headers, body):
         opensearch_log.info('Making %s request to %s', method, full_url)
         opensearch_log.debug('… with request headers %r', headers)
-        opensearch_log.info(http_body_log_message('request', body))
+        message = http_body_log_message('request', body, redact=False)
+        opensearch_log.info(message)
 
     def _log_response(self,
                       log_level: int,
@@ -112,7 +113,8 @@ class AzulUrllib3HttpConnection(Urllib3HttpConnection):
         # Note that here we log the full URL actually used, see _full_url above
         opensearch_log.log(log_level, 'Got %s response after %.3fs from %s to %s',
                            status_code, duration, method, full_url, exc_info=exception)
-        opensearch_log.log(log_level, http_body_log_message('response', response))
+        message = http_body_log_message('response', response, redact=False)
+        opensearch_log.log(log_level, message)
 
 
 class OpenSearchClientFactory:

--- a/src/azul/service/user_service.py
+++ b/src/azul/service/user_service.py
@@ -45,6 +45,7 @@ from azul.lib.objects import (
     absent,
 )
 from azul.lib.strings import (
+    assert_redactable,
     format_and_dedent as fd,
 )
 from azul.lib.types import (
@@ -254,6 +255,7 @@ class UserService:
         self._jwt.decode(apat,
                          key=config.apat_kms_key.alias,
                          algorithms=[self._apat_algorithm])
+        assert_redactable(apat)
         apat_auth = PersonalAccessTokenAuthentication(token=apat)
         log.info('Minted APAT %s for access token %s',
                  apat_auth, at_auth)
@@ -275,6 +277,7 @@ class UserService:
             log.warning('Invalid APAT %s', apat_auth, exc_info=e)
             raise InvalidPersonalAccessTokenError from e
         else:
+            assert_redactable(apat_auth.token)
             iss, sub = self._decode_identity(claims['sub'])
             user = self._load_user(iss, sub)
             jti = claims.get('jti')

--- a/src/azul/service/user_service.py
+++ b/src/azul/service/user_service.py
@@ -218,8 +218,8 @@ class UserService:
         token_info = self._oauth_client.token_info(at_auth.token)
         aud = token_info['aud']
         if aud != self._client_id:
-            log.warning('Unexpected access token audience %r for token %r',
-                        aud, at_auth.redacted())
+            log.warning('Unexpected access token audience %r for token %s',
+                        aud, at_auth)
             raise ForeignTokenException(aud)
         else:
             iss, sub = self._google_issuer, token_info['sub']
@@ -238,7 +238,7 @@ class UserService:
         perform. The APAT can be thought of as a proxy secret for the user's
         refresh token.
         """
-        log.info('Minting APAT for %r', at_auth.redacted())
+        log.info('Minting APAT for %s', at_auth)
         iss, sub = self._verify_access_token(at_auth)
         jti = self._next_jti(iss, sub)
         now = self._now()
@@ -255,8 +255,8 @@ class UserService:
                          key=config.apat_kms_key.alias,
                          algorithms=[self._apat_algorithm])
         apat_auth = PersonalAccessTokenAuthentication(token=apat)
-        log.info('Minted APAT %r for access token %r',
-                 apat_auth.redacted(), at_auth.redacted())
+        log.info('Minted APAT %s for access token %s',
+                 apat_auth, at_auth)
         return apat_auth
 
     def exchange_token(self,
@@ -266,21 +266,21 @@ class UserService:
         Return a usable access token in exchange for an APAT if valid and not
         yet expired.
         """
-        log.info('Getting access token for APAT %r', apat_auth.redacted())
+        log.info('Getting access token for APAT %s', apat_auth)
         try:
             claims = self._jwt.decode(apat_auth.token,
                                       key=config.apat_kms_key.alias,
                                       algorithms=[self._apat_algorithm])
         except jwt.exceptions.PyJWTError as e:
-            log.warning('Invalid APAT %r', apat_auth.redacted(), exc_info=e)
+            log.warning('Invalid APAT %s', apat_auth, exc_info=e)
             raise InvalidPersonalAccessTokenError from e
         else:
             iss, sub = self._decode_identity(claims['sub'])
             user = self._load_user(iss, sub)
             jti = claims.get('jti')
             if jti is None or not (user['min_jti'] <= int(jti) < user['max_jti']):
-                log.warning('APAT jti %r out of range [%d, %d) for %r',
-                            jti, user['min_jti'], user['max_jti'], apat_auth.redacted())
+                log.warning('APAT jti %r out of range [%d, %d) for %s',
+                            jti, user['min_jti'], user['max_jti'], apat_auth)
                 raise InvalidPersonalAccessTokenError
             access_token = user['access_token']
             if user['access_token_expiration'] < self._now() + 60:
@@ -292,7 +292,7 @@ class UserService:
                 access_token, expires_in = response['access_token'], response['expires_in']
                 self._update_access_token(iss, sub, access_token, expires_in)
             at_auth = AccessTokenAuthentication(access_token)
-            log.info('Exchanged %r for APAT %r', at_auth.redacted(), apat_auth.redacted())
+            log.info('Exchanged %s for APAT %s', at_auth, apat_auth)
             return at_auth
 
     def revoke_personal_access_tokens(self,
@@ -301,7 +301,7 @@ class UserService:
         """
         Revoke all APATs for the user identified by the given access token.
         """
-        log.info('Revoking all APATs for %r', at_auth.redacted())
+        log.info('Revoking all APATs for %s', at_auth)
         iss, sub = self._verify_access_token(at_auth)
         self._revoke_jti(iss, sub)
 

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -143,6 +143,9 @@ from azul.lib.collections import (
 from azul.lib.json_freeze import (
     freeze,
 )
+from azul.lib.strings import (
+    redact,
+)
 from azul.lib.types import (
     JSON,
     JSONs,
@@ -828,10 +831,7 @@ class IndexingIntegrationTest(IntegrationTestCase):
                 command_lines = self._curl_manifest_command_lines(response.data)
                 bash_command = command_lines[-1]
                 with tempfile.TemporaryDirectory() as tmpdir:
-                    # FIXME: Logs unredacted access tokens in manifest
-                    #        curl command
-                    #        https://github.com/DataBiosphere/azul-private/issues/377
-                    log.info('Running %r in %r', bash_command, tmpdir)
+                    log.info('Running %r in %r', redact(bash_command), tmpdir)
                     result = subprocess.run(bash_command,
                                             shell=True,
                                             executable='bash',

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -828,6 +828,9 @@ class IndexingIntegrationTest(IntegrationTestCase):
                 command_lines = self._curl_manifest_command_lines(response.data)
                 bash_command = command_lines[-1]
                 with tempfile.TemporaryDirectory() as tmpdir:
+                    # FIXME: Logs unredacted access tokens in manifest
+                    #        curl command
+                    #        https://github.com/DataBiosphere/azul-private/issues/377
                     log.info('Running %r in %r', bash_command, tmpdir)
                     result = subprocess.run(bash_command,
                                             shell=True,

--- a/test/service/test_app_logging.py
+++ b/test/service/test_app_logging.py
@@ -134,7 +134,7 @@ class TestServiceAppLogging(DCP1CannedBundleTestCase, WebServiceTestCase):
                         ),
                         (
                             INFO,
-                            "Authenticated request as AccessTokenAuthentication(token='ya29.foo_token')"
+                            "Authenticated request as AccessTokenAuthentication(token='yREDACTED')"
                             if authenticated else
                             'Did not authenticate request.'
                         ),

--- a/test/service/test_app_logging.py
+++ b/test/service/test_app_logging.py
@@ -134,7 +134,7 @@ class TestServiceAppLogging(DCP1CannedBundleTestCase, WebServiceTestCase):
                         ),
                         (
                             INFO,
-                            "Authenticated request as AccessTokenAuthentication(token='yREDACTED')"
+                            "Authenticated request as AccessTokenAuthentication(token='ya29.REDACTED')"
                             if authenticated else
                             'Did not authenticate request.'
                         ),

--- a/test/test_http.py
+++ b/test/test_http.py
@@ -157,9 +157,11 @@ class TestHttp(AzulUnitTestCase):
 
                 prefix, url = 'INFO:test_http:', re.escape(url)
                 http_header_pattern = (
-                    r"\{'Server': 'BaseHTTP/\d+\.\d+\s+Python/\d+\.\d+\.\d+', "
-                    r"'Date': '[A-Za-z]{3}, \d{2} [A-Za-z]{3} \d{4} \d{2}:\d{2}:\d{2} GMT', "
-                    r"'Retry-After': '\d+'\}"
+                    r"\["
+                    r"\('Server', 'BaseHTTP/\d+\.\d+\s+Python/\d+\.\d+\.\d+'\), "
+                    r"\('Date', '[A-Za-z]{3}, \d{2} [A-Za-z]{3} \d{4} \d{2}:\d{2}:\d{2} GMT'\), "
+                    r"\('Retry-After', '\d+'\)"
+                    r"\]"
                 )
 
                 expected_logs = []
@@ -180,7 +182,7 @@ class TestHttp(AzulUnitTestCase):
                         expected_logs.extend(
                             [
                                 rf'^{prefix}Got 503 response after \d.\d\d\ds from GET to {url}$',
-                                rf'^{prefix}… with response headers HTTPHeaderDict\({http_header_pattern}\)$',
+                                rf'^{prefix}… with response headers {http_header_pattern}$',
                                 f"^{prefix}… without a response body$",
                             ]
                         )


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: DataBiosphere/azul-private#377


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (mirror)

- [x] This PR is labeled `mirror:dev` <sub>or the changes introduced by it will not require mirroring of `dev`</sub>
- [x] This PR is labeled `mirror:anvildev` <sub>or the changes introduced by it will not require mirroring of `anvildev`</sub>
- [x] This PR is labeled `mirror:anvilprod` <sub>or the changes introduced by it will not require mirroring of `anvilprod`</sub>
- [x] This PR is labeled `mirror:prod` <sub>or the changes introduced by it will not require mirroring of `prod`</sub>
- [x] This PR is labeled `mirror:partial` and its description documents the specific mirroring procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full mirroring or carries none of the labels `mirror:dev`, `mirror:anvildev`, `mirror:anvilprod` and `mirror:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator and the author


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked `mirror:…` labels
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Applied upgrade instructions from UPGRADING.rst to `sandbox` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `sandbox`</sub>
- [x] Applied upgrade instructions from UPGRADING.rst to `anvilbox` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `anvilbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `sandbox`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilbox`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Started mirroring in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [x] Started mirroring in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Applied upgrade instructions from UPGRADING.rst to `dev` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `dev`</sub>
- [x] Applied upgrade instructions from UPGRADING.rst to `anvildev` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `anvildev`</sub>
- [x] Notified developers to apply upgrade instructions from UPGRADING.rst to their personal deployments <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to personal deployments</sub>
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] PR is assigned to only the operator
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>


### Operator

- [x] Propagated the `upgrade` and `API` labels to the next promotion PRs <sub>or this PR carries neither of these labels</sub>
- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem