### PR TITLE
Fix: Concurrent cache fetch retries waste work (#8245)

### DIFF
--- a/.claude/skills/promotion-board-updates.md
+++ b/.claude/skills/promotion-board-updates.md
@@ -36,7 +36,7 @@ Per `.github/PULL_REQUEST_TEMPLATE/prod-promotion.md` (lines 108-114) and
 | Item type | Expected prior status | Target status  | Exception           |
 |-----------|-----------------------|----------------|----------------------|
 | PR        | Merged lower          | Merged stable  | Already *Done* → skip |
-| Issue     | Lower                 | Stable         | (none)               |
+| Issue     | Lower                 | Stable         | Not *Lower* → skip  |
 
 ## GitHub project coordinates
 
@@ -78,7 +78,8 @@ Per `.github/PULL_REQUEST_TEMPLATE/prod-promotion.md` (lines 108-114) and
    to *Merged stable*.
 
 5. For each promoted issue, query its project item ID and current status.
-   Set status to *Stable*.
+   Skip if status is not *Lower* (the issue may still be open, tracked
+   independently, or already moved). Otherwise set status to *Stable*.
 
 6. Verify by re-querying that all transitions succeeded and report a summary
    table.

--- a/src/azul/indexer/cache_service.py
+++ b/src/azul/indexer/cache_service.py
@@ -2,8 +2,13 @@ from collections.abc import (
     Mapping,
 )
 import hashlib
+from itertools import (
+    count,
+)
 import logging
+import random
 from time import (
+    sleep,
     time,
 )
 from typing import (
@@ -41,6 +46,14 @@ from azul.lib.urls import (
 
 log = logging.getLogger(__name__)
 
+type CacheFetcher = Callable[[], bytes]
+
+
+class ConcurrentCacheFetchError(RuntimeError):
+
+    def __init__(self, cache_key: str):
+        super().__init__(f'Cache line {cache_key!r} is locked')
+
 
 @attrs.frozen(kw_only=True)
 class CacheService:
@@ -77,14 +90,7 @@ class CacheService:
     #:
     lock_expiration: int
 
-    type Fetcher = Callable[[], bytes]
-
-    class ConcurrentFetchError(RuntimeError):
-
-        def __init__(self, cache_key: str):
-            super().__init__(f'Cache line {cache_key!r} is locked')
-
-    def get(self, cache_key: str, fetcher: Fetcher) -> bytes:
+    def get(self, cache_key: str, fetcher: CacheFetcher) -> bytes:
         """
         Return the cached value for the given key, or call the fetcher to
         produce it.
@@ -173,7 +179,7 @@ class CacheService:
             )
         except ClientError as e:
             if e.response['Error']['Code'] == 'ConditionalCheckFailedException':
-                raise self.ConcurrentFetchError(cache_key) from e
+                raise ConcurrentCacheFetchError(cache_key) from e
             else:
                 raise
         else:
@@ -222,18 +228,60 @@ class CacheService:
 
 
 @attrs.frozen(kw_only=True)
-class UrlCacheService(CacheService):
+class RetryingCacheService:
     """
-    A cache of responses to HTTP(S) requests. The key under which responses are
+    A decorator for :class:`CacheService` that retries a limited number of times
+    on :class:`ConcurrentFetchError` instead of immediately raising it.
+    """
+
+    #: The number of times to retry after a :class:`ConcurrentFetchError`. If
+    # this is 0, this class behaves exactly like CacheService.
+    #:
+    num_retries: int
+
+    #: The number of seconds to wait between retries.
+    #:
+    retry_delay: float
+
+    _inner: CacheService
+
+    def get(self, cache_key: str, fetcher: CacheFetcher) -> bytes:
+        """
+        Return the cached value for the given key, or call the fetcher to
+        produce it.
+
+        :raise ConcurrentFetchError: Another caller was observed to already be
+                                     fetching the same key for :attr:`num_retries`
+                                     + 1 * :attr:`retry_delay` seconds.
+        """
+        retries = count()
+        while True:
+            try:
+                return self._inner.get(cache_key, fetcher)
+            except ConcurrentCacheFetchError:
+                if (i := next(retries)) < self.num_retries:
+                    log.info('Cache get for %r failed (attempt %d of %d)',
+                             cache_key, i + 1, self.num_retries + 1)
+                    sleep(self.retry_delay * random.uniform(0.5, 1.5))
+                else:
+                    raise
+
+
+@attrs.frozen(kw_only=True)
+class UrlCacheService:
+    """
+    A decorator for :class:`CacheService` (or :class:`RetryingCacheService`)
+    that caches responses to HTTP(S) requests. The key under which responses are
     cached is the hash of the URL and the request headers. The first caller for
     a given URL and headers will cause the request to be made. Subsequent
     callers passing the same URL and headers will get the same response, without
     causing a request to be made, until the cached response expires. The
     expiration time of the response is configurable per instance, independent of
-    any HTTP caching headers. Like the superclass, this class tries to avoid
-    making the same request concurrently, even with concurrent callers, against
-    different instances of this class, in different processes.
+    any HTTP caching headers.
     """
+
+    _inner: CacheService | RetryingCacheService
+
     http_client: HttpClient
 
     def get_url(self, url: furl, headers: Mapping[str, str] | None = None) -> BaseHTTPResponse:
@@ -242,7 +290,8 @@ class UrlCacheService(CacheService):
         it first if necessary.
 
         :raise ConcurrentFetchError: if another caller is already fetching the
-                                     same URL
+                                     same URL and the inner cache service does
+                                     not retry
         """
         assert not str(url.fragment), R(
             'URLs with a fragment cannot be cached', url)
@@ -258,7 +307,7 @@ class UrlCacheService(CacheService):
                 raise self._UncacheableResponse(response)
 
         try:
-            cached = self.get(cache_key, fetcher)
+            cached = self._inner.get(cache_key, fetcher)
         except self._UncacheableResponse as e:
             return e.args[0]
         else:

--- a/src/azul/terra.py
+++ b/src/azul/terra.py
@@ -76,6 +76,8 @@ from azul.http import (
     Propagate429HttpClient,
 )
 from azul.indexer.cache_service import (
+    CacheService,
+    RetryingCacheService,
     UrlCacheService,
 )
 from azul.lib import (
@@ -542,9 +544,9 @@ class TDRClient(SAMClient, DRSClient):
 
     @cached_property
     def _url_cache(self) -> UrlCacheService:
-        return UrlCacheService(expiration=3600 * 24,
-                               lock_expiration=60 * 2,
-                               http_client=self._http_client)
+        cache = CacheService(expiration=3600 * 24, lock_expiration=60 * 2)
+        cache = RetryingCacheService(inner=cache, num_retries=13, retry_delay=10.0)
+        return UrlCacheService(inner=cache, http_client=self._http_client)
 
     def _check_response(self,
                         endpoint: furl,

--- a/test/indexer/test_cache_service.py
+++ b/test/indexer/test_cache_service.py
@@ -3,7 +3,11 @@ from collections.abc import (
 )
 import random
 import time
+from unittest import (
+    TestCase,
+)
 from unittest.mock import (
+    MagicMock,
     patch,
 )
 
@@ -16,6 +20,8 @@ from mypy_boto3_dynamodb.literals import (
 
 from azul.indexer.cache_service import (
     CacheService,
+    ConcurrentCacheFetchError,
+    RetryingCacheService,
 )
 from azul.lib.strings import (
     hex_digits,
@@ -93,7 +99,7 @@ class TestCacheService(DynamoDBTestCase):
                 service._ttl_attribute: {'N': str(service._now() + 60)},
             }
         )
-        with self.assertRaises(CacheService.ConcurrentFetchError):
+        with self.assertRaises(ConcurrentCacheFetchError):
             service.get('locked_key', lambda: b'should not run')
 
     def test_expired_lock(self):
@@ -167,3 +173,78 @@ class TestCacheService(DynamoDBTestCase):
         with patch.object(CacheService, '_put_value', return_value=True):
             result = service.get(key, lambda: value)
         self.assertEqual(result, value)
+
+
+class TestRetryingCacheService(TestCase):
+
+    def _make_service(self, num_retries=3, retry_delay=0.1):
+        inner = MagicMock(spec=CacheService)
+        service = RetryingCacheService(inner=inner,
+                                       num_retries=num_retries,
+                                       retry_delay=retry_delay)
+        return service, inner
+
+    @patch('azul.indexer.cache_service.sleep')
+    def test_success_on_first_attempt(self, mock_sleep):
+        service, inner = self._make_service()
+        inner.get.return_value = b'hello'
+        result = service.get('key1', lambda: b'hello')
+        self.assertEqual(result, b'hello')
+        inner.get.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    @patch('azul.indexer.cache_service.sleep')
+    def test_success_after_retries(self, mock_sleep):
+        service, inner = self._make_service(num_retries=3, retry_delay=1.0)
+        inner.get.side_effect = [
+            ConcurrentCacheFetchError('key1'),
+            ConcurrentCacheFetchError('key1'),
+            b'hello',
+        ]
+        result = service.get('key1', lambda: b'hello')
+        self.assertEqual(result, b'hello')
+        self.assertEqual(inner.get.call_count, 3)
+        self.assertEqual(mock_sleep.call_count, 2)
+        for call in mock_sleep.call_args_list:
+            delay = call[0][0]
+            self.assertGreaterEqual(delay, 0.5)
+            self.assertLessEqual(delay, 1.5)
+
+    @patch('azul.indexer.cache_service.sleep')
+    def test_raises_after_exhausted_retries(self, mock_sleep):
+        service, inner = self._make_service(num_retries=2, retry_delay=1.0)
+        inner.get.side_effect = ConcurrentCacheFetchError('key1')
+        with self.assertRaises(ConcurrentCacheFetchError):
+            service.get('key1', lambda: b'hello')
+        self.assertEqual(inner.get.call_count, 3)
+        self.assertEqual(mock_sleep.call_count, 2)
+
+    @patch('azul.indexer.cache_service.sleep')
+    def test_zero_retries(self, mock_sleep):
+        service, inner = self._make_service(num_retries=0)
+        inner.get.side_effect = ConcurrentCacheFetchError('key1')
+        with self.assertRaises(ConcurrentCacheFetchError):
+            service.get('key1', lambda: b'hello')
+        inner.get.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    @patch('azul.indexer.cache_service.sleep')
+    def test_other_exceptions_not_retried(self, mock_sleep):
+        service, inner = self._make_service()
+        inner.get.side_effect = RuntimeError('boom')
+        with self.assertRaises(RuntimeError):
+            service.get('key1', lambda: b'hello')
+        inner.get.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    @patch('azul.indexer.cache_service.sleep')
+    def test_jitter_range(self, mock_sleep):
+        service, inner = self._make_service(num_retries=100, retry_delay=10.0)
+        inner.get.side_effect = [ConcurrentCacheFetchError('key1')] * 100 + [b'ok']
+        service.get('key1', lambda: b'ok')
+        delays = [call[0][0] for call in mock_sleep.call_args_list]
+        self.assertTrue(any(d < 10.0 for d in delays))
+        self.assertTrue(any(d > 10.0 for d in delays))
+        for d in delays:
+            self.assertGreaterEqual(d, 5.0)
+            self.assertLessEqual(d, 15.0)

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -125,6 +125,8 @@ from azul.indexer import (
     SourcedBundleFQID,
 )
 from azul.indexer.cache_service import (
+    CacheService,
+    ConcurrentCacheFetchError,
     UrlCacheService,
 )
 from azul.indexer.document import (
@@ -663,9 +665,8 @@ class IndexingIntegrationTest(SourceSelectingIntegrationTest):
             entity_types = list(self.metadata_plugin(catalog).exposed_indices)
             num_threads_per_endpoint = 8
 
-            service = UrlCacheService(expiration=60,
-                                      lock_expiration=30,
-                                      http_client=self._http_client)
+            cache = CacheService(expiration=60, lock_expiration=30)
+            service = UrlCacheService(inner=cache, http_client=self._http_client)
 
             assignments: list[tuple[EntityType, furl]] = []
             for entity_type in entity_types:
@@ -681,7 +682,7 @@ class IndexingIntegrationTest(SourceSelectingIntegrationTest):
                 while True:
                     try:
                         return service.get_url(url)
-                    except UrlCacheService.ConcurrentFetchError:
+                    except ConcurrentCacheFetchError:
                         time.sleep(5)
 
             results: dict[EntityType, list[BaseHTTPResponse]] = defaultdict(list)


### PR DESCRIPTION
<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: #8245


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (mirror)

- [x] This PR is labeled `mirror:dev` <sub>or the changes introduced by it will not require mirroring of `dev`</sub>
- [x] This PR is labeled `mirror:anvildev` <sub>or the changes introduced by it will not require mirroring of `anvildev`</sub>
- [x] This PR is labeled `mirror:anvilprod` <sub>or the changes introduced by it will not require mirroring of `anvilprod`</sub>
- [x] This PR is labeled `mirror:prod` <sub>or the changes introduced by it will not require mirroring of `prod`</sub>
- [x] This PR is labeled `mirror:partial` and its description documents the specific mirroring procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full mirroring or carries none of the labels `mirror:dev`, `mirror:anvildev`, `mirror:anvilprod` and `mirror:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `Dockerfile`, `environment`, `requirements*.txt`, `common.mk`, `Makefile` or `environment.boot`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `requirements*.txt`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `requirements*.txt`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator and the author


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked `mirror:…` labels
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply` <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [ ] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Applied upgrade instructions from UPGRADING.rst to `sandbox` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `sandbox`</sub>
- [x] Applied upgrade instructions from UPGRADING.rst to `anvilbox` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `anvilbox`</sub>
- [x] Deleted unreferenced indices in `sandbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `sandbox`</sub>
- [x] Deleted unreferenced indices in `anvilbox` <sub>or this PR does not remove catalogs or otherwise causes unreferenced indices in `anvilbox`</sub>
- [x] Started reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Started reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Started mirroring in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [x] Started mirroring in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Applied upgrade instructions from UPGRADING.rst to `dev` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `dev`</sub>
- [x] Applied upgrade instructions from UPGRADING.rst to `anvildev` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `anvildev`</sub>
- [x] Notified developers to apply upgrade instructions from UPGRADING.rst to their personal deployments <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to personal deployments</sub>
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] PR is assigned to only the operator
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] Deindexed all unreferenced catalogs in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed all unreferenced catalogs in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Deindexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Deindexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Indexed specific sources in `dev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:dev`</sub>
- [x] Indexed specific sources in `anvildev` <sub>or this PR is neither labeled `reindex:partial` nor `reindex:anvildev`</sub>
- [x] Started reindex in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Started reindex in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR does not require reindexing `dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR does not require reindexing `anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>


### Operator

- [x] Propagated the `upgrade` and `API` labels to the next promotion PRs <sub>or this PR carries neither of these labels</sub>
- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem