### PR TITLE
Fix: Transient IT failure due to more than one access method (#8132)

### DIFF
--- a/src/azul/drs.py
+++ b/src/azul/drs.py
@@ -45,9 +45,12 @@ from azul.lib import (
 from azul.lib.types import (
     MutableJSON,
     json_dict,
+    json_element_mappings,
     json_list,
+    json_mapping,
     json_str,
     not_none,
+    optional,
 )
 
 log = logging.getLogger(__name__)
@@ -385,11 +388,11 @@ class DRSObject:
             response = self._request(url)
             if response.status == 200:
                 # Bundles are not supported therefore we can expect 'access_methods'
-                response_data = json_dict(json.loads(response.data))
-                access_methods = map(json_dict, json_list(response_data['access_methods']))
+                response_data = json_mapping(json.loads(response.data))
+                access_methods = json_element_mappings(response_data['access_methods'])
                 method = one(m for m in access_methods if m['type'] == access_method.scheme)
-                access_url = json_dict(method.get('access_url'))
-                access_id = json_str(method.get('access_id'))
+                access_url = optional(json_mapping, method.get('access_url'))
+                access_id = optional(json_str, method.get('access_id'))
                 if access_url is not None and access_id is not None:
                     # TDR quirkily uses the GS access method to provide both a
                     # GS access URL *and* an access ID that produces an HTTPS
@@ -403,13 +406,13 @@ class DRSObject:
                 elif access_id is not None:
                     return self._get_access(access_id, access_method, headers)
                 elif access_url is not None:
-                    scheme = furl(access_url['url']).scheme
+                    access_url = json_str(access_url['url'])
+                    scheme = furl(access_url).scheme
                     assert scheme == access_method.scheme, R(
                         'Unexpected access URL scheme', scheme)
                     # We can't convert the signed URL into a furl object since
                     # the path can contain `%3A` which furl converts to `:`
-                    return Access(method=access_method,
-                                  url=access_url['url'])
+                    return Access(method=access_method, url=access_url)
                 else:
                     assert False, R("'access_url' and 'access_id' are both missing")
             elif response.status == 202:

--- a/src/azul/drs.py
+++ b/src/azul/drs.py
@@ -43,6 +43,7 @@ from azul.lib import (
     mutable_furl,
 )
 from azul.lib.types import (
+    JSON,
     MutableJSON,
     json_dict,
     json_element_mappings,
@@ -390,34 +391,49 @@ class DRSObject:
                 # Bundles are not supported therefore we can expect 'access_methods'
                 response_data = json_mapping(json.loads(response.data))
                 access_methods = json_element_mappings(response_data['access_methods'])
-                method = one(m for m in access_methods if m['type'] == access_method.scheme)
-                access_url = optional(json_mapping, method.get('access_url'))
-                access_id = optional(json_str, method.get('access_id'))
-                if access_id is None:
-                    if access_url is None:
-                        assert False, R("'access_url' and 'access_id' are both missing")
-                    else:
-                        access_url = json_str(access_url['url'])
-                        scheme = furl(access_url).scheme
-                        assert scheme == access_method.scheme, R(
-                            'Unexpected access URL scheme', scheme)
-                        # We can't convert the signed URL into a furl object since
-                        # the path can contain `%3A` which furl converts to `:`
-                        return Access(method=access_method, url=access_url)
-                else:
-                    if access_url is None:
-                        return self._get_access(access_id, access_method, headers)
-                    else:
 
-                        # TDR quirkily uses the GS access method to provide both a
-                        # GS access URL *and* an access ID that produces an HTTPS
-                        # signed URL
-                        #
-                        # https://github.com/ga4gh/data-repository-service-schemas/issues/360
-                        # https://github.com/ga4gh/data-repository-service-schemas/issues/361
-                        assert access_method is AccessMethod.gs, R(
-                            'Unexpected access method', access_method)
-                        return self._get_access(access_id, AccessMethod.https, headers)
+                def sort_key(m: JSON) -> tuple:
+                    # Prefer methods with a usable access URL and no access ID
+                    access_id = m.get('access_id')
+                    access_url = optional(json_mapping, m.get('access_url'))
+                    return (
+                        access_id is not None,
+                        '' if access_id is None else access_id,
+                        access_url is None,
+                        '' if access_url is None else json_str(access_url['url'])
+                    )
+
+                methods = sorted(
+                    (m for m in access_methods if m['type'] == access_method.scheme),
+                    key=sort_key
+                )
+                for method in methods:
+                    access_url = optional(json_mapping, method.get('access_url'))
+                    access_id = optional(json_str, method.get('access_id'))
+                    if access_id is None:
+                        if access_url is not None:
+                            access_url = json_str(access_url['url'])
+                            scheme = furl(access_url).scheme
+                            assert scheme == access_method.scheme, R(
+                                'Unexpected access URL scheme', scheme)
+                            # We can't convert the signed URL into a furl object
+                            # since the path can contain `%3A` which furl
+                            # converts to `:`
+                            return Access(method=access_method, url=access_url)
+                    else:
+                        if access_url is None:
+                            return self._get_access(access_id, access_method, headers)
+                        else:
+                            # TDR quirkily uses the GS access method to provide
+                            # both a GS access URL *and* an access ID that
+                            # produces an HTTPS signed URL
+                            #
+                            # https://github.com/ga4gh/data-repository-service-schemas/issues/360
+                            # https://github.com/ga4gh/data-repository-service-schemas/issues/361
+                            assert access_method is AccessMethod.gs, R(
+                                'Unexpected access method', access_method)
+                            return self._get_access(access_id, AccessMethod.https, headers)
+                assert False, R('No usable access method found')
             elif response.status == 202:
                 wait_time = int(response.headers['retry-after'])
                 time.sleep(wait_time)

--- a/src/azul/drs.py
+++ b/src/azul/drs.py
@@ -393,28 +393,31 @@ class DRSObject:
                 method = one(m for m in access_methods if m['type'] == access_method.scheme)
                 access_url = optional(json_mapping, method.get('access_url'))
                 access_id = optional(json_str, method.get('access_id'))
-                if access_url is not None and access_id is not None:
-                    # TDR quirkily uses the GS access method to provide both a
-                    # GS access URL *and* an access ID that produces an HTTPS
-                    # signed URL
-                    #
-                    # https://github.com/ga4gh/data-repository-service-schemas/issues/360
-                    # https://github.com/ga4gh/data-repository-service-schemas/issues/361
-                    assert access_method is AccessMethod.gs, R(
-                        'Unexpected access method', access_method)
-                    return self._get_access(access_id, AccessMethod.https, headers)
-                elif access_id is not None:
-                    return self._get_access(access_id, access_method, headers)
-                elif access_url is not None:
-                    access_url = json_str(access_url['url'])
-                    scheme = furl(access_url).scheme
-                    assert scheme == access_method.scheme, R(
-                        'Unexpected access URL scheme', scheme)
-                    # We can't convert the signed URL into a furl object since
-                    # the path can contain `%3A` which furl converts to `:`
-                    return Access(method=access_method, url=access_url)
+                if access_id is None:
+                    if access_url is None:
+                        assert False, R("'access_url' and 'access_id' are both missing")
+                    else:
+                        access_url = json_str(access_url['url'])
+                        scheme = furl(access_url).scheme
+                        assert scheme == access_method.scheme, R(
+                            'Unexpected access URL scheme', scheme)
+                        # We can't convert the signed URL into a furl object since
+                        # the path can contain `%3A` which furl converts to `:`
+                        return Access(method=access_method, url=access_url)
                 else:
-                    assert False, R("'access_url' and 'access_id' are both missing")
+                    if access_url is None:
+                        return self._get_access(access_id, access_method, headers)
+                    else:
+
+                        # TDR quirkily uses the GS access method to provide both a
+                        # GS access URL *and* an access ID that produces an HTTPS
+                        # signed URL
+                        #
+                        # https://github.com/ga4gh/data-repository-service-schemas/issues/360
+                        # https://github.com/ga4gh/data-repository-service-schemas/issues/361
+                        assert access_method is AccessMethod.gs, R(
+                            'Unexpected access method', access_method)
+                        return self._get_access(access_id, AccessMethod.https, headers)
             elif response.status == 202:
                 wait_time = int(response.headers['retry-after'])
                 time.sleep(wait_time)

--- a/test/service/test_drs.py
+++ b/test/service/test_drs.py
@@ -339,6 +339,24 @@ class TestDRSObjectGet(AzulUnitTestCase):
         access = drs_object.get(access_method=AccessMethod.https)
         self.assertEqual(Access(method=AccessMethod.https, url=signed_url), access)
 
+    def test_multiple_methods(self):
+        signed_url = 'https://storage.example.com/bucket/object?token=abc'
+        drs_object = self._drs_object(self._mock_response({
+            'access_methods': [
+                {
+                    'type': 'https',
+                    'access_url': {'url': 'https://other.example.com/bucket/other'},
+                    'access_id': 'some_access_id'
+                },
+                {
+                    'type': 'https',
+                    'access_url': {'url': signed_url}
+                }
+            ]
+        }))
+        access = drs_object.get(access_method=AccessMethod.https)
+        self.assertEqual(Access(method=AccessMethod.https, url=signed_url), access)
+
     def test_both_access_url_and_id(self):
         signed_url = 'https://storage.example.com/bucket/object?token=abc'
         drs_object = self._drs_object(

--- a/test/service/test_drs.py
+++ b/test/service/test_drs.py
@@ -310,6 +310,35 @@ class TestDRSObjectGet(AzulUnitTestCase):
         return DRSClient(http_client=http_client,
                          url=furl(self.drs_url))
 
+    def test_access_url_only(self):
+        signed_url = 'https://storage.example.com/bucket/object?token=abc'
+        drs_object = self._drs_object(self._mock_response({
+            'access_methods': [
+                {
+                    'type': 'https',
+                    'access_url': {'url': signed_url}
+                }
+            ]
+        }))
+        access = drs_object.get(access_method=AccessMethod.https)
+        self.assertEqual(Access(method=AccessMethod.https, url=signed_url), access)
+
+    def test_access_id_only(self):
+        signed_url = 'https://storage.example.com/bucket/object?token=abc'
+        drs_object = self._drs_object(
+            self._mock_response({
+                'access_methods': [
+                    {
+                        'type': 'https',
+                        'access_id': 'some_access_id'
+                    }
+                ]
+            }),
+            self._mock_response({'url': signed_url})
+        )
+        access = drs_object.get(access_method=AccessMethod.https)
+        self.assertEqual(Access(method=AccessMethod.https, url=signed_url), access)
+
     def test_both_access_url_and_id(self):
         signed_url = 'https://storage.example.com/bucket/object?token=abc'
         drs_object = self._drs_object(

--- a/test/service/test_drs.py
+++ b/test/service/test_drs.py
@@ -5,6 +5,13 @@ from unittest.mock import (
 )
 import urllib.parse
 
+from furl import (
+    furl,
+)
+from urllib3 import (
+    HTTPResponse,
+)
+
 from app_test_case import (
     LocalAppTestCase,
 )
@@ -12,7 +19,9 @@ from azul import (
     config,
 )
 from azul.drs import (
+    Access,
     AccessMethod,
+    DRSObject as DRSClient,
 )
 from azul.http import (
     raise_on_status,
@@ -285,3 +294,35 @@ class TestDRSController(AzulUnitTestCase):
         response = controller.get_object_access(bad_access_id, 'file_uuid', {})
         self.assertEqual(400, response.status_code)
         self.assertEqual('Invalid DRS access ID', response.body)
+
+
+class TestDRSObjectGet(AzulUnitTestCase):
+    drs_url = 'https://example.com/ga4gh/drs/v1/objects/abc'
+
+    def _mock_response(self, body: dict, status: int = 200) -> HTTPResponse:
+        return HTTPResponse(body=json.dumps(body).encode(),
+                            status=status,
+                            preload_content=True)
+
+    def _drs_object(self, *responses: HTTPResponse) -> DRSClient:
+        http_client = MagicMock()
+        http_client.request.side_effect = list(responses)
+        return DRSClient(http_client=http_client,
+                         url=furl(self.drs_url))
+
+    def test_both_access_url_and_id(self):
+        signed_url = 'https://storage.example.com/bucket/object?token=abc'
+        drs_object = self._drs_object(
+            self._mock_response({
+                'access_methods': [
+                    {
+                        'type': 'gs',
+                        'access_url': {'url': 'gs://bucket/object'},
+                        'access_id': 'some_access_id'
+                    }
+                ]
+            }),
+            self._mock_response({'url': signed_url})
+        )
+        access = drs_object.get(access_method=AccessMethod.gs)
+        self.assertEqual(Access(method=AccessMethod.https, url=signed_url), access)


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #8132


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (mirror)

- [x] This PR is labeled `mirror:dev` <sub>or the changes introduced by it will not require mirroring of `dev`</sub>
- [x] This PR is labeled `mirror:anvildev` <sub>or the changes introduced by it will not require mirroring of `anvildev`</sub>
- [x] This PR is labeled `mirror:anvilprod` <sub>or the changes introduced by it will not require mirroring of `anvilprod`</sub>
- [x] This PR is labeled `mirror:prod` <sub>or the changes introduced by it will not require mirroring of `prod`</sub>
- [x] This PR is labeled `mirror:partial` and its description documents the specific mirroring procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full mirroring or carries none of the labels `mirror:dev`, `mirror:anvildev`, `mirror:anvilprod` and `mirror:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] ~PR is awaiting requested review from system administrator~ SA is author
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator and the author


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked `mirror:…` labels
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Applied upgrade instructions from UPGRADING.rst to `sandbox` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `sandbox`</sub>
- [x] Applied upgrade instructions from UPGRADING.rst to `anvilbox` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `anvilbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `sandbox`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilbox`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Started mirroring in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [x] Started mirroring in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Applied upgrade instructions from UPGRADING.rst to `dev` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `dev`</sub>
- [x] Applied upgrade instructions from UPGRADING.rst to `anvildev` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `anvildev`</sub>
- [x] Notified developers to apply upgrade instructions from UPGRADING.rst to their personal deployments <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to personal deployments</sub>
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] PR is assigned to only the operator
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>


### Operator

- [x] Propagated the `upgrade` and `API` labels to the next promotion PRs <sub>or this PR carries neither of these labels</sub>
- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem
