### PR TITLE
Handle unreferenced file objects ("garbage") in mirror bucket (#7135)

### DIFF
--- a/scripts/mirror.py
+++ b/scripts/mirror.py
@@ -7,7 +7,6 @@ import logging
 import sys
 
 from azul import (
-    CatalogName,
     config,
 )
 from azul.args import (
@@ -33,25 +32,28 @@ from azul.logging import (
 log = logging.getLogger(__name__)
 
 
-def mirror_catalog(azul: AzulClient,
-                   catalog: CatalogName,
-                   source_globs: set[str],
-                   wait: bool
-                   ) -> None:
+def mirror(args, azul: AzulClient) -> None:
     fail_queue = config.mirror_queue.to_fail.name
     assert azul.is_queue_empty(fail_queue), R(
         'Cannot begin mirroring because a previous operation failed: '
         'there are still messages in the fail queue.',
         fail_queue)
 
-    sources = azul.source_service.list_sources(catalog, indexer_authentication)
-    if '*' not in source_globs:
-        matching_sources = azul.matching_sources([catalog], source_globs)[catalog]
-        sources = [source for source in sources if source.ref.spec in matching_sources]
+    if args.purge:
+        azul.queues.purge_mirror()
+    if args.mark:
+        MirrorService.mirror_catalogs(mark=True, it=False)
+    else:
+        catalog = config.default_catalog if args.catalog is None else args.catalog
+        service = MirrorService.for_catalog(catalog)
+        source_globs = get_sources(args.sources)
+        sources = azul.source_service.list_sources(catalog, indexer_authentication)
+        if '*' not in source_globs:
+            matching = azul.matching_sources([catalog], source_globs)[catalog]
+            sources = [s for s in sources if s.ref.spec in matching]
+        service.mirror_sources(sources)
 
-    MirrorService.for_catalog(catalog).mirror_sources(sources)
-
-    if wait:
+    if args.wait:
         azul.wait_for_mirroring()
         assert azul.is_queue_empty(fail_queue), R(
             'There are messages in the fail queue', fail_queue)
@@ -60,36 +62,49 @@ def mirror_catalog(azul: AzulClient,
 def main(args):
     parser = argparse.ArgumentParser(description=__doc__,
                                      formatter_class=AzulArgumentHelpFormatter)
-    parser.add_argument('--catalog',
-                        metavar='NAME',
-                        choices=config.catalogs,
-                        default=config.default_catalog,
-                        help='The name of the catalog to mirror.')
-    parser.add_argument('--sources',
-                        nargs='+',
-                        help='Limit mirroring to a subset of the configured sources. '
-                             'Supports shell-style wildcards to match multiple sources per argument. '
-                             'All sources must be public. If no values are passed, this argument will be set from the '
-                             'environment variable ``azul_current_sources``. If that variable is unset, all sources in '
-                             'the selected catalog will be used.')
-    parser.add_argument('--mirror',
-                        action='store_true',
-                        help='Mirror files in the specified catalog and sources')
-    parser.add_argument('--purge',
-                        action='store_true',
-                        help='Purge the mirror queue before taking any other action.')
-    parser.add_argument('--no-wait',
-                        action='store_false',
-                        dest='wait',
-                        help='Do not wait for queues to empty before exiting script.')
+    subparsers = parser.add_subparsers(dest='command')
+
+    sp = subparsers.add_parser('mirror',
+                               help='Mirror files to the mirror bucket.',
+                               formatter_class=AzulArgumentHelpFormatter)
+    sp.add_argument('--catalog',
+                    metavar='NAME',
+                    choices=config.catalogs,
+                    default=None,
+                    help='The name of the catalog to mirror.')
+    sp.add_argument('--sources',
+                    nargs='+',
+                    help='Limit mirroring to a subset of the configured sources. '
+                         'Supports shell-style wildcards to match multiple sources per argument. '
+                         'All sources must be public. If no values are passed, this argument will be set from the '
+                         'environment variable ``azul_current_sources``. If that variable is unset, all sources in '
+                         'the selected catalog will be used.')
+    sp.add_argument('--mark',
+                    action='store_true',
+                    help='Enable marking for garbage collection. '
+                         'Mirrors all sources in all catalogs, overwriting info objects to update '
+                         'their LastModified time. Mutually exclusive with --catalog and --sources.')
+    sp.add_argument('--purge',
+                    action='store_true',
+                    help='Purge the mirror queue before taking any other action.')
+    sp.add_argument('--no-wait',
+                    action='store_false',
+                    dest='wait',
+                    help='Do not wait for queues to empty before exiting script.')
+
     args = parser.parse_args(args)
     assert config.enable_mirroring, R('Mirroring is not enabled')
 
-    azul = AzulClient()
-    if args.purge:
-        azul.queues.purge_mirror()
-    if args.mirror:
-        mirror_catalog(azul, args.catalog, get_sources(args.sources), args.wait)
+    if args.command == 'mirror':
+        if args.mark:
+            assert args.catalog is None, R(
+                '--mark is mutually exclusive with --catalog')
+            assert args.sources is None, R(
+                '--mark is mutually exclusive with --sources')
+        azul = AzulClient()
+        mirror(args, azul)
+    else:
+        parser.print_usage()
 
 
 if __name__ == '__main__':

--- a/scripts/mirror.py
+++ b/scripts/mirror.py
@@ -59,6 +59,10 @@ def mirror(args, azul: AzulClient) -> None:
             'There are messages in the fail queue', fail_queue)
 
 
+def sweep(args) -> None:
+    MirrorService.sweep_catalogs(dry_run=args.dry_run, it=False)
+
+
 def main(args):
     parser = argparse.ArgumentParser(description=__doc__,
                                      formatter_class=AzulArgumentHelpFormatter)
@@ -92,6 +96,13 @@ def main(args):
                     dest='wait',
                     help='Do not wait for queues to empty before exiting script.')
 
+    sp = subparsers.add_parser('sweep',
+                               help='Sweep garbage from mirror buckets.',
+                               formatter_class=AzulArgumentHelpFormatter)
+    sp.add_argument('--dry-run',
+                    action='store_true',
+                    help='Report garbage objects without deleting them.')
+
     args = parser.parse_args(args)
     assert config.enable_mirroring, R('Mirroring is not enabled')
 
@@ -103,6 +114,8 @@ def main(args):
                 '--mark is mutually exclusive with --sources')
         azul = AzulClient()
         mirror(args, azul)
+    elif args.command == 'sweep':
+        sweep(args)
     else:
         parser.print_usage()
 

--- a/scripts/mirror.py
+++ b/scripts/mirror.py
@@ -20,6 +20,9 @@ from azul.auth import (
 from azul.azulclient import (
     AzulClient,
 )
+from azul.indexer.mirror_service import (
+    MirrorService,
+)
 from azul.lib import (
     R,
 )
@@ -46,7 +49,7 @@ def mirror_catalog(azul: AzulClient,
         matching_sources = azul.matching_sources([catalog], source_globs)[catalog]
         sources = [source for source in sources if source.ref.spec in matching_sources]
 
-    azul.mirror_service(catalog).mirror_sources(sources)
+    MirrorService.for_catalog(catalog).mirror_sources(sources)
 
     if wait:
         azul.wait_for_mirroring()

--- a/src/azul/azulclient.py
+++ b/src/azul/azulclient.py
@@ -45,15 +45,11 @@ from azul.indexer.index_queue_service import (
 from azul.indexer.index_service import (
     IndexService,
 )
-from azul.indexer.mirror_service import (
-    MirrorService,
-)
 from azul.indexer.repository_service import (
     RepositoryService,
 )
 from azul.lib import (
     R,
-    cache,
     cached_property,
 )
 from azul.lib.types import (
@@ -106,10 +102,6 @@ class AzulClient(SignatureHelper, HasCachedHttpClient):
 
     def metadata_plugin(self, catalog: CatalogName) -> MetadataPlugin:
         return self.index_service.metadata_plugin(catalog)
-
-    @cache
-    def mirror_service(self, catalog: CatalogName) -> MirrorService:
-        return MirrorService(catalog=catalog)
 
     @cached_property
     def source_service(self) -> SourceService:

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -572,7 +572,7 @@ class MirrorService:
         storage = self._storage_for_source(source)
         assert storage.bucket_name not in [config.mirror_bucket,
                                            config.ma_mirror_bucket]
-        object_keys = storage.list_objects(prefix)
+        object_keys = storage.list_keys(prefix)
         assert len(object_keys) <= 300, R('Too many objects', len(object_keys))
         for object_key in object_keys:
             assert object_key.startswith(prefix), (object_key, prefix)

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -698,6 +698,7 @@ class MirrorService:
                 threshold = response['LastModified']
                 summary = self._sweep_storage(storage, threshold=threshold, dry_run=dry_run)
                 summaries.append(summary)
+        log.info('--- Summary ---')
         for summary in summaries:
             summary()
 
@@ -741,11 +742,11 @@ class MirrorService:
                        '%s %d file(s) (%s total) from %r',
                        verb, num_files, format_size(total_size), storage.bucket_name)
 
-    def delete_it_files(self, source: SourceSpec):
+    def delete_it_files(self):
         """
-        Delete all objects (both file/ and info/) with the given catalog's
-        mirror prefix. Currently, the mirror prefix is only used to distinguish
-        IT catalogs from non-IT catalogs, so if an IT catalog is specified,
+        Delete all objects under the catalog's mirror prefix from both mirror
+        buckets. Currently, the mirror prefix is only used to distinguish IT
+        catalogs from non-IT catalogs, so if an IT catalog is specified,
         objects from *all* IT catalogs will be deleted, not just the specified
         catalog.
         """
@@ -753,14 +754,14 @@ class MirrorService:
             'Not an IT catalog', self.catalog)
         prefix = self._mirror_prefix
         assert len(prefix) > 1 and prefix.endswith('/'), prefix
-        storage = self._storage_for_source(source)
-        assert storage.bucket_name not in [config.mirror_bucket,
-                                           config.ma_mirror_bucket]
-        object_keys = storage.list_keys(prefix)
-        assert len(object_keys) <= 300, R('Too many objects', len(object_keys))
-        for object_key in object_keys:
-            assert object_key.startswith(prefix), (object_key, prefix)
-        storage.delete_objects(object_keys, batch_size=100)
+        for storage in (self._storage, self._ma_storage):
+            assert storage.bucket_name not in [config.mirror_bucket,
+                                               config.ma_mirror_bucket]
+            object_keys = storage.list_keys(prefix)
+            assert len(object_keys) <= 300, R('Too many objects', len(object_keys))
+            for object_key in object_keys:
+                assert object_key.startswith(prefix), (object_key, prefix)
+            storage.delete_objects(object_keys, batch_size=100)
 
 
 @attrs.frozen(kw_only=True, slots=False)

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -8,7 +8,6 @@ from functools import (
 import json
 import logging
 import math
-import string
 import time
 from typing import (
     ClassVar,
@@ -17,6 +16,7 @@ from typing import (
     Protocol,
     Self,
     TYPE_CHECKING,
+    cast,
     final,
 )
 from uuid import (
@@ -57,6 +57,8 @@ from azul.lib.attrs import (
     serializable,
 )
 from azul.lib.digests import (
+    Digest,
+    DigestType,
     Hasher,
     get_resumable_hasher,
     hasher_from_json,
@@ -68,6 +70,7 @@ from azul.lib.functions import (
 from azul.lib.types import (
     JSON,
     MutableJSON,
+    check_type,
     json_element_strings,
     json_mapping,
 )
@@ -539,19 +542,46 @@ class MirrorService:
 
     info_prefix, file_prefix = 'info', 'file'
 
+    _hex_digits = '0123456789abcdef'
+
     def _info_object_key(self, file: File) -> str:
-        return self._object_key(self.info_prefix, file, extension='.json')
+        return self._object_key(self.info_prefix, file.digest, extension='.json')
 
     def _file_object_key(self, file: File) -> str:
-        return self._object_key(self.file_prefix, file)
+        return self._object_key(self.file_prefix, file.digest, extension='')
 
-    def _object_key(self, prefix: str, file: File, *, extension: str = '') -> str:
-        digest = file.digest
+    def _object_key(self, prefix: str, digest: Digest, *, extension: str) -> str:
         digest_value = digest.value.lower()
-        assert all(c in string.hexdigits for c in digest_value), R(
+        hex_digits = self._hex_digits
+        assert all(c in hex_digits for c in digest_value), R(
             'Expected a hexadecimal digest', digest)
         mirror_prefix = self._mirror_prefix
         return f'{mirror_prefix}{prefix}/{digest_value}.{digest.type}{extension}'
+
+    def _parse_object_key(self, key: str) -> tuple[str, Digest, str]:
+        assert key.startswith(self._mirror_prefix), R('Invalid mirror prefix', key)
+        rest = key.removeprefix(self._mirror_prefix)
+        prefix, sep, file_name = rest.partition('/')
+        assert sep, R('Missing separator', key)
+        assert prefix in (self.info_prefix, self.file_prefix), R('Invalid prefix', key)
+        match file_name.split('.'):
+            case [digest_value, digest_type]:
+                extension = ''
+            case [digest_value, digest_type, extension]:
+                extension = '.' + extension
+            case _:
+                assert False, R('Invalid key', key)
+        hex_digits = self._hex_digits
+        assert all(c in hex_digits for c in digest_value), R('Invalid digest', key)
+        assert check_type(DigestType, digest_type), R('Invalid digest type', key)
+        digest = Digest(type=cast(DigestType, digest_type), value=digest_value)
+        return prefix, digest, extension
+
+    def _info_key_to_file_key(self, info_key: str) -> str:
+        prefix, digest, extension = self._parse_object_key(info_key)
+        assert prefix == self.info_prefix and extension == '.json', R(
+            'Unexpected info key', info_key)
+        return self._object_key(self.file_prefix, digest, extension='')
 
     @cached_property
     def _mirror_prefix(self) -> str:

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -47,6 +47,7 @@ from azul.http import (
 )
 from azul.lib import (
     R,
+    cache,
     cached_property,
     mutable_furl,
 )
@@ -334,6 +335,11 @@ class MirrorService:
     catalog: CatalogName
 
     info_schema_version = 2
+
+    @classmethod
+    @cache
+    def for_catalog(cls, catalog: CatalogName) -> Self:
+        return cls(catalog=catalog)
 
     @cached_property
     def _queues(self) -> Queues:

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -5,7 +5,14 @@ from abc import (
 from collections import (
     defaultdict,
 )
+from collections.abc import (
+    Callable,
+)
+from datetime import (
+    datetime,
+)
 from functools import (
+    partial,
     singledispatchmethod,
 )
 import json
@@ -70,6 +77,9 @@ from azul.lib.digests import (
 from azul.lib.functions import (
     compose,
 )
+from azul.lib.strings import (
+    format_size,
+)
 from azul.lib.types import (
     JSON,
     MutableJSON,
@@ -95,6 +105,7 @@ from azul.service.source_service import (
 )
 from azul.service.storage_service import (
     StorageObjectExists,
+    StorageObjectNotFound,
     StorageService,
 )
 from azul.source import (
@@ -635,6 +646,10 @@ class MirrorService:
     def _marked_key(self) -> str:
         return f'{self._mirror_prefix}.marked'
 
+    @cached_property
+    def _swept_key(self) -> str:
+        return f'{self._mirror_prefix}.swept'
+
     def _write_marked(self) -> None:
         """
         Write an empty ``.marked`` object to each mirror bucket at the
@@ -646,6 +661,85 @@ class MirrorService:
         for storage in (self._storage, self._ma_storage):
             log.info('Writing %r to bucket %r', key, storage.bucket_name)
             storage.put_object(object_key=key, data=b'', overwrite=True)
+
+    @classmethod
+    def sweep_catalogs(cls, *, dry_run: bool, it: bool) -> None:
+        """
+        Sweep garbage from mirror buckets for either all normal catalogs, or
+        all integration test (IT) catalogs.
+
+        :param dry_run: Whether to report garbage without deleting it.
+
+        :param it: Whether to sweep IT or non-IT catalogs.
+        """
+        # The scope of garbage collection is everything underneath a mirror
+        # prefix, which could be shared by multiple catalogs. We need to group
+        # catalogs by that prefix and perform the sweeping using the service
+        # instance for one of the catalogs, it doesn't matter which one.
+        services: dict[str, MirrorService] = {}
+        for catalog in config.catalogs.values():
+            if catalog.is_integration_test_catalog == it:
+                self = cls.for_catalog(catalog.name)
+                if self.may_mirror():
+                    services.setdefault(self._mirror_prefix, self)
+        assert services, R('No catalogs are configured for mirroring')
+        for self in services.values():
+            self._sweep(dry_run=dry_run)
+
+    def _sweep(self, *, dry_run: bool) -> None:
+        summaries: list[Callable[[], None]] = []
+        for storage in (self._storage, self._ma_storage):
+            marked_key = self._marked_key
+            try:
+                response = storage.head_object(marked_key)
+            except StorageObjectNotFound:
+                assert False, R('No such object', marked_key, storage.bucket_name)
+            else:
+                threshold = response['LastModified']
+                summary = self._sweep_storage(storage, threshold=threshold, dry_run=dry_run)
+                summaries.append(summary)
+        for summary in summaries:
+            summary()
+
+    def _sweep_storage(self,
+                       storage: StorageService,
+                       *,
+                       threshold: datetime,
+                       dry_run: bool
+                       ) -> Callable[[], None]:
+        log.info('Sweeping bucket %r with threshold %r',
+                 storage.bucket_name, threshold)
+        info_dir = self._mirror_prefix + self.info_prefix + '/'
+        num_files, total_size = 0, 0
+        for obj in storage.list_objects(info_dir):
+            if obj['LastModified'] < threshold:
+                info_key = obj['Key']
+                file_key = self._info_key_to_file_key(info_key)
+                try:
+                    file_head = storage.head_object(file_key)
+                except StorageObjectNotFound:
+                    log.warning('Garbage file object not found: %r', file_key)
+                else:
+                    total_size += file_head['ContentLength']
+                num_files += 1
+                if dry_run:
+                    log.info('Would delete %r and %r', info_key, file_key)
+                else:
+                    log.info('Deleting %r and %r', info_key, file_key)
+                    storage.delete_objects([info_key, file_key])
+        if dry_run:
+            log.info('Would write %r to %r',
+                     self._swept_key, storage.bucket_name)
+        else:
+            log.info('Writing %r to %r',
+                     self._swept_key, storage.bucket_name)
+            storage.put_object(object_key=self._swept_key,
+                               data=b'',
+                               overwrite=True)
+        verb = 'Would delete' if dry_run else 'Deleted'
+        return partial(log.info,
+                       '%s %d file(s) (%s total) from %r',
+                       verb, num_files, format_size(total_size), storage.bucket_name)
 
     def delete_it_files(self, source: SourceSpec):
         """

--- a/src/azul/indexer/mirror_service.py
+++ b/src/azul/indexer/mirror_service.py
@@ -2,6 +2,9 @@ from abc import (
     ABCMeta,
     abstractmethod,
 )
+from collections import (
+    defaultdict,
+)
 from functools import (
     singledispatchmethod,
 )
@@ -210,6 +213,13 @@ class MirrorAction(Action, metaclass=ABCMeta):
     #:
     operation_id: str = attrs.field(factory=lambda: MirrorAction._operation_id())
 
+    #: When True, info objects are overwritten even if their content hasn't
+    #: changed, ensuring their LastModified time is updated. This is used by
+    #: the garbage collection mechanism to distinguish referenced objects from
+    #: unreferenced ones.
+    #:
+    mark: bool = False
+
     @classmethod
     def _operation_id(cls):
         return str(uuid4())
@@ -417,21 +427,55 @@ class MirrorService:
         else:
             return False
 
+    @classmethod
+    def mirror_catalogs(cls, *, mark: bool, it: bool) -> None:
+        """
+        Mirror all sources in either all normal catalogs, or all integration
+        test (IT) catalogs.
+
+        :param mark: Whether to perform the mark phase of garbage collection.
+                     Marking involves touching every info object so it should
+                     be used with deliberation.
+
+        :param it: Whether to mirror IT or non-IT catalogs.
+        """
+        # The scope of garbage collection is everything underneath a mirror
+        # prefix, which could be shared by multiple catalogs. We need to group
+        # catalogs by that prefix so that we write the marker file exactly once
+        # per prefix, before mirroring and marking the first catalog sharing
+        # that prefix. When we're not marking, this ordering constraint is
+        # irrelevant but it doesn't hurt anything either.
+        services: dict[str, list[MirrorService]] = defaultdict(list)
+        for catalog in config.catalogs.values():
+            if catalog.is_integration_test_catalog == it:
+                self = cls.for_catalog(catalog.name)
+                if self.may_mirror():
+                    services[self._mirror_prefix].append(self)
+        assert services, R('No catalogs are configured for mirroring')
+        for group in services.values():
+            if mark:
+                group[0]._write_marked()
+            for self in group:
+                sources = self._source_service.list_sources(self.catalog, indexer_authentication)
+                self._mirror_sources(sources, mark=mark)
+
     def mirror_sources(self, sources: Iterable[Source]) -> None:
         """
         Of the given sources, mirror those that are configured to be mirrored,
-        ignoring those that are not. When mirroring a source, only files
-        satisfying certain size constraints will be mirrored. These constraints
-        are configured per catalog, and may depend on factors like whether the
-        catalog is an IT catalog, or whether the deployment is stable or not.
+        ignoring those that are not.
         """
+        self._mirror_sources(sources, mark=False)
+
+    def _mirror_sources(self, sources: Iterable[Source], *, mark: bool) -> None:
         if self.may_mirror():
             def actions():
                 for source in sources:
                     if source.config.mirror:
                         log.info('Mirroring files in source %r from catalog %r',
                                  str(source.ref.spec), self.catalog)
-                        yield MirrorSourceAction(catalog=self.catalog, source=source.ref)
+                        yield MirrorSourceAction(catalog=self.catalog,
+                                                 source=source.ref,
+                                                 mark=mark)
                     else:
                         log.info('Not mirroring any files in source %r from catalog %r because '
                                  'mirroring is explicitly disabled',
@@ -587,6 +631,22 @@ class MirrorService:
     def _mirror_prefix(self) -> str:
         return '_it/' if self.catalog in config.integration_test_catalogs else ''
 
+    @cached_property
+    def _marked_key(self) -> str:
+        return f'{self._mirror_prefix}.marked'
+
+    def _write_marked(self) -> None:
+        """
+        Write an empty ``.marked`` object to each mirror bucket at the
+        catalog's mirror prefix. Only the object's ``LastModified`` time is
+        significant: it records the start of the mark phase and serves as the
+        threshold for the subsequent sweep phase.
+        """
+        key = self._marked_key
+        for storage in (self._storage, self._ma_storage):
+            log.info('Writing %r to bucket %r', key, storage.bucket_name)
+            storage.put_object(object_key=key, data=b'', overwrite=True)
+
     def delete_it_files(self, source: SourceSpec):
         """
         Delete all objects (both file/ and info/) with the given catalog's
@@ -687,7 +747,7 @@ class MirrorWorkerService(MirrorService, HasCachedHttpClient):
         assert a.file.size is not None, R('File size unknown', a.file)
         if self._info_exists(a.file):
             log.info('File is already mirrored, skipping upload: %r', a.file)
-            self._update_info(a.file)
+            self._update_info(a.file, mark=a.mark)
         elif self._file_exists(a.file):
             assert False, R('File object is already present', a.file)
         else:
@@ -807,13 +867,13 @@ class MirrorWorkerService(MirrorService, HasCachedHttpClient):
                                                  version=self.info_schema_version)),
         }
 
-    def _update_info(self, file: File):
+    def _update_info(self, file: File, *, mark: bool):
         def update(data: bytes) -> bytes:
             return json.dumps(self._info(file, json.loads(data))).encode()
 
         key = self._info_object_key(file)
         storage = self._storage_for_file(file)
-        storage.update_object(key, update, content_type='application/json')
+        storage.update_object(key, update, content_type='application/json', touch=mark)
 
     def _create_info(self, file: File):
         object_key = self._info_object_key(file)

--- a/src/azul/lib/digests.py
+++ b/src/azul/lib/digests.py
@@ -41,6 +41,9 @@ def hasher_from_json(json: AnyJSON) -> Hasher:
     return hasher_from_str(json_str(json))
 
 
+type DigestType = Literal['sha256', 'sha1', 'md5']
+
+
 @attrs.frozen(kw_only=True)
 class Digest:
     """
@@ -48,5 +51,5 @@ class Digest:
     to produce said digest. The set of supported algorithms is limited to those
     we believe to present an acceptable risk of hash collisions.
     """
-    type: Literal['sha256', 'sha1', 'md5']
+    type: DigestType
     value: str

--- a/src/azul/lib/strings.py
+++ b/src/azul/lib/strings.py
@@ -17,6 +17,39 @@ from azul.lib import (
 )
 
 
+def format_size(num_bytes: int) -> str:
+    """
+    >>> format_size(0)
+    '0 bytes'
+
+    >>> format_size(1)
+    '1 byte'
+
+    >>> format_size(1023)
+    '1023 bytes'
+
+    >>> format_size(1024)
+    '1.0 KiB'
+
+    >>> format_size(1536)
+    '1.5 KiB'
+
+    >>> format_size(1024 ** 5)
+    '1.0 PiB'
+
+    >>> format_size(1024 ** 6)
+    '1024.0 PiB'
+    """
+    if abs(num_bytes) < 1024:
+        return f'{num_bytes} ' + pluralize('byte', num_bytes)
+    else:
+        for unit in ('KiB', 'MiB', 'GiB', 'TiB', 'PiB'):
+            num_bytes /= 1024
+            if abs(num_bytes) < 1024 or unit == 'PiB':
+                return f'{num_bytes:.1f} {unit}'
+        assert False
+
+
 def format_and_dedent(string: str, **kwargs) -> str:
     """
     Remove common leading whitespace from every line in text. Useful for

--- a/src/azul/service/index_service.py
+++ b/src/azul/service/index_service.py
@@ -35,9 +35,6 @@ from azul.filters import (
 from azul.indexer.mirror_service import (
     MirrorService,
 )
-from azul.lib import (
-    cache,
-)
 from azul.lib.types import (
     JSON,
     MutableJSON,
@@ -97,7 +94,7 @@ class SearchResponseStage(_OpenSearchStage[ResponseTriple, MutableJSON],
 
     def _file_mirror_uri(self, source: SourceRef, file: JSON) -> str | None:
         file_cls = self.plugin.file_class
-        mirror_service = self.service.mirror_service(self.catalog)
+        mirror_service = MirrorService.for_catalog(self.catalog)
         return mirror_service.mirror_uri(source, file_cls, file)
 
 
@@ -114,10 +111,6 @@ class SummaryResponseStage(OpenSearchStage[JSON, MutableJSON],
 
 
 class IndexService(QueryService):
-
-    @cache
-    def mirror_service(self, catalog: CatalogName) -> MirrorService:
-        return MirrorService(catalog=catalog)
 
     def search(self,
                *,

--- a/src/azul/service/manifest_service.py
+++ b/src/azul/service/manifest_service.py
@@ -809,7 +809,7 @@ class ManifestGenerator(metaclass=ABCMeta):
 
     @cached_property
     def mirror_service(self) -> MirrorService:
-        return MirrorService(catalog=self.catalog)
+        return MirrorService.for_catalog(self.catalog)
 
     @classmethod
     @abstractmethod

--- a/src/azul/service/repository_controller.py
+++ b/src/azul/service/repository_controller.py
@@ -102,7 +102,7 @@ class RepositoryController(ServiceController):
         return IndexService()
 
     def _mirror_service(self, catalog: CatalogName) -> MirrorService:
-        return self._index_service.mirror_service(catalog)
+        return MirrorService.for_catalog(catalog)
 
     def _repository_plugin(self, catalog: CatalogName) -> RepositoryPlugin:
         return self._repository_service.repository_plugin(catalog)

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -1,5 +1,6 @@
 from collections.abc import (
     Collection,
+    Iterator,
     Mapping,
     Sequence,
 )
@@ -21,6 +22,7 @@ from typing import (
     Callable,
     IO,
     TYPE_CHECKING,
+    TypedDict,
 )
 from urllib.parse import (
     urlencode,
@@ -65,6 +67,12 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 Tagging = Mapping[str, str]
+
+
+class ObjectMetadata(TypedDict):
+    Key: str
+    LastModified: datetime
+    Size: int
 
 
 class StorageObjectNotFound(Exception):
@@ -226,15 +234,24 @@ class StorageService:
         assert num_deleted == num_keys, (num_deleted, num_keys)
         log.info('Deleted %d objects overall', num_deleted)
 
-    def list_objects(self, prefix: str) -> OrderedSet[str]:
-        keys: OrderedSet[str] = OrderedSet()
-        num_keys = 0
+    def list_objects(self, prefix: str) -> Iterator[ObjectMetadata]:
         paginator = self._s3.get_paginator('list_objects_v2')
         for page in paginator.paginate(Bucket=self.bucket_name, Prefix=prefix):
             contents = page.get('Contents', ())
-            num_keys += len(contents)
-            keys.update(object['Key'] for object in contents)
-            assert len(keys) == num_keys, R('Got duplicate keys from S3')
+            log.info('Got page of %d object(s) from %r, starting at %r',
+                     len(contents), self.bucket_name,
+                     contents[0]['Key'] if contents else None)
+            for object in contents:
+                yield ObjectMetadata(Key=object['Key'],
+                                     LastModified=object['LastModified'],
+                                     Size=object['Size'])
+
+    def list_keys(self, prefix: str) -> OrderedSet[str]:
+        keys: OrderedSet[str] = OrderedSet()
+        for object in self.list_objects(prefix):
+            key = object['Key']
+            assert key not in keys, R('Got duplicate key from S3', key)
+            keys.add(key)
         return keys
 
     def create_multipart_upload(self,

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -153,6 +153,7 @@ class StorageService:
                       *,
                       max_attempts: int = 10,
                       content_type: str | None = None,
+                      touch: bool = False
                       ):
         """
         Updates the contents and/or content type of an object, based on its
@@ -160,9 +161,10 @@ class StorageService:
         overwritten. Expects a callback that returns the desired contents of the
         object given its current contents. If the callback returns its argument
         unchanged and the specified content type is None or matches the current
-        content type, no further writes will be attempted. If the object does
-        not exist at any point during the update, StorageObjectNotFound is
-        raised.
+        content type, no further writes will be attempted unless ``touch`` is
+        True, in which case the object will be written regardless, updating its
+        ``LastModified`` time. If the object does not exist at any point during
+        the update, StorageObjectNotFound is raised.
         """
         for i in range(max_attempts):
             response = self._get_object(object_key)
@@ -171,7 +173,7 @@ class StorageService:
             if content_type is None:
                 content_type = response['ContentType']
             new_data = updater(data)
-            if new_data == data and content_type == response['ContentType']:
+            if not touch and new_data == data and content_type == response['ContentType']:
                 log.info('Object contents of %r is already up to date during attempt #%r/%r.',
                          object_key, i + 1, max_attempts)
                 break

--- a/test/azul_test_case.py
+++ b/test/azul_test_case.py
@@ -60,6 +60,9 @@ from azul.http import (
     HasCachedHttpClient,
     HttpClient,
 )
+from azul.indexer.mirror_service import (
+    MirrorService,
+)
 from azul.logging import (
     configure_test_logging,
     get_test_logger,
@@ -408,6 +411,8 @@ class CatalogTestCase(AzulUnitTestCase, metaclass=ABCMeta):
             del config.integration_test_catalogs
         except AttributeError:
             pass
+        MirrorService.for_catalog.cache_clear()
+        cls.addClassCleanup(MirrorService.for_catalog.cache_clear)
         # Patch the catalog property to use a single fake test catalog.
         cls.addClassPatch(patch.object(target=type(config),
                                        attribute='catalogs',

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -46,6 +46,9 @@ from azul.lib import (
     R,
     cached_property,
 )
+from azul.lib.digests import (
+    Digest,
+)
 from azul.lib.json import (
     copy_json,
 )
@@ -410,3 +413,27 @@ class TestMirrorController(DCP2TestCase,
                     self.assertEqual(action, json.loads(one(event).body)['action'])
                     self._mirror_controller.mirror(event)
         self._validate_file_contents(big_file, big_contents)
+
+    def test_object_key_round_trip(self):
+        service = self._service
+        digest = Digest(type='sha256', value='abcdef1234567890' * 4)
+
+        with self.subTest('info_key'):
+            info_key = service._object_key(service.info_prefix, digest, extension='.json')
+            prefix, parsed_digest, extension = service._parse_object_key(info_key)
+            self.assertEqual(service.info_prefix, prefix)
+            self.assertEqual(digest, parsed_digest)
+            self.assertEqual('.json', extension)
+
+        with self.subTest('file_key'):
+            file_key = service._object_key(service.file_prefix, digest, extension='')
+            prefix, parsed_digest, extension = service._parse_object_key(file_key)
+            self.assertEqual(service.file_prefix, prefix)
+            self.assertEqual(digest, parsed_digest)
+            self.assertEqual('', extension)
+
+        with self.subTest('info_key_to_file_key'):
+            info_key = service._object_key(service.info_prefix, digest, extension='.json')
+            file_key = service._info_key_to_file_key(info_key)
+            expected = service._object_key(service.file_prefix, digest, extension='')
+            self.assertEqual(expected, file_key)

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -10,6 +10,7 @@ from unittest.mock import (
 )
 
 import attrs
+import botocore.exceptions
 from chalice.app import (
     SQSRecord,
 )
@@ -467,3 +468,57 @@ class TestMirrorController(DCP2TestCase,
         # The info object should have been touched
         after = self._s3.head_object(Bucket=bucket, Key=info_key)['LastModified']
         self.assertGreater(after, before)
+
+    def _assert_objects_exist(self, bucket: str, *keys: str):
+        for key in keys:
+            self._s3.head_object(Bucket=bucket, Key=key)
+
+    def _assert_objects_not_found(self, bucket: str, *keys: str):
+        for key in keys:
+            with self.assertRaises(botocore.exceptions.ClientError) as cm:
+                self._s3.head_object(Bucket=bucket, Key=key)
+            self.assertEqual('404', cm.exception.response['Error']['Code'])
+
+    def test_sweep(self):
+        self._create_mock_queues(config.mirror_queue_names)
+        service = self._service
+        file = self._file
+
+        # Mirror a file so there's something in the bucket
+        self._test_mirror_file(file,
+                               self._mirror_file_message(file),
+                               self._file_contents)
+
+        # Create a garbage info+file object pair by writing directly to S3
+        garbage_digest = Digest(type='sha256', value='00' * 32)
+        garbage_info_key = service._object_key(service.info_prefix, garbage_digest, extension='.json')
+        garbage_file_key = service._object_key(service.file_prefix, garbage_digest, extension='')
+        bucket = self._bucket_name(file)
+        self._s3.put_object(Bucket=bucket, Key=garbage_info_key, Body=b'{}')
+        self._s3.put_object(Bucket=bucket, Key=garbage_file_key, Body=b'garbage')
+
+        # Small delay, then write the .marked object
+        time.sleep(1)
+        service._write_marked()
+
+        # Small delay, then touch the live file's info to mark it as live
+        time.sleep(1)
+        info_key, file_key = service._info_object_key(file), service._file_object_key(file)
+        info_data = self._s3.get_object(Bucket=bucket, Key=info_key)['Body'].read()
+        self._s3.put_object(Bucket=bucket, Key=info_key,
+                            Body=info_data,
+                            ContentType='application/json')
+
+        with self.subTest('dry_run'):
+            service._sweep(dry_run=True)
+            # Garbage should still exist
+            self._assert_objects_exist(bucket, garbage_info_key, garbage_file_key)
+
+        with self.subTest('sweep'):
+            service._sweep(dry_run=False)
+            # Garbage should be deleted
+            self._assert_objects_not_found(bucket, garbage_info_key, garbage_file_key)
+            # Live file should still exist
+            self._assert_objects_exist(bucket, info_key, file_key)
+            # .swept marker should exist
+            self._assert_objects_exist(bucket, service._swept_key)

--- a/test/indexer/test_mirror_controller.py
+++ b/test/indexer/test_mirror_controller.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import time
 from typing import (
     ContextManager,
 )
@@ -166,6 +167,7 @@ class TestMirrorController(DCP2TestCase,
         return dict(action='MirrorFileAction',
                     catalog=self.catalog,
                     operation_id=self._operation_id,
+                    mark=False,
                     source=file.source.to_json(),
                     prefix='00',
                     file=file.to_json())
@@ -243,6 +245,7 @@ class TestMirrorController(DCP2TestCase,
         expected_message = dict(action='MirrorSourceAction',
                                 catalog=self.catalog,
                                 operation_id=self._operation_id,
+                                mark=False,
                                 source=self.source.ref.to_json())
         self.assertEqual(expected_message, source_message)
         return source_message
@@ -258,6 +261,7 @@ class TestMirrorController(DCP2TestCase,
             self.assertEqual(dict(action='MirrorPartitionAction',
                                   catalog=self.catalog,
                                   operation_id=self._operation_id,
+                                  mark=False,
                                   source=self.source.ref.to_json()),
                              message)
         self.assertEqual(list(self.source.ref.prefix.partition_prefixes()), partitions)
@@ -437,3 +441,29 @@ class TestMirrorController(DCP2TestCase,
             file_key = service._info_key_to_file_key(info_key)
             expected = service._object_key(service.file_prefix, digest, extension='')
             self.assertEqual(expected, file_key)
+
+    def test_mark(self):
+        self._create_mock_queues(config.mirror_queue_names)
+        file = self._file
+
+        # First, mirror the file normally
+        self._test_mirror_file(file,
+                               self._mirror_file_message(file),
+                               self._file_contents)
+
+        # Record the info object's LastModified before marking
+        info_key = self._service._info_object_key(file)
+        bucket = self._bucket_name(file)
+        before = self._s3.head_object(Bucket=bucket, Key=info_key)['LastModified']
+
+        # Small delay so that LastModified will differ
+        time.sleep(1)
+
+        # Mirror the same file again with mark=True
+        mark_message = {**self._mirror_file_message(file), 'mark': True}
+        event = self._mirror_event(mark_message)
+        self._mirror_controller.mirror(event)
+
+        # The info object should have been touched
+        after = self._s3.head_object(Bucket=bucket, Key=info_key)['LastModified']
+        self.assertGreater(after, before)

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -1962,7 +1962,7 @@ class IndexingIntegrationTest(SourceSelectingIntegrationTest):
         return list(filter(None, data.decode().split('\n')))[1::2]
 
     def _mirror_service(self, catalog: CatalogName) -> MirrorService:
-        return self.azul_client.mirror_service(catalog)
+        return MirrorService.for_catalog(catalog)
 
     def _test_mirroring(self, *, delete: bool):
         with self.subTest('mirroring'):

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -1983,13 +1983,13 @@ class IndexingIntegrationTest(SourceSelectingIntegrationTest):
 
             def _delete():
                 if delete:
-                    # This potentially causes redundant ListObjects requests,
-                    # since each IT catalog currently uses the same mirror
-                    # prefix and bucket
-                    for catalog, sources in sources_by_catalog.items():
-                        for source in sources:
-                            service = service_by_catalog[catalog]
-                            service.delete_it_files(source.ref.spec)
+                    # Multiple catalogs may share a mirror prefix, so we
+                    # group by prefix to avoid redundant deletions.
+                    services_by_prefix: dict[str, MirrorService] = {}
+                    for service in service_by_catalog.values():
+                        services_by_prefix.setdefault(service._mirror_prefix, service)
+                    for service in services_by_prefix.values():
+                        service.delete_it_files()
 
             self._assert_queues_empty([config.mirror_queue.name,
                                        config.mirror_queue.to_fail.name])
@@ -2003,11 +2003,22 @@ class IndexingIntegrationTest(SourceSelectingIntegrationTest):
                     # so the file will always be from the public source
                     repository_file, source, file_response = self._get_one_mirrorable_file(catalog)
                     indexed_files[repository_file] = source, file_response
-                    for _ in range(2):
-                        service.mirror_sources(sources)
-                        service.mirror_file(source, repository_file)
-                        self.azul_client.wait_for_mirroring()
-                        self._assert_queues_empty([config.mirror_queue.to_fail.name])
+                    service.mirror_sources(sources)
+                    service.mirror_file(source, repository_file)
+                    self.azul_client.wait_for_mirroring()
+                    self._assert_queues_empty([config.mirror_queue.to_fail.name])
+                    # Mark phase. If there are two sources, exclude one
+                    # from the second pass so its objects become garbage
+                    # for the subsequent sweep. The second pass also
+                    # verifies mirroring idempotency for the sources
+                    # included.
+                    expect_garbage = len(sources) > 1
+                    service._write_marked()
+                    mark_sources = sources[:1] if expect_garbage else sources
+                    service._mirror_sources(mark_sources, mark=True)
+                    service.mirror_file(source, repository_file)
+                    self.azul_client.wait_for_mirroring()
+                    self._assert_queues_empty([config.mirror_queue.to_fail.name])
 
                 with self.subTest('download_mirrored_files'):
                     for repository_file, (source, file_response) in indexed_files.items():
@@ -2030,6 +2041,23 @@ class IndexingIntegrationTest(SourceSelectingIntegrationTest):
                     for info_object in info_objects:
                         self.assertEqual(schema_url, info_object['$schema'])
                         jsonschema.validate(info_object, schema_response)
+
+                with self.subTest('sweep', catalog=catalog):
+                    service = service_by_catalog[catalog]
+                    if expect_garbage:
+                        dropped_source = sources[1]
+                        storage = service._storage_for_source(dropped_source.ref.spec)
+                        info_dir = service._mirror_prefix + service.info_prefix + '/'
+                        num_before = sum(1 for _ in storage.list_objects(info_dir))
+                        self.assertGreater(num_before, 0)
+                    service._sweep(dry_run=True)
+                    if expect_garbage:
+                        num_after_dry = sum(1 for _ in storage.list_objects(info_dir))
+                        self.assertEqual(num_before, num_after_dry)
+                    service._sweep(dry_run=False)
+                    if expect_garbage:
+                        num_after_wet = sum(1 for _ in storage.list_objects(info_dir))
+                        self.assertEqual(0, num_after_wet)
 
             _delete()
 


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #7135


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (mirror)

- [x] This PR is labeled `mirror:dev` <sub>or the changes introduced by it will not require mirroring of `dev`</sub>
- [x] This PR is labeled `mirror:anvildev` <sub>or the changes introduced by it will not require mirroring of `anvildev`</sub>
- [x] This PR is labeled `mirror:anvilprod` <sub>or the changes introduced by it will not require mirroring of `anvilprod`</sub>
- [x] This PR is labeled `mirror:prod` <sub>or the changes introduced by it will not require mirroring of `prod`</sub>
- [x] This PR is labeled `mirror:partial` and its description documents the specific mirroring procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full mirroring or carries none of the labels `mirror:dev`, `mirror:anvildev`, `mirror:anvilprod` and `mirror:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator and the author


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked `mirror:…` labels
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Applied upgrade instructions from UPGRADING.rst to `sandbox` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `sandbox`</sub>
- [x] Applied upgrade instructions from UPGRADING.rst to `anvilbox` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `anvilbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `sandbox`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilbox`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Started mirroring in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [x] Started mirroring in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Applied upgrade instructions from UPGRADING.rst to `dev` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `dev`</sub>
- [x] Applied upgrade instructions from UPGRADING.rst to `anvildev` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `anvildev`</sub>
- [x] Notified developers to apply upgrade instructions from UPGRADING.rst to their personal deployments <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to personal deployments</sub>
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] PR is assigned to only the operator
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>


### Operator

- [x] Propagated the `upgrade` and `API` labels to the next promotion PRs <sub>or this PR carries neither of these labels</sub>
- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem