### PR TITLE
Fix: verbatim log of client secrets and signed URLs (DataBiosphere/azul-private#412, DataBiosphere/azul-private#390)

### DIFF
--- a/scripts/check_log_redaction.py
+++ b/scripts/check_log_redaction.py
@@ -1,7 +1,7 @@
 """
-Search CloudWatch logs for unredacted security tokens (APATs, OAuth access
-tokens, refresh tokens, and authorization codes) in the currently selected
-deployment.
+Search CloudWatch logs for unredacted secrets (APATs, OAuth access tokens,
+refresh tokens, authorization codes and client secrets) in the currently
+selected deployment.
 """
 import argparse
 from collections import (
@@ -44,6 +44,7 @@ secret_types = {
     'access_token': r'ya29\.(?:[A-Za-z0-9_-]+\.)*[A-Za-z0-9_-]{40,}',
     'refresh_token': r"['\x22= ]1\/\/[A-Za-z0-9_-]{20,}",
     'auth_code': r"['\x22= ]4\/[A-Za-z0-9_-]{60,}",
+    'client_secret': r'GOCSPX-[A-Za-z0-9_-]{20,}',
 }
 
 indexer_handler_names = [

--- a/scripts/check_log_redaction.py
+++ b/scripts/check_log_redaction.py
@@ -1,7 +1,7 @@
 """
-Search CloudWatch logs for unredacted secrets (APATs, OAuth access tokens,
-refresh tokens, authorization codes and client secrets) in the currently
-selected deployment.
+Search CloudWatch logs for unredacted secrets (APATs, OAuth 2.0 access tokens,
+refresh tokens, authorization codes and OAuth 2.0 client secrets, as well as
+the signatures of signed GCS and S3 URLs) in the currently selected deployment.
 """
 import argparse
 from collections import (
@@ -45,6 +45,7 @@ secret_types = {
     'refresh_token': r"['\x22= ]1\/\/[A-Za-z0-9_-]{20,}",
     'auth_code': r"['\x22= ]4\/[A-Za-z0-9_-]{60,}",
     'client_secret': r'GOCSPX-[A-Za-z0-9_-]{20,}',
+    'signature': r'[?&](X-Amz-|X-Goog-)?Signature=[^&\s]{20,}',
 }
 
 indexer_handler_names = [

--- a/scripts/provision_credentials.py
+++ b/scripts/provision_credentials.py
@@ -30,6 +30,7 @@ from azul.lib import (
     cached_property,
 )
 from azul.lib.strings import (
+    assert_redactable,
     format_and_dedent,
 )
 from azul.logging import (
@@ -141,7 +142,9 @@ class CredentialsProvisioner:
                 3) Paste the secret value into the prompt below
             ''', url=url))
             secret_value = getpass.getpass('OAuth2 client secret (input will not be echoed back): ')
+            secret_value = secret_value.strip()
             assert secret_value, R('No secret value provided')
+            assert_redactable(secret_value)
             self._write_secret_value(secret_path, secret_value)
             print(format_and_dedent('''
                 The secret was successfully stored. Now it's time to …

--- a/src/azul/chalice.py
+++ b/src/azul/chalice.py
@@ -497,7 +497,7 @@ class AzulChaliceApp(Chalice):
 
     def _log_response(self, response: Response) -> None:
         info = {
-            'headers': response.headers
+            'headers': self._redact_headers(response.headers)
         }
         info = json.dumps(info)
         log.info('Returning %i response with headers %s.',

--- a/src/azul/chalice.py
+++ b/src/azul/chalice.py
@@ -7,6 +7,9 @@ from collections.abc import (
 from enum import (
     Enum,
 )
+from functools import (
+    partial,
+)
 import json
 import logging
 import mimetypes
@@ -28,7 +31,6 @@ from urllib.parse import (
 import attrs
 from chalice.app import (
     BadRequestError,
-    CaseInsensitiveMapping,
     Chalice,
     ChaliceViewError,
     EventSourceHandler,
@@ -467,24 +469,6 @@ class AzulChaliceApp(Chalice):
                 "Only specify 'spec' once per route path and method")
             path_methods[method] = copy_json(spec)
 
-    class _LogJSONEncoder(json.JSONEncoder):
-
-        def default(self, o: Any) -> Any:
-            def _redact(v):
-                return redact(v) if isinstance(v, str) else v
-
-            if isinstance(o, MultiDict):
-                # Convert to dict, flatten the singleton values, redact strings
-                return {
-                    k: _redact(v[0]) if len(v) == 1 else list(map(_redact, v))
-                    for k, v in ((k, o.getlist(k)) for k in o.keys())
-                }
-            elif isinstance(o, CaseInsensitiveMapping):
-                # Convert to dict, redacting the header values
-                return {k: redact_header(k, v) for k, v in o.items()}
-            else:
-                return super().default(o)
-
     def _authenticate(self) -> Authentication | None:
         """
         Authenticate the current request, return None if it is unauthenticated,
@@ -503,10 +487,10 @@ class AzulChaliceApp(Chalice):
 
     def _log_request(self, request: Request) -> None:
         info = {
-            'query': request.query_params,
-            'headers': request.headers
+            'query': self._redact_query(request.query_params),
+            'headers': self._redact_headers(request.headers)
         }
-        info = json.dumps(info, cls=self._LogJSONEncoder)
+        info = json.dumps(info)
         log.info('Received %s request for %r, with %s.',
                  request.context['httpMethod'], request.context['path'], info)
         log.info(http_body_log_message('request', request.raw_body))
@@ -515,10 +499,37 @@ class AzulChaliceApp(Chalice):
         info = {
             'headers': response.headers
         }
-        info = json.dumps(info, cls=self._LogJSONEncoder)
+        info = json.dumps(info)
         log.info('Returning %i response with headers %s.',
                  response.status_code, info)
         log.info(http_body_log_message('response', response.body))
+
+    @classmethod
+    def _redact[T: (str, Sequence[str])](cls,
+                                         value: T,
+                                         redact: Callable[[str], str]
+                                         ) -> T:
+        if isinstance(value, str):
+            return redact(value)
+        else:
+            return [cls._redact(v, redact) for v in value]
+
+    @classmethod
+    def _redact_query(cls, query: MultiDict | None) -> JSON | None:
+        if query is None:
+            return None
+        else:
+            return {
+                name: cls._redact(values[0] if len(values) == 1 else values, redact)
+                for name, values in ((name, query.getlist(name)) for name in query.keys())
+            }
+
+    @classmethod
+    def _redact_headers(cls, headers: Mapping[str, str | Sequence[str]]) -> JSON:
+        return {
+            name: cls._redact(value, partial(redact_header, name))
+            for name, value in headers.items()
+        }
 
     absent = object()
 
@@ -718,7 +729,6 @@ class AzulChaliceApp(Chalice):
             yield f'{self.unqualified_app_name}_{handler_name}'
 
     def default_routes(self):
-
         @self.route(
             '/',
             interactive=False,

--- a/src/azul/chalice.py
+++ b/src/azul/chalice.py
@@ -471,7 +471,7 @@ class AzulChaliceApp(Chalice):
 
         def default(self, o: Any) -> Any:
             def _redact(v):
-                return redact(v, fullmatch=True) if isinstance(v, str) else v
+                return redact(v) if isinstance(v, str) else v
 
             if isinstance(o, MultiDict):
                 # Convert to dict, flatten the singleton values, redact strings

--- a/src/azul/http.py
+++ b/src/azul/http.py
@@ -76,7 +76,7 @@ def redact_headers(headers: Mapping[str, str]) -> list[tuple[str, str]]:
 
 
 def redact_header(name: str, value: str) -> str:
-    result = redact(value, fullmatch=True)
+    result = redact(value)
     if result == value:
         # Our standard, pattern-based approach didn't redact anything …
         if name.lower() == 'authorization':

--- a/src/azul/lib/json.py
+++ b/src/azul/lib/json.py
@@ -367,10 +367,10 @@ def json_hash(o: AnyJSON, hash=None):
 
 def redact_json(v: AnyJSON) -> AnyJSON:
     """
-    Return a copy of the given JSON with confidential string values redacted.
+    Return a copy of the given JSON with secrets in string values redacted.
     """
     if isinstance(v, str):
-        return redact(v, fullmatch=True)
+        return redact(v)
     elif isinstance(v, dict):
         return {k: redact_json(v) for k, v in v.items()}
     elif isinstance(v, list):

--- a/src/azul/lib/strings.py
+++ b/src/azul/lib/strings.py
@@ -8,8 +8,12 @@ from typing import (
     overload,
 )
 
+from furl import (
+    furl,
+)
 from more_itertools import (
     minmax,
+    one,
 )
 
 from azul.lib import (
@@ -474,6 +478,23 @@ def double_quote(*words: str) -> str:
 
 _base64url = r'[A-Za-z0-9_-]'
 
+#: The query parameters that carry the signature of a signed URL. The signature
+#: is the secret part of such a URL.
+#:
+_url_signature_params = [
+    # AWS Signature Version 4
+    'X-Amz-Signature',
+    # Google Cloud Storage V4
+    'X-Goog-Signature',
+    # AWS Signature Version 2, which is what is used to presign S3 URLs in
+    # the us-east-1 region currently used for Azul. This alternative is the least
+    # specific of the three, so it is also the one most likely to over-match.
+    #
+    # FIXME: Remove once we switched to version 4 signatures
+    #        https://github.com/DataBiosphere/azul/issues/8272
+    'Signature',
+]
+
 # The lower bounds on the variable length patterns were chosen arbitrarily. They
 # are needed to prevent false positives if the preceding anchor is too short to
 # do so on its own.
@@ -490,12 +511,14 @@ _secret_re = re.compile('|'.join([
     rf'4/[0-9]({_base64url}{{64,}})',
     # Google OAuth2 client secret
     rf'GOCSPX-({_base64url}+)',
+    # Signature of a signed URL
+    rf'[?&](?i:{"|".join(_url_signature_params)})=([^&\s]+)',
 ]))
 
 
 def is_redactable(secret: str) -> bool:
     """
-    True if the given secret is matched, in its entirety, by the patterns above,
+    True if the given secret is matched, in its entirety, by the regex above,
     and would therefore be redacted before being logged.
 
     >>> is_redactable('ya29.' + 'a' * 100)
@@ -510,7 +533,8 @@ def is_redactable(secret: str) -> bool:
     Note that the prefix tests below are necessary to tell the kinds of token
     apart, but not sufficient to establish this property:
 
-    >>> looks_like_redactable_jwt('eyJnotajwt'), is_redactable('eyJnotajwt')
+    >>> s = 'eyJnotajwt'
+    >>> looks_like_redactable_jwt(s), is_redactable(s)
     (True, False)
     """
     return redact(secret, fullmatch=True) != secret
@@ -577,6 +601,13 @@ def redact(s: str, *, fullmatch: bool = False) -> str:
     >>> redact('client_secret=GOCSPX-' + 'c' * 28 + '!')
     'client_secret=GOCSPX-cREDACTEDc!'
 
+    Only the signature of a signed URL is redacted, leaving the rest of the URL,
+    and with it the diagnostic value of the log message, intact:
+
+    >>> redact('to https://bucket.s3.amazonaws.com/k'
+    ...        '?X-Amz-Expires=900&X-Amz-Signature=' + 'd' * 64)
+    'to https://bucket.s3.amazonaws.com/k?X-Amz-Expires=900&X-Amz-Signature=dddREDACTEDddd'
+
     With ``fullmatch=True``, only strings that are entirely a secret are
     redacted:
 
@@ -620,6 +651,29 @@ def assert_redactable(secret: str) -> None:
     AssertionError: Secret not matched by redaction regex
     """
     assert is_redactable(secret), 'Secret not matched by redaction regex'
+
+
+def assert_signed_url_redactable(url: str) -> None:
+    """
+    Assert that the signature of the given signed URL would be redacted by a
+    call to :func:`redact`. Exactly one of the signature parameters above must
+    occur in the URL, and it is that parameter's value that must be redacted.
+
+    >>> assert_signed_url_redactable('https://h/p?X-Goog-Signature=' + 'a' * 40)
+
+    >>> assert_signed_url_redactable('https://h/p?Expires=1&Signature=' + 'a' * 40)
+
+    A URL that carries none of those parameters is not a signed URL:
+
+    >>> assert_signed_url_redactable('https://h/p?Sig=' + 'a' * 40)
+    Traceback (most recent call last):
+    ...
+    ValueError: too few items in iterable (expected 1)
+    """
+    args = furl(url).args
+    name = one(name for name in _url_signature_params if name in args)
+    assert furl(redact(url)).args[name] != args[name], R(
+        'Signature not redacted', name)
 
 
 def _redact(secret: str, *, num_show: int = 3, mask='REDACTED'):

--- a/src/azul/lib/strings.py
+++ b/src/azul/lib/strings.py
@@ -488,6 +488,8 @@ _secret_re = re.compile('|'.join([
     rf'1//[0-9]{{2}}({_base64url}{{64,}})',
     # Google OAuth2 authorization code
     rf'4/[0-9]({_base64url}{{64,}})',
+    # Google OAuth2 client secret
+    rf'GOCSPX-({_base64url}+)',
 ]))
 
 
@@ -571,6 +573,9 @@ def redact(s: str, *, fullmatch: bool = False) -> str:
 
     >>> redact('refresh=1//09' + 'a' * 63 + '!') == 'refresh=1//09' + 'a' * 63 + '!'
     True
+
+    >>> redact('client_secret=GOCSPX-' + 'c' * 28 + '!')
+    'client_secret=GOCSPX-cREDACTEDc!'
 
     With ``fullmatch=True``, only strings that are entirely a secret are
     redacted:

--- a/src/azul/oauth2.py
+++ b/src/azul/oauth2.py
@@ -133,6 +133,7 @@ class OAuth2Client(HasCachedHttpClient):
                              flow.
         """
         assert_redactable(authorization_code)
+        assert_redactable(client_secret)
         if redirect_uri is None:
             # Undocumented but crucial (https://stackoverflow.com/a/48121098/4171119)
             redirect_uri = 'postmessage'
@@ -161,6 +162,7 @@ class OAuth2Client(HasCachedHttpClient):
                           client_secret: str
                           ) -> TokenResponse:
         assert_redactable(refresh_token)
+        assert_redactable(client_secret)
         fields = {
             'grant_type': 'refresh_token',
             'refresh_token': refresh_token,

--- a/src/azul/plugins/repository/tdr.py
+++ b/src/azul/plugins/repository/tdr.py
@@ -13,10 +13,6 @@ from typing import (
     TypeVar,
 )
 
-from furl import (
-    furl,
-)
-
 from azul import (
     config,
 )
@@ -43,6 +39,7 @@ from azul.lib.bigquery import (
     backtick,
 )
 from azul.lib.strings import (
+    assert_signed_url_redactable,
     longest_common_prefix,
 )
 from azul.lib.time import (
@@ -218,8 +215,7 @@ class TDRPlugin[TDR_BUNDLE: TDRBundle,
             assert access.method is AccessMethod.https, R(str(access.method))
             assert access.headers is None, R(str(access.headers))
             signed_url = access.url
-            args = furl(signed_url).args
-            assert 'X-Goog-Signature' in args, R(str(args))
+            assert_signed_url_redactable(signed_url)
             return signed_url
 
     def validate_version(self, version: str) -> None:

--- a/src/azul/service/storage_service.py
+++ b/src/azul/service/storage_service.py
@@ -49,6 +49,9 @@ from azul.lib import (
 from azul.lib.collections import (
     OrderedSet,
 )
+from azul.lib.strings import (
+    assert_signed_url_redactable,
+)
 
 if TYPE_CHECKING:
     from mypy_boto3_s3.client import (
@@ -371,8 +374,10 @@ class StorageService:
             params['ResponseContentDisposition'] = f'attachment;filename="{file_name}"'
         if content_type is not None:
             params['ResponseContentType'] = content_type
-        return self._s3.generate_presigned_url(Params=params,
-                                               ClientMethod=self._s3.get_object.__name__)
+        url = self._s3.generate_presigned_url(Params=params,
+                                              ClientMethod=self._s3.get_object.__name__)
+        assert_signed_url_redactable(url)
+        return url
 
     def put_object_tagging(self, object_key: str, tagging: Tagging):
         log.info('Tagging object %r with %r', object_key, tagging)

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -140,12 +140,14 @@ class TestRepositoryFilesWithTDR(DCP2TestCase, RepositoryFilesTestCase):
                     if fetch:
                         azul_url.path.segments.insert(0, 'fetch')
 
-                    file_name = 'foo.gz'
-                    gs_bucket_name = 'gringotts-wizarding-bank'
-                    gs_drs_id = 'some_dataset_id/some_object_id'
-                    gs_file_url = f'gs://{gs_bucket_name}/{gs_drs_id}/{file_name}'
-
-                    pre_signed_gs = furl(url=gs_file_url,
+                    pre_signed_gs = furl(scheme='https',
+                                         host='storage.googleapis.com',
+                                         path=[
+                                             'some_bucket_name',
+                                             'some_dataset_id',
+                                             'some_object_id',
+                                             'foo.gz'
+                                         ],
                                          args={
                                              'X-Goog-Algorithm': 'SOMEALGORITHM',
                                              'X-Goog-Credential': 'SOMECREDENTIAL',

--- a/test/service/test_repository_files.py
+++ b/test/service/test_repository_files.py
@@ -47,6 +47,9 @@ from azul.indexer.mirror_service import (
     MirrorService,
     MirrorWorkerService,
 )
+from azul.lib.strings import (
+    redact,
+)
 from azul.logging import (
     configure_test_logging,
     get_test_logger,
@@ -158,7 +161,19 @@ class TestRepositoryFilesWithTDR(DCP2TestCase, RepositoryFilesTestCase):
                                          })
                     access = Access(method=AccessMethod.https, url=str(pre_signed_gs))
                     with patch.object(DRSObject, 'get', return_value=access):
-                        response = client.request('GET', str(azul_url), redirect=False)
+                        with self.assertLogs('azul.chalice', level='INFO') as app_log:
+                            response = client.request('GET', str(azul_url), redirect=False)
+                        # The signature is secret, so it must not be logged
+                        signature = pre_signed_gs.args['X-Goog-Signature']
+                        for message in app_log.output:
+                            self.assertNotIn(signature, message)
+                        if not fetch:
+                            # The URL is returned in a response header, which is
+                            # logged in full, with the signature redacted
+                            redacted_url = redact(str(pre_signed_gs))
+                            self.assertNotEqual(str(pre_signed_gs), redacted_url)
+                            self.assertTrue(any(redacted_url in message
+                                                for message in app_log.output))
                         self.assertEqual(200 if fetch else 302, response.status)
                         if fetch:
                             response = json.loads(response.data)


### PR DESCRIPTION

<!--
This is the PR template for regular PRs against `develop`. Edit the URL in your
browser's location bar, appending either `&template=anvilprod-promotion.md`,
`&template=prod-promotion.md`, `&template=anvilprod-hotfix.md`, `&template=prod-
hotfix.md`, `&template=backport.md` or `&template=upgrade.md` to switch the
template.
-->

Linked issues: DataBiosphere/azul-private#412, DataBiosphere/azul-private#390


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] PR is a draft
- [x] Target branch is `develop`
- [x] Name of PR branch matches `issues/<GitHub handle of author>/<issue#>-<slug>`
- [x] PR is linked to all issues it (partially) resolves
- [x] Status of linked issues is *In progress*
- [x] PR description links to linked issues
- [x] PR title matches<sup>1</sup> that of a linked issue <sub>or comment in PR explains why they're different</sub>
- [x] PR title references all linked issues
- [x] For each linked issue, there is at least one commit whose title references that issue

<sup>1</sup> when the issue title describes a problem, the corresponding PR
title is `Fix: ` followed by the issue title


### Author (partiality)

- [x] Added `p` tag to titles of partial commits
- [x] This PR is labeled `partial` <sub>or completely resolves all linked issues</sub>
- [x] This PR partially resolves each of the linked issues <sub>or does not have the `partial` label</sub>


### Author (reindex)

- [x] Added `r` tag to commit title <sub>or the changes introduced by this PR will not require reindexing of any deployment</sub>
- [x] This PR is labeled `reindex:dev` <sub>or the changes introduced by it will not require reindexing of `dev`</sub>
- [x] This PR is labeled `reindex:anvildev` <sub>or the changes introduced by it will not require reindexing of `anvildev`</sub>
- [x] This PR is labeled `reindex:anvilprod` <sub>or the changes introduced by it will not require reindexing of `anvilprod`</sub>
- [x] This PR is labeled `reindex:prod` <sub>or the changes introduced by it will not require reindexing of `prod`</sub>
- [x] This PR is labeled `reindex:partial` and its description documents the specific reindexing procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full reindex or carries none of the labels `reindex:dev`, `reindex:anvildev`, `reindex:anvilprod` and `reindex:prod`</sub>


### Author (mirror)

- [x] This PR is labeled `mirror:dev` <sub>or the changes introduced by it will not require mirroring of `dev`</sub>
- [x] This PR is labeled `mirror:anvildev` <sub>or the changes introduced by it will not require mirroring of `anvildev`</sub>
- [x] This PR is labeled `mirror:anvilprod` <sub>or the changes introduced by it will not require mirroring of `anvilprod`</sub>
- [x] This PR is labeled `mirror:prod` <sub>or the changes introduced by it will not require mirroring of `prod`</sub>
- [x] This PR is labeled `mirror:partial` and its description documents the specific mirroring procedure for `dev`, `anvildev`, `anvilprod` and `prod` <sub>or requires a full mirroring or carries none of the labels `mirror:dev`, `mirror:anvildev`, `mirror:anvilprod` and `mirror:prod`</sub>


### Author (API changes)

- [x] This PR and its linked issues are labeled `API` <sub>or this PR does not modify a REST API</sub>
- [x] Added `a` (`A`) tag to commit title for backwards (in)compatible changes <sub>or this PR does not modify a REST API</sub>
- [x] Updated REST API version number in `app.py` <sub>or this PR does not modify a REST API</sub>


### Author (upgrading deployments)

- [x] Ran `make docker_images.json` and committed the resulting changes <sub>or this PR does not modify `azul_docker_images`, or any other variables referenced in the definition of that variable</sub>
- [x] Documented upgrading of deployments in UPGRADING.rst <sub>or this PR does not require upgrading deployments</sub>
- [x] Added `u` tag to commit title <sub>or this PR does not require upgrading deployments</sub>
- [x] This PR is labeled `upgrade` <sub>or does not require upgrading deployments</sub>
- [x] This PR is labeled `deploy:shared` <sub>or does not modify `docker_images.json`, and does not require deploying the `shared` component for any other reason</sub>
- [x] This PR is labeled `deploy:gitlab` <sub>or does not require deploying the `gitlab` component</sub>
- [x] This PR is labeled `deploy:runner` <sub>or does not require deploying the `runner` image</sub>


### Author (hotfixes)

- [x] Added `F` tag to main commit title <sub>or this PR does not include permanent fix for a temporary hotfix</sub>
- [x] Reverted the temporary hotfixes for any linked issues <sub>or the none of the stable branches (`anvilprod` and `prod`) have temporary hotfixes for any of the issues linked to this PR</sub>


### Author (before every review)

- [x] Rebased PR branch on `develop`, squashed fixups from prior reviews
- [x] Ran `make requirements_update` <sub>or this PR does not modify `pyproject.toml`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `uv.lock`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `uv.lock`</sub>
- [x] `make integration_test` passes in personal deployment <sub>or this PR does not modify functionality that could affect the IT outcome</sub>
- [x] PR is awaiting requested review from a peer
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the peer and the author


### Peer reviewer (after approval)

Note that after requesting changes, the PR must be assigned to only the author.

- [x] Actually approved the PR
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Labeled linked issues as `demo` or `no demo`
- [x] Commented on linked issues about demo expectations <sub>or all linked issues are labeled `no demo`</sub>
- [x] Decided if PR can be labeled `no sandbox`
- [x] A comment to this PR details the completed security design review
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator and the author


### Operator

- [x] Checked `reindex:…` labels and `r` commit title tag
- [x] Checked `mirror:…` labels
- [x] Checked that demo expectations are clear <sub>or all linked issues are labeled `no demo`</sub>
- [x] Squashed PR branch and rebased onto `develop`
- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (deploy `.shared` and `.gitlab` components)

- [x] Ran `_select dev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select dev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply`(an error from _login_docker_gitlab is benign if the instance was stopped for backup) <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Ran `_select anvildev.shared && CI_COMMIT_REF_NAME=develop make -C terraform/shared apply_keep_unused` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.gitlab && CI_COMMIT_REF_NAME=develop make -C terraform/gitlab apply`(an error from _login_docker_gitlab is benign if the instance was stopped for backup) <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Checked the items in the next section <sub>or this PR is labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the system administrator and the author <sub>or this PR is not labeled `deploy:gitlab`</sub>


### System administrator (post-deploy of `.gitlab` component)

- [x] Background migrations for [`dev.gitlab`](https://gitlab.dev.singlecell.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] Background migrations for [`anvildev.gitlab`](https://gitlab.anvil.gi.ucsc.edu/admin/background_migrations) are complete <sub>or this PR is not labeled `deploy:gitlab`</sub>
- [x] PR is assigned to only the operator and the author


### Operator (deploy runner image)

- [x] Ran `_select dev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>
- [x] Ran `_select anvildev.gitlab && make -C terraform/gitlab/runner` <sub>or this PR is not labeled `deploy:runner`</sub>


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Applied upgrade instructions from UPGRADING.rst to `sandbox` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `sandbox`</sub>
- [x] Applied upgrade instructions from UPGRADING.rst to `anvilbox` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `anvilbox`</sub>
- [x] In `sandbox`, deleted the catalogs specified in the notes <sub>or this PR is missing either the `reindex:partial` or the `reindex:dev` label, or both</sub>
- [x] In `anvilbox`, deleted the catalogs specified in the notes <sub>or this PR is missing either the `reindex:partial` or the `reindex:anvildev` label, or both</sub>
- [x] In `sandbox`, deindexed the sources sepcified in the notes <sub>or this PR is missing either the `reindex:partial` or the `reindex:dev` label, or both</sub>
- [x] In `anvilbox`, deindexed the sources sepcified in the notes <sub>or this PR is missing either the `reindex:partial` or the `reindex:anvildev` label, or both</sub>
- [x] In `sandbox`, indexed the sources specified in the notes <sub>or this PR is missing either the `reindex:partial` or the `reindex:dev` label, or both</sub>
- [x] In `anvilbox`, indexed the sources specified in the notes <sub>or this PR is missing either the `reindex:partial` or the `reindex:anvildev` label, or both</sub>
- [x] In `sandbox`, indexed the catalogs specified in the notes <sub>or this PR is missing either the `reindex:partial` or the `reindex:dev` label, or both</sub>
- [x] In `anvilbox`, indexed the catalogs specified in the notes <sub>or this PR is missing either the `reindex:partial` or the `reindex:anvildev` label, or both</sub>
- [x] Started full reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev` or it is labeled reindex:partial</sub>
- [x] Started full reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev` or it is labeled reindex:partial</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Started mirroring in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [x] Started mirroring in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but only included `p` if the PR is also labeled `partial`</sub>
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*
- [x] Status of blocked issues is *Triage* <sub>or no issues are blocked on the linked issues</sub>


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Applied upgrade instructions from UPGRADING.rst to `dev` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `dev`</sub>
- [x] Applied upgrade instructions from UPGRADING.rst to `anvildev` <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to `anvildev`</sub>
- [x] Notified developers to apply upgrade instructions from UPGRADING.rst to their personal deployments <sub>or this PR is not labeled `upgrade`, or upgrade instructions do not apply to personal deployments</sub>
- [x] Ran `_select dev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Ran `_select anvildev.shared && make -C terraform/shared apply` <sub>or this PR is not labeled `deploy:shared`</sub>
- [x] Deleted PR branch from GitHub
- [x] PR is assigned to only the operator
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Lower*, or *Triage*, if PR is partial


### Operator (reindex)

- [x] In `dev`, deleted the catalogs specified in the notes <sub>or this PR is missing either the `reindex:partial` or the `reindex:dev` label, or both</sub>
- [x] In `anvildev`, deleted the catalogs specified in the notes <sub>or this PR is missing either the `reindex:partial` or the `reindex:anvildev` label, or both</sub>
- [x] In `dev`, deindexed the sources sepcified in the notes <sub>or this PR is missing either the `reindex:partial` or the `reindex:dev` label, or both</sub>
- [x] In `anvildev`, deindexed the sources sepcified in the notes <sub>or this PR is missing either the `reindex:partial` or the `reindex:anvildev` label, or both</sub>
- [x] In `dev`, indexed the sources specified in the notes <sub>or this PR is missing either the `reindex:partial` or the `reindex:dev` label, or both</sub>
- [x] In `anvildev`, indexed the sources specified in the notes <sub>or this PR is missing either the `reindex:partial` or the `reindex:anvildev` label, or both</sub>
- [x] In `dev`, indexed the catalogs specified in the notes <sub>or this PR is missing either the `reindex:partial` or the `reindex:dev` label, or both</sub>
- [x] In `anvildev`, indexed the catalogs specified in the notes <sub>or this PR is missing either the `reindex:partial` or the `reindex:anvildev` label, or both</sub>
- [x] Started full reindex in `dev` <sub>or this PR is not labeled `reindex:dev` or it is labeled reindex:partial</sub>
- [x] Started full reindex in `anvildev` <sub>or this PR is not labeled `reindex:anvildev` or it is labeled reindex:partial</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `dev` <sub>or this PR is not labeled `reindex:dev` or it is labeled reindex:partial</sub>
- [x] Checked for, triaged and possibly requeued messages in both fail queues in `anvildev` <sub>or this PR is not labeled `reindex:anvildev` or it is labeled reindex:partial</sub>
- [x] Emptied fail queues in `dev` <sub>or this PR is not labeled `reindex:dev` or it is labeled reindex:partial</sub>
- [x] Emptied fail queues in `anvildev` <sub>or this PR is not labeled `reindex:anvildev` or it is labeled reindex:partial</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/hca/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fhca%2Fdev) on GitLab in `dev` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/lungmap/dev branch](https://gitlab.dev.singlecell.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Flungmap%2Fdev) on GitLab in `dev` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `dev` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Restarted the Data Browser pipeline for the [ucsc/anvil/anvildev branch](https://gitlab.anvil.gi.ucsc.edu/ucsc/data-browser/-/pipelines/new?ref=ucsc%2Fanvil%2Fanvildev) on GitLab in `anvildev` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Restarted `deploy_browser` job in the GitLab pipeline for this PR in `anvildev` <sub>or this PR is not labeled `reindex:anvildev`</sub>


### Operator (mirroring)

- [x] Started mirroring in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Started mirroring in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Checked for, triaged and possibly requeued messages in mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>
- [x] Emptied mirror fail queue in `dev` <sub>or this PR is not labelled `mirror:dev`</sub>
- [x] Emptied mirror fail queue in `anvildev` <sub>or this PR is not labelled `mirror:anvildev`</sub>


### Operator

- [x] Propagated the `upgrade` and `API` labels to the next promotion PRs <sub>or this PR carries neither of these labels</sub>
- [x] Propagated the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels to the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] Propagated any specific instructions related to the `deploy:shared`, `deploy:gitlab`, `deploy:runner`, `reindex:partial`, `reindex:anvilprod`, `reindex:prod`, `mirror:partial`, `mirror:anvilprod` and `mirror:prod` labels, from the description of this PR to that of the next promotion PRs <sub>or this PR carries none of these labels</sub>
- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem

