### PR TITLE
Backport: 5e419ec (#8282, PR #8262)

### DIFF
--- a/src/azul/terra.py
+++ b/src/azul/terra.py
@@ -407,7 +407,9 @@ class TDRClient(SAMClient, DRSClient):
 
     def _retrieve_source(self, source: TDRSourceRef) -> MutableJSON:
         endpoint = self._repository_endpoint('snapshots', source.id)
-        response = self._request('GET', endpoint)
+        # This method is called once per contribution, while the
+        # response only varies per source, so it is cached.
+        response = self._url_cache.get_url(endpoint)
         response = self._check_response(endpoint, response)
         assert source.spec.name == response['name'], R(
             'Source name changed unexpectedly', source, response)
@@ -545,6 +547,13 @@ class TDRClient(SAMClient, DRSClient):
 
     @cached_property
     def _url_cache(self) -> UrlCacheService:
+
+        # This cache serves the DUOS dataset registrations as well as the TDR
+        # snapshot metadata that `get_duos` needs in order to request them. The
+        # rate limiting below is per URL host, so the two services are allotted
+        # independent sets of slots. The cache timing is *not* per host, but per
+        # cache, so it'll have to be tuned with both DUOS and TDR in mind.
+        #
         # We were asked to time out after 30s on DUOS requests, and to retry
         # three times. The HTTP client we use for Terra services may have a
         # different timeout and retry configured. For example, when running in a
@@ -553,16 +562,21 @@ class TDRClient(SAMClient, DRSClient):
         # expiration can only be set to a fixed value so in order to avoid more
         # than one Lambda invocation retrying the same DUOS request in parallel,
         # we'll set it to the contribution Lamba's timeout.
-        cache = CacheService(expiration=3600 * 24,
-                             lock_expiration=config.contribution_lambda_timeout(retry=False))
+        #
+        timeout = config.contribution_lambda_timeout(retry=False)
+        cache = CacheService(expiration=3600 * 24, lock_expiration=timeout)
+
         # Ten concurrent requests per URL host, regardless of the URL path.
+        #
         cache = RateLimitingCacheService(inner=cache, max_slots=10)
+
         # Keep in mind that the retrying cache service handles contention on the
         # fetch lock *and* the rate limiting slots. The lock expiration above
         # essentially disables the contention-based retries on the fetch lock,
         # because the Lambda times out before it could retry to acquire the
         # lock. So the parameters for the retrying cache service are primarily
         # tuned for the slot contention retry.
+        #
         cache = RetryingCacheService(inner=cache, num_retries=13, retry_delay=10.0)
         return UrlCacheService(inner=cache, http_client=self._http_client)
 

--- a/test/indexer/test_anvil.py
+++ b/test/indexer/test_anvil.py
@@ -103,15 +103,23 @@ class DUOSTestCase(TDRTestCase, ABC):
                       ) -> Iterable[patch]:
         tdr_mock = Mock(spec=HTTPResponse, status=200,
                         data=json.dumps(tdr_response))
-        mock_url = PropertyMock(return_value=furl('https://mock_duos.lan'))
+        duos_host = 'mock_duos.lan'
+        mock_url = PropertyMock(return_value=furl(f'https://{duos_host}'))
         mock_cache = Mock(spec=UrlCacheService)
-        if duos_response is not None:
+        if duos_response is None:
+            duos_mock = None
+        else:
             duos_mock = Mock(spec=HTTPResponse, status=200,
                              data=json.dumps(duos_response))
-            mock_cache.get_url.return_value = duos_mock
+
+        def get_url(url, *_args, **_kwargs):
+            # The snapshot metadata and the DUOS dataset registration are
+            # fetched through the same cache, and are told apart by their host
+            return duos_mock if url.host == duos_host else tdr_mock
+
+        mock_cache.get_url.side_effect = get_url
         patches = [
             patch.object(type(config), 'duos_service_url', new=mock_url),
-            patch.object(TDRClient, '_request', return_value=tdr_mock),
             patch.object(TDRClient, '_url_cache', new=mock_cache),
         ]
         return patches


### PR DESCRIPTION

<!--
This is the PR template for backport PRs against `develop`.
-->

Linked issues: #8282


## Checklist


### Author

- [x] PR is assigned to the author
- [x] Status of PR is *In progress*
- [x] Target branch is `develop`
- [x] Name of PR branch matches `backports/<7-digit SHA1 of most recent backported commit>`
- [x] PR is linked to the issues it backports
- [x] Status of linked issues is *Stable*
- [x] PR title contains the 7-digit SHA1 of the backported commits
- [x] PR title references the issues relating to the backported commits
- [x] PR title references the PRs that introduced the backported commits


### Author (before every review)

- [x] PR branch is up to date (if not, merge `develop` into PR branch to integrate upstream changes)
- [x] Ran `make requirements_update` <sub>or this PR does not modify `pyproject.toml`</sub>
- [x] Added `R` tag to commit title <sub>or this PR does not modify `uv.lock`</sub>
- [x] This PR is labeled `reqs` <sub>or does not modify `uv.lock`</sub>
- [x] PR is not a draft
- [x] PR is awaiting requested review from system administrator
- [x] Status of PR is *Review requested*
- [x] PR is assigned to only the system administrator and the author


### System administrator (after approval)

- [x] Actually approved the PR
- [x] Decided if PR can be labeled `no sandbox`
- [x] PR title is appropriate as title of merge commit
- [x] `N reviews` label is accurate
- [x] Status of PR is *Approved*
- [x] PR is assigned to only the operator and the author


### Operator

- [x] Sanity-checked history
- [x] Pushed PR branch to GitHub


### Operator (sandbox build)

- [x] Added `sandbox` label <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `dev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Pushed PR branch to GitLab `anvildev` <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Build passes in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `sandbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] Reviewed build logs for anomalies in `anvilbox` deployment <sub>or PR is labeled `no sandbox`</sub>
- [x] In `sandbox`, deleted the catalogs specified in the notes <sub>or this PR is missing either the `reindex:partial` or the `reindex:dev` label, or both</sub>
- [x] In `anvilbox`, deleted the catalogs specified in the notes <sub>or this PR is missing either the `reindex:partial` or the `reindex:anvildev` label, or both</sub>
- [x] In `sandbox`, deindexed the sources sepcified in the notes <sub>or this PR is missing either the `reindex:partial` or the `reindex:dev` label, or both</sub>
- [x] In `anvilbox`, deindexed the sources sepcified in the notes <sub>or this PR is missing either the `reindex:partial` or the `reindex:anvildev` label, or both</sub>
- [x] In `sandbox`, indexed the sources specified in the notes <sub>or this PR is missing either the `reindex:partial` or the `reindex:dev` label, or both</sub>
- [x] In `anvilbox`, indexed the sources specified in the notes <sub>or this PR is missing either the `reindex:partial` or the `reindex:anvildev` label, or both</sub>
- [x] In `sandbox`, indexed the catalogs specified in the notes <sub>or this PR is missing either the `reindex:partial` or the `reindex:dev` label, or both</sub>
- [x] In `anvilbox`, indexed the catalogs specified in the notes <sub>or this PR is missing either the `reindex:partial` or the `reindex:anvildev` label, or both</sub>
- [x] Started full reindex in `sandbox` <sub>or this PR is not labeled `reindex:dev` or it is labeled reindex:partial</sub>
- [x] Started full reindex in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev` or it is labeled reindex:partial</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `reindex:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `reindex:anvildev`</sub>
- [x] Started mirroring in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [x] Started mirroring in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>
- [x] Checked for failures in `sandbox` <sub>or this PR is not labeled `mirror:dev`</sub>
- [x] Checked for failures in `anvilbox` <sub>or this PR is not labeled `mirror:anvildev`</sub>


### Operator (merge the branch)

- [x] All status checks passed and the PR is mergeable
- [x] The title of the merge commit starts with the title of this PR
- [x] Added PR # reference (to this PR) to merge commit title
- [x] Collected commit title tags in merge commit title <sub>but excluded any `p` tags</sub> Use `[H]`, the only tag carried by the sole backported commit, 5e419ec, giving `[H] Backport: 5e419ec (#8282, PR #8262, PR #8292)`.
- [x] Pushed merge commit to GitHub
- [x] Status of PR is *Merged lower*


### Operator (main build)

- [x] Pushed merge commit to GitLab `dev`
- [x] Pushed merge commit to GitLab `anvildev`
- [x] Build passes on GitLab `dev`
- [x] Reviewed build logs for anomalies on GitLab `dev`
- [x] Build passes on GitLab `anvildev`
- [x] Reviewed build logs for anomalies on GitLab `anvildev`
- [x] Deleted PR branch from GitHub
- [x] PR is assigned to only the operator
- [x] Deleted PR branch from GitLab `dev`
- [x] Deleted PR branch from GitLab `anvildev`
- [x] Status of linked issues is *Stable*


### Operator

- [x] PR is assigned to no one


## Shorthand for review comments

- `L` line is too long
- `W` line wrapping is wrong
- `Q` bad quotes
- `F` other formatting problem


