### PR TITLE
Fix: Can't filter by multiple values of a nested field (#8103)

### DIFF
--- a/lambdas/service/app.py
+++ b/lambdas/service/app.py
@@ -58,7 +58,7 @@ spec = {
         # changes and reset the minor version to zero. Otherwise, increment only
         # the minor version for backwards compatible changes. A backwards
         # compatible change is one that does not require updates to clients.
-        'version': '17.6',
+        'version': '17.7',
         'description': fd(f'''
             # Overview
 

--- a/lambdas/service/openapi.json
+++ b/lambdas/service/openapi.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.1",
     "info": {
         "title": "azul-service-dev",
-        "version": "17.6",
+        "version": "17.7",
         "description": "\n# Overview\n\nAzul is a REST web service for querying metadata associated with\nboth experimental and analysis data from a data repository. In order\nto deliver response times that make it suitable for interactive use\ncases, the set of metadata properties that it exposes for sorting,\nfiltering, and aggregation is limited. Azul provides a uniform view\nof the metadata over a range of diverse schemas, effectively\nshielding clients from changes in the schemas as they occur over\ntime. It does so, however, at the expense of detail in the set of\nmetadata properties it exposes and in the accuracy with which it\naggregates them.\n\nAzul denormalizes and aggregates metadata into several different\nindices for selected entity types. Metadata entities can be queried\nusing the [Index](#operations-tag-Index) endpoints.\n\nA set of indices forms a catalog. There is a default catalog called\n`dcp2` which will be used unless a\ndifferent catalog name is specified using the `catalog` query\nparameter. Metadata from different catalogs is completely\nindependent: a response obtained by querying one catalog does not\nnecessarily correlate to a response obtained by querying another\none. Two catalogs can contain metadata from the same sources or\ndifferent sources. It is only guaranteed that the body of a\nresponse by any given endpoint adheres to one schema,\nindependently of which catalog was specified in the request.\n\nAzul provides the ability to download data and metadata via the\n[Manifests](#operations-tag-Manifests) endpoints. The\n`curl` format manifests can be used to\ndownload data files. Other formats provide various views of the\nmetadata. Manifests can be generated for a selection of files using\nfilters. These filters are interchangeable with the filters used by\nthe [Index](#operations-tag-Index) endpoints.\n\nAzul also provides a [summary](#operations-Index-get_index_summary)\nview of indexed data.\n\n## Data model\n\nAny index, when queried, returns a JSON array of hits. Each hit\nrepresents a metadata entity. Nested in each hit is a summary of the\nproperties of entities associated with the hit. An entity is\nassociated either by a direct edge in the original metadata graph,\nor indirectly as a series of edges. The nested properties are\ngrouped by the type of the associated entity. The properties of all\ndata files associated with a particular sample, for example, are\nlisted under `hits[*].files` in a `/index/samples` response. It is\nimportant to note that while each _hit_ represents a discrete\nentity, the properties nested within that hit are the result of an\naggregation over potentially many associated entities.\n\nTo illustrate this, consider a data file that is part of two\nprojects (a project is a group of related experiments, typically by\none laboratory, institution or consortium). Querying the `files`\nindex for this file yields a hit looking something like:\n\n```\n{\n    \"projects\": [\n        {\n            \"projectTitle\": \"Project One\"\n            \"laboratory\": ...,\n            ...\n        },\n        {\n            \"projectTitle\": \"Project Two\"\n            \"laboratory\": ...,\n            ...\n        }\n    ],\n    \"files\": [\n        {\n            \"format\": \"pdf\",\n            \"name\": \"Team description.pdf\",\n            ...\n        }\n    ]\n}\n```\n\nThis example hit contains two kinds of nested entities (a hit in an\nactual Azul response will contain more): There are the two projects\nentities, and the file itself. These nested entities contain\nselected metadata properties extracted in a consistent way. This\nmakes filtering and sorting simple.\n\nAlso notice that there is only one file. When querying a particular\nindex, the corresponding entity will always be a singleton like\nthis.\n\n\n## Contact us\n\nFor technical support please file an issue at\n[GitHub](https://github.com/DataBiosphere/azul/issues) or email\n`azul-group@ucsc.edu`. To report a security concern or misconduct please email\n`azul-group@ucsc.edu`.\n"
     },
     "tags": [
@@ -1240,8 +1240,7 @@
                                                         },
                                                         "additionalProperties": false
                                                     },
-                                                    "minItems": 1,
-                                                    "maxItems": 1
+                                                    "minItems": 1
                                                 }
                                             },
                                             "required": [
@@ -2682,8 +2681,7 @@
                                                         },
                                                         "additionalProperties": false
                                                     },
-                                                    "minItems": 1,
-                                                    "maxItems": 1
+                                                    "minItems": 1
                                                 }
                                             },
                                             "required": [
@@ -3123,8 +3121,7 @@
                                                         },
                                                         "additionalProperties": false
                                                     },
-                                                    "minItems": 1,
-                                                    "maxItems": 1
+                                                    "minItems": 1
                                                 }
                                             },
                                             "required": [
@@ -4565,8 +4562,7 @@
                                                         },
                                                         "additionalProperties": false
                                                     },
-                                                    "minItems": 1,
-                                                    "maxItems": 1
+                                                    "minItems": 1
                                                 }
                                             },
                                             "required": [
@@ -5006,8 +5002,7 @@
                                                         },
                                                         "additionalProperties": false
                                                     },
-                                                    "minItems": 1,
-                                                    "maxItems": 1
+                                                    "minItems": 1
                                                 }
                                             },
                                             "required": [
@@ -6448,8 +6443,7 @@
                                                         },
                                                         "additionalProperties": false
                                                     },
-                                                    "minItems": 1,
-                                                    "maxItems": 1
+                                                    "minItems": 1
                                                 }
                                             },
                                             "required": [
@@ -6780,8 +6774,7 @@
                                                         },
                                                         "additionalProperties": false
                                                     },
-                                                    "minItems": 1,
-                                                    "maxItems": 1
+                                                    "minItems": 1
                                                 }
                                             },
                                             "required": [
@@ -8222,8 +8215,7 @@
                                                         },
                                                         "additionalProperties": false
                                                     },
-                                                    "minItems": 1,
-                                                    "maxItems": 1
+                                                    "minItems": 1
                                                 }
                                             },
                                             "required": [
@@ -8468,8 +8460,7 @@
                                                         },
                                                         "additionalProperties": false
                                                     },
-                                                    "minItems": 1,
-                                                    "maxItems": 1
+                                                    "minItems": 1
                                                 }
                                             },
                                             "required": [
@@ -9910,8 +9901,7 @@
                                                         },
                                                         "additionalProperties": false
                                                     },
-                                                    "minItems": 1,
-                                                    "maxItems": 1
+                                                    "minItems": 1
                                                 }
                                             },
                                             "required": [
@@ -10114,8 +10104,7 @@
                                                         },
                                                         "additionalProperties": false
                                                     },
-                                                    "minItems": 1,
-                                                    "maxItems": 1
+                                                    "minItems": 1
                                                 }
                                             },
                                             "required": [
@@ -11556,8 +11545,7 @@
                                                         },
                                                         "additionalProperties": false
                                                     },
-                                                    "minItems": 1,
-                                                    "maxItems": 1
+                                                    "minItems": 1
                                                 }
                                             },
                                             "required": [
@@ -11865,8 +11853,7 @@
                                                         },
                                                         "additionalProperties": false
                                                     },
-                                                    "minItems": 1,
-                                                    "maxItems": 1
+                                                    "minItems": 1
                                                 }
                                             },
                                             "required": [
@@ -13307,8 +13294,7 @@
                                                         },
                                                         "additionalProperties": false
                                                     },
-                                                    "minItems": 1,
-                                                    "maxItems": 1
+                                                    "minItems": 1
                                                 }
                                             },
                                             "required": [

--- a/src/azul/field_type.py
+++ b/src/azul/field_type.py
@@ -25,10 +25,6 @@ from typing import (
     cast,
 )
 
-from more_itertools import (
-    one,
-)
-
 from azul import (
     CatalogName,
 )
@@ -452,7 +448,6 @@ class Nested(FieldType[JSON, JSON]):
     def api_filter_values_schema(self, operator: str, mode: Mode) -> JSON:
         assert operator == 'is'
         schema = super().api_filter_values_schema(operator, mode)
-        schema = {**schema, 'maxItems': 1}
         return schema
 
     def api_filter_value_schema(self, operator: str, mode: Mode) -> JSON:
@@ -471,14 +466,16 @@ class Nested(FieldType[JSON, JSON]):
                operator: str,
                values: Iterable[AnyJSON | ApiRange]
                ) -> Iterable[JSON | IndexRange[JSON]]:
-        nested_object = one(values)
-        assert isinstance(nested_object, dict)
-        query_filters = {}
-        for nested_field, nested_value in nested_object.items():
-            nested_type = self.properties[nested_field]
-            to_index = nested_type.to_index
-            query_filters[nested_field] = to_index(nested_value)
-        return [query_filters]
+        result = []
+        for nested_object in values:
+            assert isinstance(nested_object, dict)
+            query_filters = {}
+            for nested_field, nested_value in nested_object.items():
+                nested_type = self.properties[nested_field]
+                to_index = nested_type.to_index
+                query_filters[nested_field] = to_index(nested_value)
+            result.append(query_filters)
+        return result
 
 
 class ClosedRange[N: PrimitiveJSON, X: IndexForm](FieldType[Range[N], IndexRange[X]]):

--- a/src/azul/service/query_service.py
+++ b/src/azul/service/query_service.py
@@ -254,11 +254,16 @@ class FilterStage(_OpenSearchStage[Response, Response]):
                 if operator in ('is', 'is_not'):
                     field_type = self.service.field_type(self.catalog, field_path)
                     if isinstance(field_type, Nested):
-                        term_queries = []
-                        for nested_field, nested_value in one(values).items():
-                            nested_body = {dotted(field_path, nested_field, 'keyword'): nested_value}
-                            term_queries.append(Q('term', **nested_body))
-                        query = Q('nested', path=dotted(field_path), query=Q('bool', must=term_queries))
+                        nested_queries = []
+                        for value in values:
+                            term_queries = []
+                            for nested_field, nested_value in value.items():
+                                nested_body = {dotted(field_path, nested_field, 'keyword'): nested_value}
+                                term_queries.append(Q('term', **nested_body))
+                            nested_queries.append(Q('nested',
+                                                    path=dotted(field_path),
+                                                    query=Q('bool', must=term_queries)))
+                        query = Q('bool', should=nested_queries)
                     else:
                         query = Q('terms', **{dotted(field_path, 'keyword'): values})
                         translated_none = field_type.to_index(None)

--- a/test/service/test_request_validation.py
+++ b/test/service/test_request_validation.py
@@ -303,10 +303,9 @@ class RequestParameterValidationTest(DCP1CannedBundleTestCase,
                                "('foo' was unexpected) at path $.accessions.is[0]"
             ),
             (
-                json.dumps({'accessions': {'is': [{'namespace': 'x', 'accession': 'y'}] * 2}}),
-                schema_error + "[{'namespace': 'x', 'accession': 'y'}, "
-                               "{'namespace': 'x', 'accession': 'y'}] "
-                               "is too long at path $.accessions.is"
+                '{"accessions": {"is": [{"namespace": "baz"}, {"foo": "bar"}]}}',
+                schema_error + "Additional properties are not allowed "
+                               "('foo' was unexpected) at path $.accessions.is[1]"
             ),
             (
                 '{"projectTitle":{"contains":["retina"]}}',

--- a/test/service/test_response.py
+++ b/test/service/test_response.py
@@ -2218,11 +2218,11 @@ class TestIndexResponse(IndexResponseTestCase):
             for entity_type, is_filtered in filtered_entity_types.items():
                 _test(entity_type, expect_empty=is_filtered, expect_accessible=False)
 
-    def test_filter_by_accession(self):
-        def request_accessions(nested_properties):
+    def test_filter_by_nested_field(self):
+        def request_projects(values):
             params = self._params(filters={
                 'accessions': {
-                    'is': [nested_properties]
+                    'is': values
                 }
             })
             url = self.base_url.set(path='/index/projects')
@@ -2232,41 +2232,43 @@ class TestIndexResponse(IndexResponseTestCase):
 
         cases = [
             (
-                dict(namespace='array_express', accession='E-AAAA-00'),
+                [dict(namespace='array_express', accession='E-AAAA-00')],
                 {'627cb0ba-b8a1-405a-b58f-0add82c3d635'}
             ),
             (
-                dict(namespace='geo_series', accession='GSE132044'),
+                [dict(namespace='geo_series', accession='GSE132044')],
                 {'88ec040b-8705-4f77-8f41-f81e57632f7d'}
             ),
             (
-                dict(accession='GSE132044'),
+                [dict(accession='GSE132044')],
                 {'88ec040b-8705-4f77-8f41-f81e57632f7d'}
             ),
             (
-                dict(namespace='geo_series'),
+                [dict(namespace='geo_series')],
                 {
                     '627cb0ba-b8a1-405a-b58f-0add82c3d635',
                     '88ec040b-8705-4f77-8f41-f81e57632f7d'
                 }
             )
         ]
-        for nested_properties, expected_projects in cases:
-            with self.subTest(nested_properties=nested_properties):
-                response = request_accessions(nested_properties)
+        for accession_filter, expected_projects in cases:
+            with self.subTest(accession_filter=accession_filter):
+                response = request_projects(accession_filter)
                 actual_projects = {
                     one(hit['projects'])['projectId']
                     for hit in response['hits']
                 }
                 self.assertEqual(expected_projects, actual_projects)
-                for hits in response['hits']:
-                    accession_properties = [
-                        {key: value}
-                        for accession in one(hits['projects'])['accessions']
-                        for key, value in accession.items()
-                    ]
-                    for key, value in nested_properties.items():
-                        self.assertIn({key: value}, accession_properties)
+                for hit in response['hits']:
+                    accessions = one(hit['projects'])['accessions']
+                    # In each hit, we expect to find at least one accession that
+                    # has the same key(s) and value(s) as at least one of the
+                    # dicts specified in the filter.
+                    self.assertTrue(any(
+                        set(expected.items()).issubset(actual.items())
+                        for expected in accession_filter
+                        for actual in accessions
+                    ))
 
     def test_version(self):
         commit = 'a9eb85ea214a6cfa6882f4be041d5cce7bee3e45'

--- a/test/service/test_response.py
+++ b/test/service/test_response.py
@@ -2249,6 +2249,16 @@ class TestIndexResponse(IndexResponseTestCase):
                     '627cb0ba-b8a1-405a-b58f-0add82c3d635',
                     '88ec040b-8705-4f77-8f41-f81e57632f7d'
                 }
+            ),
+            (
+                [
+                    dict(namespace='array_express', accession='E-AAAA-00'),
+                    dict(namespace='geo_series', accession='GSE132044')
+                ],
+                {
+                    '627cb0ba-b8a1-405a-b58f-0add82c3d635',
+                    '88ec040b-8705-4f77-8f41-f81e57632f7d'
+                }
             )
         ]
         for accession_filter, expected_projects in cases:


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #8103


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (mirror)

- [x] This PR is labeled `mirror:dev` <sub>or the changes introduced by it will not require mirroring of `dev`</sub>
- [x] This PR is labeled `mirror:anvildev` <sub>or the changes introduced by it will not require mirroring of `anvildev`</sub>
- [x] This PR is labeled `mirror:anvilprod` <sub>or the changes introduced by it will not require mirroring of `anvilprod`</sub>
- [x] This PR is labeled `mirror:prod` <sub>or the changes introduced by it will not require mirroring of `prod`</sub>
- [x] This PR is labeled `mirror:partial` and its description documents the specific mirroring procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full mirroring or carries none of the labels `mirror:dev`, `mirror:anvildev`, `mirror:anvilprod` and `mirror:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [ ] ~Actually approved the PR~ (Can't self-approve PRs)
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator and the author


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked `mirror:…` labels
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Applied upgrade instructions from UPGRADING.rst to `sandbox` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `sandbox`</sub>
- [x] Applied upgrade instructions from UPGRADING.rst to `anvilbox` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `anvilbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `sandbox`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilbox`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Started mirroring in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [x] Started mirroring in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Applied upgrade instructions from UPGRADING.rst to `dev` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `dev`</sub>
- [x] Applied upgrade instructions from UPGRADING.rst to `anvildev` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `anvildev`</sub>
- [x] Notified developers to apply upgrade instructions from UPGRADING.rst to their personal deployments <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to personal deployments</sub>
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] PR is assigned to only the operator
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>


### Operator

- [x] Propagated the `upgrade` and `API` labels to the next promotion PRs <sub>or this PR carries neither of these labels</sub>
- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
