### PR TITLE
Fix: Brittle coupling between config.data_browser_domain and .browser_sites (#8062)

### DIFF
--- a/.github/pull_request_template.md.template.py
+++ b/.github/pull_request_template.md.template.py
@@ -1147,7 +1147,7 @@ def emit(t: T, target_branch: str):
                                 'on GitLab'
                             ])
                             for browser_site in
-                            json.loads(deployment_env(d, 'browser')['azul_browser_sites']).values()
+                            json.loads(deployment_env(d)['azul_browser_sites']).values()
                         ],
                         'Restarted `deploy_browser` job in the GitLab pipeline for this PR'
                     ]

--- a/deployments/anvildev.browser/environment.py
+++ b/deployments/anvildev.browser/environment.py
@@ -2,12 +2,9 @@ from collections.abc import (
     Mapping,
 )
 import json
-from typing import (
-    Optional,
-)
 
 
-def env() -> Mapping[str, Optional[str]]:
+def env() -> Mapping[str, str | None]:
     """
     Returns a dictionary that maps environment variable names to values. The
     values are either None or strings. String values can contain references to

--- a/deployments/anvildev.browser/environment.py
+++ b/deployments/anvildev.browser/environment.py
@@ -1,7 +1,6 @@
 from collections.abc import (
     Mapping,
 )
-import json
 
 
 def env() -> Mapping[str, str | None]:
@@ -23,16 +22,5 @@ def env() -> Mapping[str, str | None]:
     provide the value.
     """
     return {
-        'azul_terraform_component': 'browser',
-        'azul_browser_sites': json.dumps({
-            'browser': {
-                'zone': '{AZUL_DOMAIN_NAME}',
-                'domain': '{AZUL_DOMAIN_NAME}',
-                'project': 'ucsc/data-browser',
-                'branch': 'ucsc/anvil/anvildev',
-                'tarball_name': 'anvil',
-                'tarball_path': 'out',
-                'real_path': ''
-            }
-        })
+        'azul_terraform_component': 'browser'
     }

--- a/deployments/anvildev/environment.py
+++ b/deployments/anvildev/environment.py
@@ -165,4 +165,16 @@ def env() -> Mapping[str, str | None]:
             'workspace_id': 'T09P9H91S',  # ucsc-gi.slack.com
             'channel_id': 'C04K4BQET7G'  # #team-boardwalk-anvildev
         }),
+
+        'azul_browser_sites': json.dumps({
+            'browser': {
+                'zone': '{AZUL_DOMAIN_NAME}',
+                'domain': '{AZUL_DOMAIN_NAME}',
+                'project': 'ucsc/data-browser',
+                'branch': 'ucsc/anvil/anvildev',
+                'tarball_name': 'anvil',
+                'tarball_path': 'out',
+                'real_path': ''
+            }
+        }),
     }

--- a/deployments/anvilprod.browser/environment.py
+++ b/deployments/anvilprod.browser/environment.py
@@ -1,7 +1,6 @@
 from collections.abc import (
     Mapping,
 )
-import json
 
 
 def env() -> Mapping[str, str | None]:
@@ -23,16 +22,5 @@ def env() -> Mapping[str, str | None]:
     provide the value.
     """
     return {
-        'azul_terraform_component': 'browser',
-        'azul_browser_sites': json.dumps({
-            'browser': {
-                'zone': '{AZUL_DOMAIN_NAME}',
-                'domain': '{AZUL_DOMAIN_NAME}',
-                'project': 'ucsc/data-browser',
-                'branch': 'ucsc/anvil/anvilprod',
-                'tarball_name': 'anvil',
-                'tarball_path': 'out',
-                'real_path': ''
-            }
-        })
+        'azul_terraform_component': 'browser'
     }

--- a/deployments/anvilprod.browser/environment.py
+++ b/deployments/anvilprod.browser/environment.py
@@ -2,12 +2,9 @@ from collections.abc import (
     Mapping,
 )
 import json
-from typing import (
-    Optional,
-)
 
 
-def env() -> Mapping[str, Optional[str]]:
+def env() -> Mapping[str, str | None]:
     """
     Returns a dictionary that maps environment variable names to values. The
     values are either None or strings. String values can contain references to

--- a/deployments/anvilprod/environment.py
+++ b/deployments/anvilprod/environment.py
@@ -1434,5 +1434,17 @@ def env() -> Mapping[str, str | None]:
 
         'AZUL_MIRROR_BUCKET': 'anvilproject',
 
-        'AZUL_MIRRORING_CONCURRENCY': '128'
+        'AZUL_MIRRORING_CONCURRENCY': '128',
+
+        'azul_browser_sites': json.dumps({
+            'browser': {
+                'zone': '{AZUL_DOMAIN_NAME}',
+                'domain': '{AZUL_DOMAIN_NAME}',
+                'project': 'ucsc/data-browser',
+                'branch': 'ucsc/anvil/anvilprod',
+                'tarball_name': 'anvil',
+                'tarball_path': 'out',
+                'real_path': ''
+            }
+        }),
     }

--- a/deployments/dev.browser/environment.py
+++ b/deployments/dev.browser/environment.py
@@ -2,12 +2,9 @@ from collections.abc import (
     Mapping,
 )
 import json
-from typing import (
-    Optional,
-)
 
 
-def env() -> Mapping[str, Optional[str]]:
+def env() -> Mapping[str, str | None]:
     """
     Returns a dictionary that maps environment variable names to values. The
     values are either None or strings. String values can contain references to

--- a/deployments/dev.browser/environment.py
+++ b/deployments/dev.browser/environment.py
@@ -1,7 +1,6 @@
 from collections.abc import (
     Mapping,
 )
-import json
 
 
 def env() -> Mapping[str, str | None]:
@@ -23,25 +22,5 @@ def env() -> Mapping[str, str | None]:
     provide the value.
     """
     return {
-        'azul_terraform_component': 'browser',
-        'azul_browser_sites': json.dumps({
-            'browser': {
-                'zone': '{AZUL_DOMAIN_NAME}',
-                'domain': 'explore.{AZUL_DOMAIN_NAME}',
-                'project': 'ucsc/data-browser',
-                'branch': 'ucsc/hca/dev',
-                'tarball_name': 'hca',
-                'tarball_path': 'out',
-                'real_path': ''
-            },
-            'lungmap': {
-                'zone': 'dev.data-browser.lungmap.net',
-                'domain': 'dev.data-browser.lungmap.net',
-                'project': 'ucsc/data-browser',
-                'branch': 'ucsc/lungmap/dev',
-                'tarball_name': 'lungmap',
-                'tarball_path': 'out',
-                'real_path': ''
-            }
-        })
+        'azul_terraform_component': 'browser'
     }

--- a/deployments/dev/environment.py
+++ b/deployments/dev/environment.py
@@ -338,4 +338,25 @@ def env() -> Mapping[str, str | None]:
             'workspace_id': 'T09P9H91S',  # ucsc-gi.slack.com
             'channel_id': 'C04K81HUALD'  # #team-boardwalk-dev
         }),
+
+        'azul_browser_sites': json.dumps({
+            'browser': {
+                'zone': '{AZUL_DOMAIN_NAME}',
+                'domain': 'explore.{AZUL_DOMAIN_NAME}',
+                'project': 'ucsc/data-browser',
+                'branch': 'ucsc/hca/dev',
+                'tarball_name': 'hca',
+                'tarball_path': 'out',
+                'real_path': ''
+            },
+            'lungmap': {
+                'zone': 'dev.data-browser.lungmap.net',
+                'domain': 'dev.data-browser.lungmap.net',
+                'project': 'ucsc/data-browser',
+                'branch': 'ucsc/lungmap/dev',
+                'tarball_name': 'lungmap',
+                'tarball_path': 'out',
+                'real_path': ''
+            }
+        }),
     }

--- a/deployments/prod.browser/environment.py
+++ b/deployments/prod.browser/environment.py
@@ -2,12 +2,9 @@ from collections.abc import (
     Mapping,
 )
 import json
-from typing import (
-    Optional,
-)
 
 
-def env() -> Mapping[str, Optional[str]]:
+def env() -> Mapping[str, str | None]:
     """
     Returns a dictionary that maps environment variable names to values. The
     values are either None or strings. String values can contain references to

--- a/deployments/prod.browser/environment.py
+++ b/deployments/prod.browser/environment.py
@@ -1,7 +1,6 @@
 from collections.abc import (
     Mapping,
 )
-import json
 
 
 def env() -> Mapping[str, str | None]:
@@ -23,25 +22,5 @@ def env() -> Mapping[str, str | None]:
     provide the value.
     """
     return {
-        'azul_terraform_component': 'browser',
-        'azul_browser_sites': json.dumps({
-            'browser': {
-                'zone': 'explore.data.humancellatlas.org',
-                'domain': 'explore.data.humancellatlas.org',
-                'project': 'ucsc/data-browser',
-                'branch': 'ucsc/hca/prod',
-                'tarball_name': 'hca',
-                'tarball_path': 'out',
-                'real_path': ''
-            },
-            'lungmap': {
-                'zone': 'data-browser.lungmap.net',
-                'domain': 'data-browser.lungmap.net',
-                'project': 'ucsc/data-browser',
-                'branch': 'ucsc/lungmap/prod',
-                'tarball_name': 'lungmap',
-                'tarball_path': 'out',
-                'real_path': ''
-            }
-        })
+        'azul_terraform_component': 'browser'
     }

--- a/deployments/prod/environment.py
+++ b/deployments/prod/environment.py
@@ -1986,5 +1986,26 @@ def env() -> Mapping[str, str | None]:
         'AZUL_MIRRORING_CONCURRENCY': '128',
 
         # This deployment is busy so we can afford a more sensitive threshold.
-        'azul_waf_blocked_alarm_threshold': '25'
+        'azul_waf_blocked_alarm_threshold': '25',
+
+        'azul_browser_sites': json.dumps({
+            'browser': {
+                'zone': 'explore.data.humancellatlas.org',
+                'domain': 'explore.data.humancellatlas.org',
+                'project': 'ucsc/data-browser',
+                'branch': 'ucsc/hca/prod',
+                'tarball_name': 'hca',
+                'tarball_path': 'out',
+                'real_path': ''
+            },
+            'lungmap': {
+                'zone': 'data-browser.lungmap.net',
+                'domain': 'data-browser.lungmap.net',
+                'project': 'ucsc/data-browser',
+                'branch': 'ucsc/lungmap/prod',
+                'tarball_name': 'lungmap',
+                'tarball_path': 'out',
+                'real_path': ''
+            }
+        }),
     }

--- a/deployments/prod/environment.py
+++ b/deployments/prod/environment.py
@@ -1922,6 +1922,8 @@ def env() -> Mapping[str, str | None]:
 
         'AZUL_DEPLOYMENT_STAGE': 'prod',
 
+        # FIXME: Remove 'azul.' prefix from AZUL_DOMAIN_NAME in prod
+        #        https://github.com/DataBiosphere/azul/issues/5122
         'AZUL_DOMAIN_NAME': 'azul.data.humancellatlas.org',
 
         'AZUL_CATALOGS': base64.b64encode(bz2.compress(json.dumps({

--- a/deployments/tempdev.browser/environment.py
+++ b/deployments/tempdev.browser/environment.py
@@ -1,7 +1,6 @@
 from collections.abc import (
     Mapping,
 )
-import json
 
 
 def env() -> Mapping[str, str | None]:
@@ -23,16 +22,5 @@ def env() -> Mapping[str, str | None]:
     provide the value.
     """
     return {
-        'azul_terraform_component': 'browser',
-        'azul_browser_sites': json.dumps({
-            'browser': {
-                'zone': '{AZUL_DOMAIN_NAME}',
-                'domain': '{AZUL_DOMAIN_NAME}',
-                'project': 'ucsc/data-browser',
-                'branch': 'ucsc/anvil/tempdev',
-                'tarball_name': 'anvil',
-                'tarball_path': 'out',
-                'real_path': ''
-            }
-        })
+        'azul_terraform_component': 'browser'
     }

--- a/deployments/tempdev.browser/environment.py
+++ b/deployments/tempdev.browser/environment.py
@@ -2,12 +2,9 @@ from collections.abc import (
     Mapping,
 )
 import json
-from typing import (
-    Optional,
-)
 
 
-def env() -> Mapping[str, Optional[str]]:
+def env() -> Mapping[str, str | None]:
     """
     Returns a dictionary that maps environment variable names to values. The
     values are either None or strings. String values can contain references to

--- a/deployments/tempdev/environment.py
+++ b/deployments/tempdev/environment.py
@@ -162,4 +162,16 @@ def env() -> Mapping[str, str | None]:
         'AZUL_GOOGLE_OAUTH2_CLIENT_ID': '807674395527-erth0gf1m7qme5pe6bu384vpdfjh06dg.apps.googleusercontent.com',
 
         'AZUL_ENABLE_MIRRORING': '1',
+
+        'azul_browser_sites': json.dumps({
+            'browser': {
+                'zone': '{AZUL_DOMAIN_NAME}',
+                'domain': '{AZUL_DOMAIN_NAME}',
+                'project': 'ucsc/data-browser',
+                'branch': 'ucsc/anvil/tempdev',
+                'tarball_name': 'anvil',
+                'tarball_path': 'out',
+                'real_path': ''
+            }
+        }),
     }

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -290,21 +290,10 @@ class Config:
         return int(self.environ['AZUL_OPENSEARCH_TIMEOUT'])
 
     @property
-    def data_browser_domain(self):
-        # Note that the return value must be kept synchronized with the value
-        # of azul_browser_sites.browser.domain in
-        # deployments/{stage}.browser/environment.py
-        #
-        # FIXME: Brittle coupling between config.data_browser_domain and .browser_sites
-        #        https://github.com/DataBiosphere/azul/issues/8062
-        domain = self.domain_name
+    def data_browser_domain(self) -> str:
         # FIXME: Remove 'azul.' prefix from AZUL_DOMAIN_NAME in prod
         #        https://github.com/DataBiosphere/azul/issues/5122
-        if self.deployment_stage == 'prod':
-            domain = domain.removeprefix('azul.')
-        if self.deployment_stage in ('dev', 'prod'):
-            domain = 'explore.' + domain
-        return domain
+        return self.browser_sites['browser']['domain']
 
     @property
     def dss_endpoint(self) -> str | None:

--- a/src/azul/__init__.py
+++ b/src/azul/__init__.py
@@ -291,8 +291,6 @@ class Config:
 
     @property
     def data_browser_domain(self) -> str:
-        # FIXME: Remove 'azul.' prefix from AZUL_DOMAIN_NAME in prod
-        #        https://github.com/DataBiosphere/azul/issues/5122
         return self.browser_sites['browser']['domain']
 
     @property


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #8062


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (mirror)

- [x] This PR is labeled `mirror:dev` <sub>or the changes introduced by it will not require mirroring of `dev`</sub>
- [x] This PR is labeled `mirror:anvildev` <sub>or the changes introduced by it will not require mirroring of `anvildev`</sub>
- [x] This PR is labeled `mirror:anvilprod` <sub>or the changes introduced by it will not require mirroring of `anvilprod`</sub>
- [x] This PR is labeled `mirror:prod` <sub>or the changes introduced by it will not require mirroring of `prod`</sub>
- [x] This PR is labeled `mirror:partial` and its description documents the specific mirroring procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full mirroring or carries none of the labels `mirror:dev`, `mirror:anvildev`, `mirror:anvilprod` and `mirror:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator and the author


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked `mirror:…` labels
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Applied upgrade instructions from UPGRADING.rst to `sandbox` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `sandbox`</sub>
- [x] Applied upgrade instructions from UPGRADING.rst to `anvilbox` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `anvilbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `sandbox`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilbox`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Started mirroring in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [x] Started mirroring in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Applied upgrade instructions from UPGRADING.rst to `dev` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `dev`</sub>
- [x] Applied upgrade instructions from UPGRADING.rst to `anvildev` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `anvildev`</sub>
- [x] Notified developers to apply upgrade instructions from UPGRADING.rst to their personal deployments <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to personal deployments</sub>
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] PR is assigned to only the operator
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>


### Operator

- [x] Propagated the `upgrade` and `API` labels to the next promotion PRs <sub>or this PR carries neither of these labels</sub>
- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
