### PR TITLE
Hotfix anvilprod: PFB manifests timeout in anvil14 (#8122)

### DIFF
--- a/src/azul/service/avro_pfb.py
+++ b/src/azul/service/avro_pfb.py
@@ -79,7 +79,7 @@ def write_pfb_entities(entities: Iterable[JSON], pfb_schema: JSON, path: str):
     with open(path, 'w+b') as fh:
         # Writing the entities one at a time is ~2.5 slower, but makes it clear
         # which entities fail, which is useful for debugging.
-        if config.debug > 1:
+        if config.debug > 2:
             log.info('Writing PFB entities individually')
             for entity in entities:
                 try:

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -1903,6 +1903,7 @@ class PFBManifestGenerator(FileBasedManifestGenerator):
 
 class VerbatimManifestGenerator(ClientSidePagingManifestGenerator,
                                 metaclass=ABCMeta):
+    page_size = 5000
 
     @property
     def entity_type(self) -> EntityType:


### PR DESCRIPTION
<!--
This is the PR template for hotfix PRs against `anvilprod`.
-->

Linked issue: #8122


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] Target branch is `anvilprod`
- [x] Name of PR branch matches `hotfixes/<GitHub handle of author>/<issue#>-<slug>-anvilprod`
- [x] PR is linked to the issue it hotfixes
- [x] Status of linked issue is *In progress*
- [x] PR description links to linked issue
- [x] PR title is `Hotfix anvilprod: ` followed by title of linked issue
- [x] PR title references the linked issue


### Author (hotfixes)

- [x] Added `h` tag to commit title <sub>or this PR does not include a temporary hotfix</sub>
- [x] Added `H` tag to commit title <sub>or this PR does not include a permanent hotfix</sub>
- [x] Added `hotfix` label to PR
- [x] This PR is labeled `partial` <sub>or represents a permanent hotfix</sub>


### Author (before every review)

- [x] Rebased PR branch on `anvilprod`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator and the author


### Operator

- [x] Squashed PR branch and rebased onto `anvilprod`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvilprod` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `hammerbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Deleted unreferenced indices in `hammerbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `hammerbox`</sub>
- [x] Started reindex in `hammerbox` <sub>or this PR is not labeled `reindex:anvilprod`</sub>
- [x] Checked for failures in `hammerbox` <sub>or this PR is not labeled `reindex:anvilprod`</sub>
- [x] Started mirroring in `hammerbox` <sub>or this PR is not labeled `mirror:anvilprod`</sub>
- [x] Checked for failures in `hammerbox` <sub>or this PR is not labeled `mirror:anvilprod`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but excluded any `p` tags</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged stable*


### Operator (main build)

- [x] Pushed merge commit to GitLab `anvilprod`
- [x] Build passes on GitLab `anvilprod`
- [x] Reviewed build logs for anomalies on GitLab `anvilprod`
- [x] Deleted PR branch from GitHub
- [x] PR is assigned to only the operator
- [x] Deleted PR branch from GitLab `anvilprod`
- [x] Status of linked issue is *Stable*


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `anvilprod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvilprod`</sub>
- [x] Deindexed specific sources in `anvilprod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvilprod`</sub>
- [x] Indexed specific sources in `anvilprod` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvilprod`</sub>
- [x] Started reindex in `anvilprod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvilprod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Emptied fail queues in `anvilprod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvilprod branch](https://gitlab.explore.anvilproject.org/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvilprod) on GitLab in `anvilprod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvilprod` <sub>or neither this PR nor a failed, prior promotion requires it</sub>
- [x] Created backport PR and linked to it in a comment on this PR


### Operator (mirroring)

- [x] Started mirroring in `anvilprod` <sub>or neither this PR nor a failed, prior promotion is labelled `mirror:anvilprod`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvilprod` <sub>or neither this PR nor a failed, prior promotion is labelled `mirror:anvilprod`</sub>
- [x] Emptied mirror fail queue in `anvilprod` <sub>or neither this PR nor a failed, prior promotion is labelled `mirror:anvilprod`</sub>


### Operator

- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
